### PR TITLE
web: fix status-bar disappearing

### DIFF
--- a/apps/web/src/components/status-bar/index.tsx
+++ b/apps/web/src/components/status-bar/index.tsx
@@ -62,7 +62,7 @@ function StatusBar() {
         borderTop: "1px solid",
         borderTopColor: "separator",
         justifyContent: "space-between",
-        display: ["none", "none", "flex"],
+        display: ["none", "flex", "flex"],
         flexShrink: 0,
         height: 24
       }}


### PR DESCRIPTION
Fixes: #7467

This makes the status-bar also visible on medium sized screens.
On small screens it is probably not necessary, since enabeling "focus mode" or "editor marings" does not make sense here.