### PR TITLE
Fix/slow copy and share on mobile

### DIFF
--- a/packages/core/models/note.js
+++ b/packages/core/models/note.js
@@ -102,12 +102,19 @@ export default class Note {
         type: "tiptap",
         data: "<p></p>"
       };
-    const { data, type } = await this._db.content.downloadMedia(
-      `export-${this.id}`,
-      contentItem,
-      false
-    );
-    let content = getContentFromData(type, data);
+
+    let content;
+
+    if (to !== "txt") {
+      const { data, type } = await this._db.content.downloadMedia(
+        `export-${this.id}`,
+        contentItem,
+        false
+      );
+      content = getContentFromData(type, data);
+    } else {
+      content = getContentFromData(contentItem.type, contentItem.data);
+    }
 
     switch (to) {
       case "html":


### PR DESCRIPTION
Avoid download images & media when sharing on mobile since it's just plain text that we need. Closes #2454