### PR TITLE
web: add readonly branch even in locked notes

### DIFF
--- a/apps/web/src/components/editor/index.tsx
+++ b/apps/web/src/components/editor/index.tsx
@@ -782,6 +782,7 @@ type UnlockNoteViewProps = { session: LockedEditorSession };
 function UnlockNoteView(props: UnlockNoteViewProps) {
   const { session } = props;
   const root = useRef<HTMLDivElement>(null);
+  const isReadOnly = session.note.readonly;
 
   useLayoutEffect(() => {
     const element = root.current;
@@ -811,7 +812,7 @@ function UnlockNoteView(props: UnlockNoteViewProps) {
             throw new Error("note with this id does not exist.");
 
           useEditorStore.getState().addSession({
-            type: "default",
+            type: isReadOnly ? "readonly" : "default",
             locked: true,
             id: session.id,
             note: session.note,

--- a/apps/web/src/components/editor/index.tsx
+++ b/apps/web/src/components/editor/index.tsx
@@ -782,7 +782,6 @@ type UnlockNoteViewProps = { session: LockedEditorSession };
 function UnlockNoteView(props: UnlockNoteViewProps) {
   const { session } = props;
   const root = useRef<HTMLDivElement>(null);
-  const isReadOnly = session.note.readonly;
 
   useLayoutEffect(() => {
     const element = root.current;
@@ -812,7 +811,7 @@ function UnlockNoteView(props: UnlockNoteViewProps) {
             throw new Error("note with this id does not exist.");
 
           useEditorStore.getState().addSession({
-            type: isReadOnly ? "readonly" : "default",
+            type: session.note.readonly ? "readonly" : "default",
             locked: true,
             id: session.id,
             note: session.note,

--- a/apps/web/src/stores/editor-store.ts
+++ b/apps/web/src/stores/editor-store.ts
@@ -90,6 +90,7 @@ export type ReadonlyEditorSession = BaseEditorSession & {
   content?: NoteContent<false>;
   color?: string;
   tags?: Tag[];
+  locked?: boolean;
 };
 
 export type DeletedEditorSession = BaseEditorSession & {


### PR DESCRIPTION
The issue was that the "readonly" and "locked" states were being branched by the type of session object. Therefore, we were not able to check the read only when the type was "locked". So, we modified the read only to be branched according to the value of session.note.read only when it is locked.

1. When locked, we added a readonly branch.
2. I added a type accordingly.