### PR TITLE
ui: fix submenu position

### DIFF
--- a/packages/ui/src/utils/position.ts
+++ b/packages/ui/src/utils/position.ts
@@ -92,7 +92,10 @@ export function getPosition(
   } else if (location === "left") position.left -= elementWidth;
 
   if (actualY + elementHeight > windowHeight) {
-    position.top = windowHeight - elementHeight;
+    position.top =
+      target === "mouse"
+        ? windowHeight - elementHeight
+        : windowHeight - elementHeight - actualY + y;
   } else {
     position.top = y;
   }


### PR DESCRIPTION
* position.top wasn't calculated correctly for the out of screen height case for non-mouse target
Signed-off-by: 01zulfi <85733202+01zulfi@users.noreply.github.com>