### PR TITLE
Fix issue where changes in code block were not properly highlighted

### DIFF
--- a/packages/editor/src/extensions/code-block/highlighter.ts
+++ b/packages/editor/src/extensions/code-block/highlighter.ts
@@ -160,6 +160,9 @@ export function HighlighterPlugin({
 
           return decorationSet
             .map(transaction.mapping, transaction.doc)
+            .remove(
+              decorationSet.find(block.start, block.pos + block.node.nodeSize)
+            )
             .add(transaction.doc, newDecorations);
         }
 

--- a/packages/editor/src/extensions/list-item/commands.ts
+++ b/packages/editor/src/extensions/list-item/commands.ts
@@ -68,6 +68,7 @@ export function onBackspacePressed(
       return editor.chain().joinBackward().joinBackward().run();
     }
   }
+  return false;
 }
 
 export function onArrowUpPressed(editor: Editor, name: string, type: NodeType) {


### PR DESCRIPTION
Closes #1770

This was caused by not deleting old syntax highlighting decorations before applying new ones. The result was a huge amount of extra decorations on the same nodes causing huge performance issues, not to mention other bugs.