### PR TITLE
web: fix various typos

### DIFF
--- a/apps/vericrypt/src/components/errors-list.tsx
+++ b/apps/vericrypt/src/components/errors-list.tsx
@@ -26,7 +26,7 @@ type ErrorsListProps = {
 export function ErrorsList(props: ErrorsListProps) {
   return (
     <Accordion
-      title={`${props.errors.length} errors occured`}
+      title={`${props.errors.length} errors occurred`}
       sx={{ bg: "errorBg", borderRadius: "default", mt: 2 }}
       color="#E53935"
     >

--- a/apps/web/at-rest-encryption.md
+++ b/apps/web/at-rest-encryption.md
@@ -36,7 +36,7 @@ The flow will be as follows:
 5. Use the database password to init the db & keep the user's encryption key in memory. (we have 2 choices here: either keep the encryption key in memory or keep the pin in memory)
 6. If not enabled, we will ask the keystore to give us the database password + user's encryption key
 
-We should store both the database password and the user's encryption key in a keychain. If user sets a pin, we can just double encrypt these values. This will keep things simple and seemless.
+We should store both the database password and the user's encryption key in a keychain. If user sets a pin, we can just double encrypt these values. This will keep things simple and seamless.
 
 Q: How to find out if app lock is enabled?
 

--- a/apps/web/src/common/sqlite/VFS.js
+++ b/apps/web/src/common/sqlite/VFS.js
@@ -165,7 +165,7 @@ export class Base {
   }
 
   /**
-   * Handle asynchronous operation. This implementation will be overriden on
+   * Handle asynchronous operation. This implementation will be overridden on
    * registration by an Asyncify build.
    * @param {function(): Promise<number>} f
    * @returns {number}

--- a/apps/web/src/common/sqlite/sqlite-types.ts
+++ b/apps/web/src/common/sqlite/sqlite-types.ts
@@ -269,7 +269,7 @@ export interface SQLiteModule {
  * the corresponding Javascript wrapper will throw an exception with a
  * `code` property on an error.
  *
- * Note that a few functions return a Promise in order to accomodate
+ * Note that a few functions return a Promise in order to accommodate
  * either a synchronous or asynchronous SQLite build, generally those
  * involved with opening/closing a database or executing a statement.
  *
@@ -493,7 +493,7 @@ export interface SQLiteAPI {
   column(stmt: number, i: number): SQLiteCompatibleType;
 
   /**
-   * Extract a column value from a row after a prepared statment {@link step}
+   * Extract a column value from a row after a prepared statement {@link step}
    *
    * The contents of the returned buffer may be invalid after the
    * next SQLite call. Make a copy of the data (e.g. with `.slice()`)
@@ -523,7 +523,7 @@ export interface SQLiteAPI {
   column_count(stmt: number): number;
 
   /**
-   * Extract a column value from a row after a prepared statment {@link step}
+   * Extract a column value from a row after a prepared statement {@link step}
    * @see https://www.sqlite.org/c3ref/column_blob.html
    * @param stmt prepared statement pointer
    * @param i column index
@@ -532,7 +532,7 @@ export interface SQLiteAPI {
   column_double(stmt: number, i: number): number;
 
   /**
-   * Extract a column value from a row after a prepared statment {@link step}
+   * Extract a column value from a row after a prepared statement {@link step}
    * @see https://www.sqlite.org/c3ref/column_blob.html
    * @param stmt prepared statement pointer
    * @param i column index
@@ -541,7 +541,7 @@ export interface SQLiteAPI {
   column_int(stmt: number, i: number): number;
 
   /**
-   * Extract a column value from a row after a prepared statment {@link step}
+   * Extract a column value from a row after a prepared statement {@link step}
    * @see https://www.sqlite.org/c3ref/column_blob.html
    * @param stmt prepared statement pointer
    * @param i column index
@@ -569,7 +569,7 @@ export interface SQLiteAPI {
   column_names(stmt: number): Array<string>;
 
   /**
-   * Extract a column value from a row after a prepared statment {@link step}
+   * Extract a column value from a row after a prepared statement {@link step}
    * @see https://www.sqlite.org/c3ref/column_blob.html
    * @param stmt prepared statement pointer
    * @param i column index

--- a/apps/web/src/dialogs/settings/index.tsx
+++ b/apps/web/src/dialogs/settings/index.tsx
@@ -187,7 +187,7 @@ const SettingsGroups = [
 // 2. Settings will be synced so their state must be serializable
 // 3. Settings will be grouped
 //    - Where group header is customizable
-// 4. Sections/groups must be able to accomodate tips & tutorials for future.
+// 4. Sections/groups must be able to accommodate tips & tutorials for future.
 // 5. Settings will be stateful but independent such that any one setting
 // can appear independent of others (e.g. as a search result)
 

--- a/apps/web/src/utils/stream-saver/mitm.ts
+++ b/apps/web/src/utils/stream-saver/mitm.ts
@@ -63,7 +63,7 @@ export async function postMessage(
   // so all download links needs to be prefixed to avoid any other conflict
   data.origin = window.location.origin;
 
-  // if we ever (in some feature versoin of streamsaver) would like to
+  // if we ever (in some feature version of streamsaver) would like to
   // redirect back to the page of who initiated a http request
   data.referrer = data.referrer || document.referrer || origin;
 


### PR DESCRIPTION
Found via `codespell -q 3 -D ../dictionary.txt -S "*.patch,*.po" -L actualy,childs,modifer,ontext,ontop,ony,recieved,reciever,se,seperator,te`