### PR TITLE
editor: added link popup description

### DIFF
--- a/packages/editor/src/toolbar/popups/link-popup.tsx
+++ b/packages/editor/src/toolbar/popups/link-popup.tsx
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { Input } from "@theme-ui/components";
+import { Input, Text } from "@theme-ui/components";
 import { Flex } from "@theme-ui/components";
 import { useRefValue } from "../../hooks/use-ref-value.js";
 import { Popup } from "../components/popup.js";
@@ -64,19 +64,41 @@ export function LinkPopup(props: LinkPopupProps) {
         }}
       >
         {!isImageActive && (
-          <Input
-            type="text"
-            placeholder={strings.linkText()}
-            defaultValue={link.current?.title}
-            sx={{ mb: 1 }}
-            onChange={(e) =>
-              (link.current = {
-                ...link.current,
-                title: e.target.value
-              })
-            }
-          />
+          <>
+            <Text
+              sx={{
+                mb: 1,
+                ml: 1,
+                fontSize: "body",
+                color: "paragraph"
+              }}
+            >
+              {strings.linkText()}
+            </Text>
+            <Input
+              type="text"
+              placeholder={strings.linkText()}
+              defaultValue={link.current?.title}
+              sx={{ mb: 2 }}
+              onChange={(e) =>
+                (link.current = {
+                  ...link.current,
+                  title: e.target.value
+                })
+              }
+            />
+          </>
         )}
+        <Text
+          sx={{
+            mb: 1,
+            ml: 1,
+            fontSize: "body",
+            color: "paragraph"
+          }}
+        >
+          {strings.url()}
+        </Text>
         <Input
           type="url"
           autoFocus

--- a/packages/intl/locale/en.po
+++ b/packages/intl/locale/en.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/strings.ts:2389
+#: src/strings.ts:2390
 msgid " \"Notebook > Notes\""
 msgstr " \"Notebook > Notes\""
 
@@ -279,7 +279,7 @@ msgstr "{count, plural, one {Item restored} other {# items restored}}"
 msgid "{count, plural, one {Item unpublished} other {# items unpublished}}"
 msgstr "{count, plural, one {Item unpublished} other {# items unpublished}}"
 
-#: src/strings.ts:2406
+#: src/strings.ts:2407
 msgid "{count, plural, one {Move all notes in this notebook to trash} other {Move all notes in these notebooks to trash}}"
 msgstr "{count, plural, one {Move all notes in this notebook to trash} other {Move all notes in these notebooks to trash}}"
 
@@ -724,7 +724,7 @@ msgstr "All"
 msgid "All attachments are end-to-end encrypted."
 msgstr "All attachments are end-to-end encrypted."
 
-#: src/strings.ts:2383
+#: src/strings.ts:2384
 msgid "All cached attachments have been cleared."
 msgstr "All cached attachments have been cleared."
 
@@ -911,7 +911,7 @@ msgstr "Attachment"
 msgid "Attachment preview failed"
 msgstr "Attachment preview failed"
 
-#: src/strings.ts:2376
+#: src/strings.ts:2377
 msgid "Attachment recheck cancelled"
 msgstr "Attachment recheck cancelled"
 
@@ -932,7 +932,7 @@ msgstr "Attachments"
 msgid "Attachments cache cleared!"
 msgstr "Attachments cache cleared!"
 
-#: src/strings.ts:2378
+#: src/strings.ts:2379
 msgid "Attachments recheck complete"
 msgstr "Attachments recheck complete"
 
@@ -1149,7 +1149,7 @@ msgstr "Biometrics not enrolled"
 msgid "Bold"
 msgstr "Bold"
 
-#: src/strings.ts:2388
+#: src/strings.ts:2389
 msgid "Boost your productivity with Notebooks and organize your notes."
 msgstr "Boost your productivity with Notebooks and organize your notes."
 
@@ -1310,7 +1310,7 @@ msgstr "Check roadmap"
 msgid "Check your spam folder if you haven't received an email yet."
 msgstr "Check your spam folder if you haven't received an email yet."
 
