### PR TITLE
editor: Added Total Line Number On Bottom Statusbar

### DIFF
--- a/apps/web/src/components/editor/footer.tsx
+++ b/apps/web/src/components/editor/footer.tsx
@@ -31,7 +31,7 @@ const SAVE_STATE_ICON_MAP = {
 };
 
 function EditorFooter() {
-  const { words } = useNoteStatistics();
+  const { words, lines } = useNoteStatistics();
   const dateEdited = useStore((store) => store.session.dateEdited);
   const id = useStore((store) => store.session.id);
   const saveState = useStore(
@@ -54,6 +54,15 @@ function EditorFooter() {
       >
         {words.total + " words"}
         {words.selected ? ` (${words.selected} selected)` : ""}
+      </Text>
+      <Text
+        className="selectable"
+        data-test-id="editor-line-count"
+        variant="subBody"
+        mr={2}
+        sx={{ color: "paragraph" }}
+      >
+        {lines.total + " lines"}
       </Text>
       <Text
         className="selectable"

--- a/apps/web/src/components/editor/tiptap.tsx
+++ b/apps/web/src/components/editor/tiptap.tsx
@@ -99,6 +99,9 @@ function save(
       words: {
         total: countWords(content.textBetween(0, content.size, "\n", " ")),
         selected: 0
+      },
+      lines: {
+        total: content.content.length //Takes the fragment and return the fragment array length
       }
     }
   });
@@ -202,6 +205,9 @@ function TipTap(props: TipTapProps) {
             words: {
               total: getTotalWords(editor as Editor),
               selected: 0
+            },
+            lines: {
+              total: editor.state.doc.content.content.length //Takes the fragment and return the fragment array length
             }
           }
         });

--- a/apps/web/src/components/editor/types.ts
+++ b/apps/web/src/components/editor/types.ts
@@ -24,6 +24,9 @@ export type NoteStatistics = {
     total: number;
     selected?: number;
   };
+  lines: {
+    total: number;
+  };
 };
 
 export interface IEditor {


### PR DESCRIPTION
Fixes #3943 Option to display line numbers

This PR adds a indicator of Total Number of lines at bottom statusbar of editor, See Image Below
![image](https://github.com/streetwriters/notesnook/assets/77344771/67052427-e78b-4d90-87d6-61002304839a)
