### PR TITLE
editor: ensure consistent gap between heading and first element in callout

### DIFF
--- a/packages/editor/styles/styles.css
+++ b/packages/editor/styles/styles.css
@@ -698,7 +698,7 @@ p > *::selection {
   margin-bottom: 1em;
 }
 
-.ProseMirror div.callout > :first-child + p {
+.ProseMirror div.callout > :first-child + * {
   margin-top: 1em !important;
 }
 

--- a/packages/editor/styles/styles.css
+++ b/packages/editor/styles/styles.css
@@ -698,6 +698,9 @@ p > *::selection {
   margin-bottom: 1em;
 }
 
+.ProseMirror div.callout > :first-child + p {
+  margin-top: 1em !important;
+}
 
 .ProseMirror div.callout > :first-child {
   margin: 0px;


### PR DESCRIPTION
This pull request includes a small change to the `styles.css` file. The change adds a new CSS rule to ensure consistent space between heading and first element in callout

Closes #7738