-#: src/strings.ts:2380
+#: src/strings.ts:2381
 msgid "Checking all attachments"
 msgstr "Checking all attachments"
 
@@ -1322,7 +1322,7 @@ msgstr "Checking for new version"
 msgid "Checking for updates"
 msgstr "Checking for updates"
 
-#: src/strings.ts:2379
+#: src/strings.ts:2380
 msgid "Checking note attachments"
 msgstr "Checking note attachments"
 
@@ -1468,7 +1468,7 @@ msgstr "Click to preview"
 msgid "Click to remove"
 msgstr "Click to remove"
 
-#: src/strings.ts:2371
+#: src/strings.ts:2372
 msgid "Click to reset {title}"
 msgstr "Click to reset {title}"
 
@@ -1569,7 +1569,7 @@ msgstr "Compressed images are uploaded in Full HD resolution and usually are goo
 msgid "Configure"
 msgstr "Configure"
 
-#: src/strings.ts:2385
+#: src/strings.ts:2386
 msgid "Configure server URLs for Notesnook"
 msgstr "Configure server URLs for Notesnook"
 
@@ -1892,7 +1892,7 @@ msgstr "Debug logs downloaded"
 msgid "Debugging"
 msgstr "Debugging"
 
-#: src/strings.ts:2373
+#: src/strings.ts:2374
 msgid "Decrease {title}"
 msgstr "Decrease {title}"
 
@@ -2190,7 +2190,7 @@ msgstr "Duplicate"
 msgid "Earliest first"
 msgstr "Earliest first"
 
-#: src/strings.ts:2397
+#: src/strings.ts:2398
 msgid "Easy access"
 msgstr "Easy access"
 
@@ -2224,7 +2224,7 @@ msgstr "Editor"
 msgid "Email"
 msgstr "Email"
 
-#: src/strings.ts:2410
+#: src/strings.ts:2411
 msgid "Email copied"
 msgstr "Email copied"
 
@@ -2392,7 +2392,7 @@ msgstr "Enter the 6 digit code sent to your email to continue logging in"
 msgid "Enter the 6 digit code sent to your phone number to continue logging in"
 msgstr "Enter the 6 digit code sent to your phone number to continue logging in"
 
-#: src/strings.ts:2412
+#: src/strings.ts:2413
 msgid "Enter the gift code to redeem your subscription."
 msgstr "Enter the gift code to redeem your subscription."
 
@@ -2412,7 +2412,7 @@ msgstr "Enter your new email"
 msgid "Enter your username"
 msgstr "Enter your username"
 
-#: src/strings.ts:2404
+#: src/strings.ts:2405
 msgid "Error"
 msgstr "Error"
 
@@ -2452,15 +2452,15 @@ msgstr "Errors in {count} attachments"
 msgid "Events server"
 msgstr "Events server"
 
-#: src/strings.ts:2390
+#: src/strings.ts:2391
 msgid "Every Notebook can have notes and sub notebooks."
 msgstr "Every Notebook can have notes and sub notebooks."
 
-#: src/strings.ts:2392
+#: src/strings.ts:2393
 msgid "Everything related to my job in one place."
 msgstr "Everything related to my job in one place."
 
-#: src/strings.ts:2401
+#: src/strings.ts:2402
 msgid "Everything related to my school in one place."
 msgstr "Everything related to my school in one place."
 
@@ -2517,7 +2517,7 @@ msgstr "EXTREMELY DANGEROUS! This action is irreversible. All your data includin
 msgid "Faced an issue or have a suggestion? Click here to create a bug report"
 msgstr "Faced an issue or have a suggestion? Click here to create a bug report"
 
-#: src/strings.ts:2382
+#: src/strings.ts:2383
 msgid "Failed"
 msgstr "Failed"
 
@@ -2602,11 +2602,11 @@ msgstr "Favorite"
 msgid "Favorites"
 msgstr "Favorites"
 
