### PR TITLE
Add support for caching base64 images

### DIFF
--- a/apps/web/src/interfaces/fs.js
+++ b/apps/web/src/interfaces/fs.js
@@ -102,14 +102,14 @@ async function writeEncryptedFile(file, key, hash) {
  * 3. We encrypt the Uint8Array
  * 4. We save the encrypted Uint8Array
  */
-async function writeEncrypted(filename, { data, type, key }) {
+async function writeEncrypted(filename, { data, type, key, mimeType }) {
   if (type === "base64") data = new Uint8Array(Buffer.from(data, "base64"));
 
   const { hash, type: hashType } = await hashBuffer(data);
   if (!filename) filename = hash;
 
   const file = new File([data.buffer], filename, {
-    type: "application/octet-stream"
+    type: mimeType || "application/octet-stream"
   });
 
   const result = await writeEncryptedFile(file, key, hash);
@@ -291,6 +291,7 @@ async function uploadFile(filename, requestOptions) {
     await fileHandle.addAdditionalData("uploaded", true);
     // Keep the images cached; delete everything else.
     if (!fileHandle.file.type?.startsWith("image/")) {
+      console.log("DELETING FILE", fileHandle);
       await streamablefs.deleteFile(filename);
     }
     await checkUpload(filename);

--- a/packages/core/collections/attachments.js
+++ b/packages/core/collections/attachments.js
@@ -282,9 +282,15 @@ export default class Attachments extends Collection {
     return this._collection.updateItem(attachment);
   }
 
-  async save(data, type) {
+  async save(data, type, mimeType) {
     const key = await this._db.attachments.generateKey();
-    const metadata = await this._db.fs.writeEncrypted(null, data, type, key);
+    const metadata = await this._db.fs.writeEncrypted(
+      null,
+      data,
+      type,
+      key,
+      mimeType
+    );
     return { key, metadata };
   }
 

--- a/packages/core/collections/content.js
+++ b/packages/core/collections/content.js
@@ -163,7 +163,7 @@ export default class Content extends Collection {
     const content = getContentFromData(contentItem.type, contentItem.data);
     if (!content) return contentItem;
     const { data, attachments } = await content.extractAttachments(
-      (data, type) => this._db.attachments.save(data, type)
+      (data, type, mimeType) => this._db.attachments.save(data, type, mimeType)
     );
 
     const noteAttachments = allAttachments.filter((attachment) =>

--- a/packages/core/content-types/tiptap.js
+++ b/packages/core/content-types/tiptap.js
@@ -161,7 +161,7 @@ export class Tiptap {
       try {
         const { data, mime } = dataurl.toObject(image.src);
         if (!data) continue;
-        const storeResult = await store(data, "base64");
+        const storeResult = await store(data, "base64", mime);
         if (!storeResult) continue;
 
         images[image.id] = { ...storeResult, mime };

--- a/packages/core/database/fs.js
+++ b/packages/core/database/fs.js
@@ -73,11 +73,12 @@ export default class FileStorage {
     return this.fs.readEncrypted(filename, encryptionKey, cipherData);
   }
 
-  writeEncrypted(filename, data, type, encryptionKey) {
+  writeEncrypted(filename, data, type, encryptionKey, mimeType) {
     return this.fs.writeEncrypted(filename, {
       data,
       type,
-      key: encryptionKey
+      key: encryptionKey,
+      mimeType
     });
   }
 


### PR DESCRIPTION
This fixes a critical issue where images appeared broken after switching notes.

Closes #1536
Closes #1453
Closes #1197
Closes #1195