### PR TITLE
Fix potential RCEs when pasting unknown content into the editor

### DIFF
--- a/packages/editor/src/extensions/embed/component.tsx
+++ b/packages/editor/src/extensions/embed/component.tsx
@@ -115,9 +115,10 @@ export function EmbedComponent(
         </Box>
         <Embed
           ref={embedRef}
-          src={src}
+          src={src.startsWith("javascript:") ? "about:blank" : src}
           width={"100%"}
           height={"100%"}
+          sandbox="allow-scripts"
           sx={{
             bg: "var(--background-secondary)",
             border: selected

--- a/packages/editor/src/extensions/image/component.tsx
+++ b/packages/editor/src/extensions/image/component.tsx
@@ -251,15 +251,16 @@ export function ImageComponent(
             </Flex>
           )}
           <Image
-            as={isSVG ? "object" : "img"}
+            as={isSVG ? "iframe" : "img"}
             data-drag-image
             ref={imageRef}
             alt={alt}
             crossOrigin="anonymous"
             {...(isSVG
               ? {
-                  data: bloburl || corsify(src, downloadOptions?.corsHost),
-                  type: mime
+                  src: bloburl || corsify(src, downloadOptions?.corsHost),
+                  type: mime,
+                  sandbox: ""
                 }
               : {
                   src: bloburl || corsify(src, downloadOptions?.corsHost)
@@ -273,7 +274,8 @@ export function ImageComponent(
               border: selected
                 ? "2px solid var(--accent) !important"
                 : "2px solid transparent !important",
-              borderRadius: "default"
+              borderRadius: "default",
+              ...(isSVG ? { bg: "transparent" } : {})
             }}
             onDoubleClick={() => {
               const { hash, filename, mime, size } = node.attrs;

--- a/packages/editor/src/toolbar/popups/embed-popup.tsx
+++ b/packages/editor/src/toolbar/popups/embed-popup.tsx
@@ -101,6 +101,9 @@ export function EmbedPopup(props: EmbedPopupProps) {
           }
           const convertedUrl = convertUrlToEmbedUrl(_src);
           if (convertedUrl) _src = convertedUrl;
+          if (_src.startsWith("javascript:")) {
+            return setError("Embedding javascript code is not supported.");
+          }
           onClose({
             height: _height,
             width: _width,


### PR DESCRIPTION
This fixes a potential security vulnerability where pasting unknown content into the editor could create an RCE risk.

This PR fixes two issues:

1. Potential RCE when pasting/inserting an `iframe` containing a `javascript` link.
2. Potential RCE when pasting/inserting an `svg` containing JavaScript (why do SVGs allow JS in the first place?).

Mitigations include disallowing all execution of JS inside an SVG by rendering it in a sandboxed `iframe`. While we cannot disallow JS execution in embeds (that would break all embeds like YouTube videos), we have disallowed access to the parent window to all `iframe`s, again, by using a sandboxed `iframe` and by disallowing embedding of `javascript:` links.

To be clear, both of these issues can only be triggered when pasting/importing untrusted content (which you shouldn't be doing anyway).

**These cannot be used to steal or access your notes or any other data. They could be used to access what's shown in the window or do automated clicks etc. but since everything is stored and access from an encrypted SQLite database, your data would be 100% safe and isolated from such an attack.**