-#: src/strings.ts:2394
+#: src/strings.ts:2395
 msgid "February 2022 Week 2"
 msgstr "February 2022 Week 2"
 
-#: src/strings.ts:2395
+#: src/strings.ts:2396
 msgid "February 2022 Week 3"
 msgstr "February 2022 Week 3"
 
@@ -2784,7 +2784,7 @@ msgstr "Get Notesnook Pro"
 msgid "Get Notesnook Pro to enable automatic backups"
 msgstr "Get Notesnook Pro to enable automatic backups"
 
-#: src/strings.ts:2386
+#: src/strings.ts:2387
 msgid "Get Priority support"
 msgstr "Get Priority support"
 
@@ -2956,7 +2956,7 @@ msgstr "I have a recovery code"
 msgid "I have saved my key"
 msgstr "I have saved my key"
 
-#: src/strings.ts:2403
+#: src/strings.ts:2404
 msgid "I love cooking and collecting recipes."
 msgstr "I love cooking and collecting recipes."
 
@@ -3064,7 +3064,7 @@ msgstr "Incoming note"
 msgid "Incorrect {type}"
 msgstr "Incorrect {type}"
 
-#: src/strings.ts:2372
+#: src/strings.ts:2373
 msgid "Increase {title}"
 msgstr "Increase {title}"
 
@@ -3072,7 +3072,7 @@ msgstr "Increase {title}"
 msgid "Insert"
 msgstr "Insert"
 
-#: src/strings.ts:2369
+#: src/strings.ts:2370
 msgid "Insert a {rows}x{columns} table"
 msgstr "Insert a {rows}x{columns} table"
 
@@ -3527,7 +3527,7 @@ msgstr "Maximize"
 msgid "Meet other privacy-minded people & talk to us directly about your concerns, issues and suggestions."
 msgstr "Meet other privacy-minded people & talk to us directly about your concerns, issues and suggestions."
 
-#: src/strings.ts:2396
+#: src/strings.ts:2397
 msgid "Meetings"
 msgstr "Meetings"
 
@@ -4114,7 +4114,7 @@ msgstr "Partial backups contain all your data except attachments. They are creat
 msgid "Partially refunded"
 msgstr "Partially refunded"
 
-#: src/strings.ts:2381
+#: src/strings.ts:2382
 msgid "Passed"
 msgstr "Passed"
 
@@ -4308,7 +4308,7 @@ msgstr "Please select the day to repeat the reminder on"
 msgid "please send us an email from your registered email address"
 msgstr "please send us an email from your registered email address"
 
-#: src/strings.ts:2370
+#: src/strings.ts:2371
 msgid "Please set a table size"
 msgstr "Please set a table size"
 
@@ -4602,7 +4602,7 @@ msgstr "Receipt"
 msgid "RECENT BACKUPS"
 msgstr "RECENT BACKUPS"
 
-#: src/strings.ts:2377
+#: src/strings.ts:2378
 msgid "Recheck all"
 msgstr "Recheck all"
 
@@ -4610,7 +4610,7 @@ msgstr "Recheck all"
 msgid "Rechecking failed"
 msgstr "Rechecking failed"
 
-#: src/strings.ts:2402
+#: src/strings.ts:2403
 msgid "Recipes"
 msgstr "Recipes"
 
@@ -4654,15 +4654,15 @@ msgstr "Recovery key text file saved"
 msgid "Recovery successful!"
 msgstr "Recovery successful!"
 
-#: src/strings.ts:2414
+#: src/strings.ts:2415
 msgid "Redeem"
 msgstr "Redeem"
 
-#: src/strings.ts:2411
+#: src/strings.ts:2412
 msgid "Redeem gift code"
 msgstr "Redeem gift code"
 
-#: src/strings.ts:2413
+#: src/strings.ts:2414
 msgid "Redeeming gift code"
 msgstr "Redeeming gift code"
 
