### PR TITLE
Try to reconnect sync on window focus

### DIFF
--- a/apps/web/src/utils/page-visibility.ts
+++ b/apps/web/src/utils/page-visibility.ts
@@ -35,7 +35,7 @@ function isDocumentHidden() {
 
 export function onPageVisibilityChanged(
   handler: (
-    status: "online" | "offline" | "visibilitychange",
+    status: "online" | "offline" | "visibilitychange" | "focus",
     bool: boolean
   ) => void
 ) {
@@ -46,6 +46,8 @@ export function onPageVisibilityChanged(
   document.addEventListener(visibilityChange(), () =>
     handler("visibilitychange", isDocumentHidden())
   );
+
+  window.addEventListener("focus", () => handler("focus", false));
 }
 
 function onDeviceOnline(handler: () => void) {


### PR DESCRIPTION
Page Visibility API is not really reliable and even network change events don't work on all platforms and in all cases. Window Focus Events seem to be a much more reliable and foolproof way to handle this.

Closes #2367