### PR TITLE
web: use snarkdown to render setting item descriptions

### DIFF
--- a/apps/web/src/dialogs/settings/index.tsx
+++ b/apps/web/src/dialogs/settings/index.tsx
@@ -77,6 +77,7 @@ import { AppLockSettings } from "./app-lock-settings";
 import { BaseDialogProps, DialogManager } from "../../common/dialog-manager";
 import { ServersSettings } from "./servers-settings";
 import { strings } from "@notesnook/intl";
+import { mdToHtml } from "../../utils/md";
 
 type SettingsDialogProps = BaseDialogProps<false> & {
   activeSection?: SectionKeys;
@@ -470,13 +471,17 @@ function SettingItem(props: { item: Setting }) {
           <Text variant={"subtitle"}>{item.title}</Text>
           {item.description && (
             <Text
+              as={"div"}
               variant={"body"}
               sx={{ mt: 1, color: "paragraph", whiteSpace: "pre-wrap" }}
-            >
-              {typeof item.description === "function"
-                ? item.description(state)
-                : item.description}
-            </Text>
+              dangerouslySetInnerHTML={{
+                __html: mdToHtml(
+                  typeof item.description === "function"
+                    ? item.description(state)
+                    : item.description
+                )
+              }}
+            />
           )}
         </Flex>
 


### PR DESCRIPTION
Signed-off-by: 01zulfi <85733202+01zulfi@users.noreply.github.com>

### Because: 

![image](https://github.com/user-attachments/assets/ca3e5a97-702d-4904-956b-7a1d748b45a9)
