### PR TITLE
Get rid of noteIds in notebook topics

### DIFF
--- a/apps/mobile/app/components/list-items/note/index.js
+++ b/apps/mobile/app/components/list-items/note/index.js
@@ -22,13 +22,12 @@ import React from "react";
 import { View } from "react-native";
 import Icon from "react-native-vector-icons/MaterialCommunityIcons";
 import { notesnook } from "../../../../e2e/test.ids";
+import { db } from "../../../common/database";
 import { TaggedNotes } from "../../../screens/notes/tagged";
 import { TopicNotes } from "../../../screens/notes/topic-notes";
-import useNavigationStore from "../../../stores/use-navigation-store";
 import { useSettingStore } from "../../../stores/use-setting-store";
 import { useThemeStore } from "../../../stores/use-theme-store";
 import { COLORS_NOTE } from "../../../utils/color-scheme";
-import { db } from "../../../common/database";
 import { SIZE } from "../../../utils/size";
 import { Properties } from "../../properties";
 import { Button } from "../../ui/button";
@@ -54,24 +53,24 @@ const showActionSheet = (item) => {
 function getNotebook(item) {
   const isTrash = item.type === "trash";
   if (isTrash || !item.notebooks || item.notebooks.length < 1) return [];
-  const currentScreen = useNavigationStore.getState().currentScreen;
-  const filteredNotebooks = item.notebooks?.filter(
-    (n) => n.id !== currentScreen.notebookId
-  );
-  let item_notebook =
-    filteredNotebooks?.length > 0 ? filteredNotebooks.slice(0, 1)[0] : null;
-  let notebook = item_notebook && db.notebooks.notebook(item_notebook.id);
-  if (!notebook) return [];
-  let topic = notebook.topics.topic(item_notebook.topics[0])?._topic;
-  if (!topic) return [];
-  notebook = notebook.data;
-  return [
-    {
-      title: `${notebook?.title} › ${topic?.title}`,
-      notebook: notebook,
-      topic: topic
-    }
-  ];
+
+  return item.notebooks.reduce(function (prev, curr) {
+    if (prev) return prev;
+    const topicId = curr.topics[0];
+    const notebook = db.notebooks?.notebook(curr.id)?.data;
+    if (!notebook) return;
+
+    const topic = notebook.topics.find((t) => t.id === topicId);
+    if (!topic) return;
+
+    return [
+      {
+        title: `${notebook?.title} › ${topic?.title}`,
+        notebook: notebook,
+        topic: topic
+      }
+    ];
+  }, []);
 }
 
 const NoteItem = ({

--- a/apps/mobile/app/components/selection-header/index.js
+++ b/apps/mobile/app/components/selection-header/index.js
@@ -246,10 +246,14 @@ export const SelectionHeader = React.memo(() => {
               if (selectedItemsList.length > 0) {
                 const currentTopic =
                   useNavigationStore.getState().currentScreen;
-                await db.notebooks
-                  .notebook(currentTopic.notebookId)
-                  .topics.topic(currentTopic.id)
-                  .delete(...selectedItemsList.map((item) => item.id));
+                await db.notes.removeFromNotebook(
+                  {
+                    id: currentTopic.notebookId,
+                    topic: currentTopic.id
+                  },
+                  ...selectedItemsList.map((item) => item.id)
+                );
+
                 Navigation.queueRoutesForUpdate(
                   "Notes",
                   "Favorites",

--- a/apps/mobile/app/components/sheets/add-to/index.js
+++ b/apps/mobile/app/components/sheets/add-to/index.js
@@ -194,6 +194,7 @@ const MoveNoteComponent = ({ note }) => {
         ? selectedItemsList.map((n) => n.id)
         : [note?.id];
     let ids = [];
+
     let notebooks = db.notebooks.all;
     for (let i = 0; i < notebooks.length; i++) {
       if (notebooks[i].topics) {
@@ -201,7 +202,8 @@ const MoveNoteComponent = ({ note }) => {
           let topic = notebooks[i].topics[t];
           if (topic.type !== "topic") continue;
           for (let id of notes) {
-            if (topic.notes.indexOf(id) > -1) {
+            const noteIds = db.notes?.topicReferences.get(topic.id);
+            if (noteIds.indexOf(id) > -1) {
               if (ids.indexOf(notebooks[i].id) === -1) {
                 ids.push(notebooks[i].id);
               }
@@ -237,7 +239,8 @@ const MoveNoteComponent = ({ note }) => {
         : [note?.id];
     let count = 0;
     for (let id of notes) {
-      if (topic.notes.indexOf(id) > -1) {
+      const noteIds = db.notes?.topicReferences.get(topic.id);
+      if (noteIds.indexOf(id) > -1) {
         count++;
       }
     }

--- a/apps/mobile/app/components/sheets/add-to/index.js
+++ b/apps/mobile/app/components/sheets/add-to/index.js
@@ -435,7 +435,7 @@ const MoveNoteComponent = ({ note }) => {
                           {item.title}
                         </Paragraph>
                         <Paragraph color={colors.icon} size={SIZE.xs}>
-                          {item.notes.length + " notes"}
+                          {getTotalNotes(item) + " notes"}
                         </Paragraph>
                         {getCount(item) ? (
                           <View

--- a/apps/mobile/app/components/sheets/add-to/index.js
+++ b/apps/mobile/app/components/sheets/add-to/index.js
@@ -151,15 +151,19 @@ const MoveNoteComponent = ({ note }) => {
         : [note?.id];
 
     if (getCount(item)) {
-      await db.notebooks
-        .notebook(item.notebookId)
-        .topics.topic(item.id)
-        .delete(...noteIds);
+      await db.notes.removeFromNotebook(
+        {
+          id: item.notebookId,
+          topic: item.id
+        },
+        ...noteIds
+      );
     } else {
-      await db.notes.move(
+      await db.notes.addToNotebook(
         {
           topic: item.id,
-          id: item.notebookId
+          id: item.notebookId,
+          rebuildCache: true
         },
         ...noteIds
       );

--- a/apps/mobile/app/components/sheets/move-notes/movenote.tsx
+++ b/apps/mobile/app/components/sheets/move-notes/movenote.tsx
@@ -67,7 +67,12 @@ export const MoveNotes = ({
 
   const [selectedNoteIds, setSelectedNoteIds] = useState<string[]>([]);
   const [topic, setTopic] = useState(selectedTopic);
-  notes = notes.filter((note) => topic?.notes.indexOf(note.id) === -1);
+
+  notes = notes.filter((note) => {
+    if (!topic) return [];
+    const noteIds = db.notes?.topicReferences.get(topic.id);
+    return noteIds.indexOf(note.id) === -1;
+  });
 
   const select = (id: string) => {
     const index = selectedNoteIds.indexOf(id);

--- a/apps/mobile/app/components/sheets/move-notes/movenote.tsx
+++ b/apps/mobile/app/components/sheets/move-notes/movenote.tsx
@@ -298,10 +298,11 @@ export const MoveNotes = ({
       {selectedNoteIds.length > 0 ? (
         <Button
           onPress={async () => {
-            await db.notes?.move(
+            if (!topic) return;
+            await db.notes?.addToNotebook(
               {
-                topic: topic?.id,
-                id: topic?.notebookId
+                topic: topic.id,
+                id: topic.notebookId
               },
               ...selectedNoteIds
             );

--- a/apps/mobile/app/hooks/use-actions.js
+++ b/apps/mobile/app/hooks/use-actions.js
@@ -99,10 +99,9 @@ export const useActions = ({ close = () => null, item }) => {
   const isNoteInTopic = () => {
     const currentScreen = useNavigationStore.getState().currentScreen;
     if (item.type !== "note" || currentScreen.name !== "TopicNotes") return;
-    return db.notebooks
-      .notebook(currentScreen.notebookId)
-      .topics.topic(currentScreen.id)
-      .has(item.id);
+    return (
+      db.notes?.topicReferences.get(currentScreen.id).indexOf(item.id) > -1
+    );
   };
 
   const onUpdate = useCallback(

--- a/apps/mobile/app/hooks/use-actions.js
+++ b/apps/mobile/app/hooks/use-actions.js
@@ -480,10 +480,13 @@ export const useActions = ({ close = () => null, item }) => {
   async function removeNoteFromTopic() {
     const currentScreen = useNavigationStore.getState().currentScreen;
     if (currentScreen.name !== "TopicNotes") return;
-    await db.notebooks
-      .notebook(currentScreen.notebookId)
-      .topics.topic(currentScreen.id)
-      .delete(item.id);
+    await db.notes.removeFromNotebook(
+      {
+        id: currentScreen.notebookId,
+        topic: currentScreen.id
+      },
+      item.id
+    );
     Navigation.queueRoutesForUpdate(
       "TaggedNotes",
       "ColoredNotes",

--- a/apps/mobile/app/hooks/use-actions.js
+++ b/apps/mobile/app/hooks/use-actions.js
@@ -100,7 +100,7 @@ export const useActions = ({ close = () => null, item }) => {
     const currentScreen = useNavigationStore.getState().currentScreen;
     if (item.type !== "note" || currentScreen.name !== "TopicNotes") return;
     return (
-      db.notes?.topicReferences.get(currentScreen.id).indexOf(item.id) > -1
+      db.notes?.topicReferences?.get(currentScreen.id)?.indexOf(item.id) > -1
     );
   };
 

--- a/apps/mobile/app/screens/notes/common.ts
+++ b/apps/mobile/app/screens/notes/common.ts
@@ -83,22 +83,12 @@ export const setOnFirstSave = (
   editorState().onNoteCreated = (id) => onNoteCreated(id, data);
 };
 
-export function isSynced(params: NotesScreenParams) {
-  if (params.item.type === "topic") {
-    const topic = db.notebooks
-      ?.notebook(params.item.notebookId)
-      ?.topics.topic(params.item.id);
-
-    return !topic ? true : topic?.synced();
-  }
-  return true;
-}
-
 async function onNoteCreated(id: string, params: FirstSaveData) {
   if (!params) return;
   switch (params.type) {
     case "topic": {
-      await db.notes?.move(
+      if (!params.notebook) break;
+      await db.notes?.addToNotebook(
         {
           topic: params.id,
           id: params.notebook

--- a/apps/mobile/app/screens/notes/index.tsx
+++ b/apps/mobile/app/screens/notes/index.tsx
@@ -37,7 +37,6 @@ import { useNoteStore } from "../../stores/use-notes-store";
 import { NoteType, TopicType } from "../../utils/types";
 import {
   getAlias,
-  isSynced,
   openEditor,
   openMonographsWebpage,
   setOnFirstSave,
@@ -95,7 +94,6 @@ const NotesPage = ({
 >) => {
   const params = useRef<NotesScreenParams>(route?.params);
   const [notes, setNotes] = useState<NoteType[]>(get(route.params, true));
-  const [warning, setWarning] = useState(!isSynced(route.params));
   const loading = useNoteStore((state) => state.loading);
   const [loadingNotes, setLoadingNotes] = useState(false);
   const alias = getAlias(params.current);
@@ -178,7 +176,6 @@ const NotesPage = ({
         ) {
           return Navigation.goBack();
         }
-        if (item.type === "topic") setWarning(!isSynced(params.current));
         setNotes(notes);
         syncWithNavigation();
       } catch (e) {
@@ -213,7 +210,6 @@ const NotesPage = ({
     >
       <List
         listData={notes}
-        warning={warning ? WARNING_DATA : null}
         type="notes"
         refreshCallback={onRequestUpdate}
         loading={loading || !isFocused}

--- a/apps/mobile/app/utils/index.js
+++ b/apps/mobile/app/utils/index.js
@@ -127,17 +127,13 @@ export function setWidthHeight(size) {
   dHeight = size.height;
 }
 
-export function getTotalNotes(notebook) {
-  if (!notebook || notebook.type === "header") return 0;
-  if (notebook.type === "topic") {
-    if (!notebook.notes) return 0;
-    return notebook.notes.length;
+export function getTotalNotes(item) {
+  if (!item || item.type === "header") return 0;
+  if (item.type === "topic") {
+    return db.notebooks.notebook(item.notebookId)?.topics.topic(item.id)
+      .totalNotes;
   }
-  if (!notebook.topics) return 0;
-  return notebook.topics.reduce((sum, topic) => {
-    let length = topic?.notes ? topic.notes.length : 0;
-    return sum + length;
-  }, 0);
+  return db.notebooks.notebook(item.id)?.totalNotes;
 }
 
 export async function toTXT(note, notitle) {

--- a/apps/web/src/common/index.js
+++ b/apps/web/src/common/index.js
@@ -142,10 +142,7 @@ export async function restoreBackupFile(backup) {
 }
 
 export function getTotalNotes(notebook) {
-  return notebook.topics.reduce((sum, topic) => {
-    if (!topic || !topic.notes) return sum;
-    return sum + topic.notes.length;
-  }, 0);
+  return db.notebooks.notebook(notebook)?.totalNotes;
 }
 
 export async function verifyAccount() {

--- a/apps/web/src/common/multi-select.ts
+++ b/apps/web/src/common/multi-select.ts
@@ -104,6 +104,7 @@ async function deleteTopics(notebookId: string, topics: Item[]) {
         ?.notebook(notebookId)
         .topics.delete(...topics.map((t) => t.id));
       notebookStore.setSelectedNotebook(notebookId);
+      noteStore.refresh();
     }
   });
   showToast("success", `${topics.length} topics deleted`);

--- a/apps/web/src/components/dialogs/move-note-dialog.js
+++ b/apps/web/src/components/dialogs/move-note-dialog.js
@@ -58,7 +58,7 @@ function MoveDialog({ onClose, noteIds }) {
                   .topics.topic(item.topic)
                   .delete(...noteIds);
               } else if (item.type === "add") {
-                await db.notes.move(item, ...noteIds);
+                await db.notes.addToNotebook(item, ...noteIds);
               }
             } catch (e) {
               showToast("error", e.message);

--- a/apps/web/src/components/note/index.js
+++ b/apps/web/src/components/note/index.js
@@ -445,11 +445,12 @@ const topicNoteMenuItems = [
           throw new Error("context is missing");
 
         const ids = items.map((i) => i.id);
-        const topic = db.notebooks
-          .notebook(context.value.id)
-          ?.topics?.topic(context.value.topic);
-        if (!topic) throw new Error("topic not found");
-        await topic.delete(...ids);
+
+        await db.notes.removeFromNotebook(
+          { id: context.value.id, topic: context.value.topic },
+          ...ids
+        );
+
         store.refresh();
 
         showToast("success", "Note removed from topic.");

--- a/apps/web/src/components/topic/index.js
+++ b/apps/web/src/components/topic/index.js
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import React from "react";
+import React, { useMemo } from "react";
 import ListItem from "../list-item";
 import { db } from "../../common/db";
 import { store as appStore } from "../../stores/app-store";
@@ -28,7 +28,12 @@ import { Multiselect } from "../../common/multi-select";
 import { pluralize } from "../../utils/string";
 
 function Topic({ item, index, onClick }) {
+  const { id, notebookId } = item;
   const topic = item;
+  const totalNotes = useMemo(() => {
+    return db.notebooks.notebook(notebookId)?.topics.topic(id).totalNotes;
+  }, [id, notebookId]);
+
   return (
     <ListItem
       selectable
@@ -50,7 +55,7 @@ function Topic({ item, index, onClick }) {
             •
           </Text>
           <Text variant="subBody">
-            {pluralize(topic.notes?.length || 0, "note", "notes")}
+            {pluralize(totalNotes || 0, "note", "notes")}
           </Text>
         </Flex>
       }
@@ -64,10 +69,7 @@ function Topic({ item, index, onClick }) {
 }
 
 export default React.memo(Topic, (prev, next) => {
-  return (
-    prev?.item?.title === next?.item?.title &&
-    prev?.item?.notes.length === next?.item?.notes.length
-  );
+  return prev?.item?.title === next?.item?.title;
 });
 
 const menuItems = [

--- a/apps/web/src/stores/editor-store.js
+++ b/apps/web/src/stores/editor-store.js
@@ -160,7 +160,7 @@ class EditorStore extends BaseStore {
 
       if (currentSession.context) {
         const { type, value } = currentSession.context;
-        if (type === "topic") await db.notes.move(value, id);
+        if (type === "topic") await db.notes.addToNotebook(value, id);
         else if (type === "color") await db.notes.note(id).color(value);
         else if (type === "tag") await db.notes.note(id).tag(value);
         // update the note.

--- a/apps/web/src/utils/importer.js
+++ b/apps/web/src/utils/importer.js
@@ -68,7 +68,7 @@ async function importNote(note) {
   const noteId = await db.notes.add(note);
 
   for (let notebook of notebooks) {
-    await db.notes.move(await importNotebook(notebook), noteId);
+    await db.notes.addToNotebook(await importNotebook(notebook), noteId);
   }
 }
 

--- a/apps/web/src/views/notes.js
+++ b/apps/web/src/views/notes.js
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import ListContainer from "../components/list-container";
 import { useStore as useNotesStore } from "../stores/note-store";
 import NotesPlaceholder from "../components/placeholders/notesplacholder";
@@ -25,11 +25,8 @@ import { hashNavigate, navigate } from "../navigation";
 import FavoritesPlaceholder from "../components/placeholders/favorites-placeholder";
 import { groupArray } from "@notesnook/core/utils/grouping";
 import { db } from "../common/db";
-import { Flex, Text } from "@theme-ui/components";
-import { SyncError } from "../components/icons";
 
 function Notes() {
-  const [isSynced, setIsSynced] = useState(true);
   const context = useNotesStore((store) => store.context);
   const refreshContext = useNotesStore((store) => store.refreshContext);
   const type = context?.type === "favorite" ? "favorites" : "notes";
@@ -37,14 +34,6 @@ function Notes() {
   useEffect(() => {
     if (context?.type === "color" && context?.notes?.length <= 0) {
       navigate("/", true);
-    }
-  }, [context]);
-
-  useEffect(() => {
-    if (context?.type === "topic") {
-      const { id, topic } = context.value;
-      if (!db.notebooks.notebook(id)?.topics.topic(topic)?.synced())
-        setIsSynced(false);
     }
   }, [context]);
 
@@ -56,16 +45,6 @@ function Notes() {
       refresh={refreshContext}
       context={{ ...context, notes: undefined }}
       items={groupArray(context.notes, db.settings.getGroupOptions(type))}
-      header={
-        isSynced ? null : (
-          <Flex bg="errorBg" p={2} py={1} sx={{ alignItems: "center" }}>
-            <SyncError color="error" size={16} />
-            <Text variant={"body"} ml={1} sx={{ color: "error" }}>
-              Some notes of this topic are not synced.
-            </Text>
-          </Flex>
-        )
-      }
       placeholder={
         context.type === "favorite" ? FavoritesPlaceholder : NotesPlaceholder
       }

--- a/packages/core/__tests__/notebooks.test.js
+++ b/packages/core/__tests__/notebooks.test.js
@@ -128,38 +128,12 @@ test("merge notebook when local notebook is also edited", () =>
     expect(notebook.topics.has("hello")).toBe(false);
   }));
 
-test("merge notebook when local notebook is also edited should merge noteIds too", () =>
-  notebookTest().then(async ({ db, id }) => {
-    let notebook = db.notebooks.notebook(id);
-
-    let note = await db.notes.add(TEST_NOTE);
-    await db.notes.move(
-      { id: notebook.data.id, topic: notebook.data.topics[0].id },
-      note
-    );
-
-    const newNotebook = { ...notebook.data, remote: true };
-    newNotebook.topics[0].title = "hello (edited)";
-    newNotebook.topics[0].notes.push("hello-new-note");
-
-    await delay(500);
-
-    await notebook.topics.add({
-      ...notebook.topics.all[0],
-      title: "hello (edited too)"
-    });
-
-    await expect(db.notebooks.merge(newNotebook)).resolves.not.toThrow();
-
-    expect(notebook.topics.all[0].notes).toHaveLength(2);
-  }));
-
 test("merging notebook when local notebook is not edited should not update remote notebook dateEdited", () =>
   notebookTest().then(async ({ db, id }) => {
     let notebook = db.notebooks.notebook(id);
 
     let note = await db.notes.add(TEST_NOTE);
-    await db.notes.move(
+    await db.notes.addToNotebook(
       { id: notebook.data.id, topic: notebook.data.topics[0].id },
       note
     );

--- a/packages/core/__tests__/topics.test.js
+++ b/packages/core/__tests__/topics.test.js
@@ -51,25 +51,25 @@ test("add note to topic", () =>
     let topics = db.notebooks.notebook(id).topics;
     let topic = topics.topic("hello");
     let noteId = await db.notes.add(TEST_NOTE);
-    await topic.add(noteId);
+    await db.notes.addToNotebook({ id, topic: topic.id }, noteId);
 
     topic = topics.topic("hello");
     expect(topic.totalNotes).toBe(1);
     expect(db.notebooks.notebook(id).totalNotes).toBe(1);
   }));
 
-test("delete note to topic", () =>
+test("delete note of a topic", () =>
   notebookTest().then(async ({ db, id }) => {
     let topics = db.notebooks.notebook(id).topics;
     let topic = topics.topic("hello");
     let noteId = await db.notes.add(TEST_NOTE);
-    await topic.add(noteId);
+    await db.notes.addToNotebook({ id, topic: topic.id }, noteId);
 
     topic = topics.topic("hello");
     expect(topic.totalNotes).toBe(1);
     expect(db.notebooks.notebook(id).totalNotes).toBe(1);
 
-    await topic.delete(noteId);
+    await db.notes.removeFromNotebook({ id, topic: topic.id }, noteId);
 
     topic = topics.topic("hello");
     expect(topic.totalNotes).toBe(0);
@@ -116,7 +116,8 @@ test("get topic", () =>
     let noteId = await db.notes.add({
       content: TEST_NOTE.content
     });
-    await topic.add(noteId);
+    await db.notes.addToNotebook({ id, topic: topic.id }, noteId);
+
     topic = topics.topic("Home");
     expect(await db.content.get(topic.all[0].contentId)).toBeDefined();
     expect(topic.totalNotes).toBe(1);
@@ -136,7 +137,7 @@ test("delete note from edited topic", () =>
       let topics = db.notebooks.notebook(id).topics;
       await topics.add("Home");
       let topic = topics.topic("Home");
-      await db.notes.move({ id, topic: topic._topic.title }, noteId);
+      await db.notes.addToNotebook({ id, topic: topic._topic.title }, noteId);
       await topics.add({ id: topic._topic.id, title: "Hello22" });
       await db.notes.delete(noteId);
     })

--- a/packages/core/api/__tests__/__snapshots__/debug.test.js.snap
+++ b/packages/core/api/__tests__/__snapshots__/debug.test.js.snap
@@ -4,10 +4,10 @@ exports[`strip note with content: stripped-note-with-content 1`] = `"{\\"title\\
 
 exports[`strip note: stripped-note 1`] = `"{\\"title\\":true,\\"description\\":false,\\"headline\\":true,\\"colored\\":false,\\"type\\":\\"note\\",\\"tags\\":[],\\"id\\":\\"hello\\",\\"contentId\\":\\"hello2\\",\\"dateModified\\":123,\\"dateEdited\\":123,\\"dateCreated\\":123}"`;
 
-exports[`strip notebook: stripped-notebook 1`] = `"{\\"title\\":true,\\"description\\":true,\\"headline\\":false,\\"colored\\":false,\\"type\\":\\"notebook\\",\\"id\\":\\"hello\\",\\"dateModified\\":123,\\"dateEdited\\":123,\\"dateCreated\\":123,\\"additionalData\\":[{\\"type\\":\\"topic\\",\\"id\\":\\"hello\\",\\"notebookId\\":\\"hello23\\",\\"title\\":\\"hello\\",\\"dateCreated\\":123,\\"dateEdited\\":123,\\"notes\\":[],\\"dateModified\\":123}]}"`;
+exports[`strip notebook: stripped-notebook 1`] = `"{\\"title\\":true,\\"description\\":true,\\"headline\\":false,\\"colored\\":false,\\"type\\":\\"notebook\\",\\"id\\":\\"hello\\",\\"dateModified\\":123,\\"dateEdited\\":123,\\"dateCreated\\":123,\\"additionalData\\":[{\\"type\\":\\"topic\\",\\"id\\":\\"hello\\",\\"notebookId\\":\\"hello23\\",\\"title\\":\\"hello\\",\\"dateCreated\\":123,\\"dateEdited\\":123,\\"dateModified\\":123}]}"`;
 
 exports[`strip tag: stripped-tag 1`] = `"{\\"title\\":true,\\"description\\":false,\\"headline\\":false,\\"colored\\":false,\\"type\\":\\"tag\\",\\"noteIds\\":[],\\"id\\":\\"hello\\",\\"dateModified\\":123,\\"dateEdited\\":123,\\"dateCreated\\":123}"`;
 
-exports[`strip topic: stripped-topic 1`] = `"{\\"title\\":true,\\"description\\":false,\\"headline\\":false,\\"colored\\":false,\\"type\\":\\"topic\\",\\"notes\\":[],\\"id\\":\\"hello\\",\\"dateModified\\":123,\\"dateEdited\\":123,\\"dateCreated\\":123}"`;
+exports[`strip topic: stripped-topic 1`] = `"{\\"title\\":true,\\"description\\":false,\\"headline\\":false,\\"colored\\":false,\\"type\\":\\"topic\\",\\"id\\":\\"hello\\",\\"dateModified\\":123,\\"dateEdited\\":123,\\"dateCreated\\":123}"`;
 
 exports[`strip trashed note: stripped-trashed-note 1`] = `"{\\"title\\":true,\\"description\\":false,\\"headline\\":true,\\"colored\\":false,\\"type\\":\\"trash\\",\\"tags\\":[],\\"id\\":\\"hello\\",\\"contentId\\":\\"hello2\\",\\"dateModified\\":123,\\"dateEdited\\":123,\\"dateDeleted\\":123,\\"dateCreated\\":123}"`;

--- a/packages/core/api/sync/__tests__/sync.test.skip.js
+++ b/packages/core/api/sync/__tests__/sync.test.skip.js
@@ -296,7 +296,7 @@ test("issue: remove notebook reference from notes that are removed from topic du
   expect(deviceB.notebooks.notebook(id)).toBeDefined();
 
   const noteA = await deviceA.notes.add({ title: "Note 1" });
-  await deviceA.notes.move({ id, topic: "Topic 1" }, noteA);
+  await deviceA.notes.addToNotebook({ id, topic: "Topic 1" }, noteA);
 
   expect(
     deviceA.notebooks.notebook(id).topics.topic("Topic 1").totalNotes
@@ -305,7 +305,7 @@ test("issue: remove notebook reference from notes that are removed from topic du
   await delay(2000);
 
   const noteB = await deviceB.notes.add({ title: "Note 2" });
-  await deviceB.notes.move({ id, topic: "Topic 1" }, noteB);
+  await deviceB.notes.addToNotebook({ id, topic: "Topic 1" }, noteB);
 
   expect(
     deviceB.notebooks.notebook(id).topics.topic("Topic 1").totalNotes

--- a/packages/core/api/sync/index.js
+++ b/packages/core/api/sync/index.js
@@ -371,6 +371,8 @@ class Sync {
   async onRemoteSyncCompleted(lastSynced) {
     // refresh monographs on sync completed
     await this.db.monographs.init();
+    // refresh topic references
+    this.db.notes.topicReferences.refresh();
 
     await this.start(false, false, lastSynced);
   }

--- a/packages/core/collections/topics.js
+++ b/packages/core/collections/topics.js
@@ -116,7 +116,7 @@ export default class Topics {
       const topic = this.topic(topicId);
       if (!topic) continue;
 
-      await topic.delete(...topic._topic.notes);
+      await topic.clear();
       await this._db.settings.unpin(topicId);
 
       const topicIndex = allTopics.findIndex(
@@ -138,7 +138,6 @@ export function makeTopic(topic, notebookId) {
     notebookId,
     title: topic.trim(),
     dateCreated: Date.now(),
-    dateEdited: Date.now(),
-    notes: []
+    dateEdited: Date.now()
   };
 }

--- a/packages/core/database/backup.js
+++ b/packages/core/database/backup.js
@@ -181,12 +181,7 @@ export default class Backup {
     ];
 
     await this._db.syncer.acquireLock(async () => {
-      if (
-        await this._migrator.migrate(collections, (id) => data[id], version)
-      ) {
-        await this._db.notes.repairReferences();
-        await this._db.notebooks.repairReferences();
-      }
+      await this._migrator.migrate(collections, (id) => data[id], version);
     });
   }
 

--- a/packages/core/models/notebook.js
+++ b/packages/core/models/notebook.js
@@ -32,7 +32,7 @@ export default class Notebook {
 
   get totalNotes() {
     return this._notebook.topics.reduce((sum, topic) => {
-      return sum + topic.notes.length;
+      return sum + this._db.notes.topicReferences.count(topic.id);
     }, 0);
   }
 

--- a/packages/core/models/topic.js
+++ b/packages/core/models/topic.js
@@ -17,9 +17,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { qclone } from "qclone";
-import { deleteItem, findById } from "../utils/array";
-
 export default class Topic {
   /**
    * @param {Object} topic
@@ -33,98 +30,36 @@ export default class Topic {
   }
 
   get totalNotes() {
-    return this._topic.notes.length;
+    return this._db.notes.topicReferences.count(this.id);
+  }
+
+  get id() {
+    return this._topic.id;
   }
 
   has(noteId) {
-    return this._topic.notes.indexOf(noteId) > -1;
-  }
-
-  async add(...noteIds) {
-    const topic = qclone(this._topic);
-    for (let noteId of noteIds) {
-      let note = this._db.notes.note(noteId);
-      if (!note || note.data.deleted) continue;
-
-      const notebooks = note.notebooks || [];
-
-      const noteNotebook = notebooks.find((nb) => nb.id === this._notebookId);
-      const noteHasNotebook = !!noteNotebook;
-      const noteHasTopic =
-        noteHasNotebook && noteNotebook.topics.indexOf(topic.id) > -1;
-      if (noteHasNotebook && !noteHasTopic) {
-        // 1 note can be inside multiple topics
-        noteNotebook.topics.push(topic.id);
-      } else if (!noteHasNotebook) {
-        notebooks.push({
-          id: this._notebookId,
-          topics: [topic.id]
-        });
-      }
-
-      if (!noteHasNotebook || !noteHasTopic) {
-        await this._db.notes.add({
-          id: noteId,
-          notebooks
-        });
-      }
-
-      if (!this.has(noteId)) {
-        topic.notes.push(noteId);
-        await this._save(topic);
-      }
-    }
-  }
-
-  async delete(...noteIds) {
-    const topic = qclone(this._topic);
-    for (let noteId of noteIds) {
-      let note = this._db.notes.note(noteId);
-      if (
-        !note ||
-        note.deleted ||
-        !deleteItem(topic.notes, noteId) ||
-        !note.notebooks
-      ) {
-        continue;
-      }
-
-      let { notebooks } = note;
-
-      const notebook = findById(notebooks, this._notebookId);
-      if (!notebook) continue;
-
-      const { topics } = notebook;
-      if (!deleteItem(topics, topic.id)) continue;
-
-      if (topics.length <= 0) deleteItem(notebooks, notebook);
-
-      await this._db.notes.add({
-        id: noteId,
-        notebooks
-      });
-    }
-    return await this._save(topic);
-  }
-
-  async _save(topic) {
-    await this._db.notebooks.notebook(this._notebookId).topics.add(topic);
-    return this;
+    return this._db.notes.topicReferences.has(this.id, noteId);
   }
 
   get all() {
-    return this._topic.notes.reduce((arr, noteId) => {
+    const noteIds = this._db.notes.topicReferences.get(this.id);
+    if (!noteIds.length) return [];
+
+    return noteIds.reduce((arr, noteId) => {
       let note = this._db.notes.note(noteId);
       if (note) arr.push(note.data);
       return arr;
     }, []);
   }
 
-  synced() {
-    const notes = this._topic.notes;
-    for (let id of notes) {
-      if (!this._db.notes.exists(id)) return false;
-    }
-    return true;
+  clear() {
+    const noteIds = this._db.notes.topicReferences.get(this.id);
+    if (!noteIds.length) return;
+
+    return this._db.notes.deleteFromNotebook(
+      this._notebookId,
+      this.id,
+      ...noteIds
+    );
   }
 }


### PR DESCRIPTION
## What's changed?

This is a BREAKING change in the core & will require updating the clients. The way it works is instead of keeping noteIds of all the notes in the topic, it keeps an in-memory cache. This in-memory cache `topicReferences` lives in the notes collection & decouples notes from notebooks/topics. This also simplifies all the different actions where references would persist after the note was deleted. Since the note acts as the source of truth for where it currently is, there is nothing else to do except rebuild the `topicReferences` cache.

## What's broken?

1. `db.notes.move` is now `db.notes.addToNotebook`
2. There is no longer any `.add` or `.delete` function on topic (e.g. `db.notebooks.notebook(id).topics.topic(id).delete(...noteIds)` no longer works). This functionality has been moved under `notes` collection: `db.notes.removeFromNotebook` and works similar to `addToNotebook` function.
3. `topic` no longer has any `notes` property. Which means we must use the `db` to get total notes count in a notebook or topic.

## What's fixed?

Fixes #615 
Fixes #889
Fixes #643
Fixes #477 

## Additional notes

@ammarahm-ed I have done the changes on the `web` side. You'll have to do the necessary changes on the `mobile` side.