### PR TITLE
editor: fix image padding in readonly mode

### DIFF
--- a/packages/editor/src/extensions/image/component.tsx
+++ b/packages/editor/src/extensions/image/component.tsx
@@ -105,7 +105,7 @@ export function ImageComponent(
   return (
     <>
       <Box
-        className=".image-container"
+        className="image-container"
         sx={{
           ...getAlignmentStyles(node.attrs),
           height: float ? size.height : "unset",

--- a/packages/editor/src/extensions/image/component.tsx
+++ b/packages/editor/src/extensions/image/component.tsx
@@ -105,6 +105,7 @@ export function ImageComponent(
   return (
     <>
       <Box
+        className=".image-container"
         sx={{
           ...getAlignmentStyles(node.attrs),
           height: float ? size.height : "unset",

--- a/packages/editor/styles/styles.css
+++ b/packages/editor/styles/styles.css
@@ -601,11 +601,11 @@ p > *::selection {
   pointer-events: none;
 }
 
-.ProseMirror > p[data-spacing="double"] .resizer {
+.ProseMirror > p[data-spacing="double"] .image-container {
   margin-bottom: 1em;
 }
 
-.ProseMirror > p[data-spacing="single"] .resizer {
+.ProseMirror > p[data-spacing="single"] .image-container {
   margin-top: 1em !important;
   margin-bottom: 1em;
 }


### PR DESCRIPTION
In read-only mode, the resizer is removed causing the image to lose padding when line spacing is set to "single".

Closes #7741