### PR TITLE
web: selecting the programming language by pressing Enter key

### DIFF
--- a/packages/editor/src/extensions/code-block/component.tsx
+++ b/packages/editor/src/extensions/code-block/component.tsx
@@ -258,6 +258,15 @@ function LanguageSelector(props: LanguageSelectorProps) {
             zIndex: 999,
             mt: 1
           }}
+          onKeyDown={(e: React.KeyboardEvent) => {
+            if (e.key === "Enter" && languages.length > 0) {
+              onLanguageSelected(languages[0].filename);
+              e.preventDefault();
+            } else if (e.key === "Escape") {
+              onClose();
+              e.preventDefault();
+            }
+          }}
           onChange={(e) => {
             if (!e.target.value) return setLanguages(Languages);
             const query = e.target.value.toLowerCase();


### PR DESCRIPTION
Fixes: https://github.com/streetwriters/notesnook/issues/7284

This PR adds support for selecting the programming language by pressing the Enter key.