### PR TITLE
Fetch announcements only once on app startup

### DIFF
--- a/apps/web/src/app-effects.js
+++ b/apps/web/src/app-effects.js
@@ -24,6 +24,7 @@ import { useStore as useNotesStore } from "./stores/note-store";
 import { useStore as useThemeStore } from "./stores/theme-store";
 import { useStore as useAttachmentStore } from "./stores/attachment-store";
 import { useStore as useEditorStore } from "./stores/editor-store";
+import { useStore as useAnnouncementStore } from "./stores/announcement-store";
 import { resetReminders, scheduleBackups } from "./common/reminders";
 import { introduceFeatures, showUpgradeReminderDialogs } from "./common";
 import { AppEventManager, AppEvents } from "./common/app-events";
@@ -32,7 +33,6 @@ import { EV, EVENTS } from "@notesnook/core/common";
 import { EVENTS as DESKTOP_APP_EVENTS } from "@notesnook/desktop/events";
 import { registerKeyMap } from "./common/key-map";
 import { isUserPremium } from "./hooks/use-is-user-premium";
-import useAnnouncements from "./hooks/use-announcements";
 import {
   showAnnouncementDialog,
   showBuyDialog,
@@ -63,7 +63,9 @@ export default function AppEffects({ setShow }) {
   const setTheme = useThemeStore((store) => store.setTheme);
   const followSystemTheme = useThemeStore((store) => store.followSystemTheme);
   const initEditorStore = useEditorStore((store) => store.init);
-  const [announcements, remove] = useAnnouncements("dialog");
+  const dialogAnnouncements = useAnnouncementStore(
+    (store) => store.dialogAnnouncements
+  );
   const isSystemThemeDark = useSystemTheme();
 
   useEffect(
@@ -188,11 +190,11 @@ export default function AppEffects({ setShow }) {
   }, []);
 
   useEffect(() => {
-    if (!announcements.length || isTesting()) return;
+    if (!dialogAnnouncements.length || isTesting()) return;
     (async () => {
-      await showAnnouncementDialog(announcements[0], remove);
+      await showAnnouncementDialog(dialogAnnouncements[0]);
     })();
-  }, [announcements, remove]);
+  }, [dialogAnnouncements]);
 
   useEffect(() => {
     if (!followSystemTheme) return;

--- a/apps/web/src/common/dialog-controller.tsx
+++ b/apps/web/src/common/dialog-controller.tsx
@@ -656,18 +656,11 @@ export function showEditReminderDialog(reminderId: string) {
   ));
 }
 
