### PR TITLE
web: changes related to table of contents (#4977)

### DIFF
--- a/apps/web/src/components/editor/action-bar.tsx
+++ b/apps/web/src/components/editor/action-bar.tsx
@@ -169,8 +169,7 @@ export function EditorActionBar() {
         activeSession.type !== "locked" &&
         activeSession.type !== "diff" &&
         activeSession.type !== "conflicted",
-      onClick: () => useEditorStore.getState().toggleTableOfContents(),
-      toc: true
+      onClick: () => useEditorStore.getState().toggleTableOfContents()
     },
     {
       title: strings.search(),
@@ -225,7 +224,7 @@ export function EditorActionBar() {
           title={tool.title}
           key={tool.title}
           sx={{
-            height: tool.toc ? 32 : "100%",
+            height: "100%",
             alignItems: "center",
             bg: "transparent",
             display: [
@@ -239,11 +238,7 @@ export function EditorActionBar() {
                 tool.title === "Close"
                   ? "var(--accentForeground-error) !important"
                   : "var(--icon)"
-            },
-            position: tool.toc ? "absolute" : "static",
-            right: tool.toc ? 10 : "auto",
-            top: tool.toc ? 32 : "auto",
-            zIndex: tool.toc ? 1999 : "auto"
+            }
           }}
           onClick={tool.onClick}
         >

--- a/apps/web/src/components/editor/action-bar.tsx
+++ b/apps/web/src/components/editor/action-bar.tsx
@@ -169,7 +169,8 @@ export function EditorActionBar() {
         activeSession.type !== "locked" &&
         activeSession.type !== "diff" &&
         activeSession.type !== "conflicted",
-      onClick: () => useEditorStore.getState().toggleTableOfContents()
+      onClick: () => useEditorStore.getState().toggleTableOfContents(),
+      toc: true
     },
     {
       title: strings.search(),
@@ -224,7 +225,7 @@ export function EditorActionBar() {
           title={tool.title}
           key={tool.title}
           sx={{
-            height: "100%",
+            height: tool.toc ? 32 : "100%",
             alignItems: "center",
             bg: "transparent",
             display: [
@@ -238,7 +239,11 @@ export function EditorActionBar() {
                 tool.title === "Close"
                   ? "var(--accentForeground-error) !important"
                   : "var(--icon)"
-            }
+            },
+            position: tool.toc ? "absolute" : "static",
+            right: tool.toc ? 10 : "auto",
+            top: tool.toc ? 32 : "auto",
+            zIndex: tool.toc ? 1999 : "auto"
           }}
           onClick={tool.onClick}
         >

--- a/apps/web/src/components/editor/index.tsx
+++ b/apps/web/src/components/editor/index.tsx
@@ -63,7 +63,7 @@ import { debounce, debounceWithId } from "@notesnook/common";
 import { Freeze } from "react-freeze";
 import { UnlockView } from "../unlock";
 import DiffViewer from "../diff-viewer";
-import TableOfContents from "./table-of-contents";
+import TableOfContents, { TABLE_OF_CONTENTS_WIDTH } from "./table-of-contents";
 import { scrollIntoViewById } from "@notesnook/editor";
 import { IEditor } from "./types";
 import { EditorActionBar } from "./action-bar";
@@ -568,6 +568,7 @@ function EditorChrome(props: PropsWithChildren<EditorProps>) {
   const editorMargins = useEditorStore((store) => store.editorMargins);
   const editorContainerRef = useRef<HTMLElement>(null);
   const editorScrollRef = useRef<HTMLElement>(null);
+  const isTOCVisible = useEditorStore((store) => store.isTOCVisible);
 
   useEffect(() => {
     if (!editorScrollRef.current) return;
@@ -624,9 +625,15 @@ function EditorChrome(props: PropsWithChildren<EditorProps>) {
           variant="columnFill"
           className="editor"
           sx={{
-            alignSelf: ["stretch", focusMode ? "center" : "stretch", "center"],
+            alignSelf: [
+              "stretch",
+              focusMode ? "center" : "stretch",
+              !editorMargins ? (isTOCVisible ? "stretch" : "center") : "center"
+            ],
             maxWidth: editorMargins ? "min(100%, 850px)" : "auto",
-            width: "100%"
+            width: isTOCVisible
+              ? `calc(100% - ${TABLE_OF_CONTENTS_WIDTH}px)`
+              : "100%"
           }}
           pl={[2, 2, 6]}
           pr={[2, 2, 6]}

--- a/apps/web/src/components/editor/index.tsx
+++ b/apps/web/src/components/editor/index.tsx
@@ -63,7 +63,7 @@ import { debounce, debounceWithId } from "@notesnook/common";
 import { Freeze } from "react-freeze";
 import { UnlockView } from "../unlock";
 import DiffViewer from "../diff-viewer";
-import TableOfContents, { TABLE_OF_CONTENTS_WIDTH } from "./table-of-contents";
+import TableOfContents from "./table-of-contents";
 import { scrollIntoViewById } from "@notesnook/editor";
 import { IEditor } from "./types";
 import { EditorActionBar } from "./action-bar";
@@ -152,7 +152,12 @@ export default function TabsView() {
                 ) : session.type === "conflicted" || session.type === "diff" ? (
                   <DiffViewer session={session} />
                 ) : (
-                  <MemoizedEditorView session={session} />
+                  <Flex sx={{ overflow: "hidden" }}>
+                    <MemoizedEditorView session={session} />
+                    {isTOCVisible && activeSessionId && (
+                      <TableOfContents sessionId={activeSessionId} />
+                    )}
+                  </Flex>
                 )}
               </Freeze>
             ))}
@@ -208,9 +213,6 @@ export default function TabsView() {
         <DropZone overlayRef={overlayRef} />
         {arePropertiesVisible && activeSessionId && (
           <Properties sessionId={activeSessionId} />
-        )}
-        {isTOCVisible && activeSessionId && (
-          <TableOfContents sessionId={activeSessionId} />
         )}
       </ScopedThemeProvider>
     </>
@@ -568,7 +570,6 @@ function EditorChrome(props: PropsWithChildren<EditorProps>) {
   const editorMargins = useEditorStore((store) => store.editorMargins);
   const editorContainerRef = useRef<HTMLElement>(null);
   const editorScrollRef = useRef<HTMLElement>(null);
-  const isTOCVisible = useEditorStore((store) => store.isTOCVisible);
 
   useEffect(() => {
     if (!editorScrollRef.current) return;
@@ -625,15 +626,9 @@ function EditorChrome(props: PropsWithChildren<EditorProps>) {
           variant="columnFill"
           className="editor"
           sx={{
-            alignSelf: [
-              "stretch",
-              focusMode ? "center" : "stretch",
-              !editorMargins ? (isTOCVisible ? "stretch" : "center") : "center"
-            ],
+            alignSelf: ["stretch", focusMode ? "center" : "stretch", "center"],
             maxWidth: editorMargins ? "min(100%, 850px)" : "auto",
-            width: isTOCVisible
-              ? `calc(100% - ${TABLE_OF_CONTENTS_WIDTH}px)`
-              : "100%"
+            width: "100%"
           }}
           pl={[2, 2, 6]}
           pr={[2, 2, 6]}

--- a/apps/web/src/components/editor/index.tsx
+++ b/apps/web/src/components/editor/index.tsx
@@ -152,12 +152,7 @@ export default function TabsView() {
                 ) : session.type === "conflicted" || session.type === "diff" ? (
                   <DiffViewer session={session} />
                 ) : (
-                  <Flex sx={{ overflow: "hidden" }}>
-                    <MemoizedEditorView session={session} />
-                    {isTOCVisible && activeSessionId && (
-                      <TableOfContents sessionId={activeSessionId} />
-                    )}
-                  </Flex>
+                  <MemoizedEditorView session={session} />
                 )}
               </Freeze>
             ))}
@@ -206,6 +201,15 @@ export default function TabsView() {
                     <DownloadAttachmentProgress hash={documentPreview.hash} />
                   )}
                 </ScopedThemeProvider>
+              </Panel>
+            </>
+          )}
+
+          {isTOCVisible && activeSessionId && (
+            <>
+              <PanelResizeHandle className="panel-resize-handle" />
+              <Panel id="toc-panel" order={3} defaultSize={25} minSize={15}>
+                <TableOfContents sessionId={activeSessionId} />
               </Panel>
             </>
           )}

--- a/apps/web/src/components/editor/table-of-contents.tsx
+++ b/apps/web/src/components/editor/table-of-contents.tsx
@@ -49,6 +49,8 @@ import { useEditorManager } from "./manager";
 import { TITLE_BAR_HEIGHT } from "../title-bar";
 import { strings } from "@notesnook/intl";
 
+export const TABLE_OF_CONTENTS_WIDTH = 300;
+
 type TableOfContentsProps = {
   sessionId: string;
 };
@@ -102,10 +104,10 @@ function TableOfContents(props: TableOfContentsProps) {
         display: "flex",
         position: "absolute",
         right: 0,
-        top: TITLE_BAR_HEIGHT,
+        top: 32,
         zIndex: 999,
         height: "100%",
-        width: "300px",
+        width: TABLE_OF_CONTENTS_WIDTH,
         borderLeft: "1px solid",
         borderLeftColor: "border"
       }}
@@ -150,7 +152,7 @@ function TableOfContents(props: TableOfContentsProps) {
                     key={t.id}
                     sx={{
                       textAlign: "left",
-                      paddingLeft: `${t.level * 5 + (t.level - 1) * 5}px`,
+                      paddingLeft: `${t.level * 10 + (t.level - 1) * 10}px`,
                       py: 1,
                       pr: 1,
                       borderLeft: "5px solid transparent",

--- a/apps/web/src/components/editor/table-of-contents.tsx
+++ b/apps/web/src/components/editor/table-of-contents.tsx
@@ -49,8 +49,6 @@ import { useEditorManager } from "./manager";
 import { TITLE_BAR_HEIGHT } from "../title-bar";
 import { strings } from "@notesnook/intl";
 
-export const TABLE_OF_CONTENTS_WIDTH = 300;
-
 type TableOfContentsProps = {
   sessionId: string;
 };
@@ -102,12 +100,10 @@ function TableOfContents(props: TableOfContentsProps) {
       initial={{ x: 600 }}
       sx={{
         display: "flex",
-        position: "absolute",
-        right: 0,
-        top: 32,
+        top: TITLE_BAR_HEIGHT,
         zIndex: 999,
         height: "100%",
-        width: TABLE_OF_CONTENTS_WIDTH,
+        width: "300px",
         borderLeft: "1px solid",
         borderLeftColor: "border"
       }}

--- a/apps/web/src/components/editor/table-of-contents.tsx
+++ b/apps/web/src/components/editor/table-of-contents.tsx
@@ -37,9 +37,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 import React, { useEffect, useState } from "react";
-import { ArrowLeft } from "../icons";
+import { Cross } from "../icons";
 import { useEditorStore } from "../../stores/editor-store";
-import { AnimatedFlex } from "../animated";
 import ScrollContainer from "../scroll-container";
 import { ScopedThemeProvider } from "../theme-provider";
 import { Section } from "../properties";
@@ -87,23 +86,12 @@ function TableOfContents(props: TableOfContentsProps) {
   }, [sessionId, tableOfContents]);
 
   return (
-    <AnimatedFlex
-      animate={{
-        x: 0
-      }}
-      transition={{
-        duration: 0.1,
-        bounceDamping: 1,
-        bounceStiffness: 1,
-        ease: "easeOut"
-      }}
-      initial={{ x: 600 }}
+    <Flex
       sx={{
         display: "flex",
         top: TITLE_BAR_HEIGHT,
         zIndex: 999,
         height: "100%",
-        width: "300px",
         borderLeft: "1px solid",
         borderLeftColor: "border"
       }}
@@ -122,8 +110,9 @@ function TableOfContents(props: TableOfContentsProps) {
         <ScrollContainer>
           <Section
             title={strings.toc()}
+            buttonPosition="right"
             button={
-              <ArrowLeft
+              <Cross
                 data-test-id="toc-close"
                 onClick={() => toggleTableOfContents(false)}
                 size={18}
@@ -169,7 +158,7 @@ function TableOfContents(props: TableOfContentsProps) {
           </Section>
         </ScrollContainer>
       </ScopedThemeProvider>
-    </AnimatedFlex>
+    </Flex>
   );
 }
 export default React.memo(TableOfContents);

--- a/apps/web/src/components/properties/index.tsx
+++ b/apps/web/src/components/properties/index.tsx
@@ -715,11 +715,17 @@ function SessionHistory({ noteId }: { noteId: string }) {
   );
 }
 
-type SectionProps = { title: string; subtitle?: string; button?: JSX.Element };
+type SectionProps = {
+  title: string;
+  subtitle?: string;
+  button?: JSX.Element;
+  buttonPosition?: "left" | "right";
+};
 export function Section({
   title,
   subtitle,
   button,
+  buttonPosition = "left",
   children
 }: PropsWithChildren<SectionProps>) {
   return (
@@ -729,9 +735,18 @@ export function Section({
         flexDirection: "column"
       }}
     >
-      <Flex mx={1} mt={2} sx={{ alignItems: "center" }}>
-        {button}
+      <Flex
+        mx={1}
+        mt={2}
+        sx={{
+          alignItems: "center",
+          justifyContent:
+            buttonPosition === "right" ? "space-between" : "flex-start"
+        }}
+      >
+        {buttonPosition === "left" && button}
         <Text variant="subtitle">{title}</Text>
+        {buttonPosition === "right" && button}
       </Flex>
       {subtitle && (
         <Text variant="subBody" mb={1} mx={1}>

--- a/apps/web/src/stores/editor-store.ts
+++ b/apps/web/src/stores/editor-store.ts
@@ -166,7 +166,7 @@ class EditorStore extends BaseStore<EditorStore> {
 
   arePropertiesVisible = false;
   documentPreview?: DocumentPreview;
-  isTOCVisible = false;
+  isTOCVisible = Config.get("editor:toc", false);
   editorMargins = Config.get("editor:margins", true);
   history: string[] = [];
 
@@ -935,11 +935,11 @@ class EditorStore extends BaseStore<EditorStore> {
   };
 
   toggleTableOfContents = (toggleState?: boolean) => {
-    this.set(
-      (state) =>
-        (state.isTOCVisible =
-          toggleState !== undefined ? toggleState : !state.isTOCVisible)
-    );
+    this.set((state) => {
+      state.isTOCVisible =
+        toggleState !== undefined ? toggleState : !state.isTOCVisible;
+      Config.set("editor:toc", !state.isTOCVisible);
+    });
   };
 
   toggleEditorMargins = (toggleState?: boolean) => {


### PR DESCRIPTION
* move toc button out of action bar into fixed position
* adjust editor width based on toc state
* save toc state in local storage
* increase indentation in toc

Signed-off-by: Zulfiqar Ali <85733202+01zulfi@users.noreply.github.com>

Closes #4977 
Closes #6711