### PR TITLE
Fix selection scrolls to incorrect position on focus and press enter on mobile

### DIFF
--- a/packages/editor-mobile/src/components/statusbar.tsx
+++ b/packages/editor-mobile/src/components/statusbar.tsx
@@ -62,9 +62,12 @@ function StatusBar({
     };
   }, [tab.id, statusBar]);
 
+  const scrollState = useRef({
+    isMovingUp: false,
+    startingOffset: 0
+  });
   const onScroll = React.useCallback((event: Event) => {
     const currentOffset = (event.target as HTMLElement)?.scrollTop;
-    post("editor-event:scroll", currentOffset);
     if (currentOffset < 200) {
       if (stickyRef.current) {
         stickyRef.current = false;
@@ -76,11 +79,39 @@ function StatusBar({
     }
     if (Date.now() - lastStickyChangeTime.current < 300) return;
     if (currentOffset > prevScroll.current) {
-      setSticky(false);
-      stickyRef.current = false;
+      scrollState.current.isMovingUp = false;
+      if (
+        !scrollState.current.startingOffset ||
+        scrollState.current.isMovingUp
+      ) {
+        scrollState.current.startingOffset = currentOffset;
+      }
     } else {
-      setSticky(true);
-      stickyRef.current = true;
+      if (
+        !scrollState.current.startingOffset ||
+        !scrollState.current.isMovingUp
+      ) {
+        scrollState.current.startingOffset = currentOffset;
+      }
+      scrollState.current.isMovingUp = true;
+    }
+
+    if (scrollState.current.isMovingUp) {
+      if (currentOffset < scrollState.current.startingOffset - 50) {
+        stickyRef.current = true;
+        setSticky(true);
+        lastStickyChangeTime.current = Date.now();
+        prevScroll.current = currentOffset;
+        scrollState.current.startingOffset = 0;
+      }
+    } else {
+      if (currentOffset > scrollState.current.startingOffset + 50) {
+        stickyRef.current = false;
+        setSticky(false);
+        lastStickyChangeTime.current = Date.now();
+        prevScroll.current = currentOffset;
+        scrollState.current.startingOffset = 0;
+      }
     }
     lastStickyChangeTime.current = Date.now();
     prevScroll.current = currentOffset;

--- a/packages/editor-mobile/src/components/statusbar.tsx
+++ b/packages/editor-mobile/src/components/statusbar.tsx
@@ -98,18 +98,18 @@ function StatusBar({
 
     if (scrollState.current.isMovingUp) {
       if (currentOffset < scrollState.current.startingOffset - 50) {
-        stickyRef.current = true;
-        setSticky(true);
-        lastStickyChangeTime.current = Date.now();
-        prevScroll.current = currentOffset;
+        if (!stickyRef.current) {
+          stickyRef.current = true;
+          setSticky(true);
+        }
         scrollState.current.startingOffset = 0;
       }
     } else {
       if (currentOffset > scrollState.current.startingOffset + 50) {
-        stickyRef.current = false;
-        setSticky(false);
-        lastStickyChangeTime.current = Date.now();
-        prevScroll.current = currentOffset;
+        if (stickyRef.current) {
+          stickyRef.current = false;
+          setSticky(false);
+        }
         scrollState.current.startingOffset = 0;
       }
     }

--- a/packages/editor-mobile/src/components/statusbar.tsx
+++ b/packages/editor-mobile/src/components/statusbar.tsx
@@ -79,13 +79,13 @@ function StatusBar({
     }
     if (Date.now() - lastStickyChangeTime.current < 300) return;
     if (currentOffset > prevScroll.current) {
-      scrollState.current.isMovingUp = false;
       if (
         !scrollState.current.startingOffset ||
         scrollState.current.isMovingUp
       ) {
         scrollState.current.startingOffset = currentOffset;
       }
+      scrollState.current.isMovingUp = false;
     } else {
       if (
         !scrollState.current.startingOffset ||

--- a/packages/editor/src/extensions/keep-in-view/keep-in-view.ts
+++ b/packages/editor/src/extensions/keep-in-view/keep-in-view.ts
@@ -82,9 +82,7 @@ export function keepLastLineInView(
   )
     return;
 
-  const isPopupVisible = document.getElementsByClassName(
-    "editor-mobile-toolbar-popup"
-  );
+  const isPopupVisible = document.querySelector(".editor-mobile-toolbar-popup");
 
   const node = editor.state.selection.$from;
   if (node.pos > editor.state.doc.nodeSize) return;


### PR DESCRIPTION
- This also fixes an issue where scrolling up and down even a single px will make the statusbar keep toggling. now added a safe threshold
Closes [#5700](https://github.com/streetwriters/notesnook/issues/5700)