### PR TITLE
Improve note search

### DIFF
--- a/apps/web/src/components/editor/index.tsx
+++ b/apps/web/src/components/editor/index.tsx
@@ -336,39 +336,53 @@ function EditorChrome(props: PropsWithChildren<EditorProps>) {
   return (
     <>
       <Toolbar />
-      <FlexScrollContainer
-        className="editorScroll"
-        style={{ display: "flex", flexDirection: "column", flex: 1 }}
-      >
-        <Flex
-          variant="columnFill"
-          className="editor"
-          sx={{
-            alignSelf: ["stretch", focusMode ? "center" : "stretch", "center"],
-            maxWidth: editorMargins ? "min(100%, 850px)" : "auto",
-            width: "100%"
-          }}
-          px={6}
-          onClick={onRequestFocus}
+      <Flex sx={{ justifyContent: "center", overflow: "hidden" }}>
+        <FlexScrollContainer
+          className="editorScroll"
+          style={{ display: "flex", flexDirection: "column", flex: 1 }}
         >
-          {!isMobile && (
-            <Box
-              id="editorToolbar"
-              sx={{
-                display: readonly ? "none" : "flex",
-                bg: "background",
-                position: "sticky",
-                top: 0,
-                mb: 1,
-                zIndex: 2
-              }}
-            />
-          )}
-          <Titlebox readonly={readonly || false} />
-          <Header readonly={readonly} />
-          {children}
-        </Flex>
-      </FlexScrollContainer>
+          <Flex
+            variant="columnFill"
+            className="editor"
+            sx={{
+              alignSelf: [
+                "stretch",
+                focusMode ? "center" : "stretch",
+                "center"
+              ],
+              maxWidth: editorMargins ? "min(100%, 850px)" : "auto",
+              width: "100%"
+            }}
+            px={6}
+            onClick={onRequestFocus}
+          >
+            {!isMobile && (
+              <Box
+                id="editorToolbar"
+                sx={{
+                  display: readonly ? "none" : "flex",
+                  bg: "background",
+                  position: "sticky",
+                  top: 0,
+                  mb: 1,
+                  zIndex: 2
+                }}
+              />
+            )}
+            <Titlebox readonly={readonly || false} />
+            <Header readonly={readonly} />
+            {children}
+          </Flex>
+        </FlexScrollContainer>
+        <Flex
+          id="editorSidebar"
+          sx={{
+            flexDirection: "column",
+            overflow: "hidden",
+            borderLeft: "1px solid var(--border)"
+          }}
+        ></Flex>
+      </Flex>
 
       {isMobile && (
         <Box

--- a/packages/editor/src/toolbar/floating-menus/search-replace.tsx
+++ b/packages/editor/src/toolbar/floating-menus/search-replace.tsx
@@ -20,31 +20,47 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import { SearchStorage } from "../../extensions/search-replace";
 import { FloatingMenuProps } from "./types";
 import { SearchReplacePopup } from "../popups/search-replace";
-import { ResponsivePresenter } from "../../components/responsive";
+import { SearchReplacePopupMobile } from "../popups/search-replace.mobile";
+import {
+  DesktopOnly,
+  MobileOnly,
+  ResponsivePresenter
+} from "../../components/responsive";
 import { getToolbarElement } from "../utils/dom";
+import ReactDOM from "react-dom";
 
 export function SearchReplaceFloatingMenu(props: FloatingMenuProps) {
   const { editor } = props;
   const { isSearching } = editor.storage.searchreplace as SearchStorage;
 
   return (
-    <ResponsivePresenter
-      mobile="sheet"
-      desktop="menu"
-      isOpen={isSearching}
-      onClose={() => editor.commands.endSearch()}
-      position={{
-        target: getToolbarElement(),
-        isTargetAbsolute: true,
-        location: "below",
-        align: "end",
-        yOffset: 5
-      }}
-      blocking={false}
-      focusOnRender={false}
-      draggable={false}
-    >
-      <SearchReplacePopup editor={editor} />
-    </ResponsivePresenter>
+    <>
+      <DesktopOnly>
+        {isSearching &&
+          ReactDOM.createPortal(
+            <SearchReplacePopup editor={editor} />,
+            document.getElementById("editorSidebar") || document.body
+          )}
+      </DesktopOnly>
+      <MobileOnly>
+        <ResponsivePresenter
+          mobile="sheet"
+          isOpen={isSearching}
+          onClose={() => editor.commands.endSearch()}
+          position={{
+            target: getToolbarElement(),
+            isTargetAbsolute: true,
+            location: "below",
+            align: "end",
+            yOffset: 5
+          }}
+          blocking={false}
+          focusOnRender={false}
+          draggable={false}
+        >
+          <SearchReplacePopupMobile editor={editor} />
+        </ResponsivePresenter>
+      </MobileOnly>
+    </>
   );
 }

--- a/packages/editor/src/toolbar/popups/search-replace.mobile.tsx
+++ b/packages/editor/src/toolbar/popups/search-replace.mobile.tsx
@@ -17,15 +17,15 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { Button, Input } from "@theme-ui/components";
+import { Input } from "@theme-ui/components";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Flex, Text } from "@theme-ui/components";
-import { SearchResult, SearchStorage } from "../../extensions/search-replace";
+import { SearchStorage } from "../../extensions/search-replace";
 import { ToolButton } from "../components/tool-button";
 import { Editor } from "../../types";
 
 export type SearchReplacePopupProps = { editor: Editor };
-export function SearchReplacePopup(props: SearchReplacePopupProps) {
+export function SearchReplacePopupMobile(props: SearchReplacePopupProps) {
   const { editor } = props;
   const { selectedText, results, selectedIndex } = editor.storage
     .searchreplace as SearchStorage;
@@ -71,21 +71,16 @@ export function SearchReplacePopup(props: SearchReplacePopupProps) {
   return (
     <Flex
       sx={{
+        p: 1,
         bg: "background",
         flexDirection: "column",
-        width: 300,
-        flex: 1,
-        overflow: "hidden"
+        boxShadow: ["none", "menu"],
+        borderRadius: [0, "default"]
       }}
     >
-      <Flex sx={{ p: 1 }}>
+      <Flex>
         <Flex
-          sx={{
-            flexDirection: "column",
-            flex: 1,
-            width: 300,
-            mr: 1
-          }}
+          sx={{ flexDirection: "column", flex: 1, width: ["auto", 300], mr: 1 }}
         >
           <Flex
             sx={{
@@ -176,6 +171,17 @@ export function SearchReplacePopup(props: SearchReplacePopupProps) {
                   />
                 </>
               )}
+              <Text
+                variant={"subBody"}
+                sx={{
+                  flexShrink: 0,
+                  borderLeft: "1px solid var(--border)",
+                  color: "fontTertiary",
+                  px: 1
+                }}
+              >
+                {results ? `${selectedIndex + 1}/${results.length}` : ""}
+              </Text>
             </Flex>
           </Flex>
           {isReplacing && (
@@ -194,6 +200,33 @@ export function SearchReplacePopup(props: SearchReplacePopupProps) {
               id="toggleReplace"
               icon="replace"
               onClick={() => setIsReplacing((s) => !s)}
+              sx={{ mr: 0 }}
+              iconSize={"big"}
+            />
+            <ToolButton
+              toggled={false}
+              title="Previous match"
+              id="previousMatch"
+              icon="previousMatch"
+              onClick={() => editor.commands.moveToPreviousResult()}
+              sx={{ mr: 0 }}
+              iconSize={"big"}
+            />
+            <ToolButton
+              toggled={false}
+              title="Next match"
+              id="nextMatch"
+              icon="nextMatch"
+              onClick={() => editor.commands.moveToNextResult()}
+              sx={{ mr: 0 }}
+              iconSize={"big"}
+            />
+            <ToolButton
+              toggled={false}
+              title="Close"
+              id="close"
+              icon="close"
+              onClick={() => editor.chain().focus().endSearch().run()}
               sx={{ mr: 0 }}
               iconSize={"big"}
             />
@@ -222,155 +255,6 @@ export function SearchReplacePopup(props: SearchReplacePopupProps) {
           )}
         </Flex>
       </Flex>
-      <Flex
-        sx={{
-          flexDirection: "column",
-          mt: 1,
-          flex: 1,
-          overflowY: "auto",
-          overflowX: "hidden"
-        }}
-      >
-        {results?.map((result, index) => (
-          <SearchResultPreview
-            key={result.from}
-            index={index}
-            searchResult={result}
-            selectedIndex={selectedIndex}
-            onClick={() => editor.current?.commands.moveToResult(index)}
-          />
-        ))}
-      </Flex>
-      {!!results?.length && (
-        <Flex
-          sx={{
-            alignItems: "center",
-            justifyContent: "space-between",
-            p: 1,
-            // mt: 1,
-            borderTop: "1px solid var(--border)"
-          }}
-        >
-          <Text
-            variant={"subBody"}
-            sx={{
-              flexShrink: 0,
-              color: "fontTertiary"
-            }}
-          >
-            {`${selectedIndex + 1} of ${results.length} results`}
-          </Text>
-          <Flex>
-            <ToolButton
-              toggled={false}
-              title="Previous match"
-              id="previousMatch"
-              icon="previousMatch"
-              onClick={() => editor.commands.moveToPreviousResult()}
-              sx={{ mr: 0 }}
-              iconSize={"big"}
-            />
-            <ToolButton
-              toggled={false}
-              title="Next match"
-              id="nextMatch"
-              icon="nextMatch"
-              onClick={() => editor.commands.moveToNextResult()}
-              sx={{ mr: 0 }}
-              iconSize={"big"}
-            />
-          </Flex>
-        </Flex>
-      )}
     </Flex>
   );
 }
-
-function SearchResultPreview({
-  searchResult,
-  index,
-  selectedIndex,
-  onClick
-}: {
-  searchResult: SearchResult;
-  index: number;
-  selectedIndex: number;
-  onClick: () => void;
-}) {
-  const { end, match, start } = splitSearchResult(searchResult);
-  return (
-    <Button
-      variant="menuitem"
-      title={searchResult.preview.text}
-      sx={{
-        whiteSpace: "nowrap",
-        overflow: "hidden",
-        textOverflow: "ellipsis",
-        px: 1,
-        py: 1,
-        m: 0,
-        alignSelf: "start",
-        flexShrink: 0,
-        textAlign: "left",
-        width: "100%",
-        ...(selectedIndex === index
-          ? {
-              bg: "hover",
-              color: "primary"
-            }
-          : {})
-      }}
-      onClick={onClick}
-    >
-      <Text variant="subBody" sx={{ pr: 1 }}>
-        {index + 1}.
-      </Text>
-      <Text variant="body">{start}</Text>
-      <Text variant="body" sx={{ bg: "shade", color: "primary" }}>
-        {match}
-      </Text>
-      <Text variant="body">{end}</Text>
-    </Button>
-  );
-}
-
-function splitSearchResult(searchResult: SearchResult, maxLength = 50) {
-  const {
-    text,
-    match: { from, to }
-  } = searchResult.preview;
-  const remainingLength = maxLength - (to - from);
-  const partLength = remainingLength / 2;
-
-  const match = text.substring(from, to);
-  const start = truncate(text.substring(0, from), partLength, "start");
-  const end = truncate(
-    text.substring(to),
-    partLength + (start.length < partLength ? partLength - start.length : 0),
-    "end"
-  );
-
-  return {
-    start,
-    match,
-    end
-  };
-}
-
-function truncate(text: string, maxLength: number, type: "end" | "start") {
-  if (text.length <= maxLength) return text;
-  if (type === "end") {
-    return `${text.substring(0, maxLength)}...`;
-  } else {
-    return `...${text.slice(-maxLength)}`;
-  }
-}
-// <ToolButton
-//               toggled={false}
-//               title="Close"
-//               id="close"
-//               icon="close"
-//               onClick={() => editor.chain().focus().endSearch().run()}
-//               sx={{ mr: 0 }}
-//               iconSize={"big"}
-//             />


### PR DESCRIPTION
Note search currently uses a traditional search input which is not the most intuitive or useful way to search for a couple of reasons:

1. It is cumbersome to search long notes
2. It appears over the text (below the toolbar) blocking a couple of lines
3. It's hard to use because everything is clustered in a single horizontal line

In light of these reasons, we are introducing a new search UI that looks somewhat like this:

![new-search](https://user-images.githubusercontent.com/7473959/214764137-39ac6709-7e13-49cc-8613-b76e1add5147.gif)

There are a few main goals behind this radical change:

1. User shouldn't be afraid to search i.e., search should be so intuitive that users reach out for it
2. It should be easy to navigate & jump to a specific result
3. Search should give a quick overview over all the results without having to scroll through the entire note
4. Selectively replacing items should be possible