### PR TITLE
mobile: reload editor if rendered view lost

### DIFF
--- a/apps/mobile/app/components/launcher/index.js
+++ b/apps/mobile/app/components/launcher/index.js
@@ -37,6 +37,7 @@ import { useNoteStore } from "../../stores/use-notes-store";
 import { useSettingStore } from "../../stores/use-setting-store";
 import { useThemeStore } from "../../stores/use-theme-store";
 import { useUserStore } from "../../stores/use-user-store";
+import { AndroidModule } from "../../utils";
 import { eOpenAnnouncementDialog } from "../../utils/events";
 import { getGithubVersion } from "../../utils/github-version";
 import { SIZE } from "../../utils/size";
@@ -192,6 +193,11 @@ const Launcher = React.memo(
 
     const onUnlockBiometrics = useCallback(async () => {
       if (!(await BiometricService.isBiometryAvailable())) return;
+      if (Platform.OS === "android") {
+        const activityName = await AndroidModule.getActivityName();
+        if (activityName !== "MainActivity") return;
+      }
+
       let verified = await BiometricService.validateUser(
         "Unlock to access your notes",
         ""

--- a/apps/mobile/app/hooks/use-app-events.js
+++ b/apps/mobile/app/hooks/use-app-events.js
@@ -571,8 +571,8 @@ export const useAppEvents = () => {
       if (notesAddedFromIntent || shareExtensionOpened) {
         let id = useEditorStore.getState().currentEditingNote;
         let note = id && db.notes.note(id).data;
-        eSendEvent("loadingNote", note);
         eSendEvent("webview_reset");
+        setTimeout(() => eSendEvent("loadingNote", note), 1);
         MMKV.removeItem("shareExtensionOpened");
       }
     } catch (e) {

--- a/apps/mobile/app/screens/editor/tiptap/use-editor.ts
+++ b/apps/mobile/app/screens/editor/tiptap/use-editor.ts
@@ -635,6 +635,7 @@ export const useEditor = (
     saveContent,
     onContentChanged,
     editorId: editorId,
-    markImageLoaded
+    markImageLoaded,
+    overlay
   };
 };

--- a/apps/mobile/app/screens/editor/tiptap/use-editor.ts
+++ b/apps/mobile/app/screens/editor/tiptap/use-editor.ts
@@ -580,22 +580,21 @@ export const useEditor = (
 
   const onReady = useCallback(async () => {
     if (!(await isEditorLoaded(editorRef, sessionIdRef.current))) {
-      overlay(true);
-      setLoading(true);
+      eSendEvent("webview_reset");
     } else {
       isDefaultEditor && restoreEditorState();
     }
-  }, [overlay, isDefaultEditor, restoreEditorState]);
+  }, [isDefaultEditor, restoreEditorState]);
 
   useEffect(() => {
     state.current.saveCount = 0;
-    async () => {
+    (async () => {
       await commands.setSessionId(sessionIdRef.current);
       if (sessionIdRef.current) {
         if (!state.current?.ready) return;
         await onReady();
       }
-    };
+    })();
   }, [sessionId, loading, commands, onReady]);
 
   const onLoad = useCallback(async () => {

--- a/apps/mobile/app/screens/editor/wrapper.js
+++ b/apps/mobile/app/screens/editor/wrapper.js
@@ -51,6 +51,7 @@ export const EditorWrapper = ({ width }) => {
     if (editorState().movedAway) return;
     if (state === "active") {
       editorController.current.onReady();
+      editorController.current.overlay(false);
     }
   };
 

--- a/apps/mobile/app/services/notifications.ts
+++ b/apps/mobile/app/services/notifications.ts
@@ -86,8 +86,9 @@ async function getNextMonthlyReminderDate(
 }
 
 async function initDatabase(notes = true) {
-  if (db.isInitialized) return;
-  await db.initCollections();
+  if (!db.isInitialized) {
+    await db.initCollections();
+  }
   if (notes) {
     await db.notes?.init();
   }

--- a/apps/mobile/native/android/app/src/main/java/com/streetwriters/notesnook/RCTNNativeModule.java
+++ b/apps/mobile/native/android/app/src/main/java/com/streetwriters/notesnook/RCTNNativeModule.java
@@ -4,6 +4,7 @@ package com.streetwriters.notesnook;
 import android.graphics.Color;
 import android.view.WindowManager;
 
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -35,6 +36,16 @@ public class RCTNNativeModule extends ReactContextBaseJavaModule {
 
         }
     }
+
+    @ReactMethod
+    public void getActivityName(Promise promise) {
+        try {
+            promise.resolve(getCurrentActivity().getClass().getSimpleName());
+        } catch (Exception e) {
+            promise.resolve(null);
+        }
+    }
+
 
 
     @ReactMethod

--- a/apps/mobile/share/store.js
+++ b/apps/mobile/share/store.js
@@ -31,8 +31,8 @@ export async function initDatabase() {
   if (!db.isInitialized) {
     // Only load collections in database.
     await db.initCollections();
-    await db.notes.init();
   }
+  await db.notes.init();
 }
 
 const StorageKeys = {


### PR DESCRIPTION
Reload the editor if rendered view is lost and WebView messaging is not functional.

Closes #2420
Closes #2425
Closes #2422