### PR TITLE
mobile: remove dateEdited from sort options in Tags

### DIFF
--- a/apps/mobile/app/components/sheets/sort/index.js
+++ b/apps/mobile/app/components/sheets/sort/index.js
@@ -35,7 +35,6 @@ const Sort = ({ type, screen }) => {
   const [groupOptions, setGroupOptions] = useState(
     db.settings.getGroupOptions(type)
   );
-
   const updateGroupOptions = async (_groupOptions) => {
     await db.settings.setGroupOptions(type, _groupOptions);
 
@@ -141,7 +140,8 @@ const Sort = ({ type, screen }) => {
           />
         ) : (
           Object.keys(SORT).map((item) =>
-            item === "title" && groupOptions.groupBy !== "none" ? null : (
+            (item === "title" && groupOptions.groupBy !== "none") ||
+            (screen === "Tags" && item === "dateEdited") ? null : (
               <Button
                 key={item}
                 type={groupOptions.sortBy === item ? "grayBg" : "gray"}

--- a/apps/mobile/app/utils/constants.js
+++ b/apps/mobile/app/utils/constants.js
@@ -35,6 +35,7 @@ export const GROUP = {
 };
 
 export const SORT = {
+  dateModified: "Date modified",
   dateEdited: "Date edited",
   dateCreated: "Date created",
   title: "Title"


### PR DESCRIPTION
Removed sort option 'dateEdited' from tags screen & replaced it with 'dateModified'.