### PR TITLE
web: fix copy link button copying link text instead of link (#6642)

### DIFF
--- a/packages/editor/src/toolbar/tools/link.tsx
+++ b/packages/editor/src/toolbar/tools/link.tsx
@@ -250,12 +250,7 @@ export function CopyLink(props: ToolProps) {
       {...props}
       toggled={false}
       onClick={() => {
-        editor.storage.copyToClipboard?.(
-          href,
-          `<a href="${href}">${
-            selectedNode.current?.node?.textContent || link?.attrs.title
-          }</a>`
-        );
+        editor.storage.copyToClipboard?.(href);
         hide();
       }}
     />


### PR DESCRIPTION
Signed-off-by: Zulfiqar Ali <85733202+01zulfi@users.noreply.github.com>

Closes #6642 