### PR TITLE
Do a healthcheck before logging out user on session revoke

### DIFF
--- a/packages/core/api/healthcheck.js
+++ b/packages/core/api/healthcheck.js
@@ -1,0 +1,31 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+import hosts from "../utils/constants";
+import http from "../utils/http";
+
+export class HealthCheck {
+  static async isAuthServerHealthy() {
+    try {
+      const response = await http.get(`${hosts.AUTH_HOST}/health`);
+      return response.trim() === "Healthy";
+    } catch {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
This closes #1362.

Previously, we were force logging out users anytime we got a `401 unauthorized` error. This was finicky and caused a lot of frustration to users. This PR adds a health check to the auth server (in case the auth server is down) + a few other checks to make sure that when we do log out the user, it is under correct circumstances.