### PR TITLE
Simplify subscription cancellation

### DIFF
--- a/apps/web/src/views/settings.js
+++ b/apps/web/src/views/settings.js
@@ -1288,40 +1288,49 @@ function AccountStatus(props) {
         </>
       ) : isPro ? (
         <>
-          <Button
-            variant="list"
-            onClick={async () => {
-              if (!user.subscription.updateURL)
-                return showToast(
-                  "error",
-                  "Failed to update. Please reach out to us at support@streetwriters.co so we can help you resolve the issue."
-                );
-              window.open(user.subscription.updateURL, "_blank");
-            }}
-          >
-            <Tip
-              text="Update payment method"
-              tip="Update the payment method you used to purchase this subscription."
-            />
-          </Button>
-          <Button
-            variant="list"
-            sx={{ ":hover": { borderColor: "error" } }}
-            onClick={async () => {
-              if (!user.subscription.cancelURL)
-                return showToast(
-                  "error",
-                  "Failed to cancel subscription. Please reach out to us at support@streetwriters.co so we can help you resolve the issue."
-                );
-              window.open(user.subscription.cancelURL, "_blank");
-            }}
-          >
-            <Tip
-              color="error"
-              text="Cancel subscription"
-              tip="You will be downgraded to the Basic plan at the end of your billing period."
-            />
-          </Button>
+          {provider === "Web" ? (
+            <>
+              <Button
+                variant="list"
+                onClick={async () => {
+                  try {
+                    window.open(await db.subscriptions.updateUrl(), "_blank");
+                  } catch (e) {
+                    showToast("error", e.message);
+                  }
+                }}
+              >
+                <Tip
+                  text="Update payment method"
+                  tip="Update the payment method you used to purchase this subscription."
+                />
+              </Button>
+              <Button
+                variant="list"
+                sx={{ ":hover": { borderColor: "error" } }}
+                onClick={async () => {
+                  try {
+                    await db.subscriptions.cancel();
+                    showToast(
+                      "success",
+                      "Your subscription has been cancelled."
+                    );
+                    setTimeout(() => {
+                      window.location.reload();
+                    }, 5000);
+                  } catch (e) {
+                    showToast("error", e.message);
+                  }
+                }}
+              >
+                <Tip
+                  color="error"
+                  text="Cancel subscription"
+                  tip="You will be downgraded to the Basic plan at the end of your billing period."
+                />
+              </Button>
+            </>
+          ) : null}
           <Text
             variant="subBody"
             mt={1}

--- a/packages/core/api/index.js
+++ b/packages/core/api/index.js
@@ -49,6 +49,7 @@ import { logger } from "../logger";
 import Shortcuts from "../collections/shortcuts";
 import Reminders from "../collections/reminders";
 import Relations from "../collections/relations";
+import Subscriptions from "./subscriptions";
 
 /**
  * @type {EventSource}
@@ -128,6 +129,7 @@ class Database {
     this.offers = new Offers();
     this.debug = new Debug();
     this.pricing = new Pricing();
+    this.subscriptions = new Subscriptions(this.user.tokenManager);
 
     // collections
     /** @type {Notes} */

--- a/packages/core/api/subscriptions.js
+++ b/packages/core/api/subscriptions.js
@@ -1,0 +1,45 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import hosts from "../utils/constants";
+import http from "../utils/http";
+
+export default class Subscriptions {
+  /**
+   * @param {import("../api/token-manager").default} tokenManager
+   */
+  constructor(tokenManager) {
+    this._tokenManager = tokenManager;
+  }
+
+  async cancel() {
+    const token = this._tokenManager.getAccessToken();
+    if (!token) return;
+    await http.delete(`${hosts.SUBSCRIPTIONS_HOST}/subscriptions`, token);
+  }
+
+  async updateUrl() {
+    const token = this._tokenManager.getAccessToken();
+    if (!token) return;
+    return await http.get(
+      `${hosts.SUBSCRIPTIONS_HOST}/subscriptions/update_url`,
+      token
+    );
+  }
+}


### PR DESCRIPTION
This was a long standing bug where a user was required to reach out to us via email to get their subscription cancelled. This was highly cumbersome & user unfriendly behavior.

This PR fixes this by making subscription cancellation a one click process. 