@@ -4913,7 +4913,7 @@ msgstr "Restore"
 msgid "Restore backup"
 msgstr "Restore backup"
 
-#: src/strings.ts:2384
+#: src/strings.ts:2385
 msgid "Restore backup?"
 msgstr "Restore backup?"
 
@@ -5073,11 +5073,11 @@ msgstr "Save your data recovery key in a safe place. You will need it to recover
 msgid "Save your recovery codes in a safe place. You will need them to recover your account in case you lose access to your two-factor authentication methods."
 msgstr "Save your recovery codes in a safe place. You will need them to recover your account in case you lose access to your two-factor authentication methods."
 
-#: src/strings.ts:2374
+#: src/strings.ts:2375
 msgid "Saved"
 msgstr "Saved"
 
-#: src/strings.ts:2375
+#: src/strings.ts:2376
 msgid "Saving"
 msgstr "Saving"
 
@@ -5097,7 +5097,7 @@ msgstr "Saving zip file. Please wait..."
 msgid "Scan the QR code with your authenticator app"
 msgstr "Scan the QR code with your authenticator app"
 
-#: src/strings.ts:2400
+#: src/strings.ts:2401
 msgid "School work"
 msgstr "School work"
 
@@ -5857,7 +5857,7 @@ msgstr "Tap twice to confirm you have saved the recovery key."
 msgid "Task list"
 msgstr "Task list"
 
-#: src/strings.ts:2393
+#: src/strings.ts:2394
 msgid "Tasks"
 msgstr "Tasks"
 
@@ -6322,6 +6322,10 @@ msgstr "Uploads"
 msgid "Urgent"
 msgstr "Urgent"
 
+#: src/strings.ts:2367
+msgid "URL"
+msgstr "URL"
+
 #: src/strings.ts:1770
 msgid "Use"
 msgstr "Use"
@@ -6595,7 +6599,7 @@ msgstr "What went wrong?"
 msgid "Width"
 msgstr "Width"
 
-#: src/strings.ts:2391
+#: src/strings.ts:2392
 msgid "Work & Office"
 msgstr "Work & Office"
 
@@ -6660,7 +6664,7 @@ msgstr "You can add as many tags as you want."
 msgid "You can change the theme at any time from Settings or the side menu."
 msgstr "You can change the theme at any time from Settings or the side menu."
 
-#: src/strings.ts:2399
+#: src/strings.ts:2400
 msgid "You can create shortcuts of frequently accessed notebooks in the side menu"
 msgstr "You can create shortcuts of frequently accessed notebooks in the side menu"
 

--- a/packages/intl/locale/pseudo-LOCALE.po
+++ b/packages/intl/locale/pseudo-LOCALE.po
@@ -273,7 +273,7 @@ msgstr ""
 #: generated/actions.ts:137
 #: generated/actions.ts:150
 msgid "{count, plural, one {Item restored} other {# items restored}}"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: generated/actions.ts:121
 msgid "{count, plural, one {Item unpublished} other {# items unpublished}}"
@@ -722,7 +722,7 @@ msgstr ""
 
 #: src/strings.ts:91
 msgid "All attachments are end-to-end encrypted."
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2384
 msgid "All cached attachments have been cleared."
@@ -909,7 +909,7 @@ msgstr ""
 
 #: src/strings.ts:1916
 msgid "Attachment preview failed"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2377
 msgid "Attachment recheck cancelled"
@@ -930,7 +930,7 @@ msgstr ""
 
 #: src/strings.ts:1865
 msgid "Attachments cache cleared!"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2379
 msgid "Attachments recheck complete"
@@ -1147,7 +1147,7 @@ msgstr ""
 
 #: src/strings.ts:2235
 msgid "Bold"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2389
 msgid "Boost your productivity with Notebooks and organize your notes."
@@ -1308,7 +1308,7 @@ msgstr ""
 
 #: src/strings.ts:673
 msgid "Check your spam folder if you haven't received an email yet."
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2381
 msgid "Checking all attachments"
