### PR TITLE
Prevent unintentional note saving on open

### DIFF
--- a/packages/editor/src/extensions/code-block/highlighter.ts
+++ b/packages/editor/src/extensions/code-block/highlighter.ts
@@ -171,6 +171,8 @@ export function HighlighterPlugin({
             changedNodes.forEach(({ node, pos }) => {
               tr.setNodeMarkup(pos, node.type, node.attrs);
             });
+            tr.setMeta("preventUpdate", true);
+            tr.setMeta("addToHistory", false);
             view.dispatch(tr);
           }
         }


### PR DESCRIPTION
Things to test:

- [x] Add a codeblock and make sure note is not saved on refreshing the app