### PR TITLE
Fix color picker height with bottom toolbar on desktop

### DIFF
--- a/packages/editor/src/toolbar/popups/color-picker.tsx
+++ b/packages/editor/src/toolbar/popups/color-picker.tsx
@@ -178,7 +178,6 @@ export function ColorPicker(props: ColorPickerProps) {
               p: 1,
               overflowX: ["auto", "hidden"],
               flexWrap: ["nowrap", "wrap"],
-              maxHeight: ["auto", 100],
               overflowY: ["hidden", "auto"]
             }}
           >


### PR DESCRIPTION
Closes #2942
Closes #2952 