@@ -1320,7 +1320,7 @@ msgstr ""
 
 #: src/strings.ts:1686
 msgid "Checking for updates"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2380
 msgid "Checking note attachments"
@@ -1455,7 +1455,7 @@ msgstr ""
 
 #: src/strings.ts:1753
 msgid "Click to remove"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2372
 msgid "Click to reset {title}"
@@ -1556,7 +1556,7 @@ msgstr ""
 
 #: src/strings.ts:2230
 msgid "Configure"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2386
 msgid "Configure server URLs for Notesnook"
@@ -1879,7 +1879,7 @@ msgstr ""
 
 #: src/strings.ts:1252
 msgid "Debugging"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2374
 msgid "Decrease {title}"
@@ -2177,7 +2177,7 @@ msgstr ""
 
 #: src/strings.ts:636
 msgid "Earliest first"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2398
 msgid "Easy access"
@@ -2211,7 +2211,7 @@ msgstr ""
 
 #: src/strings.ts:1464
 msgid "Email"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2411
 msgid "Email copied"
@@ -2399,7 +2399,7 @@ msgstr ""
 
 #: src/strings.ts:2070
 msgid "Enter your username"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2405
 msgid "Error"
@@ -2439,7 +2439,7 @@ msgstr ""
 
 #: src/strings.ts:1609
 msgid "Events server"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2391
 msgid "Every Notebook can have notes and sub notebooks."
@@ -2504,7 +2504,7 @@ msgstr ""
 
 #: src/strings.ts:1245
 msgid "Faced an issue or have a suggestion? Click here to create a bug report"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2383
 msgid "Failed"
@@ -2589,7 +2589,7 @@ msgstr ""
 #: src/strings.ts:321
 #: src/strings.ts:1503
 msgid "Favorites"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2395
 msgid "February 2022 Week 2"
@@ -2764,7 +2764,7 @@ msgstr ""
 
 #: src/strings.ts:1350
 msgid "Get Notesnook Pro to enable automatic backups"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2387
 msgid "Get Priority support"
@@ -2936,7 +2936,7 @@ msgstr ""
 
 #: src/strings.ts:1867
 msgid "I have saved my key"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2404
 msgid "I love cooking and collecting recipes."
@@ -3042,7 +3042,7 @@ msgstr ""
 
 #: src/strings.ts:773
 msgid "Incorrect {type}"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2373
 msgid "Increase {title}"
@@ -3050,7 +3050,7 @@ msgstr ""
 
 #: src/strings.ts:2216
 msgid "Insert"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2370
 msgid "Insert a {rows}x{columns} table"
@@ -3505,7 +3505,7 @@ msgstr ""
 
 #: src/strings.ts:2051
 msgid "Meet other privacy-minded people & talk to us directly about your concerns, issues and suggestions."
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2397
 msgid "Meetings"
@@ -4086,7 +4086,7 @@ msgstr ""
 
 #: src/strings.ts:44
 msgid "Partially refunded"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2382
 msgid "Passed"
@@ -4280,7 +4280,7 @@ msgstr ""
 
 #: src/strings.ts:1379
 msgid "please send us an email from your registered email address"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2371
 msgid "Please set a table size"
@@ -4574,7 +4574,7 @@ msgstr ""
 
 #: src/strings.ts:1592
 msgid "RECENT BACKUPS"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2378
 msgid "Recheck all"
@@ -4582,7 +4582,7 @@ msgstr ""
 
 #: src/strings.ts:1982
 msgid "Rechecking failed"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2403
 msgid "Recipes"
@@ -4885,7 +4885,7 @@ msgstr ""
 
 #: src/strings.ts:1221
 msgid "Restore backup"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2385
 msgid "Restore backup?"
@@ -5045,7 +5045,7 @@ msgstr ""
 
 #: src/strings.ts:491
 msgid "Save your recovery codes in a safe place. You will need them to recover your account in case you lose access to your two-factor authentication methods."
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2375
 msgid "Saved"
