### PR TITLE
Improve UX around Topics Sheet

### DIFF
--- a/apps/mobile/app/components/dialogs/add-topic/index.js
+++ b/apps/mobile/app/components/dialogs/add-topic/index.js
@@ -22,6 +22,7 @@ import { View } from "react-native";
 
 import { useMenuStore } from "../../../stores/use-menu-store";
 import {
+  eSendEvent,
   eSubscribeEvent,
   eUnSubscribeEvent,
   ToastEvent
@@ -30,6 +31,7 @@ import Navigation from "../../../services/navigation";
 import { db } from "../../../common/database";
 import {
   eCloseAddTopicDialog,
+  eOnTopicSheetUpdate,
   eOpenAddTopicDialog
 } from "../../../utils/events";
 import { sleep } from "../../../utils/time";
@@ -40,6 +42,7 @@ import DialogHeader from "../../dialog/dialog-header";
 import Input from "../../ui/input";
 import Seperator from "../../ui/seperator";
 import { Toast } from "../../toast";
+import { useRelationStore } from "../../../stores/use-relation-store";
 
 export class AddTopicDialog extends React.Component {
   constructor(props) {
@@ -81,6 +84,8 @@ export class AddTopicDialog extends React.Component {
         Navigation.queueRoutesForUpdate("Notebooks", "Notebook", "TopicNotes");
         useMenuStore.getState().setMenuPins();
       });
+      eSendEvent(eOnTopicSheetUpdate);
+      useRelationStore.getState().update();
     } catch (e) {
       console.error(e);
     }

--- a/apps/mobile/app/components/list-items/note/index.js
+++ b/apps/mobile/app/components/list-items/note/index.js
@@ -27,6 +27,7 @@ import { db } from "../../../common/database";
 import Notebook from "../../../screens/notebook";
 import { TaggedNotes } from "../../../screens/notes/tagged";
 import { TopicNotes } from "../../../screens/notes/topic-notes";
+import useNavigationStore from "../../../stores/use-navigation-store";
 import { useRelationStore } from "../../../stores/use-relation-store";
 import { useSettingStore } from "../../../stores/use-setting-store";
 import { useThemeStore } from "../../../stores/use-theme-store";
@@ -52,12 +53,14 @@ const showActionSheet = (item) => {
 
 function getNotebook(item) {
   const isTrash = item.type === "trash";
+  const currentId = useNavigationStore.getState().currentScreen.id;
   if (isTrash) return [];
   const items = [];
   const notebooks = db.relations.to(item, "notebook") || [];
 
   for (let notebook of notebooks) {
     if (items.length > 1) break;
+    if (notebook.id === currentId) continue;
     items.push(notebook);
   }
 
@@ -68,6 +71,7 @@ function getNotebook(item) {
       if (!notebook) continue;
       for (let topicId of nb.topics) {
         if (items.length > 1) break;
+        if (topicId === currentId) continue;
         const topic = notebook.topics.find((t) => t.id === topicId);
         if (!topic) continue;
         items.push(topic);
@@ -117,7 +121,12 @@ const NoteItem = ({
           >
             {notebooks?.map((item) => (
               <Button
-                title={item.title}
+                title={
+                  item.title.length > 25
+                    ? item.title.slice(0, 25) + "..."
+                    : item.title
+                }
+                tooltipText={item.title}
                 key={item.id}
                 height={25}
                 icon={item.type === "topic" ? "bookmark" : "book-outline"}

--- a/apps/mobile/app/components/list/index.js
+++ b/apps/mobile/app/components/list/index.js
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import React, { useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import { RefreshControl, View } from "react-native";
 import { FlashList } from "@shopify/flash-list";
 import Animated, { FadeInDown } from "react-native-reanimated";
@@ -153,6 +153,14 @@ const List = ({
     },
     [screen]
   );
+
+  useEffect(() => {
+    eSendEvent(eScrollEvent, {
+      y: 0,
+      screen
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   let styles = {
     width: "100%",

--- a/apps/mobile/app/components/selection-header/index.js
+++ b/apps/mobile/app/components/selection-header/index.js
@@ -21,18 +21,18 @@ import React, { useCallback, useEffect } from "react";
 import { BackHandler, Platform, View } from "react-native";
 import { db } from "../../common/database";
 import useGlobalSafeAreaInsets from "../../hooks/use-global-safe-area-insets";
-import { eSendEvent, ToastEvent } from "../../services/event-manager";
+import { ToastEvent } from "../../services/event-manager";
 import Navigation from "../../services/navigation";
 import SearchService from "../../services/search";
 import useNavigationStore from "../../stores/use-navigation-store";
 import { useSelectionStore } from "../../stores/use-selection-store";
 import { useThemeStore } from "../../stores/use-theme-store";
-import { eOpenMoveNoteDialog } from "../../utils/events";
 import { deleteItems } from "../../utils/functions";
 import { tabBarRef } from "../../utils/global-refs";
 import { SIZE } from "../../utils/size";
 import { sleep } from "../../utils/time";
 import { presentDialog } from "../dialog/functions";
+import MoveNoteSheet from "../sheets/add-to";
 import ExportNotesSheet from "../sheets/export-notes";
 import { IconButton } from "../ui/icon-button";
 import Heading from "../ui/typography/heading";
@@ -237,7 +237,7 @@ export const SelectionHeader = React.memo(() => {
               onPress={async () => {
                 //setSelectionMode(false);
                 await sleep(100);
-                eSendEvent(eOpenMoveNoteDialog);
+                MoveNoteSheet.present();
               }}
               customStyle={{
                 marginLeft: 10

--- a/apps/mobile/app/components/sheets/add-notebook/index.js
+++ b/apps/mobile/app/components/sheets/add-notebook/index.js
@@ -92,7 +92,7 @@ export class AddNotebookSheet extends React.Component {
 
   close = () => {
     refs = [];
-    this.props.close();
+    this.props.close(true);
   };
 
   onDelete = (index) => {
@@ -182,6 +182,7 @@ export class AddNotebookSheet extends React.Component {
       });
 
       await db.notebooks.notebook(toEdit.id).topics.add(...nextTopics);
+      this.close();
     } else {
       newNotebookId = await db.notebooks.add({
         title: this.title,

--- a/apps/mobile/app/components/sheets/add-to/index.js
+++ b/apps/mobile/app/components/sheets/add-to/index.js
@@ -21,13 +21,18 @@ import React, { useCallback, useEffect, useMemo } from "react";
 import { Keyboard, TouchableOpacity, View } from "react-native";
 import Icon from "react-native-vector-icons/MaterialCommunityIcons";
 import { db } from "../../../common/database";
-import { presentSheet, ToastEvent } from "../../../services/event-manager";
+import {
+  eSendEvent,
+  presentSheet,
+  ToastEvent
+} from "../../../services/event-manager";
 import Navigation from "../../../services/navigation";
 import SearchService from "../../../services/search";
 import { useNotebookStore } from "../../../stores/use-notebook-store";
 import { useSelectionStore } from "../../../stores/use-selection-store";
 import { useSettingStore } from "../../../stores/use-setting-store";
 import { useThemeStore } from "../../../stores/use-theme-store";
+import { eOnTopicSheetUpdate } from "../../../utils/events";
 import { Dialog } from "../../dialog";
 import DialogHeader from "../../dialog/dialog-header";
 import { presentDialog } from "../../dialog/functions";
@@ -296,6 +301,7 @@ const MoveNoteSheet = ({ note, actionSheetRef }) => {
       "Notebook"
     );
     setNotebooks();
+    eSendEvent(eOnTopicSheetUpdate);
     SearchService.updateAndSearch();
     actionSheetRef.current?.hide();
   };

--- a/apps/mobile/app/components/sheets/topic-sheet/index.tsx
+++ b/apps/mobile/app/components/sheets/topic-sheet/index.tsx
@@ -86,11 +86,7 @@ export const TopicsSheet = () => {
         )
       : []
   );
-  const [animations] = useState({
-    translate: new Animated.Value(0),
-    display: new Animated.Value(0),
-    opacity: new Animated.Value(1)
-  });
+
   const [groupOptions, setGroupOptions] = useState(
     db.settings?.getGroupOptions("topics")
   );
@@ -180,21 +176,19 @@ export const TopicsSheet = () => {
   useEffect(() => {
     if (canShow) {
       const isTopic = currentScreen.name === "TopicNotes";
-      const id = isTopic ? currentScreen?.notebookId : currentScreen?.id;
-      if (id) {
-        onRequestUpdate({
-          item: db.notebooks?.notebook(id)?.data
-        } as any);
-      }
+      ref.current?.show();
       setTimeout(() => {
-        ref.current?.show();
-      }, 1);
+        const id = isTopic ? currentScreen?.notebookId : currentScreen?.id;
+        if (id) {
+          onRequestUpdate({
+            item: db.notebooks?.notebook(id)?.data
+          } as any);
+        }
+      }, 300);
     } else {
       ref.current?.hide();
     }
   }, [
-    animations.display,
-    animations.opacity,
     canShow,
     currentScreen?.id,
     currentScreen.name,
@@ -212,8 +206,11 @@ export const TopicsSheet = () => {
         borderTopLeftRadius: 15,
         backgroundColor: colors.bg,
         borderWidth: 1,
-        borderColor: colors.border,
+        borderColor: colors.nav,
         borderBottomWidth: 0
+      }}
+      openAnimationConfig={{
+        friction: 10
       }}
       closable={!canShow}
       elevation={10}
@@ -229,48 +226,37 @@ export const TopicsSheet = () => {
       }
       initialSnapIndex={Config.isTesting === "true" ? 0 : 1}
       backgroundInteractionEnabled
-      onChange={(position) => {
-        if (position === 0) return;
-        animations.translate.setValue(position - 60);
-      }}
       gestureEnabled
-      ExtraOverlayComponent={
-        <Animated.View
-          style={{
-            top: animations.translate,
-            position: "absolute",
-            right: 12,
-            transform: [
-              {
-                translateY: animations.display
-              }
-            ]
+    >
+      <View
+        style={{
+          position: "absolute",
+          right: 12,
+          marginTop: -80
+        }}
+      >
+        <PressableButton
+          testID={notesnook.buttons.add}
+          type="accent"
+          accentColor={"accent"}
+          accentText="light"
+          onPress={openEditor}
+          customStyle={{
+            borderRadius: 100
           }}
         >
-          <PressableButton
-            testID={notesnook.buttons.add}
-            type="accent"
-            accentColor={"accent"}
-            accentText="light"
-            onPress={openEditor}
-            customStyle={{
-              borderRadius: 100
+          <View
+            style={{
+              alignItems: "center",
+              justifyContent: "center",
+              height: normalize(60),
+              width: normalize(60)
             }}
           >
-            <View
-              style={{
-                alignItems: "center",
-                justifyContent: "center",
-                height: normalize(60),
-                width: normalize(60)
-              }}
-            >
-              <Icon name="plus" color="white" size={SIZE.xxl} />
-            </View>
-          </PressableButton>
-        </Animated.View>
-      }
-    >
+            <Icon name="plus" color="white" size={SIZE.xxl} />
+          </View>
+        </PressableButton>
+      </View>
       <View
         style={{
           maxHeight: 300,

--- a/apps/mobile/app/components/sheets/topic-sheet/index.tsx
+++ b/apps/mobile/app/components/sheets/topic-sheet/index.tsx
@@ -25,13 +25,7 @@ import React, {
   useRef,
   useState
 } from "react";
-import {
-  Animated,
-  Dimensions,
-  View,
-  RefreshControl,
-  Platform
-} from "react-native";
+import { Animated, Platform, RefreshControl, View } from "react-native";
 import ActionSheet, {
   ActionSheetRef,
   FlatList
@@ -59,16 +53,16 @@ import {
 import { normalize, SIZE } from "../../../utils/size";
 import { GroupHeader, NotebookType, TopicType } from "../../../utils/types";
 
+import { groupArray } from "@notesnook/core/utils/grouping";
+import Config from "react-native-config";
 import Icon from "react-native-vector-icons/MaterialCommunityIcons";
+import { notesnook } from "../../../../e2e/test.ids";
 import { openEditor } from "../../../screens/notes/common";
 import { getTotalNotes, history } from "../../../utils";
-import { Properties } from "../../properties";
 import { deleteItems } from "../../../utils/functions";
 import { presentDialog } from "../../dialog/functions";
-import Config from "react-native-config";
-import { notesnook } from "../../../../e2e/test.ids";
+import { Properties } from "../../properties";
 import Sort from "../sort";
-import { groupArray } from "@notesnook/core/utils/grouping";
 
 export const TopicsSheet = () => {
   const currentScreen = useNavigationStore((state) => state.currentScreen);
@@ -94,8 +88,8 @@ export const TopicsSheet = () => {
   );
   const [animations] = useState({
     translate: new Animated.Value(0),
-    display: new Animated.Value(-5000),
-    opacity: new Animated.Value(0)
+    display: new Animated.Value(0),
+    opacity: new Animated.Value(1)
   });
   const [groupOptions, setGroupOptions] = useState(
     db.settings?.getGroupOptions("topics")
@@ -187,16 +181,14 @@ export const TopicsSheet = () => {
     if (canShow) {
       const isTopic = currentScreen.name === "TopicNotes";
       const id = isTopic ? currentScreen?.notebookId : currentScreen?.id;
-      if (!ref.current?.isOpen()) {
-        animations.display.setValue(5000);
-        animations.opacity.setValue(0);
-      }
       if (id) {
         onRequestUpdate({
           item: db.notebooks?.notebook(id)?.data
         } as any);
       }
-      ref.current?.show();
+      setTimeout(() => {
+        ref.current?.show();
+      }, 1);
     } else {
       ref.current?.hide();
     }
@@ -215,7 +207,7 @@ export const TopicsSheet = () => {
       ref={ref}
       isModal={false}
       containerStyle={{
-        maxHeight: 400,
+        maxHeight: 300,
         borderTopRightRadius: 15,
         borderTopLeftRadius: 15,
         backgroundColor: colors.bg,
@@ -235,21 +227,11 @@ export const TopicsSheet = () => {
           ? [100]
           : [Platform.OS === "ios" ? 25 : 20, 100]
       }
-      initialSnapIndex={0}
+      initialSnapIndex={Config.isTesting === "true" ? 0 : 1}
       backgroundInteractionEnabled
-      onChange={(position, height) => {
+      onChange={(position) => {
+        if (position === 0) return;
         animations.translate.setValue(position - 60);
-        const h = Dimensions.get("window").height;
-        const minPos = h - height;
-        if (position - 100 < minPos || !canShow) {
-          animations.display.setValue(5000);
-          animations.opacity.setValue(0);
-        } else {
-          animations.display.setValue(0);
-          setTimeout(() => {
-            animations.opacity.setValue(1);
-          }, 300);
-        }
       }}
       gestureEnabled
       ExtraOverlayComponent={
@@ -258,7 +240,6 @@ export const TopicsSheet = () => {
             top: animations.translate,
             position: "absolute",
             right: 12,
-            opacity: animations.opacity,
             transform: [
               {
                 translateY: animations.display
@@ -292,8 +273,8 @@ export const TopicsSheet = () => {
     >
       <View
         style={{
-          maxHeight: 400,
-          height: 400,
+          maxHeight: 300,
+          height: 300,
           width: "100%"
         }}
       >

--- a/apps/mobile/app/components/sheets/topic-sheet/index.tsx
+++ b/apps/mobile/app/components/sheets/topic-sheet/index.tsx
@@ -25,7 +25,7 @@ import React, {
   useRef,
   useState
 } from "react";
-import { Animated, Platform, RefreshControl, View } from "react-native";
+import { Platform, RefreshControl, View } from "react-native";
 import ActionSheet, {
   ActionSheetRef,
   FlatList

--- a/apps/mobile/app/hooks/use-actions.js
+++ b/apps/mobile/app/hooks/use-actions.js
@@ -52,7 +52,11 @@ import { useThemeStore } from "../stores/use-theme-store";
 import { useUserStore } from "../stores/use-user-store";
 import { toTXT } from "../utils";
 import { toggleDarkMode } from "../utils/color-scheme/utils";
-import { eOpenAddTopicDialog, eOpenLoginDialog } from "../utils/events";
+import {
+  eOnTopicSheetUpdate,
+  eOpenAddTopicDialog,
+  eOpenLoginDialog
+} from "../utils/events";
 import { deleteItems } from "../utils/functions";
 import { sleep } from "../utils/time";
 
@@ -512,6 +516,7 @@ export const useActions = ({ close = () => null, item }) => {
       "Notebook",
       "Notebooks"
     );
+    eSendEvent(eOnTopicSheetUpdate);
     close();
   }
 

--- a/apps/mobile/app/package.json
+++ b/apps/mobile/app/package.json
@@ -15,7 +15,7 @@
     "html-to-text": "8.1.0",
     "phone": "^3.1.14",
     "qclone": "^1.2.0",
-    "react-native-actions-sheet": "0.9.0-alpha.17",
+    "react-native-actions-sheet": "0.9.0-alpha.18",
     "react-native-check-version": "https://github.com/flexible-agency/react-native-check-version",
     "react-native-drax": "^0.10.2",
     "react-native-image-zoom-viewer": "^3.0.1",

--- a/apps/mobile/app/package.json
+++ b/apps/mobile/app/package.json
@@ -15,7 +15,7 @@
     "html-to-text": "8.1.0",
     "phone": "^3.1.14",
     "qclone": "^1.2.0",
-    "react-native-actions-sheet": "0.9.0-alpha.16",
+    "react-native-actions-sheet": "0.9.0-alpha.17",
     "react-native-check-version": "https://github.com/flexible-agency/react-native-check-version",
     "react-native-drax": "^0.10.2",
     "react-native-image-zoom-viewer": "^3.0.1",

--- a/apps/mobile/app/screens/notebook/index.tsx
+++ b/apps/mobile/app/screens/notebook/index.tsx
@@ -22,9 +22,9 @@ import { db } from "../../common/database";
 import DelayLayout from "../../components/delay-layout";
 import List from "../../components/list";
 import { NotebookHeader } from "../../components/list-items/headers/notebook-header";
+import { AddNotebookSheet } from "../../components/sheets/add-notebook";
 import { useNavigationFocus } from "../../hooks/use-navigation-focus";
 import {
-  eSendEvent,
   eSubscribeEvent,
   eUnSubscribeEvent
 } from "../../services/event-manager";
@@ -33,7 +33,7 @@ import SearchService from "../../services/search";
 import useNavigationStore, {
   NotebookScreenParams
 } from "../../stores/use-navigation-store";
-import { eOnNewTopicAdded, eOpenAddNotebookDialog } from "../../utils/events";
+import { eOnNewTopicAdded } from "../../utils/events";
 import { NotebookType } from "../../utils/types";
 import { openEditor, setOnFirstSave } from "../notes/common";
 const Notebook = ({ route, navigation }: NavigationProps<"Notebook">) => {
@@ -148,7 +148,7 @@ const Notebook = ({ route, navigation }: NavigationProps<"Notebook">) => {
           ListHeader={
             <NotebookHeader
               onEditNotebook={() => {
-                eSendEvent(eOpenAddNotebookDialog, params.current.item);
+                AddNotebookSheet.present(params.current.item);
               }}
               notebook={params.current.item}
             />

--- a/apps/mobile/app/screens/notes/index.tsx
+++ b/apps/mobile/app/screens/notes/index.tsx
@@ -276,7 +276,8 @@ const NotesPage = ({
         placeholderData={placeholderData}
       />
 
-      {notes?.length > 0 || (isFocused && !isMonograph) ? (
+      {notes?.length > 0 ||
+      (isFocused && !isMonograph && route.name !== "TopicNotes") ? (
         <FloatingButton title="Create a note" onPress={onPressFloatingButton} />
       ) : null}
     </DelayLayout>

--- a/apps/mobile/app/utils/functions.js
+++ b/apps/mobile/app/utils/functions.js
@@ -25,7 +25,7 @@ import SearchService from "../services/search";
 import { useSelectionStore } from "../stores/use-selection-store";
 import { useMenuStore } from "../stores/use-menu-store";
 import { db } from "../common/database";
-import { eClearEditor } from "./events";
+import { eClearEditor, eOnTopicSheetUpdate } from "./events";
 import { useRelationStore } from "../stores/use-relation-store";
 import { presentDialog } from "../components/dialog/functions";
 
@@ -38,11 +38,14 @@ function deleteConfirmDialog(items, type, context) {
       positiveText: "Delete",
       negativeText: "Cancel",
       positivePress: (value) => {
-        console.log(value);
-        resolve({ delete: true, deleteNotes: value });
+        setTimeout(() => {
+          resolve({ delete: true, deleteNotes: value });
+        });
       },
       onClose: () => {
-        resolve({ delete: false });
+        setTimeout(() => {
+          resolve({ delete: false });
+        });
       },
       context: context,
       check: {
@@ -196,6 +199,7 @@ export const deleteItems = async (item, context) => {
   useMenuStore.getState().setMenuPins();
   useMenuStore.getState().setColorNotes();
   SearchService.updateAndSearch();
+  eSendEvent(eOnTopicSheetUpdate);
 };
 
 export const openLinkInBrowser = async (link) => {

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -42,7 +42,7 @@
         "qclone": "^1.2.0",
         "react": "18.0.0",
         "react-native": "0.69.7",
-        "react-native-actions-sheet": "0.9.0-alpha.16",
+        "react-native-actions-sheet": "0.9.0-alpha.18",
         "react-native-check-version": "https://github.com/flexible-agency/react-native-check-version",
         "react-native-drax": "^0.10.2",
         "react-native-image-zoom-viewer": "^3.0.1",
@@ -17958,9 +17958,9 @@
       }
     },
     "node_modules/react-native-actions-sheet": {
-      "version": "0.9.0-alpha.16",
-      "resolved": "https://registry.npmjs.org/react-native-actions-sheet/-/react-native-actions-sheet-0.9.0-alpha.16.tgz",
-      "integrity": "sha512-/aR+MsJR1IgeZIg7elD2Zu/6In7Ztsvt4fPeOt2sM++FmsAofprsJ4JHjwPFEO06E5djS8ky8VvpaeCrC8HoFg==",
+      "version": "0.9.0-alpha.18",
+      "resolved": "https://registry.npmjs.org/react-native-actions-sheet/-/react-native-actions-sheet-0.9.0-alpha.18.tgz",
+      "integrity": "sha512-X3PBVXyI7DQMfa1p3TbEFY2UjAUGqwl9ej6HxZ6ohm4KacqmGoDUZKLNz9lKCzw0vYeK8lwxtCC7qDSuEEgGQg==",
       "peerDependencies": {
         "react-native": "*",
         "react-native-gesture-handler": "*"
@@ -24318,7 +24318,7 @@
         "qclone": "^1.2.0",
         "react": "18.0.0",
         "react-native": "0.69.7",
-        "react-native-actions-sheet": "0.9.0-alpha.16",
+        "react-native-actions-sheet": "0.9.0-alpha.18",
         "react-native-check-version": "https://github.com/flexible-agency/react-native-check-version",
         "react-native-drax": "^0.10.2",
         "react-native-image-zoom-viewer": "^3.0.1",
@@ -34863,9 +34863,9 @@
       }
     },
     "react-native-actions-sheet": {
-      "version": "0.9.0-alpha.16",
-      "resolved": "https://registry.npmjs.org/react-native-actions-sheet/-/react-native-actions-sheet-0.9.0-alpha.16.tgz",
-      "integrity": "sha512-/aR+MsJR1IgeZIg7elD2Zu/6In7Ztsvt4fPeOt2sM++FmsAofprsJ4JHjwPFEO06E5djS8ky8VvpaeCrC8HoFg=="
+      "version": "0.9.0-alpha.18",
+      "resolved": "https://registry.npmjs.org/react-native-actions-sheet/-/react-native-actions-sheet-0.9.0-alpha.18.tgz",
+      "integrity": "sha512-X3PBVXyI7DQMfa1p3TbEFY2UjAUGqwl9ej6HxZ6ohm4KacqmGoDUZKLNz9lKCzw0vYeK8lwxtCC7qDSuEEgGQg=="
     },
     "react-native-actions-shortcuts": {
       "version": "1.0.1",


### PR DESCRIPTION
Some UX issues have been reported by users related to Topics Sheet that was introduced with Top Level Notebooks. The Topics Sheet is here to stay however we have now improved the UX around it so it adapts to how you use Notebooks.

1. Topic Sheet at Notebook level will now remember last position independently for each Notebook, fully open or collapsed. For example if you have a Notebook with no top level notes, you will want the Sheet to be already  opened when you enter the Notebook. Similarly if you only have top  level notes in a Notebook, you will most probably want the Sheet to be collapsed. 
2. Navigating to a Topic from Topic Sheet will automatically collapse the Sheet to bottom as it seems to  be the most common case that once entering a Topic, user will open a note in the editor rather than going to another topic.
3. Navigating back to Notebook will restore the Topic Sheet position back to how it was at Notebook level.