### PR TITLE
web: fix nav menu collapse

### DIFF
--- a/apps/web/src/components/split-pane/index.tsx
+++ b/apps/web/src/components/split-pane/index.tsx
@@ -96,7 +96,7 @@ export const SplitPane = React.forwardRef<
   const wrapSize = useRef(0);
   const childrenLength = childrenToArray(children).length;
   const autoSaveKey = autoSaveId ? `csp:${autoSaveId}` : undefined;
-  const previousSize = useRef(0);
+  const lastCollapsedPaneSize = useRef(0);
 
   const { sizeName, splitPos, splitAxis } = useMemo(
     () =>
@@ -257,13 +257,13 @@ export const SplitPane = React.forwardRef<
       return {
         collapse: (index: number) => {
           paneSizes.current[index].collapsed = true;
-          previousSize.current = paneSizes.current[index].size;
+          lastCollapsedPaneSize.current = paneSizes.current[index].size;
           setSizes(paneSizes.current, wrapSize.current);
         },
         expand: (index: number) => {
           paneSizes.current[index].collapsed = false;
-          paneSizes.current[index].size = previousSize.current
-            ? previousSize.current
+          paneSizes.current[index].size = lastCollapsedPaneSize.current
+            ? lastCollapsedPaneSize.current
             : paneSizes.current[index].initialSize;
           setSizes(paneSizes.current, wrapSize.current);
         }

--- a/apps/web/src/components/split-pane/index.tsx
+++ b/apps/web/src/components/split-pane/index.tsx
@@ -96,14 +96,15 @@ export const SplitPane = React.forwardRef<
   const wrapSize = useRef(0);
   const childrenLength = childrenToArray(children).length;
   const autoSaveKey = autoSaveId ? `csp:${autoSaveId}` : undefined;
+  const previousSize = useRef(0);
 
   const { sizeName, splitPos, splitAxis } = useMemo(
     () =>
-    ({
-      sizeName: direction === "vertical" ? "width" : "height",
-      splitPos: direction === "vertical" ? "left" : "top",
-      splitAxis: direction === "vertical" ? "x" : "y"
-    } as const),
+      ({
+        sizeName: direction === "vertical" ? "width" : "height",
+        splitPos: direction === "vertical" ? "left" : "top",
+        splitAxis: direction === "vertical" ? "x" : "y"
+      } as const),
     [direction]
   );
 
@@ -256,10 +257,14 @@ export const SplitPane = React.forwardRef<
       return {
         collapse: (index: number) => {
           paneSizes.current[index].collapsed = true;
+          previousSize.current = paneSizes.current[index].size;
           setSizes(paneSizes.current, wrapSize.current);
         },
         expand: (index: number) => {
           paneSizes.current[index].collapsed = false;
+          paneSizes.current[index].size = previousSize.current
+            ? previousSize.current
+            : paneSizes.current[index].initialSize;
           setSizes(paneSizes.current, wrapSize.current);
         }
       };


### PR DESCRIPTION
Fixes: #7335

This should also fix #7393 since the same functionality is used when toggeling the subnotebook folder.