### PR TITLE
core: fix DATE_TIME_STRIP_REGEX

### DIFF
--- a/packages/core/src/utils/title-format.ts
+++ b/packages/core/src/utils/title-format.ts
@@ -27,7 +27,7 @@ const COUNT_REGEX = /\$count\$/g;
 const TIME_REGEX = /\$time\$/g;
 const HEADLINE_REGEX = /\$headline\$/g;
 const TIMESTAMP_REGEX = /\$timestamp\$/g;
-const DATE_TIME_STRIP_REGEX = /[\\\-: ]/g;
+const DATE_TIME_STRIP_REGEX = /[\\\-:./, ]/g;
 
 export function formatTitle(
   titleFormat: string,


### PR DESCRIPTION
`DATE_TIME_STRIP_REGEX` should strip `.,/` characters.

Closes #7310