### PR TITLE
monograph: fix monograph version endpoints cors

### DIFF
--- a/apps/monograph/app/routes/api.version.ts
+++ b/apps/monograph/app/routes/api.version.ts
@@ -17,12 +17,15 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+import { json, LoaderFunctionArgs } from "@remix-run/node";
+import { cors } from "remix-utils/cors";
 import { COMPATIBILITY_VERSION, INSTANCE_NAME } from "../utils/env";
 
-export async function loader() {
-  return Response.json({
+export async function loader({ request }: LoaderFunctionArgs) {
+  const response = json({
     version: COMPATIBILITY_VERSION,
     id: "monograph",
     instance: INSTANCE_NAME
   });
+  return cors(request, response);
 }


### PR DESCRIPTION
Fix `/api/version` endpoints cors and fix `Response.json()` is not function.