### PR TITLE
editor: fix task-list stats

### DIFF
--- a/packages/editor/src/extensions/task-list/task-list.ts
+++ b/packages/editor/src/extensions/task-list/task-list.ts
@@ -63,7 +63,6 @@ export const TaskListNode = TaskList.extend({
           const checked = element.querySelectorAll(
             "li.checklist--item.checked"
           ).length;
-
           return { checked, total };
         }
       },

--- a/packages/editor/src/extensions/task-list/task-list.ts
+++ b/packages/editor/src/extensions/task-list/task-list.ts
@@ -57,11 +57,16 @@ export const TaskListNode = TaskList.extend({
         rendered: false,
         parseHTML: (element) => {
           // do not update stats for nested task lists
-          if (!!element.closest("ul")) return { checked: 0, total: 0 };
-          const total = element.querySelectorAll("li.checklist--item").length;
-          const checked = element.querySelectorAll(
-            "li.checklist--item.checked"
+          if (!!element.closest("ul.tasklist-content-wrapper ul"))
+            return { checked: 0, total: 0 };
+
+          const total = element.querySelectorAll(
+            ":scope > li.checklist--item"
           ).length;
+          const checked = element.querySelectorAll(
+            ":scope > li.checklist--item.checked"
+          ).length;
+
           return { checked, total };
         }
       },

--- a/packages/editor/src/extensions/task-list/task-list.ts
+++ b/packages/editor/src/extensions/task-list/task-list.ts
@@ -61,10 +61,10 @@ export const TaskListNode = TaskList.extend({
             return { checked: 0, total: 0 };
 
           const total = element.querySelectorAll(
-            ":scope > li.checklist--item"
+            "li.checklist--item"
           ).length;
           const checked = element.querySelectorAll(
-            ":scope > li.checklist--item.checked"
+            "li.checklist--item.checked"
           ).length;
 
           return { checked, total };

--- a/packages/editor/src/extensions/task-list/task-list.ts
+++ b/packages/editor/src/extensions/task-list/task-list.ts
@@ -57,12 +57,9 @@ export const TaskListNode = TaskList.extend({
         rendered: false,
         parseHTML: (element) => {
           // do not update stats for nested task lists
-          if (!!element.closest("ul.tasklist-content-wrapper ul"))
+          if (element.parentElement?.closest("ul"))
             return { checked: 0, total: 0 };
-
-          const total = element.querySelectorAll(
-            "li.checklist--item"
-          ).length;
+          const total = element.querySelectorAll("li.checklist--item").length;
           const checked = element.querySelectorAll(
             "li.checklist--item.checked"
           ).length;

--- a/packages/editor/src/extensions/task-list/utils.ts
+++ b/packages/editor/src/extensions/task-list/utils.ts
@@ -28,12 +28,12 @@ import { TaskItemNode } from "../task-item/index.js";
 export function countCheckedItems(node: ProsemirrorNode) {
   let checked = 0;
   let total = 0;
-  let content = node.content;
-
-  for (let i = 0; i < content.childCount; i++) {
-    if (content.child(i).attrs.checked) checked++;
-    total++;
-  }
+  node.descendants((node) => {
+    if (node.type.name === TaskItem.name) {
+      if (node.attrs.checked) checked++;
+      total++;
+    }
+  });
   return { checked, total };
 }
 

--- a/packages/editor/src/extensions/task-list/utils.ts
+++ b/packages/editor/src/extensions/task-list/utils.ts
@@ -28,12 +28,12 @@ import { TaskItemNode } from "../task-item/index.js";
 export function countCheckedItems(node: ProsemirrorNode) {
   let checked = 0;
   let total = 0;
-  node.descendants((node) => {
-    if (node.type.name === TaskItem.name) {
-      if (node.attrs.checked) checked++;
-      total++;
-    }
-  });
+  let content = node.content;
+
+  for (let i = 0; i < content.childCount; i++) {
+    if (content.child(i).attrs.checked) checked++;
+    total++;
+  }
   return { checked, total };
 }
 


### PR DESCRIPTION
Fixes: #7269

And this implements the desired functionality of not updating the stats for nested task lists, as described in the comments of the code.