@@ -5069,7 +5069,7 @@ msgstr ""
 
 #: src/strings.ts:1703
 msgid "Scan the QR code with your authenticator app"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2401
 msgid "School work"
@@ -5821,7 +5821,7 @@ msgstr ""
 
 #: src/strings.ts:2324
 msgid "Task list"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2394
 msgid "Tasks"
@@ -6279,7 +6279,7 @@ msgstr ""
 
 #: src/strings.ts:51
 msgid "Urgent"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2367
 msgid "URL"
@@ -6548,7 +6548,7 @@ msgstr ""
 
 #: src/strings.ts:2363
 msgid "Width"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2392
 msgid "Work & Office"
@@ -6613,7 +6613,7 @@ msgstr ""
 
 #: src/strings.ts:2045
 msgid "You can change the theme at any time from Settings or the side menu."
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2400
 msgid "You can create shortcuts of frequently accessed notebooks in the side menu"

--- a/packages/intl/locale/pseudo-LOCALE.po
+++ b/packages/intl/locale/pseudo-LOCALE.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/strings.ts:2389
+#: src/strings.ts:2390
 msgid " \"Notebook > Notes\""
 msgstr ""
 
@@ -273,13 +273,13 @@ msgstr ""
 #: generated/actions.ts:137
 #: generated/actions.ts:150
 msgid "{count, plural, one {Item restored} other {# items restored}}"
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
 #: generated/actions.ts:121
 msgid "{count, plural, one {Item unpublished} other {# items unpublished}}"
 msgstr ""
 
-#: src/strings.ts:2406
+#: src/strings.ts:2407
 msgid "{count, plural, one {Move all notes in this notebook to trash} other {Move all notes in these notebooks to trash}}"
 msgstr ""
 
@@ -722,9 +722,9 @@ msgstr ""
 
 #: src/strings.ts:91
 msgid "All attachments are end-to-end encrypted."
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2383
+#: src/strings.ts:2384
 msgid "All cached attachments have been cleared."
 msgstr ""
 
@@ -909,9 +909,9 @@ msgstr ""
 
 #: src/strings.ts:1916
 msgid "Attachment preview failed"
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2376
+#: src/strings.ts:2377
 msgid "Attachment recheck cancelled"
 msgstr ""
 
@@ -930,9 +930,9 @@ msgstr ""
 
 #: src/strings.ts:1865
 msgid "Attachments cache cleared!"
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2378
+#: src/strings.ts:2379
 msgid "Attachments recheck complete"
 msgstr ""
 
@@ -1147,9 +1147,9 @@ msgstr ""
 
 #: src/strings.ts:2235
 msgid "Bold"
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2388
+#: src/strings.ts:2389
 msgid "Boost your productivity with Notebooks and organize your notes."
 msgstr ""
 
@@ -1308,9 +1308,9 @@ msgstr ""
 
 #: src/strings.ts:673
 msgid "Check your spam folder if you haven't received an email yet."
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2380
+#: src/strings.ts:2381
 msgid "Checking all attachments"
 msgstr ""
 
@@ -1320,9 +1320,9 @@ msgstr ""
 
 #: src/strings.ts:1686
 msgid "Checking for updates"
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2379
+#: src/strings.ts:2380
 msgid "Checking note attachments"
 msgstr ""
 
@@ -1455,9 +1455,9 @@ msgstr ""
 
 #: src/strings.ts:1753
 msgid "Click to remove"
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2371
+#: src/strings.ts:2372
 msgid "Click to reset {title}"
 msgstr ""
 
@@ -1556,9 +1556,9 @@ msgstr ""
 
 #: src/strings.ts:2230
 msgid "Configure"
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2385
+#: src/strings.ts:2386
 msgid "Configure server URLs for Notesnook"
 msgstr ""
 
@@ -1879,9 +1879,9 @@ msgstr ""
 
 #: src/strings.ts:1252
 msgid "Debugging"
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2373
+#: src/strings.ts:2374
 msgid "Decrease {title}"
 msgstr ""
 
