### PR TITLE
Fix/trial expired notice shows on app restart for new users

### DIFF
--- a/apps/mobile/app/components/walkthroughs/walkthroughs.tsx
+++ b/apps/mobile/app/components/walkthroughs/walkthroughs.tsx
@@ -277,7 +277,6 @@ const ChooseTheme = () => {
   return (
     <View
       style={{
-        maxHeight: 170,
         alignItems: "center",
         marginTop: 20
       }}
@@ -295,7 +294,7 @@ const ChooseTheme = () => {
         Pick a theme of your choice
       </Paragraph>
       <Seperator />
-      <AccentColorPicker settings={false} />
+      <AccentColorPicker />
       <Seperator />
     </View>
   );

--- a/apps/mobile/app/services/premium.js
+++ b/apps/mobile/app/services/premium.js
@@ -319,7 +319,8 @@ const subscriptions = {
 
 async function getRemainingTrialDaysStatus() {
   let user = await db.user.getUser();
-  if (!user) return false;
+  if (!user || !user.subscription || user.subscription?.expiry === 0) return;
+
   let premium = user.subscription.type !== SUBSCRIPTION_STATUS.BASIC;
   let isTrial = user.subscription.type === SUBSCRIPTION_STATUS.TRIAL;
   let total = user.subscription.expiry - user.subscription.start;

--- a/apps/web/src/common/index.js
+++ b/apps/web/src/common/index.js
@@ -199,7 +199,7 @@ export async function showUpgradeReminderDialogs() {
   if (isTesting()) return;
 
   const user = userstore.get().user;
-  if (!user) return;
+  if (!user || !user.subscription || user.subscription?.expiry === 0) return;
 
   const consumed = totalSubscriptionConsumed(user);
   const isTrial = user?.subscription?.type === SUBSCRIPTION_STATUS.TRIAL;


### PR DESCRIPTION
New users should not get the trial expired notice before they subscribe to the 14 day free trial.