-export function showAnnouncementDialog(
-  announcement: { id: string },
-  remove: (id: string) => void
-) {
+export function showAnnouncementDialog(announcement: { id: string }) {
   return showDialog("AnnouncementDialog", (Dialog, perform) => (
     <Dialog
       announcement={announcement}
-      removeAnnouncement={() => remove(announcement.id)}
-      onClose={(res: boolean) => {
-        remove(announcement.id);
-        perform(res);
-      }}
+      onClose={(res: boolean) => perform(res)}
     />
   ));
 }

--- a/apps/web/src/components/announcements/body.js
+++ b/apps/web/src/components/announcements/body.js
@@ -24,7 +24,6 @@ import {
   Image as RebassImage,
   Text as RebassText
 } from "@theme-ui/components";
-import { allowedPlatforms } from "../../hooks/use-announcements";
 import {
   closeOpenedDialog,
   showBuyDialog
@@ -33,6 +32,7 @@ import { ANALYTICS_EVENTS, trackEvent } from "../../utils/analytics";
 import * as Icon from "../icons";
 import { store as appStore } from "../../stores/app-store";
 import { createBackup } from "../../common";
+import { allowedPlatforms } from "../../stores/announcement-store";
 
 var margins = [0, 2];
 var HORIZONTAL_MARGIN = 3;
@@ -48,11 +48,7 @@ const features = [
   { icon: Icon.Edit, title: "Rich text editor" }
 ];
 
-export default function AnnouncementBody({
-  removeAnnouncement,
-  components,
-  type
-}) {
+export default function AnnouncementBody({ components, type, dismiss }) {
   return components
     .filter((item) =>
       item.platforms.some((platform) => allowedPlatforms.indexOf(platform) > -1)
@@ -85,10 +81,7 @@ export default function AnnouncementBody({
             );
           case "callToActions":
             return (
-              <InlineCalltoActions
-                item={item}
-                removeAnnouncement={removeAnnouncement}
-              />
+              <InlineCalltoActions item={item} dismissAnnouncement={dismiss} />
             );
           case "text":
             return (
@@ -117,12 +110,7 @@ export default function AnnouncementBody({
           case "description":
             return <Description item={item} fontSize="subtitle" />;
           case "callToActions":
-            return (
-              <CalltoActions
-                item={item}
-                removeAnnouncement={removeAnnouncement}
-              />
-            );
+            return <CalltoActions item={item} dismissAnnouncement={dismiss} />;
           case "features":
             return <Features item={item} />;
           case "text":
@@ -212,7 +200,7 @@ function Text({ value, ...restProps }) {
   );
 }
 
-function CalltoActions({ item, removeAnnouncement }) {
+function CalltoActions({ item, dismissAnnouncement }) {
   const { actions, style } = item;
   return (
     <Flex
@@ -250,14 +238,14 @@ function CalltoActions({ item, removeAnnouncement }) {
                 mr: 1
               }
             }}
-            removeAnnouncement={removeAnnouncement}
+            dismissAnnouncement={dismissAnnouncement}
           />
         ))}
     </Flex>
   );
 }
 
-function InlineCalltoActions({ item, removeAnnouncement }) {
+function InlineCalltoActions({ item, dismissAnnouncement }) {
   const { actions, style } = item;
   return (
     <Flex px={2} sx={mapStyle(style)}>
@@ -283,20 +271,20 @@ function InlineCalltoActions({ item, removeAnnouncement }) {
                 mr: 1
               }
             }}
-            removeAnnouncement={removeAnnouncement}
+            dismissAnnouncement={dismissAnnouncement}
           />
         ))}
     </Flex>
   );
 }
 
