### PR TITLE
Don't create a new task list when dropping items at end

### DIFF
--- a/packages/editor/src/extensions/react/react-node-view.tsx
+++ b/packages/editor/src/extensions/react/react-node-view.tsx
@@ -314,16 +314,6 @@ export class ReactNodeView<P extends ReactNodeViewProps> implements NodeView {
     const isClickEvent = event.type === "mousedown";
     const isDragEvent = event.type.startsWith("drag");
 
-    // if (event instanceof DragEvent && event.dataTransfer) {
-    //   console.log(
-    //     `[${event.type}]:`,
-    //     this.editor.view.dragging,
-    //     event.dataTransfer.getData("Text"),
-    //     event.dataTransfer.getData("text/plain"),
-    //     event.dataTransfer.getData("text/html")
-    //   );
-    // }
-
     // ProseMirror tries to drag selectable nodes
     // even if `draggable` is set to `false`
     // this fix prevents that

--- a/packages/editor/src/extensions/task-list/task-list.ts
+++ b/packages/editor/src/extensions/task-list/task-list.ts
@@ -21,12 +21,17 @@ import { mergeAttributes } from "@tiptap/core";
 import { TaskList } from "@tiptap/extension-task-list";
 import { createNodeView } from "../react";
 import { TaskListComponent } from "./component";
+import { Plugin, PluginKey, NodeSelection } from "prosemirror-state";
+import TaskItem from "@tiptap/extension-task-item";
+import { dropPoint } from "prosemirror-transform";
+import { findChildrenByType } from "prosemirror-utils";
 
 export type TaskListAttributes = {
   title: string;
   collapsed: boolean;
 };
 
+const stateKey = new PluginKey("task-item-drop-override");
 export const TaskListNode = TaskList.extend({
   addAttributes() {
     return {
@@ -112,5 +117,75 @@ export const TaskListNode = TaskList.extend({
         return { dom: content };
       }
     });
+  },
+  addProseMirrorPlugins() {
+    const thisType = this.type;
+    return [
+      new Plugin({
+        key: stateKey,
+        props: {
+          // This overrides the default task item drop behavior to make dropping
+          // items at the very end of the task list more reliable.
+          // Currently, dropping the item at the end of the list creates a
+          // new list which is often not what you want. We look for such
+          // behavior and instead moves the item to the very end.
+          handleDrop(view, event, slice, moved) {
+            const isTaskItem =
+              slice.content.firstChild?.type.name === TaskItem.name;
+            if (isTaskItem) {
+              const eventPos = view.posAtCoords(eventCoords(event));
+              if (!eventPos) return;
+              const $mouse = view.state.doc.resolve(eventPos.pos);
+
+              let insertPos = slice
+                ? dropPoint(view.state.doc, $mouse.pos, slice)
+                : $mouse.pos;
+              if (insertPos == null) insertPos = $mouse.pos;
+
+              const taskLists = findChildrenByType(
+                view.state.doc,
+                thisType,
+                false
+              );
+
+              // we iterate over all the first level task lists and see if
+              // the drop point is at the end of any of the task lists.
+              // TODO: this can get slow if there are a lot of task lists.
+              // We should loook for an alternative way to detect exactly
+              // which task list the user wants to drop the item into.
+              for (const taskList of taskLists) {
+                const range = {
+                  from: taskList.pos,
+                  to: taskList.pos + taskList.node.nodeSize
+                };
+                const isDroppedAtEnd = range.to === insertPos;
+                if (isDroppedAtEnd) {
+                  // This logic is taken from https://github.com/ProseMirror/prosemirror-view/blob/c47178ce2d5726f07a21d0759b3350ee1d185fd5/src/input.ts#L685
+                  const tr = view.state.tr;
+                  if (moved) tr.deleteSelection();
+                  const pos = tr.mapping.map(insertPos - 1);
+                  const beforeInsert = tr.doc;
+
+                  tr.replaceRangeWith(pos, pos, slice.content.firstChild);
+                  if (tr.doc.eq(beforeInsert)) return;
+
+                  const $pos = tr.doc.resolve(pos);
+                  tr.setSelection(new NodeSelection($pos));
+
+                  view.focus();
+                  view.dispatch(tr.setMeta("uiEvent", "drop"));
+                  return true;
+                }
+              }
+            }
+            return false;
+          }
+        }
+      })
+    ];
   }
 });
+
+function eventCoords(event: MouseEvent) {
+  return { left: event.clientX, top: event.clientY };
+}


### PR DESCRIPTION
This overrides the default task item drop behavior to make dropping items at the very end of the task list more reliable. Currently, dropping the item at the end of the list creates a new list which is often not what you want. We look for such behavior and instead moves the item to the very end.

Fixes #1127 