### PR TITLE
clipper: fix duplicate notes created on save

### DIFF
--- a/extensions/web-clipper/src/content-scripts/all.ts
+++ b/extensions/web-clipper/src/content-scripts/all.ts
@@ -27,6 +27,11 @@ import {
 import { ClipArea, ClipMode } from "../common/bridge";
 import type { Config } from "@notesnook/clipper/dist/types";
 
+declare global {
+  // eslint-disable-next-line no-var
+  var messagingPortAttached: boolean;
+}
+
 type ClipMessage = {
   type: "clip";
   mode?: ClipMode;
@@ -37,30 +42,31 @@ type ClipMessage = {
 type ViewportMessage = {
   type: "viewport";
 };
+function attachMessagePort() {
+  browser.runtime.onMessage.addListener(async (request) => {
+    const message = request as ClipMessage | ViewportMessage;
 
-browser.runtime.onMessage.addListener(async (request) => {
-  const message = request as ClipMessage | ViewportMessage;
-
-  switch (message.type) {
-    case "clip": {
-      const sizeable =
-        message.area === "full-page" &&
-        (message.mode === "complete" || message.mode === "screenshot");
-      return {
-        height: sizeable ? document.body.clientHeight : 0,
-        width: sizeable ? document.body.clientWidth : 0,
-        data: await clip(request)
-      };
+    switch (message.type) {
+      case "clip": {
+        const sizeable =
+          message.area === "full-page" &&
+          (message.mode === "complete" || message.mode === "screenshot");
+        return {
+          height: sizeable ? document.body.clientHeight : 0,
+          width: sizeable ? document.body.clientWidth : 0,
+          data: await clip(request)
+        };
+      }
+      case "viewport":
+        return {
+          x: 0,
+          y: 0,
+          height: document.body.clientHeight,
+          width: document.body.clientWidth
+        };
     }
-    case "viewport":
-      return {
-        x: 0,
-        y: 0,
-        height: document.body.clientHeight,
-        width: document.body.clientWidth
-      };
-  }
-});
+  });
+}
 
 function clip(message: ClipMessage) {
   try {
@@ -86,4 +92,9 @@ function clip(message: ClipMessage) {
   } finally {
     if (message.area !== "selection") cleanup();
   }
+}
+
+if (!globalThis.messagingPortAttached) {
+  attachMessagePort();
+  globalThis.messagingPortAttached = true;
 }

--- a/extensions/web-clipper/src/content-scripts/all.ts
+++ b/extensions/web-clipper/src/content-scripts/all.ts
@@ -43,6 +43,9 @@ type ViewportMessage = {
   type: "viewport";
 };
 function attachMessagePort() {
+  if (globalThis.messagingPortAttached) return;
+  globalThis.messagingPortAttached = true;
+
   browser.runtime.onMessage.addListener(async (request) => {
     const message = request as ClipMessage | ViewportMessage;
 
@@ -94,7 +97,4 @@ function clip(message: ClipMessage) {
   }
 }
 
-if (!globalThis.messagingPortAttached) {
-  attachMessagePort();
-  globalThis.messagingPortAttached = true;
-}
+attachMessagePort();

--- a/extensions/web-clipper/src/content-scripts/nn.ts
+++ b/extensions/web-clipper/src/content-scripts/nn.ts
@@ -32,6 +32,9 @@ declare global {
 }
 
 function attachOnConnectListener() {
+  if (globalThis.clipperBridgeConnected) return;
+  globalThis.clipperBridgeConnected = true;
+
   browser.runtime.onConnect.addListener((port) => {
     window.addEventListener("message", (ev) => {
       const { type } = ev.data;
@@ -74,7 +77,4 @@ class BackgroundGateway implements Gateway {
   }
 }
 
-if (!globalThis.clipperBridgeConnected) {
-  globalThis.clipperBridgeConnected = true;
-  attachOnConnectListener();
-}
+attachOnConnectListener();

--- a/extensions/web-clipper/src/content-scripts/nn.ts
+++ b/extensions/web-clipper/src/content-scripts/nn.ts
@@ -26,37 +26,44 @@ import {
   WEB_EXTENSION_CHANNEL_EVENTS
 } from "../common/bridge";
 
-browser.runtime.onConnect.addListener((port) => {
-  window.addEventListener("message", (ev) => {
-    const { type } = ev.data;
-    switch (type) {
-      case WEB_EXTENSION_CHANNEL_EVENTS.ON_CREATED:
-        if (ev.ports.length) {
-          const mainPort = ev.ports.at(0);
-          if (mainPort) {
-            expose(new BackgroundGateway(), mainPort);
-            const server: Remote<Server> = wrap<Server>(mainPort);
-            expose(
-              {
-                login: () => server.login(),
-                getNotes: () => server.getNotes(),
-                getNotebooks: () => server.getNotebooks(),
-                getTags: () => server.getTags(),
-                saveClip: (clip: Clip) => server.saveClip(clip)
-              },
-              createEndpoint(port)
-            );
-            port.postMessage({ success: true });
-          } else {
-            port.postMessage({ success: false });
-          }
-        }
-        break;
-    }
-  });
+declare global {
+  // eslint-disable-next-line no-var
+  var clipperBridgeConnected: boolean;
+}
 
-  window.postMessage({ type: WEB_EXTENSION_CHANNEL_EVENTS.ON_READY }, "*");
-});
+function attachOnConnectListener() {
+  browser.runtime.onConnect.addListener((port) => {
+    window.addEventListener("message", (ev) => {
+      const { type } = ev.data;
+      switch (type) {
+        case WEB_EXTENSION_CHANNEL_EVENTS.ON_CREATED:
+          if (ev.ports.length) {
+            const mainPort = ev.ports.at(0);
+            if (mainPort) {
+              expose(new BackgroundGateway(), mainPort);
+              const server: Remote<Server> = wrap<Server>(mainPort);
+              expose(
+                {
+                  login: () => server.login(),
+                  getNotes: () => server.getNotes(),
+                  getNotebooks: () => server.getNotebooks(),
+                  getTags: () => server.getTags(),
+                  saveClip: (clip: Clip) => server.saveClip(clip)
+                },
+                createEndpoint(port)
+              );
+              port.postMessage({ success: true });
+            } else {
+              port.postMessage({ success: false });
+            }
+          }
+          break;
+      }
+    });
+
+    window.postMessage({ type: WEB_EXTENSION_CHANNEL_EVENTS.ON_READY }, "*");
+  });
+}
 
 class BackgroundGateway implements Gateway {
   connect() {
@@ -65,4 +72,9 @@ class BackgroundGateway implements Gateway {
       id: "unknown-id"
     };
   }
+}
+
+if (!globalThis.clipperBridgeConnected) {
+  globalThis.clipperBridgeConnected = true;
+  attachOnConnectListener();
 }


### PR DESCRIPTION
Webclipper creates many duplicate notes on when clipping websites. This fixes it by ensuring only one listener is attached with Notesnook App & the website.

Closes #2604