### PR TITLE
web: update toast position

### DIFF
--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -46,6 +46,7 @@ import { AppEventManager, AppEvents } from "./common/app-events";
 import { TITLE_BAR_HEIGHT } from "./components/title-bar";
 import { getFontSizes } from "@notesnook/theme/theme/font/fontsize.js";
 import { useWindowControls } from "./hooks/use-window-controls";
+import { STATUS_BAR_HEIGHT } from "./common/constants";
 
 new WebExtensionRelay();
 
@@ -130,7 +131,10 @@ function App() {
         ) : (
           <DesktopAppContents setShow={setShow} show={show} />
         )}
-        <Toaster containerClassName="toasts-container" />
+        <Toaster
+          containerClassName="toasts-container"
+          containerStyle={{ bottom: STATUS_BAR_HEIGHT + 10 }}
+        />
       </Flex>
     </>
   );

--- a/apps/web/src/common/constants.ts
+++ b/apps/web/src/common/constants.ts
@@ -25,3 +25,5 @@ export const SUBSCRIPTION_STATUS = {
   PREMIUM_EXPIRED: 6,
   PREMIUM_CANCELED: 7
 } as const;
+
+export const STATUS_BAR_HEIGHT = 24 as const;

--- a/apps/web/src/components/status-bar/index.tsx
+++ b/apps/web/src/components/status-bar/index.tsx
@@ -44,6 +44,7 @@ import { showUpdateAvailableNotice } from "../../dialogs/confirm";
 import { strings } from "@notesnook/intl";
 import { useVault } from "../../hooks/use-vault";
 import { useKeyStore } from "../../interfaces/key-store";
+import { STATUS_BAR_HEIGHT } from "../../common/constants";
 
 function StatusBar() {
   const user = useUserStore((state) => state.user);
@@ -64,7 +65,7 @@ function StatusBar() {
         justifyContent: "space-between",
         display: ["none", "flex", "flex"],
         flexShrink: 0,
-        height: 24
+        height: STATUS_BAR_HEIGHT
       }}
       px={2}
     >


### PR DESCRIPTION
* current position would overlap slightly with the status bar, this commit moves the toast a little higher so it doesn't overlap
Signed-off-by: 01zulfi <85733202+01zulfi@users.noreply.github.com>

### Before
![image](https://github.com/user-attachments/assets/05569d7f-7225-4841-bbd6-8ef56a39564a)

### After
![image](https://github.com/user-attachments/assets/0900cdb0-8732-4481-8e21-c6b129fd82a8)

