### PR TITLE
core: fix notes marked as local only get deleted on sync

### DIFF
--- a/packages/core/api/sync/collector.js
+++ b/packages/core/api/sync/collector.js
@@ -85,7 +85,8 @@ class Collector {
         result.items.push({
           id: item.id,
           deleted: true,
-          dateModified: Date.now()
+          dateModified: item.dateModified,
+          deleteReason: "localOnly"
         });
         result.types.push(itemType);
       } else if (isUnsynced && isSyncable) {

--- a/packages/core/collections/notes.js
+++ b/packages/core/collections/notes.js
@@ -56,7 +56,12 @@ export default class Notes extends Collection {
       }
     }
 
-    if (remoteNote.deleted) return await this._collection.addItem(remoteNote);
+    if (
+      remoteNote.deleted &&
+      remoteNote.deleteReason !== "localOnly" &&
+      !localNote.localOnly
+    )
+      return await this._collection.addItem(remoteNote);
 
     await this._resolveColorAndTags(remoteNote);
 


### PR DESCRIPTION
Deleted notes in core must specify if they were deleted after being marked as local only. Otherwise there's a chance that offline note might get deleted on force sync from other devices. Closes #2291