### PR TITLE
global: clarify explanations for force push and force pull

### DIFF
--- a/apps/mobile/app/screens/settings/settings-data.tsx
+++ b/apps/mobile/app/screens/settings/settings-data.tsx
@@ -475,7 +475,7 @@ export const settingsGroups: SettingSection[] = [
           {
             id: "pull-sync",
             name: "Force pull changes",
-            description: `Use this if some changes are not appearing on this device from other devices. This will pull everything from the server and overwrite with whatever is one this device.\n\nThese must only be used for troubleshooting. Using them regularly for sync is not recommended and will lead to unexpected data loss and other issues. If you are having persistent issues with sync, please report them to us at support@streetwriters.co.`,
+            description: `Use this if changes from other devices are not appearing on this device. This will overwrite the data on this device with the latest data from the server.\n\nThis must only be used for troubleshooting. Using it regularly for sync is not recommended and will lead to unexpected data loss and other issues. If you are having persistent issues with sync, please report them to us at support@streetwriters.co.`,
             modifer: () => {
               presentDialog({
                 title: "Force Pull changes",
@@ -497,7 +497,7 @@ export const settingsGroups: SettingSection[] = [
           {
             id: "push-sync",
             name: "Force push changes",
-            description: `Use this if some changes are not appearing on this device from other devices. This will pull everything from the server and overwrite with whatever is one this device.`,
+            description: `Use this if changes made on this device are not appearing on other devices. This will overwrite the data on the server with the data from this device.\n\nThis must only be used for troubleshooting. Using it regularly for sync is not recommended and will lead to unexpected data loss and other issues. If you are having persistent issues with sync, please report them to us at support@streetwriters.co.`,
             modifer: () => {
               presentDialog({
                 title: "Force Push changes",

--- a/apps/web/src/dialogs/settings/sync-settings.ts
+++ b/apps/web/src/dialogs/settings/sync-settings.ts
@@ -80,10 +80,10 @@ export const SyncSettings: SettingsGroup[] = [
         key: "force-sync",
         title: "Having problems with sync?",
         description: `Force push:
-Use this if some changes from this device are not appearing on other devices.This will push everything on this device and overwrite whatever is one the server.
+Use this if changes made on this device are not appearing on other devices. This will overwrite the data on the server with the data from this device.
 
 Force pull:
-Use this if some changes are not appearing on this device from other devices. This will pull everything from the server and overwrite with whatever is one this device.
+Use this if changes from other devices are not appearing on this device. This will overwrite the data on this device with the latest data from the server.
 
 **These must only be used for troubleshooting. Using them regularly for sync is not recommended and will lead to unexpected data loss and other issues. If you are having persistent issues with sync, please report them to us at support@streetwriters.co.**`,
         keywords: ["force sync", "sync troubleshoot"],


### PR DESCRIPTION
- I noticed the explanation of force push is misdescribed in the mobile version, it has the same explanation as for force pull
- There's a spelling mistake I noticed being made `with whatever is one` that I fixed => `with whatever is on`
- I rephrased the wording to clarify when the buttons need to be pressed and what happens:
  from: `Use this if some changes from this device are not appearing on other devices.`
  to: `Use this if changes made on this device are not appearing on other devices.`
  and:
  from: `This will pull everything from the server and overwrite with whatever is one this device.`
  to: `This will overwrite the data on this device with the latest data from the server.`
- I noticed on mobile it only shows `These must only be used for troubleshooting...` between pull sync and push sync, which I thought could be a bit confusing - as only pull sync was explained so far, it isn't 100% clear what "these" refers to. Also, it could result in some people not knowing that this also relates to push sync, as it appears only after pull sync.
  - I considered only adding it after push sync, as then both pull and push sync already appeared, so "these" would make more sense, but as both operations are quite critical, I thought it would be better to stay on the safe side and decided to explain it with force push and force pull once each.

Let me know if you disagree with my decisions or feel something could be improved further!