### PR TITLE
web: pinned tab fixes

### DIFF
--- a/apps/web/__e2e__/tabs.test.ts
+++ b/apps/web/__e2e__/tabs.test.ts
@@ -408,7 +408,7 @@ test("when active tab is pinned, opening other notes should open existing note t
   await expect(tabs[0].titleElement).toHaveText("Note 2");
 });
 
-test("pinned tab should work as expected after page reload", async ({
+test("activating pinned tab after page reload should not open a duplicate tab", async ({
   page
 }) => {
   const app = new AppModel(page);

--- a/apps/web/src/components/note/index.tsx
+++ b/apps/web/src/components/note/index.tsx
@@ -144,7 +144,9 @@ function Note(props: NoteProps) {
       }}
       context={{ color, locked }}
       menuItems={noteMenuItems}
-      onClick={() => useEditorStore.getState().openSession(note)}
+      onClick={() =>
+        useEditorStore.getState().openSession(note, { considerPinnedTab: true })
+      }
       onMiddleClick={() =>
         useEditorStore.getState().openSession(note, { openInNewTab: true })
       }

--- a/apps/web/src/stores/editor-store.ts
+++ b/apps/web/src/stores/editor-store.ts
@@ -679,10 +679,12 @@ class EditorStore extends BaseStore<EditorStore> {
     const noteId = typeof noteOrId === "string" ? noteOrId : noteOrId.id;
     const oldTabForNote = options.force ? null : getTabsForNote(noteId).at(0);
     const activeTab = getActiveTab();
+    const isReactivatingTab =
+      options.force && getTabsForNote(noteId).some((t) => t.id === activeTabId);
     const tabId =
+      // if a tab is pinned then always open a new tab.
       options.openInNewTab ||
-      // if a tab is pinned then always open a new tab, unless there's an existing tab for the note
-      (options.considerPinnedTab && activeTab?.pinned && !oldTabForNote)
+      (activeTab?.pinned && !oldTabForNote && !isReactivatingTab)
         ? addTab(getId())
         : oldTabForNote?.id || activeTabId || addTab(getId());
 

--- a/apps/web/src/stores/editor-store.ts
+++ b/apps/web/src/stores/editor-store.ts
@@ -659,6 +659,10 @@ class EditorStore extends BaseStore<EditorStore> {
       activeBlockId?: string;
       silent?: boolean;
       openInNewTab?: boolean;
+      /**
+       * Should be true if we want to open a new tab when the active tab is pinned
+       */
+      considerPinnedTab?: boolean;
     } = {}
   ): Promise<void> => {
     const {
@@ -676,8 +680,9 @@ class EditorStore extends BaseStore<EditorStore> {
     const oldTabForNote = options.force ? null : getTabsForNote(noteId).at(0);
     const activeTab = getActiveTab();
     const tabId =
-      // if a tab is pinned then always open a new tab.
-      options.openInNewTab || activeTab?.pinned
+      options.openInNewTab ||
+      // if a tab is pinned then always open a new tab, unless there's an existing tab for the note
+      (options.considerPinnedTab && activeTab?.pinned && !oldTabForNote)
         ? addTab(getId())
         : oldTabForNote?.id || activeTabId || addTab(getId());
 


### PR DESCRIPTION
* fix pinned tab not working after page reload
* fix note opening in new tab even if its tab is present when active note is pinned

Closes #7683 