### PR TITLE
editor: prevent creation of multiple empty notes

### DIFF
--- a/apps/web/src/common/index.ts
+++ b/apps/web/src/common/index.ts
@@ -50,7 +50,15 @@ import { ZipFile } from "../utils/streams/zip-stream";
 export const CREATE_BUTTON_MAP = {
   notes: {
     title: strings.addItem("note"),
-    onClick: () => useEditorStore.getState().newSession()
+    onClick: () => {
+      const { sessions, newSession } = useEditorStore.getState();
+      if (sessions.some((session) => "note" in session === false)) {
+        const invalidSession = sessions.find((session) => !("note" in session));
+        useEditorStore.getState().activateSession(invalidSession?.id);
+      } else {
+        newSession();
+      }
+    }
   },
   notebooks: {
     title: strings.addItem("notebook"),

--- a/apps/web/src/common/index.ts
+++ b/apps/web/src/common/index.ts
@@ -50,15 +50,7 @@ import { ZipFile } from "../utils/streams/zip-stream";
 export const CREATE_BUTTON_MAP = {
   notes: {
     title: strings.addItem("note"),
-    onClick: () => {
-      const { sessions, newSession } = useEditorStore.getState();
-      if (sessions.some((session) => "note" in session === false)) {
-        const invalidSession = sessions.find((session) => !("note" in session));
-        useEditorStore.getState().activateSession(invalidSession?.id);
-      } else {
-        newSession();
-      }
-    }
+    onClick: () => useEditorStore.getState().newSession()
   },
   notebooks: {
     title: strings.addItem("notebook"),

--- a/apps/web/src/stores/editor-store.ts
+++ b/apps/web/src/stores/editor-store.ts
@@ -871,12 +871,20 @@ class EditorStore extends BaseStore<EditorStore> {
   };
 
   newSession = () => {
-    this.addSession({
-      type: "new",
-      id: getId(),
-      context: useNoteStore.getState().context,
-      saveState: SaveState.NotSaved
-    });
+    const state = useEditorStore.getState();
+    if (state.sessions.some((session) => session.type === "new")) {
+      const invalidSession = state.sessions.find(
+        (session) => session.type === "new"
+      );
+      this.activateSession(invalidSession?.id);
+    } else {
+      this.addSession({
+        type: "new",
+        id: getId(),
+        context: useNoteStore.getState().context,
+        saveState: SaveState.NotSaved
+      });
+    }
   };
 
   closeSessions = (...ids: string[]) => {

--- a/apps/web/src/stores/editor-store.ts
+++ b/apps/web/src/stores/editor-store.ts
@@ -874,8 +874,8 @@ class EditorStore extends BaseStore<EditorStore> {
     const state = useEditorStore.getState();
     const session = state.sessions.find((session) => session.type === "new");
     if (session) {
-      this.activateSession(session?.id);
       session.context = useNoteStore.getState().context;
+      this.activateSession(session.id);
     } else {
       this.addSession({
         type: "new",

--- a/apps/web/src/stores/editor-store.ts
+++ b/apps/web/src/stores/editor-store.ts
@@ -872,11 +872,9 @@ class EditorStore extends BaseStore<EditorStore> {
 
   newSession = () => {
     const state = useEditorStore.getState();
-    if (state.sessions.some((session) => session.type === "new")) {
-      const invalidSession = state.sessions.find(
-        (session) => session.type === "new"
-      );
-      this.activateSession(invalidSession?.id);
+    const session = state.sessions.find((session) => session.type === "new");
+    if (session) {
+      this.activateSession(session?.id);
     } else {
       this.addSession({
         type: "new",

--- a/apps/web/src/stores/editor-store.ts
+++ b/apps/web/src/stores/editor-store.ts
@@ -875,6 +875,7 @@ class EditorStore extends BaseStore<EditorStore> {
     const session = state.sessions.find((session) => session.type === "new");
     if (session) {
       this.activateSession(session?.id);
+      session.context = useNoteStore.getState().context;
     } else {
       this.addSession({
         type: "new",


### PR DESCRIPTION
This fixes the issue mentioned in #5202 by checking if an empty note already exists and if so, just setting the focus on the existing empty note instead of creating a new one when clicking the add note button.