@@ -2177,9 +2177,9 @@ msgstr ""
 
 #: src/strings.ts:636
 msgid "Earliest first"
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2397
+#: src/strings.ts:2398
 msgid "Easy access"
 msgstr ""
 
@@ -2211,9 +2211,9 @@ msgstr ""
 
 #: src/strings.ts:1464
 msgid "Email"
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2410
+#: src/strings.ts:2411
 msgid "Email copied"
 msgstr ""
 
@@ -2381,7 +2381,7 @@ msgstr ""
 msgid "Enter the 6 digit code sent to your phone number to continue logging in"
 msgstr ""
 
-#: src/strings.ts:2412
+#: src/strings.ts:2413
 msgid "Enter the gift code to redeem your subscription."
 msgstr ""
 
@@ -2399,9 +2399,9 @@ msgstr ""
 
 #: src/strings.ts:2070
 msgid "Enter your username"
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2404
+#: src/strings.ts:2405
 msgid "Error"
 msgstr ""
 
@@ -2439,17 +2439,17 @@ msgstr ""
 
 #: src/strings.ts:1609
 msgid "Events server"
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2390
+#: src/strings.ts:2391
 msgid "Every Notebook can have notes and sub notebooks."
 msgstr ""
 
-#: src/strings.ts:2392
+#: src/strings.ts:2393
 msgid "Everything related to my job in one place."
 msgstr ""
 
-#: src/strings.ts:2401
+#: src/strings.ts:2402
 msgid "Everything related to my school in one place."
 msgstr ""
 
@@ -2504,9 +2504,9 @@ msgstr ""
 
 #: src/strings.ts:1245
 msgid "Faced an issue or have a suggestion? Click here to create a bug report"
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2382
+#: src/strings.ts:2383
 msgid "Failed"
 msgstr ""
 
@@ -2589,13 +2589,13 @@ msgstr ""
 #: src/strings.ts:321
 #: src/strings.ts:1503
 msgid "Favorites"
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2394
+#: src/strings.ts:2395
 msgid "February 2022 Week 2"
 msgstr ""
 
-#: src/strings.ts:2395
+#: src/strings.ts:2396
 msgid "February 2022 Week 3"
 msgstr ""
 
@@ -2764,9 +2764,9 @@ msgstr ""
 
 #: src/strings.ts:1350
 msgid "Get Notesnook Pro to enable automatic backups"
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2386
+#: src/strings.ts:2387
 msgid "Get Priority support"
 msgstr ""
 
@@ -2936,9 +2936,9 @@ msgstr ""
 
 #: src/strings.ts:1867
 msgid "I have saved my key"
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2403
+#: src/strings.ts:2404
 msgid "I love cooking and collecting recipes."
 msgstr ""
 
@@ -3042,17 +3042,17 @@ msgstr ""
 
 #: src/strings.ts:773
 msgid "Incorrect {type}"
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2372
+#: src/strings.ts:2373
 msgid "Increase {title}"
 msgstr ""
 
 #: src/strings.ts:2216
 msgid "Insert"
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2369
+#: src/strings.ts:2370
 msgid "Insert a {rows}x{columns} table"
 msgstr ""
 
@@ -3505,9 +3505,9 @@ msgstr ""
 
 #: src/strings.ts:2051
 msgid "Meet other privacy-minded people & talk to us directly about your concerns, issues and suggestions."
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2396
+#: src/strings.ts:2397
 msgid "Meetings"
 msgstr ""
 
@@ -4086,9 +4086,9 @@ msgstr ""
 
 #: src/strings.ts:44
 msgid "Partially refunded"
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2381
+#: src/strings.ts:2382
 msgid "Passed"
 msgstr ""
 
@@ -4280,9 +4280,9 @@ msgstr ""
 
 #: src/strings.ts:1379
 msgid "please send us an email from your registered email address"
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2370
+#: src/strings.ts:2371
 msgid "Please set a table size"
 msgstr ""
 
