### PR TITLE
Mobile editor improvements

### DIFF
--- a/apps/mobile/app/package.json
+++ b/apps/mobile/app/package.json
@@ -4,8 +4,6 @@
   "main": "./App.js",
   "license": "GPL-3.0-or-later",
   "dependencies": {
-    "react": "18.0.0",
-    "react-native": "0.69.7",
     "@flyerhq/react-native-link-preview": "^1.6.0",
     "@mdi/js": "^6.7.96",
     "absolutify": "^0.1.0",

--- a/apps/mobile/app/screens/editor/loading.js
+++ b/apps/mobile/app/screens/editor/loading.js
@@ -42,7 +42,7 @@ const EditorOverlay = ({ editorId = "", editor }) => {
   const colors = useThemeStore((state) => state.colors);
   const [error, setError] = useState(false);
   const opacity = useSharedValue(1);
-  const translateValue = useSharedValue(6000);
+  const translateValue = useSharedValue(0);
   const deviceMode = useSettingStore((state) => state.deviceMode);
   const isTablet = deviceMode !== "mobile";
   const insets = useGlobalSafeAreaInsets();
@@ -83,16 +83,14 @@ const EditorOverlay = ({ editorId = "", editor }) => {
           opacity.value = 0;
           translateValue.value = 6000;
         } else {
+          setError(false);
+          editorState().overlay = false;
+          opacity.value = withTiming(0, {
+            duration: 500
+          });
           setTimeout(() => {
-            setError(false);
-            editorState().overlay = false;
-            opacity.value = withTiming(0, {
-              duration: timeDiffSinceLoadStarted
-            });
-            setTimeout(() => {
-              translateValue.value = 6000;
-            }, timeDiffSinceLoadStarted);
-          }, 0);
+            translateValue.value = 6000;
+          }, 500);
         }
       }
     },
