### PR TITLE
Use native electron notifications in desktop app

### DIFF
--- a/apps/web/desktop/events.js
+++ b/apps/web/desktop/events.js
@@ -23,5 +23,6 @@ export const EVENTS = {
   updateDownloadProgress: "updateDownloadProgress",
   updateDownloadCompleted: "updateDownloadCompleted",
   updateNotAvailable: "updateNotAvailable",
-  themeChanged: "themeChanged"
+  themeChanged: "themeChanged",
+  notificationClicked: "notificationClicked"
 };

--- a/apps/web/desktop/ipc/actions/bringToFront.js
+++ b/apps/web/desktop/ipc/actions/bringToFront.js
@@ -17,22 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { AppEventManager } from "../common/app-events";
-import { isDesktop } from "../utils/platform";
-
-export function invokeCommand(type, payload = {}) {
-  if (!isDesktop()) return;
-
-  window.api.send("fromRenderer", {
-    type,
-    ...payload
-  });
-}
-
-if (isDesktop()) {
-  window.api.receive("fromMain", (args) => {
-    console.log(args);
-    const { type, ...other } = args;
-    AppEventManager.publish(type, other);
-  });
-}
+export default () => {
+  if (!global.win) return;
+  global.win.show();
+  global.win.moveTop();
+};

--- a/apps/web/desktop/ipc/actions/index.js
+++ b/apps/web/desktop/ipc/actions/index.js
@@ -25,6 +25,8 @@ import open from "./open";
 import saveFile from "./saveFile";
 import setZoomFactor from "./setZoomFactor";
 import setPrivacyMode from "./setPrivacyMode";
+import showNotification from "./showNotification";
+import bringToFront from "./bringToFront";
 
 const actions = {
   changeAppTheme,
@@ -34,7 +36,9 @@ const actions = {
   open,
   saveFile,
   setZoomFactor,
-  setPrivacyMode
+  setPrivacyMode,
+  showNotification,
+  bringToFront
 };
 
 export function getAction(actionName) {

--- a/apps/web/src/commands/bring-to-front.js
+++ b/apps/web/src/commands/bring-to-front.js
@@ -17,22 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { AppEventManager } from "../common/app-events";
-import { isDesktop } from "../utils/platform";
+import { invokeCommand } from "./index";
 
-export function invokeCommand(type, payload = {}) {
-  if (!isDesktop()) return;
-
-  window.api.send("fromRenderer", {
-    type,
-    ...payload
-  });
-}
-
-if (isDesktop()) {
-  window.api.receive("fromMain", (args) => {
-    console.log(args);
-    const { type, ...other } = args;
-    AppEventManager.publish(type, other);
-  });
+export default function bringToFront() {
+  invokeCommand("bringToFront");
 }

--- a/apps/web/src/commands/show-notification.js
+++ b/apps/web/src/commands/show-notification.js
@@ -17,22 +17,24 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+import { EVENTS } from "@notesnook/desktop/events";
 import { AppEventManager } from "../common/app-events";
-import { isDesktop } from "../utils/platform";
+import { invokeCommand } from "./index";
 
-export function invokeCommand(type, payload = {}) {
-  if (!isDesktop()) return;
-
-  window.api.send("fromRenderer", {
-    type,
-    ...payload
-  });
-}
-
-if (isDesktop()) {
-  window.api.receive("fromMain", (args) => {
-    console.log(args);
-    const { type, ...other } = args;
-    AppEventManager.publish(type, other);
-  });
+/**
+ *
+ * @param {import("electron").NotificationConstructorOptions & { tag: string }} options
+ * @param {() => void} onClicked
+ */
+export default function showNotification(options, onClicked) {
+  invokeCommand("showNotification", options);
+  const { unsubscribe } = AppEventManager.subscribe(
+    EVENTS.notificationClicked,
+    ({ tag }) => {
+      if (tag === options.tag) {
+        onClicked();
+        unsubscribe();
+      }
+    }
+  );
 }


### PR DESCRIPTION
This gives us access to APIs such as `urgency` & `timeoutType` which map well to reminder priorities.