### PR TITLE
web: Fix inconsistent zoom amount when adjusting with scroll wheel.

### DIFF
--- a/apps/web/src/components/editor/tiptap.tsx
+++ b/apps/web/src/components/editor/tiptap.tsx
@@ -453,7 +453,9 @@ function TiptapWrapper(
         const delta =
           (e.deltaY > 0 && e.deltaY < 10) || (e.deltaY > -10 && e.deltaY < 0)
             ? -e.deltaY
-            : Math.ceil(-e.deltaY / 10 / EDITOR_ZOOM.STEP) * EDITOR_ZOOM.STEP;
+            : e.deltaY > 0
+            ? -EDITOR_ZOOM.STEP
+            : EDITOR_ZOOM.STEP;
         const zoom = Math.min(
           EDITOR_ZOOM.MAX,
           Math.max(EDITOR_ZOOM.MIN, editorConfig.zoom + delta)


### PR DESCRIPTION
Zoom steps are always in increments of 10 when using a mouse wheel or trackpad.

Running `npm run prettier` as directed in the contributing guidelines modified many files, and I included them in this PR. Should I not run this command? 