### PR TITLE
All toolbars should scroll if buttons overflow

### DIFF
--- a/packages/editor/src/toolbar/components/split-button.tsx
+++ b/packages/editor/src/toolbar/components/split-button.tsx
@@ -39,7 +39,8 @@ function _SplitButton(props: PropsWithChildren<SplitButtonProps>) {
       <Flex
         ref={ref}
         sx={{
-          borderRadius: "default"
+          borderRadius: "default",
+          flexShrink: 0
         }}
       >
         <ToolButton


### PR DESCRIPTION
This fixes one of the issues reported in #2330