### PR TITLE
editor: Fix search in complex text elements

### DIFF
--- a/packages/editor/src/extensions/search-replace/search-replace.ts
+++ b/packages/editor/src/extensions/search-replace/search-replace.ts
@@ -63,9 +63,7 @@ export type SearchStorage = {
 interface TextNodesWithPosition {
   text: string;
   startPos: number;
-  endPos: number;
   start: number;
-  end: number;
 }
 
 const updateView = (state: EditorState, dispatch: DispatchFn) => {
@@ -113,14 +111,11 @@ function searchDocument(
     if (node.isText) {
       if (textNodesWithPosition[index]) {
         textNodesWithPosition[index].text += node.text;
-        textNodesWithPosition[index].end = cursor + (node.text?.length || 0);
       } else {
         textNodesWithPosition[index] = {
           text: node.text || "",
           startPos: pos,
-          endPos: pos + node.nodeSize,
-          start: cursor,
-          end: cursor + (node.text?.length || 0)
+          start: cursor
         };
       }
       cursor += node.text?.length || 0;
@@ -128,8 +123,6 @@ function searchDocument(
       const lastNode = textNodesWithPosition[index];
       if (lastNode) {
         lastNode.text += "\n";
-        lastNode.end++;
-        lastNode.endPos = pos;
         cursor++;
       }
       index++;
@@ -145,7 +138,7 @@ function searchDocument(
     // search term in them. This adds support for multi line regex searches.
     const nodes = textNodesWithPosition.filter((node) => {
       const nodeStart = node.start;
-      const nodeEnd = node.end;
+      const nodeEnd = nodeStart + node.text.length;
       return (
         (start >= nodeStart && start < nodeEnd) ||
         (end >= nodeStart && end < nodeEnd)
@@ -157,8 +150,9 @@ function searchDocument(
     const startNode = nodes[0];
     results.push({
       // reposition our RegExp match index relative to the actual node.
-      from: start + (startNode.startPos - startNode.start),
-      to: end + (endNode.endPos - endNode.end)
+      from:
+        startNode.startPos + /*offset in startNode=*/ (start - startNode.start),
+      to: endNode.startPos + /*length inside endNode=*/ (end - endNode.start)
     });
   }
 


### PR DESCRIPTION
The current search algorithm while accumulating text assumes that the text nodes are always followed by a paragraph node with endPos == textNode.endPos + 1. This is not true for complex text elements like tables where the endPos can be higher. Thus the start,end offsets of TextNodesWithPosition start getting off and results in incorrectly highlighted search results.

To fix this, simplify the TextNodesWithPosition to only hold start position and offset since startPos is always correct. We can calculate the end position on the fly by simply adding text length to startPos.

Issue #7431