@@ -4574,17 +4574,17 @@ msgstr ""
 
 #: src/strings.ts:1592
 msgid "RECENT BACKUPS"
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2377
+#: src/strings.ts:2378
 msgid "Recheck all"
 msgstr ""
 
 #: src/strings.ts:1982
 msgid "Rechecking failed"
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2402
+#: src/strings.ts:2403
 msgid "Recipes"
 msgstr ""
 
@@ -4628,15 +4628,15 @@ msgstr ""
 msgid "Recovery successful!"
 msgstr ""
 
-#: src/strings.ts:2414
+#: src/strings.ts:2415
 msgid "Redeem"
 msgstr ""
 
-#: src/strings.ts:2411
+#: src/strings.ts:2412
 msgid "Redeem gift code"
 msgstr ""
 
-#: src/strings.ts:2413
+#: src/strings.ts:2414
 msgid "Redeeming gift code"
 msgstr ""
 
@@ -4885,9 +4885,9 @@ msgstr ""
 
 #: src/strings.ts:1221
 msgid "Restore backup"
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2384
+#: src/strings.ts:2385
 msgid "Restore backup?"
 msgstr ""
 
@@ -5045,13 +5045,13 @@ msgstr ""
 
 #: src/strings.ts:491
 msgid "Save your recovery codes in a safe place. You will need them to recover your account in case you lose access to your two-factor authentication methods."
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2374
+#: src/strings.ts:2375
 msgid "Saved"
 msgstr ""
 
-#: src/strings.ts:2375
+#: src/strings.ts:2376
 msgid "Saving"
 msgstr ""
 
@@ -5069,9 +5069,9 @@ msgstr ""
 
 #: src/strings.ts:1703
 msgid "Scan the QR code with your authenticator app"
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2400
+#: src/strings.ts:2401
 msgid "School work"
 msgstr ""
 
@@ -5821,9 +5821,9 @@ msgstr ""
 
 #: src/strings.ts:2324
 msgid "Task list"
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2393
+#: src/strings.ts:2394
 msgid "Tasks"
 msgstr ""
 
@@ -6279,6 +6279,10 @@ msgstr ""
 
 #: src/strings.ts:51
 msgid "Urgent"
+msgstr "<<<<<<< HEAD"
+
+#: src/strings.ts:2367
+msgid "URL"
 msgstr ""
 
 #: src/strings.ts:1770
@@ -6544,9 +6548,9 @@ msgstr ""
 
 #: src/strings.ts:2363
 msgid "Width"
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2391
+#: src/strings.ts:2392
 msgid "Work & Office"
 msgstr ""
 
@@ -6609,9 +6613,9 @@ msgstr ""
 
 #: src/strings.ts:2045
 msgid "You can change the theme at any time from Settings or the side menu."
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2399
+#: src/strings.ts:2400
 msgid "You can create shortcuts of frequently accessed notebooks in the side menu"
 msgstr ""
 

--- a/packages/intl/src/strings.ts
+++ b/packages/intl/src/strings.ts
@@ -2364,6 +2364,7 @@ Use this if changes from other devices are not appearing on this device. This wi
   height: () => t`Height`,
   pasteImageURL: () => t`Paste image URL here`,
   linkText: () => t`Link text`,
+  url: () => t`URL`,
 
   insertTableOfSize: (rows: number, columns: number) =>
     t`Insert a ${rows}x${columns} table`,


### PR DESCRIPTION
The popup that appears when you want to edit a link, seemed a bit unintuitive, as you only saw the link in an input field twice:

![image](https://github.com/user-attachments/assets/3eb9853b-3ac7-448b-8083-e214c63d8f7c)

Only the placeholders of the inputs suggested what is meant, so I added labels describing the fields:

![image](https://github.com/user-attachments/assets/7d995853-e91e-4cc6-9c8a-2a10f252d2c2)
