### PR TITLE
mobile: add verification prompts

### DIFF
--- a/apps/mobile/app/screens/settings/functions.js
+++ b/apps/mobile/app/screens/settings/functions.js
@@ -42,7 +42,8 @@ export async function verifyUser(
     negativeText: closeText || "Cancel",
     positivePress: async (value) => {
       try {
-        let verified = await db.user.verifyPassword(value);
+        const user = await db.user.getUser();
+        let verified = !user ? true : await db.user.verifyPassword(value);
         if (verified) {
           sleep(300).then(async () => {
             await onsuccess();
@@ -58,7 +59,7 @@ export async function verifyUser(
         }
       } catch (e) {
         ToastEvent.show({
-          heading: "Failed to backup data",
+          heading: "Failed to verify",
           message: e.message,
           type: "error",
           context: "global"

--- a/apps/mobile/app/screens/settings/picker/index.tsx
+++ b/apps/mobile/app/screens/settings/picker/index.tsx
@@ -27,6 +27,8 @@ import PremiumService from "../../../services/premium";
 import { useThemeColors } from "@notesnook/theme";
 import { SIZE } from "../../../utils/size";
 import { sleep } from "../../../utils/time";
+import { verifyUser } from "../functions";
+import { Dialog } from "../../../components/dialog";
 
 interface PickerOptions<T> {
   getValue: () => T;
@@ -37,6 +39,7 @@ interface PickerOptions<T> {
   options: T[];
   premium?: boolean;
   onCheckOptionIsPremium?: (item: T) => boolean;
+  requiresVerification?: () => boolean;
 }
 
 export function SettingsPicker<T>({
@@ -47,7 +50,8 @@ export function SettingsPicker<T>({
   options,
   getItemKey,
   premium,
-  onCheckOptionIsPremium = () => true
+  onCheckOptionIsPremium = () => true,
+  requiresVerification = () => false
 }: PickerOptions<T>) {
   const { colors } = useThemeColors("contextMenu");
   const menuRef = useRef<any>();
@@ -118,11 +122,18 @@ export function SettingsPicker<T>({
           </PressableButton>
         }
       >
+        <Dialog context="local" />
         {options.map((item) => (
           <MenuItem
             key={getItemKey(item)}
             onPress={async () => {
-              onChange(item);
+              if (requiresVerification?.()) {
+                verifyUser("local", () => {
+                  onChange(item);
+                });
+              } else {
+                onChange(item);
+              }
             }}
             style={{
               backgroundColor: compareValue(currentValue, item)

--- a/apps/mobile/app/screens/settings/picker/pickers.jsx
+++ b/apps/mobile/app/screens/settings/picker/pickers.jsx
@@ -26,6 +26,7 @@ import { createSettingsPicker } from ".";
 import { getFontById, getFonts } from "@notesnook/editor/dist/utils/font";
 import { DATE_FORMATS, TIME_FORMATS } from "@notesnook/core/common";
 import dayjs from "dayjs";
+import { useUserStore } from "../../../stores/use-user-store";
 
 export const FontPicker = createSettingsPicker({
   getValue: () => useSettingStore.getState().settings.defaultFontFamily,
@@ -127,6 +128,12 @@ export const BackupReminderPicker = createSettingsPicker({
   options: ["useroff", "daily", "weekly", "monthly"],
   compareValue: (current, item) => current === item,
   premium: true,
+  requiresVerification: () => {
+    return (
+      !useSettingStore.getState().settings.encryptedBackup &&
+      useUserStore.getState().user
+    );
+  },
   onCheckOptionIsPremium: (item) => {
     return item !== "useroff";
   }

--- a/apps/mobile/app/screens/settings/settings-data.tsx
+++ b/apps/mobile/app/screens/settings/settings-data.tsx
@@ -783,10 +783,11 @@ export const settingsGroups: SettingSection[] = [
             description: "Create a backup of your data",
             modifer: async () => {
               const user = useUserStore.getState().user;
-              if (!user) {
+              if (!user || SettingsService.getProperty("encryptedBackup")) {
                 await BackupService.run(true);
                 return;
               }
+
               verifyUser(null, () => BackupService.run(true));
             }
           },
@@ -870,9 +871,17 @@ export const settingsGroups: SettingSection[] = [
                 });
                 return;
               }
-              SettingsService.set({
-                encryptedBackup: !settings.encryptedBackup
-              });
+              if (settings.encryptedBackup) {
+                await verifyUser(null, () => {
+                  SettingsService.set({
+                    encryptedBackup: false
+                  });
+                });
+              } else {
+                SettingsService.set({
+                  encryptedBackup: true
+                });
+              }
             }
           }
         ]
@@ -902,7 +911,9 @@ export const settingsGroups: SettingSection[] = [
         description:
           "Export all notes as pdf, markdown, html or text in a single zip file",
         modifer: () => {
-          ExportNotesSheet.present(undefined, true);
+          verifyUser(null, () => {
+            ExportNotesSheet.present(undefined, true);
+          });
         }
       }
     ]


### PR DESCRIPTION
Added verification prompts in the following places:

1. Turning off encrypted backups (turning on encryption is a safe operation)
2. Exporting all notes
3. Turning on automatic backups if backups encryption is turned off


Additionally, removed password verification when creating a manual backup if encryption is _**on**_ as its a safe operation and poses no risk.