### PR TITLE
Update monograph Dockerfile

### DIFF
--- a/apps/monograph/Dockerfile
+++ b/apps/monograph/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM --platform=$BUILDPLATFORM oven/bun:1.2.2-alpine
+FROM oven/bun:1.2.2-alpine
 
 RUN mkdir -p /home/bun/app && chown -R bun:bun /home/bun/app
 


### PR DESCRIPTION
fix arm64 compatibility issue

--platform=$BUILDPLATFORM will overwrite buildx settings

reference:
https://github.com/streetwriters/notesnook/issues/6887