### PR TITLE
Allow tabbing inside editor

### DIFF
--- a/packages/editor/src/extensions/key-map/index.ts
+++ b/packages/editor/src/extensions/key-map/index.ts
@@ -1,0 +1,20 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2022 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+export * from "./key-map";

--- a/packages/editor/src/extensions/key-map/key-map.ts
+++ b/packages/editor/src/extensions/key-map/key-map.ts
@@ -1,0 +1,32 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2022 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { Extension } from "@tiptap/core";
+
+export const KeyMap = Extension.create({
+  name: "key-map",
+
+  addKeyboardShortcuts() {
+    return {
+      Tab: ({ editor }) => {
+        return editor.commands.insertContent("\t");
+      }
+    };
+  }
+});

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -73,6 +73,7 @@ import { Code } from "@tiptap/extension-code";
 import { DateTime } from "./extensions/date-time";
 import { OpenLink, OpenLinkOptions } from "./extensions/open-link";
 import HorizontalRule from "@tiptap/extension-horizontal-rule";
+import { KeyMap } from "./extensions/key-map";
 
 const CoreExtensions = Object.entries(TiptapCoreExtensions)
   // we will implement our own customized clipboard serializer
@@ -222,7 +223,8 @@ const useTiptap = (
         MathBlock,
         KeepInView,
         SelectionPersist,
-        DateTime
+        DateTime,
+        KeyMap
       ],
       onBeforeCreate: ({ editor }) => {
         editor.storage.portalProviderAPI = PortalProviderAPI;


### PR DESCRIPTION
Pressing `Tab` inside the editor will now add the `\t` character at the selection position.