### PR TITLE
Add separate collection for shortcuts

### DIFF
--- a/apps/mobile/app/components/list-items/headers/notebook-header.js
+++ b/apps/mobile/app/components/list-items/headers/notebook-header.js
@@ -33,7 +33,7 @@ import Paragraph from "../../ui/typography/paragraph";
 export const NotebookHeader = ({ notebook, onEditNotebook }) => {
   const colors = useThemeStore((state) => state.colors);
   const [isPinnedToMenu, setIsPinnedToMenu] = useState(
-    db.settings.isPinned(notebook.id)
+    db.shortcuts.exists(notebook.id)
   );
   const setMenuPins = useMenuStore((state) => state.setMenuPins);
   const totalNotes = getTotalNotes(notebook);
@@ -42,15 +42,20 @@ export const NotebookHeader = ({ notebook, onEditNotebook }) => {
   const onPinNotebook = async () => {
     try {
       if (isPinnedToMenu) {
-        await db.settings.unpin(notebook.id);
+        await db.shortcuts.remove(notebook.id);
       } else {
-        await db.settings.pin(notebook.type, { id: notebook.id });
+        await db.shortcuts.add({
+          item: {
+            id: notebook.id,
+            type: "notebook"
+          }
+        });
         ToastEvent.show({
           heading: "Shortcut created",
           type: "success"
         });
       }
-      setIsPinnedToMenu(db.settings.isPinned(notebook.id));
+      setIsPinnedToMenu(db.shortcuts.exists(notebook.id));
       setMenuPins();
     } catch (e) {
       console.error(e);

--- a/apps/mobile/app/components/list-items/selection-wrapper/action-strip.js
+++ b/apps/mobile/app/components/list-items/selection-wrapper/action-strip.js
@@ -47,7 +47,7 @@ export const ActionStrip = ({ note, setActionStrip }) => {
   const [width, setWidth] = useState(dWidth - 16);
   useEffect(() => {
     if (note.type === "note") return;
-    setIsPinnedToMenu(db.settings.isPinned(note.id));
+    setIsPinnedToMenu(db.shortcuts.exists(note.id));
   }, [note.id, note.type]);
 
   const updateNotes = () => {
@@ -117,26 +117,34 @@ export const ActionStrip = ({ note, setActionStrip }) => {
       onPress: async () => {
         try {
           if (isPinnedToMenu) {
-            await db.settings.unpin(note.id);
+            await db.shortcuts.remove(note.id);
             ToastEvent.show({
               heading: "Shortcut removed from menu",
               type: "success"
             });
           } else {
             if (note.type === "topic") {
-              await db.settings.pin(note.type, {
-                id: note.id,
-                notebookId: note.notebookId
+              await db.shortcuts.add({
+                item: {
+                  type: "topic",
+                  id: note.id,
+                  notebookId: note.notebookId
+                }
               });
             } else {
-              await db.settings.pin(note.type, { id: note.id });
+              await db.shortcuts.add({
+                item: {
+                  type: "notebook",
+                  id: note.id
+                }
+              });
             }
             ToastEvent.show({
               heading: "Shortcut added to menu",
               type: "success"
             });
           }
-          setIsPinnedToMenu(db.settings.isPinned(note.id));
+          setIsPinnedToMenu(db.shortcuts.exists(note.id));
           setMenuPins();
 
           setActionStrip(false);

--- a/apps/mobile/app/components/side-menu/pinned-section.js
+++ b/apps/mobile/app/components/side-menu/pinned-section.js
@@ -158,7 +158,7 @@ export const PinItem = React.memo(
               title="Remove Shortcut"
               type="error"
               onPress={async () => {
-                await db.settings.unpin(item.id);
+                await db.shortcuts.remove(item.id);
                 setVisible(false);
                 setMenuPins();
               }}

--- a/apps/mobile/app/hooks/use-actions.js
+++ b/apps/mobile/app/hooks/use-actions.js
@@ -64,7 +64,7 @@ export const useActions = ({ close = () => null, item }) => {
   const setSelectedItem = useSelectionStore((state) => state.setSelectedItem);
   const setMenuPins = useMenuStore((state) => state.setMenuPins);
   const [isPinnedToMenu, setIsPinnedToMenu] = useState(
-    db.settings.isPinned(item.id)
+    db.shortcuts.exists(item.id)
   );
   const user = useUserStore((state) => state.user);
   const [notifPinned, setNotifPinned] = useState(null);
@@ -77,7 +77,7 @@ export const useActions = ({ close = () => null, item }) => {
     if (item.id === null) return;
     checkNotifPinned();
     if (item.type !== "note") {
-      setIsPinnedToMenu(db.settings.isPinned(item.id));
+      setIsPinnedToMenu(db.shortcuts.exists(item.id));
     }
   }, [checkNotifPinned, item]);
 
@@ -366,21 +366,29 @@ export const useActions = ({ close = () => null, item }) => {
     close();
     try {
       if (isPinnedToMenu) {
-        await db.settings.unpin(item.id);
+        await db.shortcuts.remove(item.id);
       } else {
         if (item.type === "topic") {
-          await db.settings.pin(item.type, {
-            id: item.id,
-            notebookId: item.notebookId
+          await db.shortcuts.add({
+            item: {
+              type: "topic",
+              id: item.id,
+              notebookId: item.notebookId
+            }
           });
         } else {
-          await db.settings.pin(item.type, { id: item.id });
+          await db.shortcuts.add({
+            item: {
+              type: item.type,
+              id: item.id
+            }
+          });
         }
       }
-      setIsPinnedToMenu(db.settings.isPinned(item.id));
+      setIsPinnedToMenu(db.shortcuts.exists(item.id));
       setMenuPins();
     } catch (e) {
-      console.error(e);
+      console.error("error", e);
     }
   }
 

--- a/apps/mobile/app/stores/use-menu-store.ts
+++ b/apps/mobile/app/stores/use-menu-store.ts
@@ -34,11 +34,11 @@ export const useMenuStore = create<MenuStore>((set) => ({
   colorNotes: [],
   setMenuPins: () => {
     try {
-      set({ menuPins: db.settings?.pins || [] });
+      set({ menuPins: [...(db.shortcuts?.resolved as [])] });
     } catch (e) {
       setTimeout(() => {
         try {
-          set({ menuPins: db.settings?.pins || [] });
+          set({ menuPins: [...(db.shortcuts?.resolved as [])] });
         } catch (e) {
           console.error(e);
         }

--- a/apps/web/src/components/navigation-menu/index.js
+++ b/apps/web/src/components/navigation-menu/index.js
@@ -90,7 +90,7 @@ function NavigationMenu(props) {
   const [location, previousLocation, state] = useLocation();
   const isFocusMode = useAppStore((store) => store.isFocusMode);
   const colors = useAppStore((store) => store.colors);
-  const pins = useAppStore((store) => store.menuPins);
+  const shortcuts = useAppStore((store) => store.shortcuts);
   const refreshNavItems = useAppStore((store) => store.refreshNavItems);
   const isLoggedIn = useUserStore((store) => store.isLoggedIn);
   const isMobile = useMobile();
@@ -188,40 +188,40 @@ function NavigationMenu(props) {
             my={1}
             sx={{ width: "85%", height: "0.8px", alignSelf: "center" }}
           />
-          {pins.map((pin) => (
+          {shortcuts.map((item) => (
             <NavigationItem
               isTablet={isTablet}
-              key={pin.id}
-              title={pin.type === "tag" ? db.tags.alias(pin.id) : pin.title}
+              key={item.id}
+              title={item.type === "tag" ? db.tags.alias(item.id) : item.title}
               menu={{
                 items: [
                   {
                     key: "removeshortcut",
                     title: () => "Remove shortcut",
-                    onClick: async ({ pin }) => {
-                      await db.settings.unpin(pin.id);
+                    onClick: async ({ item }) => {
+                      await db.shortcuts.remove(item.id);
                       refreshNavItems();
                     }
                   }
                 ],
-                extraData: { pin }
+                extraData: { item }
               }}
               icon={
-                pin.type === "notebook"
+                item.type === "notebook"
                   ? Notebook2
-                  : pin.type === "tag"
+                  : item.type === "tag"
                   ? Tag2
                   : Topic
               }
               isShortcut
-              selected={shouldSelectNavItem(location, pin)}
+              selected={shouldSelectNavItem(location, item)}
               onClick={() => {
-                if (pin.type === "notebook") {
-                  _navigate(`/notebooks/${pin.id}`);
-                } else if (pin.type === "topic") {
-                  _navigate(`/notebooks/${pin.notebookId}/${pin.id}`);
-                } else if (pin.type === "tag") {
-                  _navigate(`/tags/${pin.id}`);
+                if (item.type === "notebook") {
+                  _navigate(`/notebooks/${item.id}`);
+                } else if (item.type === "topic") {
+                  _navigate(`/notebooks/${item.notebookId}/${item.id}`);
+                } else if (item.type === "tag") {
+                  _navigate(`/tags/${item.id}`);
                 }
               }}
             />

--- a/apps/web/src/components/notebook/index.js
+++ b/apps/web/src/components/notebook/index.js
@@ -143,8 +143,8 @@ const menuItems = [
     key: "shortcut",
     icon: Icon.Shortcut,
     title: ({ notebook }) =>
-      db.settings.isPinned(notebook.id) ? "Remove shortcut" : "Create shortcut",
-    onClick: ({ notebook }) => appStore.pinItemToMenu(notebook)
+      db.shortcuts.exists(notebook.id) ? "Remove shortcut" : "Create shortcut",
+    onClick: ({ notebook }) => appStore.addToShortcuts(notebook)
   },
   {
     key: "movetotrash",

--- a/apps/web/src/components/tag/index.js
+++ b/apps/web/src/components/tag/index.js
@@ -39,9 +39,9 @@ const menuItems = [
   {
     key: "shortcut",
     title: ({ tag }) =>
-      db.settings.isPinned(tag.id) ? "Remove shortcut" : "Create shortcut",
+      db.shortcuts.exists(tag.id) ? "Remove shortcut" : "Create shortcut",
     icon: Icon.Shortcut,
-    onClick: ({ tag }) => appStore.pinItemToMenu(tag)
+    onClick: ({ tag }) => appStore.addToShortcuts(tag)
   },
   {
     key: "delete",

--- a/apps/web/src/components/topic/index.js
+++ b/apps/web/src/components/topic/index.js
@@ -81,9 +81,9 @@ const menuItems = [
   {
     key: "shortcut",
     title: ({ topic }) =>
-      db.settings.isPinned(topic.id) ? "Remove shortcut" : "Create shortcut",
+      db.shortcuts.exists(topic.id) ? "Remove shortcut" : "Create shortcut",
     icon: Icon.Shortcut,
-    onClick: ({ topic }) => appStore.pinItemToMenu(topic)
+    onClick: ({ topic }) => appStore.addToShortcuts(topic)
   },
   {
     key: "delete",

--- a/apps/web/src/stores/app-store.js
+++ b/apps/web/src/stores/app-store.js
@@ -48,7 +48,7 @@ class AppStore extends BaseStore {
   colors = [];
   globalMenu = { items: [], data: {} };
   reminders = [];
-  menuPins = [];
+  shortcuts = [];
   lastSynced = 0;
 
   init = () => {
@@ -101,7 +101,7 @@ class AppStore extends BaseStore {
 
   refreshNavItems = () => {
     this.set((state) => {
-      state.menuPins = db.settings.pins;
+      state.shortcuts = db.shortcuts.resolved;
       state.colors = db.colors.all;
     });
   };
@@ -158,15 +158,18 @@ class AppStore extends BaseStore {
     });
   };
 
-  pinItemToMenu = async (item) => {
-    if (db.settings.isPinned(item.id)) {
-      await db.settings.unpin(item.id);
+  addToShortcuts = async (item) => {
+    if (db.shortcuts.exists(item.id)) {
+      await db.shortcuts.remove(item.id);
       this.refreshNavItems();
       showToast("success", `Shortcut removed!`);
     } else {
-      await db.settings.pin(item.type, {
-        id: item.id,
-        notebookId: item.notebookId
+      await db.shortcuts.add({
+        item: {
+          type: item.type,
+          id: item.id,
+          notebookId: item.notebookId
+        }
       });
       this.refreshNavItems();
       showToast("success", `Shortcut created!`);

--- a/apps/web/src/views/topics.js
+++ b/apps/web/src/views/topics.js
@@ -64,12 +64,13 @@ export default Topics;
 function NotebookHeader({ notebook }) {
   const { title, description, topics, dateEdited } = notebook;
   const [isShortcut, setIsShortcut] = useState(false);
-  const menuPins = useAppStore((store) => store.menuPins);
-  const pinItemToMenu = useAppStore((store) => store.pinItemToMenu);
-  useEffect(() => {
-    setIsShortcut(menuPins.findIndex((p) => p.id === notebook.id) > -1);
-  }, [menuPins, notebook]);
+  const shortcuts = useAppStore((store) => store.shortcuts);
+  const addToShortcuts = useAppStore((store) => store.addToShortcuts);
   const totalNotes = getTotalNotes(notebook);
+
+  useEffect(() => {
+    setIsShortcut(shortcuts.findIndex((p) => p.id === notebook.id) > -1);
+  }, [shortcuts, notebook]);
 
   return (
     <Flex mx={2} my={2} sx={{ flexDirection: "column" }}>
@@ -83,7 +84,7 @@ function NotebookHeader({ notebook }) {
             mr={1}
             p={0}
             title={isShortcut ? "Remove shortcut" : "Create shortcut"}
-            onClick={() => pinItemToMenu(notebook)}
+            onClick={() => addToShortcuts(notebook)}
           >
             {isShortcut ? (
               <RemoveShortcutLink size={16} />

--- a/packages/core/__tests__/settings.test.js
+++ b/packages/core/__tests__/settings.test.js
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { databaseTest, notebookTest, StorageInterface } from "./utils";
+import { databaseTest, StorageInterface } from "./utils";
 
 beforeEach(() => {
   StorageInterface.clear();
@@ -35,7 +35,7 @@ test("settings' dateModified should update after merge conflict resolve", () =>
   databaseTest().then(async (db) => {
     await db.storage.write("lastSynced", 0);
     const beforeDateModified = (db.settings._settings.dateModified = 1);
-    await db.settings.merge({ pins: [], groupOptions: {}, aliases: {} });
+    await db.settings.merge({ groupOptions: {}, aliases: {} });
     const afterDateModified = db.settings._settings.dateModified;
     expect(afterDateModified).toBeGreaterThan(beforeDateModified);
   }));
@@ -44,7 +44,6 @@ test("tag alias should update if aliases in settings update", () =>
   databaseTest().then(async (db) => {
     const tag = await db.tags.add("hello");
     await db.settings.merge({
-      pins: [],
       groupOptions: {},
       aliases: {
         [tag.id]: "hello232"
@@ -72,55 +71,4 @@ test("save toolbar config", () =>
     };
     await db.settings.setToolbarConfig("mobile", toolbarConfig);
     expect(db.settings.getToolbarConfig("mobile")).toMatchObject(toolbarConfig);
-  }));
-
-test("pinning an invalid item should throw", () =>
-  databaseTest().then(async (db) => {
-    await expect(() => db.settings.pin("lolo", {})).rejects.toThrow(
-      /item cannot be pinned/i
-    );
-  }));
-
-test("pin a notebook", () =>
-  notebookTest().then(async ({ db, id }) => {
-    await db.settings.pin("notebook", { id });
-    expect(db.settings.pins).toHaveLength(1);
-    expect(db.settings.pins[0].id).toBe(id);
-  }));
-
-test("pin an already pinned notebook", () =>
-  notebookTest().then(async ({ db, id }) => {
-    await db.settings.pin("notebook", { id });
-    await db.settings.pin("notebook", { id });
-
-    expect(db.settings.pins).toHaveLength(1);
-    expect(db.settings.pins[0].id).toBe(id);
-  }));
-
-test("pin a topic", () =>
-  notebookTest().then(async ({ db, id }) => {
-    const notebook = db.notebooks.notebook(id)._notebook;
-    const topic = notebook.topics[0];
-    await db.settings.pin("topic", { id: topic.id, notebookId: id });
-    expect(db.settings.pins).toHaveLength(1);
-    expect(db.settings.pins[0].id).toBe(topic.id);
-  }));
-
-test("pin a tag", () =>
-  databaseTest().then(async (db) => {
-    const tag = await db.tags.add("HELLO!");
-    await db.settings.pin("tag", { id: tag.id });
-    expect(db.settings.pins).toHaveLength(1);
-    expect(db.settings.pins[0].id).toBe(tag.id);
-  }));
-
-test("unpin a pinned item", () =>
-  databaseTest().then(async (db) => {
-    const tag = await db.tags.add("HELLO!");
-    await db.settings.pin("tag", { id: tag.id });
-    expect(db.settings.pins).toHaveLength(1);
-    expect(db.settings.pins[0].id).toBe(tag.id);
-
-    await db.settings.unpin(tag.id);
-    expect(db.settings.pins).toHaveLength(0);
   }));

--- a/packages/core/__tests__/shortcuts.test.js
+++ b/packages/core/__tests__/shortcuts.test.js
@@ -26,56 +26,56 @@ beforeEach(() => {
 test("create a shortcut of an invalid item should throw", () =>
   databaseTest().then(async (db) => {
     await expect(() =>
-      db.shorcuts.add({ item: { type: "HELLO!" } })
+      db.shortcuts.add({ item: { type: "HELLO!" } })
     ).rejects.toThrow(/cannot create a shortcut/i);
   }));
 
 test("create a shortcut of notebook", () =>
   notebookTest().then(async ({ db, id }) => {
-    await db.shorcuts.add({ item: { type: "notebook", id } });
-    expect(db.shorcuts.exists(id)).toBe(true);
-    expect(db.shorcuts.all[0].item.id).toBe(id);
+    await db.shortcuts.add({ item: { type: "notebook", id } });
+    expect(db.shortcuts.exists(id)).toBe(true);
+    expect(db.shortcuts.all[0].item.id).toBe(id);
   }));
 
 test("create a duplicate shortcut of notebook", () =>
   notebookTest().then(async ({ db, id }) => {
-    await db.shorcuts.add({ item: { type: "notebook", id } });
-    await db.shorcuts.add({ item: { type: "notebook", id } });
+    await db.shortcuts.add({ item: { type: "notebook", id } });
+    await db.shortcuts.add({ item: { type: "notebook", id } });
 
-    expect(db.shorcuts.all).toHaveLength(1);
-    expect(db.shorcuts.all[0].item.id).toBe(id);
+    expect(db.shortcuts.all).toHaveLength(1);
+    expect(db.shortcuts.all[0].item.id).toBe(id);
   }));
 
 test("create shortcut of a topic", () =>
   notebookTest().then(async ({ db, id }) => {
     const notebook = db.notebooks.notebook(id)._notebook;
     const topic = notebook.topics[0];
-    await db.shorcuts.add({
+    await db.shortcuts.add({
       item: { type: "topic", id: topic.id, notebookId: id }
     });
 
-    expect(db.shorcuts.all).toHaveLength(1);
-    expect(db.shorcuts.all[0].item.id).toBe(topic.id);
+    expect(db.shortcuts.all).toHaveLength(1);
+    expect(db.shortcuts.all[0].item.id).toBe(topic.id);
   }));
 
 test("pin a tag", () =>
   databaseTest().then(async (db) => {
     const tag = await db.tags.add("HELLO!");
-    await db.shorcuts.add({ item: { type: "tag", id: tag.id } });
+    await db.shortcuts.add({ item: { type: "tag", id: tag.id } });
 
-    expect(db.shorcuts.all).toHaveLength(1);
-    expect(db.shorcuts.all[0].item.id).toBe(tag.id);
+    expect(db.shortcuts.all).toHaveLength(1);
+    expect(db.shortcuts.all[0].item.id).toBe(tag.id);
   }));
 
 test("remove shortcut", () =>
   databaseTest().then(async (db) => {
     const tag = await db.tags.add("HELLO!");
-    const shortcutId = await db.shorcuts.add({
+    const shortcutId = await db.shortcuts.add({
       item: { type: "tag", id: tag.id }
     });
 
-    expect(db.shorcuts.all).toHaveLength(1);
+    expect(db.shortcuts.all).toHaveLength(1);
 
-    await db.shorcuts.remove(shortcutId);
-    expect(db.shorcuts.all).toHaveLength(0);
+    await db.shortcuts.remove(shortcutId);
+    expect(db.shortcuts.all).toHaveLength(0);
   }));

--- a/packages/core/__tests__/shortcuts.test.js
+++ b/packages/core/__tests__/shortcuts.test.js
@@ -1,0 +1,81 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2022 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { databaseTest, notebookTest, StorageInterface } from "./utils";
+
+beforeEach(() => {
+  StorageInterface.clear();
+});
+
+test("create a shortcut of an invalid item should throw", () =>
+  databaseTest().then(async (db) => {
+    await expect(() =>
+      db.shorcuts.add({ item: { type: "HELLO!" } })
+    ).rejects.toThrow(/cannot create a shortcut/i);
+  }));
+
+test("create a shortcut of notebook", () =>
+  notebookTest().then(async ({ db, id }) => {
+    await db.shorcuts.add({ item: { type: "notebook", id } });
+    expect(db.shorcuts.exists(id)).toBe(true);
+    expect(db.shorcuts.all[0].item.id).toBe(id);
+  }));
+
+test("create a duplicate shortcut of notebook", () =>
+  notebookTest().then(async ({ db, id }) => {
+    await db.shorcuts.add({ item: { type: "notebook", id } });
+    await db.shorcuts.add({ item: { type: "notebook", id } });
+
+    expect(db.shorcuts.all).toHaveLength(1);
+    expect(db.shorcuts.all[0].item.id).toBe(id);
+  }));
+
+test("create shortcut of a topic", () =>
+  notebookTest().then(async ({ db, id }) => {
+    const notebook = db.notebooks.notebook(id)._notebook;
+    const topic = notebook.topics[0];
+    await db.shorcuts.add({
+      item: { type: "topic", id: topic.id, notebookId: id }
+    });
+
+    expect(db.shorcuts.all).toHaveLength(1);
+    expect(db.shorcuts.all[0].item.id).toBe(topic.id);
+  }));
+
+test("pin a tag", () =>
+  databaseTest().then(async (db) => {
+    const tag = await db.tags.add("HELLO!");
+    await db.shorcuts.add({ item: { type: "tag", id: tag.id } });
+
+    expect(db.shorcuts.all).toHaveLength(1);
+    expect(db.shorcuts.all[0].item.id).toBe(tag.id);
+  }));
+
+test("remove shortcut", () =>
+  databaseTest().then(async (db) => {
+    const tag = await db.tags.add("HELLO!");
+    const shortcutId = await db.shorcuts.add({
+      item: { type: "tag", id: tag.id }
+    });
+
+    expect(db.shorcuts.all).toHaveLength(1);
+
+    await db.shorcuts.remove(shortcutId);
+    expect(db.shorcuts.all).toHaveLength(0);
+  }));

--- a/packages/core/api/index.js
+++ b/packages/core/api/index.js
@@ -141,7 +141,7 @@ class Database {
     /**@type {NoteHistory} */
     this.noteHistory = await NoteHistory.new(this, "notehistory", false);
     /**@type {Shortcuts} */
-    this.shorcuts = await Shortcuts.new(this, "shorcuts");
+    this.shortcuts = await Shortcuts.new(this, "shortcuts");
 
     this.trash = new Trash(this);
 

--- a/packages/core/api/index.js
+++ b/packages/core/api/index.js
@@ -46,6 +46,7 @@ import MFAManager from "./mfa-manager";
 import EventManager from "../utils/event-manager";
 import Pricing from "./pricing";
 import { logger } from "../logger";
+import Shortcuts from "../collections/shortcuts";
 
 /**
  * @type {EventSource}
@@ -139,6 +140,8 @@ class Database {
     this.attachments = await Attachments.new(this, "attachments");
     /**@type {NoteHistory} */
     this.noteHistory = await NoteHistory.new(this, "notehistory", false);
+    /**@type {Shortcuts} */
+    this.shorcuts = await Shortcuts.new(this, "shorcuts");
 
     this.trash = new Trash(this);
 

--- a/packages/core/api/migrations.js
+++ b/packages/core/api/migrations.js
@@ -76,6 +76,10 @@ class Migrations {
         type: "settings"
       },
       {
+        index: this._db.shorcuts.raw,
+        dbCollection: this._db.shorcuts
+      },
+      {
         index: this._db.notes.raw,
         dbCollection: this._db.notes
       }

--- a/packages/core/api/migrations.js
+++ b/packages/core/api/migrations.js
@@ -76,8 +76,8 @@ class Migrations {
         type: "settings"
       },
       {
-        index: this._db.shorcuts.raw,
-        dbCollection: this._db.shorcuts
+        index: this._db.shortcuts.raw,
+        dbCollection: this._db.shortcuts
       },
       {
         index: this._db.notes.raw,

--- a/packages/core/api/settings.js
+++ b/packages/core/api/settings.js
@@ -20,7 +20,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import { EV, EVENTS } from "../common";
 import id from "../utils/id";
 import "../types";
-import setManipulator from "../utils/set";
 
 class Settings {
   /**
@@ -49,11 +48,6 @@ class Settings {
   async merge(item) {
     if (this._settings.dateModified > (await this._db.lastSynced())) {
       this._settings.id = item.id;
-      this._settings.pins = setManipulator.union(
-        this._settings.pins,
-        item.pins,
-        (p) => p.data.id
-      );
       this._settings.groupOptions = {
         ...this._settings.groupOptions,
         ...item.groupOptions
@@ -131,55 +125,10 @@ class Settings {
     return this._settings.aliases[id];
   }
 
-  async pin(type, data) {
-    if (type !== "notebook" && type !== "topic" && type !== "tag")
-      throw new Error("This item cannot be pinned.");
-    if (this.isPinned(data.id)) return;
-    this._settings.pins.push({ type, data });
-
-    await this._saveSettings();
-  }
-
-  async unpin(id) {
-    const index = this._settings.pins.findIndex((i) => i.data.id === id);
-    if (index <= -1) return;
-    this._settings.pins.splice(index, 1);
-
-    await this._saveSettings();
-  }
-
-  isPinned(id) {
-    return !!this._settings.pins.find((v) => v.data.id === id);
-  }
-
-  get pins() {
-    return this._settings.pins.reduce((prev, pin) => {
-      if (!pin || !pin.data) return;
-
-      let item = null;
-      if (pin.type === "notebook") {
-        const notebook = this._db.notebooks.notebook(pin.data.id);
-        item = notebook ? notebook.data : null;
-      } else if (pin.type === "topic") {
-        const notebook = this._db.notebooks.notebook(pin.data.notebookId);
-        if (notebook) {
-          const topic = notebook.topics.topic(pin.data.id);
-          if (topic) item = topic._topic;
-        }
-      } else if (pin.type === "tag") {
-        item = this._db.tags.tag(pin.data.id);
-      }
-      if (item) prev.push(item);
-      else this.unpin(pin.data.id); // TODO risky.
-      return prev;
-    }, []);
-  }
-
   _initSettings(settings) {
     this._settings = {
       type: "settings",
       id: id(),
-      pins: [],
       groupOptions: {},
       toolbarConfig: {},
       aliases: {},

--- a/packages/core/api/sync/collector.js
+++ b/packages/core/api/sync/collector.js
@@ -23,7 +23,7 @@ import { logger } from "../../logger";
 class Collector {
   /**
    *
-   * @param {Database} db
+   * @param {import("../index").default} db
    */
   constructor(db) {
     this._db = db;
@@ -38,6 +38,7 @@ class Collector {
 
     const items = [
       ...this._collect("note", this._db.notes.raw, isForceSync),
+      ...this._collect("shortcut", this._db.shorcuts.raw, isForceSync),
       ...this._collect("notebook", this._db.notebooks.raw, isForceSync),
       ...this._collect("content", await this._db.content.all(), isForceSync),
       ...this._collect(

--- a/packages/core/api/sync/collector.js
+++ b/packages/core/api/sync/collector.js
@@ -38,7 +38,7 @@ class Collector {
 
     const items = [
       ...this._collect("note", this._db.notes.raw, isForceSync),
-      ...this._collect("shortcut", this._db.shorcuts.raw, isForceSync),
+      ...this._collect("shortcut", this._db.shortcuts.raw, isForceSync),
       ...this._collect("notebook", this._db.notebooks.raw, isForceSync),
       ...this._collect("content", await this._db.content.all(), isForceSync),
       ...this._collect(

--- a/packages/core/api/sync/merger.js
+++ b/packages/core/api/sync/merger.js
@@ -44,8 +44,8 @@ class Merger {
         set: (item) => this._db.notes.merge(item)
       },
       shortcut: {
-        get: (id) => this._db.shorcuts.shortcut(id),
-        set: (item) => this._db.shorcuts.merge(item)
+        get: (id) => this._db.shortcuts.shortcut(id),
+        set: (item) => this._db.shortcuts.merge(item)
       },
       notebook: {
         threshold: 1000,

--- a/packages/core/api/sync/merger.js
+++ b/packages/core/api/sync/merger.js
@@ -43,6 +43,10 @@ class Merger {
         get: (id) => this._db.notes.note(id),
         set: (item) => this._db.notes.merge(item)
       },
+      shortcut: {
+        get: (id) => this._db.shorcuts.shortcut(id),
+        set: (item) => this._db.shorcuts.merge(item)
+      },
       notebook: {
         threshold: 1000,
         get: (id) => this._db.notebooks.notebook(id),

--- a/packages/core/collections/notebooks.js
+++ b/packages/core/collections/notebooks.js
@@ -165,7 +165,7 @@ export default class Notebooks extends Collection {
       const notebookData = qclone(notebook.data);
       await notebook.topics.delete(...notebook.data.topics);
       await this._collection.removeItem(id);
-      await this._db.settings.unpin(id);
+      await this._db.shortcuts.remove(id);
       await this._db.trash.add(notebookData);
     }
   }

--- a/packages/core/collections/shortcuts.js
+++ b/packages/core/collections/shortcuts.js
@@ -1,0 +1,148 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2022 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import Collection from "./collection";
+import getId from "../utils/id";
+
+/**
+ * @typedef {{
+ *  id: string,
+ *  type: "tag" | "notebook" | "topic",
+ *  notebookId?: string
+ * }} ShortcutRef
+ *
+ * @typedef {{
+ *  id: string,
+ *  type: "shortcut",
+ *  item: ShortcutRef,
+ *  dateCreated: number,
+ *  dateModified: number,
+ *  sortIndex: number
+ * }} Shortcut
+ *
+ */
+
+const ALLOWED_SHORTCUT_TYPES = ["notebook", "topic", "tag"];
+export default class Shortcuts extends Collection {
+  shortcut(id) {
+    return this._collection.getItem(id);
+  }
+
+  async merge(shortcut) {
+    if (!shortcut) return;
+    await this._collection.addItem(shortcut);
+  }
+
+  /**
+   *
+   * @param {Partial<Shortcut>} shortcut
+   * @returns
+   */
+  async add(shortcut) {
+    if (!shortcut) return;
+    if (shortcut.remote)
+      throw new Error("Please use db.shortcuts.merge to merge remote notes.");
+
+    if (!ALLOWED_SHORTCUT_TYPES.includes(shortcut.item.type))
+      throw new Error("Cannot create a shortcut for this type of item.");
+
+    let oldShortcut = shortcut.item
+      ? this.find(shortcut.item.id)
+      : shortcut.id
+      ? this._collection.getItem(shortcut.id)
+      : null;
+    const id = shortcut.id || (oldShortcut && oldShortcut.id) || getId();
+
+    shortcut = {
+      ...oldShortcut,
+      ...shortcut
+    };
+
+    shortcut = {
+      id,
+      type: "shortcut",
+      item: {
+        type: shortcut.item.type,
+        id: shortcut.item.id,
+        notebookId: shortcut.item.notebookId
+      },
+      dateCreated: shortcut.dateCreated,
+      dateModified: shortcut.dateModified,
+      sortIndex: this._collection.count()
+    };
+
+    await this._collection.addItem(shortcut);
+    return shortcut.id;
+  }
+
+  get raw() {
+    return this._collection.getRaw();
+  }
+
+  /**
+   * @return {Shortcut[]}
+   */
+  get all() {
+    return this._collection.getItems();
+  }
+
+  get resolved() {
+    return this.all.reduce((prev, shortcut) => {
+      const {
+        item: { id, type, notebookId }
+      } = shortcut;
+
+      let item = null;
+      switch (type) {
+        case "notebook": {
+          const notebook = this._db.notebooks.notebook(id);
+          item = notebook ? notebook.data : null;
+          break;
+        }
+        case "topic": {
+          const notebook = this._db.notebooks.notebook(notebookId);
+          if (notebook) {
+            const topic = notebook.topics.topic(id);
+            if (topic) item = topic._topic;
+          }
+          break;
+        }
+        case "tag":
+          item = this._db.tags.tag(id);
+          break;
+      }
+      if (item) prev.push(item);
+      return prev;
+    }, []);
+  }
+
+  exists(itemId) {
+    return !!this.find(itemId);
+  }
+
+  find(itemId) {
+    return this.all.find((shortcut) => shortcut.item.id === itemId);
+  }
+
+  async remove(...shortcutIds) {
+    for (const id of shortcutIds) {
+      await this._collection.removeItem(id);
+    }
+  }
+}

--- a/packages/core/collections/shortcuts.js
+++ b/packages/core/collections/shortcuts.js
@@ -40,10 +40,6 @@ import getId from "../utils/id";
 
 const ALLOWED_SHORTCUT_TYPES = ["notebook", "topic", "tag"];
 export default class Shortcuts extends Collection {
-  shortcut(id) {
-    return this._collection.getItem(id);
-  }
-
   async merge(shortcut) {
     if (!shortcut) return;
     await this._collection.addItem(shortcut);
@@ -133,15 +129,22 @@ export default class Shortcuts extends Collection {
   }
 
   exists(itemId) {
-    return !!this.find(itemId);
+    return !!this.shortcut(itemId);
   }
 
-  find(itemId) {
-    return this.all.find((shortcut) => shortcut.item.id === itemId);
+  shortcut(id) {
+    return this.all.find(
+      (shortcut) => shortcut.item.id === id || shortcut.id === id
+    );
   }
 
   async remove(...shortcutIds) {
-    for (const id of shortcutIds) {
+    const shortcuts = this.all.filter((shortcut) =>
+      shortcutIds.includes(
+        shortcut.item.id0 || shortcutIds.includes(shortcut.id)
+      )
+    );
+    for (const { id } of shortcuts) {
       await this._collection.removeItem(id);
     }
   }

--- a/packages/core/collections/shortcuts.js
+++ b/packages/core/collections/shortcuts.js
@@ -59,7 +59,7 @@ export default class Shortcuts extends Collection {
       throw new Error("Cannot create a shortcut for this type of item.");
 
     let oldShortcut = shortcut.item
-      ? this.find(shortcut.item.id)
+      ? this.shortcut(shortcut.item.id)
       : shortcut.id
       ? this._collection.getItem(shortcut.id)
       : null;

--- a/packages/core/collections/shortcuts.js
+++ b/packages/core/collections/shortcuts.js
@@ -141,7 +141,7 @@ export default class Shortcuts extends Collection {
   async remove(...shortcutIds) {
     const shortcuts = this.all.filter((shortcut) =>
       shortcutIds.includes(
-        shortcut.item.id0 || shortcutIds.includes(shortcut.id)
+        shortcut.item.id || shortcutIds.includes(shortcut.id)
       )
     );
     for (const { id } of shortcuts) {

--- a/packages/core/collections/tags.js
+++ b/packages/core/collections/tags.js
@@ -120,7 +120,7 @@ export default class Tags extends Collection {
       if (hasItem(note.tags, tag.title)) await note.untag(tag.title);
     }
 
-    await this._db.settings.unpin(tagId);
+    await this._db.shortcuts.remove(tagId);
     await this._collection.deleteItem(tagId);
   }
 
@@ -135,7 +135,7 @@ export default class Tags extends Collection {
 
     if (tag.noteIds.length > 0) await this._collection.addItem(tag);
     else {
-      await this._db.settings.unpin(tag.id);
+      await this._db.shortcuts.remove(tag.id);
       await this._collection.deleteItem(tag.id);
     }
   }

--- a/packages/core/collections/topics.js
+++ b/packages/core/collections/topics.js
@@ -117,7 +117,7 @@ export default class Topics {
       if (!topic) continue;
 
       await topic.delete(...topic._topic.notes);
-      await this._db.settings.unpin(topicId);
+      await this._db.shortcuts.remove(topicId);
 
       const topicIndex = allTopics.findIndex(
         (t) => t.id === topicId || t.title === topicId

--- a/packages/core/database/backup.js
+++ b/packages/core/database/backup.js
@@ -171,7 +171,7 @@ export default class Backup {
       },
       {
         index: data["shortcuts"],
-        dbCollection: this._db.shorcuts
+        dbCollection: this._db.shortcuts
       },
       {
         index: data["notes"],

--- a/packages/core/database/backup.js
+++ b/packages/core/database/backup.js
@@ -170,6 +170,10 @@ export default class Backup {
         dbCollection: this._db.content
       },
       {
+        index: data["shortcuts"],
+        dbCollection: this._db.shorcuts
+      },
+      {
         index: data["notes"],
         dbCollection: this._db.notes
       },

--- a/packages/core/database/cached-collection.js
+++ b/packages/core/database/cached-collection.js
@@ -70,6 +70,10 @@ export default class CachedCollection extends IndexedCollection {
     return this.map.has(id);
   }
 
+  count() {
+    return this.map.size;
+  }
+
   getItem(id) {
     return this.map.get(id);
   }

--- a/packages/core/migrations.js
+++ b/packages/core/migrations.js
@@ -57,6 +57,7 @@ export const migrations = {
   5.5: {},
   5.6: {
     note: false,
+    shortcut: false,
     notebook: false,
     tag: false,
     attachment: false,


### PR DESCRIPTION
## What's changed?

This is a **BREAKING** change. We are moving `pins` out of `settings` as they really don't belong there (not to mention the confusing name). Shortcuts (formerly `pins`) will have their own collection which will be synced like `notes`, `notebooks` etc.

## What's broken?

1. `db.settings.pins` -> `db.shortcuts.resolved`
2. `db.settings.isPinned` -> `db.shortcuts.exists`
3. `db.settings.pin` -> `db.shortcuts.add`
4. `db.settings.unpin` -> `db.shortcuts.remove`

## What's fixed?

This will fix various issues where shortcuts would randomly go missing.

Fixes #534
Fixes #536

@ammarahm-ed this will require changes in the client code.