### PR TITLE
editor: hide edit button when in read only mode

### DIFF
--- a/packages/editor/src/toolbar/tools/link.tsx
+++ b/packages/editor/src/toolbar/tools/link.tsx
@@ -107,6 +107,7 @@ export function EditLink(props: ToolProps) {
   const link = node ? findMark(node, LinkNode.name) : null;
   const attrs = link?.attrs || getMarkAttributes(editor.state, LinkNode.name);
 
+  if (!editor.isEditable) return null;
   if (attrs && isInternalLink(attrs.href))
     return (
       <ToolButton


### PR DESCRIPTION
I noticed that when a note is in read only mode, the `edit link` button is still showing up and the link can be edited.
I added the same line to the `EditLink` function as in `RemoveLink`