@@ -100,12 +98,17 @@ const EditorOverlay = ({ editorId = "", editor }) => {
   );
 
   useEffect(() => {
+    setTimeout(() => {
+      if (!loadingState.current.startTime) {
+        translateValue.value = 6000;
+      }
+    }, 1000);
     eSubscribeEvent("loadingNote" + editorId, load);
     return () => {
       clearTimers();
       eUnSubscribeEvent("loadingNote" + editorId, load);
     };
-  }, [editorId, load]);
+  }, [editorId, load, translateValue]);
 
   const animatedStyle = useAnimatedStyle(() => {
     return {

--- a/apps/mobile/app/screens/editor/loading.js
+++ b/apps/mobile/app/screens/editor/loading.js
@@ -28,12 +28,12 @@ import { Button } from "../../components/ui/button";
 import { IconButton } from "../../components/ui/icon-button";
 import Paragraph from "../../components/ui/typography/paragraph";
 import useGlobalSafeAreaInsets from "../../hooks/use-global-safe-area-insets";
-import { DDS } from "../../services/device-detection";
 import {
   eSendEvent,
   eSubscribeEvent,
   eUnSubscribeEvent
 } from "../../services/event-manager";
+import { useSettingStore } from "../../stores/use-setting-store";
 import { useThemeStore } from "../../stores/use-theme-store";
 import { eClearEditor } from "../../utils/events";
 import { SIZE } from "../../utils/size";
@@ -43,6 +43,8 @@ const EditorOverlay = ({ editorId = "", editor }) => {
   const [error, setError] = useState(false);
   const opacity = useSharedValue(1);
   const translateValue = useSharedValue(6000);
+  const deviceMode = useSettingStore((state) => state.deviceMode);
+  const isTablet = deviceMode !== "mobile";
   const insets = useGlobalSafeAreaInsets();
   const isDefaultEditor = editorId === "";
   const timers = useRef({
@@ -153,7 +155,7 @@ const EditorOverlay = ({ editorId = "", editor }) => {
               paddingRight: 12
             }}
           >
-            {DDS.isTablet() ? (
+            {isTablet ? (
               <View />
             ) : (
               <IconButton
@@ -197,7 +199,9 @@ const EditorOverlay = ({ editorId = "", editor }) => {
                 alignItems: "center",
                 flexDirection: "row",
                 paddingHorizontal: 10,
-                marginTop: 10
+                marginTop: 5,
+                borderWidth: 1,
+                borderColor: colors.border
               }}
             >
               <Paragraph color={colors.icon} size={13}>

--- a/apps/mobile/app/screens/editor/tiptap/use-editor.ts
+++ b/apps/mobile/app/screens/editor/tiptap/use-editor.ts
@@ -239,7 +239,8 @@ export const useEditor = (
 
           if (
             useEditorStore.getState().currentEditingNote !== id &&
-            isDefaultEditor
+            isDefaultEditor &&
+            state.current.currentlyEditing
           ) {
             setTimeout(() => {
               id && useEditorStore.getState().setCurrentlyEditingNote(id);
@@ -505,17 +506,22 @@ export const useEditor = (
           noteId: currentNote.current?.id as string
         };
       }
+      const noteIdFromSessionId =
+        !sessionIdRef.current || sessionIdRef.current.startsWith("session")
+          ? null
+          : sessionIdRef.current.split("_")[0];
+
+      const noteId = currentNote.current?.id || noteIdFromSessionId;
       const params = {
         title,
         data: content,
         type: "tiptap",
         sessionId,
-        id: currentNote.current?.id,
+        id: noteId,
         sessionHistoryId: sessionHistoryId.current
       };
-
       withTimer(
-        currentNote.current?.id || "newnote",
+        noteId || "newnote",
         () => {
           if (
             currentNote.current &&
@@ -530,7 +536,7 @@ export const useEditor = (
           }
           saveNote(params);
         },
-        500
+        150
       );
     },
     [sessionId, withTimer, onChange, saveNote]

--- a/apps/mobile/app/screens/editor/tiptap/use-editor.ts
+++ b/apps/mobile/app/screens/editor/tiptap/use-editor.ts
@@ -368,6 +368,8 @@ export const useEditor = (
         useEditorStore.getState().setReadonly(false);
       } else {
         if (!item.forced && currentNote.current?.id === item.id) return;
+        state.current.movedAway = false;
+        state.current.currentlyEditing = true;
         isDefaultEditor && editorState.setCurrentlyEditingNote(item.id);
         currentNote.current && (await reset(false, false));
         await loadContent(item as NoteType);

--- a/apps/mobile/native/package.json
+++ b/apps/mobile/native/package.json
@@ -58,7 +58,8 @@
     "react-native-date-picker": "4.2.6",
     "react-native-notification-sounds": "0.5.5",
     "@bam.tech/react-native-image-resizer": "3.0.5",
-    "react-native-navigation-bar-color": "2.0.2"
+    "react-native-navigation-bar-color": "2.0.2",
+    "react-native-actions-shortcuts": "^1.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -28,12 +28,10 @@
     "otplib": "12.0.1"
   },
   "dependencies": {
+    "react": "18.0.0",
+    "react-native": "0.69.7",
     "@notesnook/core": "*",
     "@notesnook/editor": "*",
-    "@notesnook/editor-mobile": "*",
-    "fflate": "^0.7.3",
-    "react-native-actions-shortcuts": "^1.0.1",
-    "react-native-fingerprint-scanner": "https://github.com/ammarahm-ed/react-native-fingerprint-scanner.git",
-    "react-native-iap": "7.5.6"
+    "@notesnook/editor-mobile": "*"
   }
 }

--- a/packages/editor-mobile/src/components/editor.tsx
+++ b/packages/editor-mobile/src/components/editor.tsx
@@ -119,6 +119,10 @@ const Tiptap = ({
 
   const update = useCallback(() => {
     setTick((tick) => tick + 1);
+    containerRef.current?.scrollTo?.({
+      left: 0,
+      top: 0
+    });
     globalThis.editorController.setTitlePlaceholder("Note title");
   }, []);
 

--- a/packages/editor-mobile/src/components/statusbar.tsx
+++ b/packages/editor-mobile/src/components/statusbar.tsx
@@ -33,7 +33,12 @@ function StatusBar({ container }: { container: RefObject<HTMLDivElement> }) {
   const currentWords = useRef(words);
   const interval = useRef(0);
   const statusBar = useRef({
-    set: setStatus
+    set: setStatus,
+    updateWords: () => {
+      const words = getTotalWords(editor as Editor) + " words";
+      if (currentWords.current === words) return;
+      setWords(words);
+    }
   });
   globalThis.statusBar = statusBar;
 
@@ -66,11 +71,10 @@ function StatusBar({ container }: { container: RefObject<HTMLDivElement> }) {
 
   useEffect(() => {
     clearInterval(interval.current);
-    interval.current = setInterval(() => {
-      const words = getTotalWords(editor as Editor) + " words";
-      if (currentWords.current === words) return;
-      setWords(words);
-    }, 3000) as unknown as number;
+    interval.current = setInterval(
+      statusBar.current.updateWords,
+      3000
+    ) as unknown as number;
     return () => {
       clearInterval(interval.current);
     };

--- a/packages/editor-mobile/src/hooks/useEditorController.ts
+++ b/packages/editor-mobile/src/hooks/useEditorController.ts
@@ -123,12 +123,13 @@ export function useEditorController(update: () => void): EditorController {
             from,
             to
           });
-
+          statusBar.current?.updateWords();
           break;
         }
         case "native:html":
           htmlContentRef.current = value;
           update();
+          statusBar.current?.updateWords();
           break;
         case "native:theme":
           useEditorThemeStore.getState().setColors(message.value);
@@ -156,7 +157,6 @@ export function useEditorController(update: () => void): EditorController {
     if (isSafari) {
       root = window;
     }
-    console.log("recreating messaging");
     root.addEventListener("message", onMessage);
 
     return () => {

--- a/packages/editor-mobile/src/utils/index.ts
+++ b/packages/editor-mobile/src/utils/index.ts
@@ -51,6 +51,7 @@ declare global {
         saved: string;
       }>
     >;
+    updateWords: () => void;
   }>;
   var __PLATFORM__: "ios" | "android";
   var readonly: boolean;


### PR DESCRIPTION
1. Previously if a note had smaller content, loading would still take quite a bit long which seemed unnecessary. Now loading will show only if note takes long enough to load which should make the app feel much more snappier than before when opening notes. The editor also assumes that notes with less characters in content will load quickly meaning no loading screen for notes at all which are count less than 50K characters. This seems to be a fair limit I think.

2.  Previously when opening note, the word count on mobile would be 0, then update to actual word count. This has been fixed so correct word count shows when opening note without any delay.
3. When changing a note, editor will scroll to top automatically now.
4. I noticed a race condition in the editor causing the content to be saved in a new note in some rare cases, that's been fixed.
5. Note saving is now much faster on mobile