-function CalltoAction({ action, variant, sx, removeAnnouncement }) {
+function CalltoAction({ action, variant, sx, dismissAnnouncement }) {
   return (
     <Button
       variant={variant}
       sx={sx}
       onClick={async () => {
-        if (removeAnnouncement) removeAnnouncement();
+        if (dismissAnnouncement) dismissAnnouncement();
         closeOpenedDialog();
         trackEvent(ANALYTICS_EVENTS.announcementCta, action);
         switch (action.type) {

--- a/apps/web/src/components/announcements/index.js
+++ b/apps/web/src/components/announcements/index.js
@@ -17,15 +17,21 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { useMemo } from "react";
 import { Flex, Text } from "@theme-ui/components";
 import * as Icon from "../icons";
 import { ANALYTICS_EVENTS, trackEvent } from "../../utils/analytics";
 import AnnouncementBody from "./body";
+import { useStore as useAnnouncementStore } from "../../stores/announcement-store";
+import ReminderBar from "../reminder-bar";
 
-function Announcements({ announcements, removeAnnouncement }) {
-  const announcement = useMemo(() => announcements[0], [announcements]);
+function Announcements() {
+  const announcements = useAnnouncementStore(
+    (store) => store.inlineAnnouncements
+  );
+  const dismiss = useAnnouncementStore((store) => store.dismiss);
+  const announcement = announcements[0];
 
+  if (!announcement) return <ReminderBar />;
   return (
     <Flex
       mx={1}
@@ -52,7 +58,7 @@ function Announcements({ announcements, removeAnnouncement }) {
         title="Dismiss announcement"
         onClick={() => {
           trackEvent(ANALYTICS_EVENTS.announcementDismissed, announcement);
-          removeAnnouncement && removeAnnouncement(announcement.id);
+          dismiss(announcement.id);
         }}
       >
         <Icon.Cross color="error" size={16} />

--- a/apps/web/src/components/dialogs/announcement-dialog.js
+++ b/apps/web/src/components/dialogs/announcement-dialog.js
@@ -21,10 +21,17 @@ import Modal from "react-modal";
 import { useTheme } from "@emotion/react";
 import { Flex } from "@theme-ui/components";
 import AnnouncementBody from "../announcements/body";
+import { store as announcementStore } from "../../stores/announcement-store";
+import { useCallback } from "react";
 
 function AnnouncementDialog(props) {
-  const { announcement, removeAnnouncement } = props;
+  const { announcement, onClose } = props;
   const theme = useTheme();
+
+  const dismiss = useCallback(() => {
+    announcementStore.get().dismiss(announcement.id);
+    onClose(true);
+  }, [announcement, onClose]);
 
   return (
     <Modal
@@ -48,7 +55,6 @@ function AnnouncementDialog(props) {
             props.onClose();
           }
         };
-        if (props.onOpen) props.onOpen();
       }}
       style={{
         content: {
@@ -85,8 +91,8 @@ function AnnouncementDialog(props) {
         }}
       >
         <AnnouncementBody
+          dismiss={dismiss}
           components={announcement.body}
-          removeAnnouncement={removeAnnouncement}
           type="dialog"
         />
       </Flex>

--- a/apps/web/src/components/list-container/index.tsx
+++ b/apps/web/src/components/list-container/index.tsx
@@ -34,7 +34,6 @@ import {
 } from "./list-profiles";
 import ReminderBar from "../reminder-bar";
 import Announcements from "../announcements";
-import useAnnouncements from "../../hooks/use-announcements";
 import { ListLoader } from "../loaders/list-loader";
 import ScrollContainer from "../scroll-container";
 import { useKeyboardListNavigation } from "../../hooks/use-keyboard-list-navigation";
@@ -74,7 +73,6 @@ function ListContainer(props: ListContainerProps) {
 
   const [focusedGroupIndex, setFocusedGroupIndex] = useState(-1);
 
-  const [announcements, removeAnnouncement] = useAnnouncements();
   const setSelectedItems = useSelectionStore((store) => store.setSelectedItems);
   const isSelected = useSelectionStore((store) => store.isSelected);
   const selectItem = useSelectionStore((store) => store.selectItem);
@@ -172,17 +170,7 @@ function ListContainer(props: ListContainerProps) {
                     {props.children}
                   </div>
                 ),
-                Header: () =>
-                  header ? (
-                    header
-                  ) : announcements.length ? (
-                    <Announcements
-                      announcements={announcements}
-                      removeAnnouncement={removeAnnouncement}
-                    />
-                  ) : (
-                    <ReminderBar />
-                  )
+                Header: () => (header ? header : <Announcements />)
               }}
               itemContent={(index, item) => {
                 if (!item) return null;

--- a/apps/web/src/stores/app-store.js
+++ b/apps/web/src/stores/app-store.js
@@ -27,6 +27,7 @@ import { store as editorstore } from "./editor-store";
 import { store as attachmentStore } from "./attachment-store";
 import { store as monographStore } from "./monograph-store";
 import { store as reminderStore } from "./reminder-store";
+import { store as announcementStore } from "./announcement-store";
 import BaseStore from "./index";
 import { showToast } from "../utils/toast";
 import { resetReminders } from "../common/reminders";
@@ -60,6 +61,7 @@ class AppStore extends BaseStore {
   init = () => {
     // this needs to happen here so reminders can be set on app load.
     reminderStore.refresh();
+    announcementStore.refresh();
 
     let count = 0;
     EV.subscribe(EVENTS.appRefreshRequested, () => this.refresh());


### PR DESCRIPTION
Previously, we were fetching the announcements multiple times on app startup. This was unnecessary. This PR moves announcements to their own zustand store which gives global access to the whole app.

Next steps would include regular fetching or using SSE.