### PR TITLE
mobile: Add support to Android adaptive themed icon

### DIFF
--- a/apps/mobile/native/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/apps/mobile/native/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_foreground"/>
 </adaptive-icon>

--- a/apps/mobile/native/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/apps/mobile/native/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_foreground"/>
 </adaptive-icon>


### PR DESCRIPTION
This pull request adds support to the [Android themed adaptive icons](https://developer.android.com/develop/ui/views/launch/icon_design_adaptive).

### Changes Made
Added `<monochrome .. />` icon support to `ic_launcher.xml` and `ic_launcher_round.xml`. 

### Linked Issue
[Issue #4026](https://github.com/streetwriters/notesnook/issues/4026)