### PR TITLE
editor: fix markdown link pasting (#6639)

### DIFF
--- a/packages/editor/src/extensions/link/link.ts
+++ b/packages/editor/src/extensions/link/link.ts
@@ -95,7 +95,7 @@ declare module "@tiptap/core" {
   }
 }
 
-const linkRegex = /(?:__|[*#])|\[(.*?)\]\(.*?\)/gm;
+export const linkRegex = /(?:__|[*#])|\[([^\]]+)\]\(.*?\)/gm;
 const regExp = /(?:__|[*#])|\[.*?\]\((.*?)\)/gm;
 export const Link = Mark.create<LinkOptions>({
   name: "link",
@@ -221,6 +221,8 @@ export const Link = Mark.create<LinkOptions>({
         find: linkRegex,
         type: this.type,
         getAttributes(match) {
+          // reset in case of multiple matches
+          regExp.lastIndex = 0;
           return {
             href: regExp.exec(match[0])?.[1]
           };

--- a/packages/editor/src/extensions/link/tests/__snapshots__/link.test.ts.snap
+++ b/packages/editor/src/extensions/link/tests/__snapshots__/link.test.ts.snap
@@ -1,0 +1,5 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`paste text > with markdown link 1`] = `"<div><div contenteditable="true" translate="no" class="tiptap ProseMirror" tabindex="0"><p><a target="_blank" rel="noopener noreferrer nofollow" href="example.com">test</a></p></div></div>"`;
+
+exports[`paste text > with multiple markdown links 1`] = `"<div><div contenteditable="true" translate="no" class="tiptap ProseMirror" tabindex="0"><p><a target="_blank" rel="noopener noreferrer nofollow" href="example.com">test</a> some text <a target="_blank" rel="noopener noreferrer nofollow" href="example2.com">test2</a></p></div></div>"`;

--- a/packages/editor/src/extensions/link/tests/link.test.ts
+++ b/packages/editor/src/extensions/link/tests/link.test.ts
@@ -52,7 +52,7 @@ const input = [
 ];
 
 input.forEach(({ text, expected }, i) => {
-  test(`link regex ${i + 1}`, () => {
+  test(`link regex ${text}`, () => {
     const result = text.match(linkRegex);
     expect(result).toEqual(expected);
   });

--- a/packages/editor/src/extensions/link/tests/link.test.ts
+++ b/packages/editor/src/extensions/link/tests/link.test.ts
@@ -1,0 +1,117 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { describe, expect, test } from "vitest";
+import { createEditor, h } from "../../../../test-utils";
+import { Link, linkRegex } from "../link";
+
+const input = [
+  {
+    text: "[Example](https://www.google.com)",
+    expected: ["[Example](https://www.google.com)"]
+  },
+  {
+    text: "[Example](https://www.example1.com) and [Example2](https://www.example2.com)",
+    expected: [
+      "[Example](https://www.example1.com)",
+      "[Example2](https://www.example2.com)"
+    ]
+  },
+  {
+    text: "[]()",
+    expected: null
+  },
+  {
+    text: "[] [Link](http://example.com)",
+    expected: ["[Link](http://example.com)"]
+  },
+  {
+    text: "[not a link] [Link](http://example.com)",
+    expected: ["[Link](http://example.com)"]
+  },
+  {
+    text: "[NoLink]",
+    expected: null
+  }
+];
+
+input.forEach(({ text, expected }, i) => {
+  test(`link regex ${i + 1}`, () => {
+    const result = text.match(linkRegex);
+    expect(result).toEqual(expected);
+  });
+});
+
+describe("paste text", () => {
+  test("with markdown link", async () => {
+    const editorElement = h("div");
+    const { editor } = createEditor({
+      element: editorElement,
+      extensions: {
+        link: Link
+      }
+    });
+
+    const clipboardEvent = new Event("paste", {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    });
+
+    (clipboardEvent as unknown as any)["clipboardData"] = {
+      getData: (type: string) =>
+        type === "text/plain" ? "[test](example.com)" : undefined
+    };
+
+    editor.view.dom.dispatchEvent(clipboardEvent);
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(editorElement.outerHTML).toMatchSnapshot();
+  });
+
+  test("with multiple markdown links", async () => {
+    const editorElement = h("div");
+    const { editor } = createEditor({
+      element: editorElement,
+      extensions: {
+        link: Link
+      }
+    });
+
+    const clipboardEvent = new Event("paste", {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    });
+
+    (clipboardEvent as unknown as any)["clipboardData"] = {
+      getData: (type: string) =>
+        type === "text/plain"
+          ? "[test](example.com) some text [test2](example2.com)"
+          : undefined
+    };
+
+    editor.view.dom.dispatchEvent(clipboardEvent);
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(editorElement.outerHTML).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
* don't include empty square brackets in link
* handle multiple markdown links during pasting

Closes #6639 