### PR TITLE
mobile: always load note content in editor

### DIFF
--- a/packages/editor-mobile/src/hooks/useEditorController.ts
+++ b/packages/editor-mobile/src/hooks/useEditorController.ts
@@ -366,7 +366,6 @@ export function useEditorController({
           break;
         }
         case "native:html":
-          if (htmlContentRef.current === value) break;
           htmlContentRef.current = value;
           logger("info", "LOADING NOTE HTML");
           if (!editor) break;


### PR DESCRIPTION
Always load note's content if a load request is received in editor. Closes #7278