### PR TITLE
theme: make link color align with theme

### DIFF
--- a/apps/web/src/dialogs/settings/components/importer.tsx
+++ b/apps/web/src/dialogs/settings/components/importer.tsx
@@ -169,7 +169,7 @@ export function Importer() {
                 <Link
                   href="https://importer.notesnook.com/"
                   target="_blank"
-                  sx={{ color: "paragraph-secondary" }}
+                  sx={{ color: "accent" }}
                 >
                   https://importer.notesnook.com/
                 </Link>

--- a/apps/web/src/dialogs/settings/components/importer.tsx
+++ b/apps/web/src/dialogs/settings/components/importer.tsx
@@ -166,7 +166,11 @@ export function Importer() {
             <Box as="ol" sx={{ my: 1 }}>
               <Text as="li" variant="body">
                 Go to{" "}
-                <Link href="https://importer.notesnook.com/" target="_blank">
+                <Link
+                  href="https://importer.notesnook.com/"
+                  target="_blank"
+                  sx={{ color: "paragraph-secondary" }}
+                >
                   https://importer.notesnook.com/
                 </Link>
               </Text>


### PR DESCRIPTION
I noticed that for some dark themes the link was hard to read, so I made the color align with the current theme.