### PR TITLE
Add borders/scrolling to tagbar on mobile

### DIFF
--- a/packages/editor-mobile/src/components/tags.tsx
+++ b/packages/editor-mobile/src/components/tags.tsx
@@ -43,22 +43,18 @@ export default function Tags(): JSX.Element {
         padding: "0px 12px",
         display: "flex",
         alignItems: "center",
-        marginTop: 10
+        overflowX: "scroll",
+        minHeight: "40px"
       }}
     >
       <button
         className={styles.btn}
-        onMouseUp={(e) => {
-          e.preventDefault();
-          openManageTagsSheet();
-        }}
-        onMouseDown={(e) => e.preventDefault()}
-        onTouchEnd={(e) => {
+        onClick={(e) => {
           e.preventDefault();
           openManageTagsSheet();
         }}
         style={{
-          borderWidth: 0,
+          border: "1px solid var(--nn_border)",
           backgroundColor: "var(--nn_nav)",
           marginRight: 5,
           borderRadius: 100,
@@ -66,7 +62,9 @@ export default function Tags(): JSX.Element {
           fontFamily: "Open Sans",
           display: "flex",
           alignItems: "center",
-          height: "30px"
+          height: "30px",
+          userSelect: "none",
+          WebkitUserSelect: "none"
         }}
       >
         {tags.length === 0 ? (
@@ -100,7 +98,7 @@ export default function Tags(): JSX.Element {
           key={tag.title}
           className={styles.btn}
           style={{
-            borderWidth: 0,
+            border: "1px solid var(--nn_border)",
             backgroundColor: "var(--nn_nav)",
             marginRight: 5,
             borderRadius: 100,
@@ -108,14 +106,11 @@ export default function Tags(): JSX.Element {
             height: "30px",
             fontFamily: "Open Sans",
             fontSize: 13,
-            color: "var(--nn_icon)"
+            color: "var(--nn_icon)",
+            userSelect: "none",
+            WebkitUserSelect: "none"
           }}
-          onMouseUp={(e) => {
-            e.preventDefault();
-            post(EventTypes.tag, tag.title);
-          }}
-          onMouseDown={(e) => e.preventDefault()}
-          onTouchEnd={(e) => {
+          onClick={(e) => {
             e.preventDefault();
             post(EventTypes.tag, tag.title);
           }}

--- a/packages/editor-mobile/src/components/title.tsx
+++ b/packages/editor-mobile/src/components/title.tsx
@@ -51,7 +51,7 @@ function Title({
       contentEditable={!readonly}
       disabled={readonly}
       style={{
-        height: 50,
+        height: 40,
         fontSize: 25,
         width: "100%",
         boxSizing: "border-box",
@@ -62,7 +62,8 @@ function Title({
         fontFamily: "Open Sans",
         backgroundColor: "transparent",
         color: "var(--nn_heading)",
-        caretColor: "var(--nn_accent)"
+        caretColor: "var(--nn_accent)",
+        borderRadius: 0
       }}
       maxLength={150}
       onChange={(event) => {


### PR DESCRIPTION
On some mobile screens, tags appear to have no background color, therefore I have added borders to distinguish them properly. 

- Fixed clicking on tag to delete
- Added scrolling when tags are greater than screen width.