### PR TITLE
Better separation between notes in the list

### DIFF
--- a/apps/web/src/components/list-item/index.js
+++ b/apps/web/src/components/list-item/index.js
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { Box, Flex, Text } from "@theme-ui/components";
+import { Box, Flex, Text, Divider } from "@theme-ui/components";
 import * as Icon from "../icons";
 import {
   store as selectionStore,
@@ -78,6 +78,7 @@ function ListItem(props) {
   });
 
   return (
+  <>
     <Flex
       id={`id_${props.item.id}`}
       className={isSelected ? "selected" : ""}
@@ -198,7 +199,9 @@ function ListItem(props) {
           {props.footer}
         </Box>
       ) : null}
-    </Flex>
+      </Flex>
+      {props.divider && <Divider  sx={{margin: "0", color: "border"}} />}
+    </>  
   );
 }
 export default ListItem;

--- a/apps/web/src/components/note/index.js
+++ b/apps/web/src/components/note/index.js
@@ -242,6 +242,7 @@ function Note(props) {
           )}
         </Flex>
       }
+      divider
     />
   );
 }

--- a/apps/web/src/components/notebook/index.js
+++ b/apps/web/src/components/notebook/index.js
@@ -97,6 +97,7 @@ function Notebook(props) {
           </>
         )
       }
+      divider
     />
   );
 }

--- a/apps/web/src/components/tag/index.js
+++ b/apps/web/src/components/tag/index.js
@@ -82,6 +82,7 @@ function Tag({ item, index }) {
       onClick={() => {
         navigate(`/tags/${id}`);
       }}
+      divider
     />
   );
 }

--- a/apps/web/src/components/topic/index.js
+++ b/apps/web/src/components/topic/index.js
@@ -59,6 +59,7 @@ function Topic({ item, index, onClick }) {
         items: menuItems,
         extraData: { topic, notebookId: topic.notebookId }
       }}
+      divider
     />
   );
 }


### PR DESCRIPTION
Added a border for better separation between notes in the Lists, Notebooks, Topics, and Tags.

Fixes [#474](https://github.com/streetwriters/notesnook/issues/474)
### Dark mode:
![image](https://user-images.githubusercontent.com/1501599/217264433-884f5a83-337f-491b-95c8-ee9db63988ac.png)

### Light mode:
![image](https://user-images.githubusercontent.com/1501599/217264605-3f49f5bc-6890-46c1-9d71-943d1eb18c30.png)
