### PR TITLE
docs(help): Fix typo in is-there-an-eta.md

### DIFF
--- a/docs/help/contents/faqs/is-there-an-eta.md
+++ b/docs/help/contents/faqs/is-there-an-eta.md
@@ -13,6 +13,6 @@ We maintain an up-to-date [roadmap](https://notesnook.com/roadmap) which lists e
 
 In case you are still curious, a huge part of developing any software are **deadlines**. Giving any ETA means we want to be held accountable for when a feature might land. That is something we cannot afford because another huge part of developing any software are **delays**. As any engineer might tell you, "X will land in 1 month" almost always means "X will land in 4 months".
 
-Users do not understand or tolerate delays, and developers do not like incessant pestering on why something didn't land on X date when we said it'll land on X date. To avoid all these headaches we simply do not give out any ETAs. Obviously, internally we do have timelines for each feature but disclosing these is unncessary.
+Users do not understand or tolerate delays, and developers do not like incessant pestering on why something didn't land on X date when we said it'll land on X date. To avoid all these headaches we simply do not give out any ETAs. Obviously, internally we do have timelines for each feature but disclosing these is unnecessary.
 
 In short, it'll land when it'll land. No promises.


### PR DESCRIPTION
docs(help): Fix typo in is-there-an-eta.md - unnecessary was incorrectly spelled

Signed-off-by: Stephen Argent <stevesbrain@users.noreply.github.com>