### PR TITLE
Fix creating backups ios

### DIFF
--- a/apps/mobile/app/common/filesystem/io.ts
+++ b/apps/mobile/app/common/filesystem/io.ts
@@ -231,6 +231,26 @@ export async function deleteDCacheFiles() {
   }
 }
 
+export async function getCachePathForFile(filename: string) {
+  const path = `${cacheDir}/${filename}`;
+
+  const iosAppGroup =
+    Platform.OS === "ios"
+      ? await (RNFetchBlob.fs as any).pathForAppGroup(IOS_APPGROUPID)
+      : null;
+  const appGroupPath = `${iosAppGroup}/${filename}`;
+
+  const exists = await RNFetchBlob.fs.exists(path);
+
+  // Check if file is present in app group path.
+  let existsInAppGroup = false;
+  if (!exists && Platform.OS === "ios") {
+    existsInAppGroup = await RNFetchBlob.fs.exists(appGroupPath);
+  }
+
+  return existsInAppGroup ? appGroupPath : path;
+}
+
 export async function exists(filename: string) {
   const path = `${cacheDir}/${filename}`;
 

--- a/apps/mobile/app/services/backup.ts
+++ b/apps/mobile/app/services/backup.ts
@@ -260,10 +260,14 @@ async function run(
           progress: `Saving attachments in backup... ${file.hash}`
         });
         if (await FileStorage.exists(file.hash)) {
-          await RNFetchBlob.fs.cp(
-            await getCachePathForFile(file.hash),
-            `${attachmentsDir}/${file.hash}`
-          );
+          await RNFetchBlob.fs
+            .cp(
+              await getCachePathForFile(file.hash),
+              `${attachmentsDir}/${file.hash}`
+            )
+            .catch((e) =>
+              DatabaseLogger.error(e, "Error saving attachment to backup file")
+            );
         }
       }
     }

--- a/apps/mobile/app/services/backup.ts
+++ b/apps/mobile/app/services/backup.ts
@@ -39,6 +39,7 @@ import { eCloseSheet } from "../utils/events";
 import { sleep } from "../utils/time";
 import { ToastManager, eSendEvent, presentSheet } from "./event-manager";
 import SettingsService from "./settings";
+import { getCachePathForFile } from "../common/filesystem/io";
 
 const MS_DAY = 86400000;
 const MS_WEEK = MS_DAY * 7;
@@ -260,7 +261,7 @@ async function run(
         });
         if (await FileStorage.exists(file.hash)) {
           await RNFetchBlob.fs.cp(
-            `${cacheDir}/${file.hash}`,
+            await getCachePathForFile(file.hash),
             `${attachmentsDir}/${file.hash}`
           );
         }


### PR DESCRIPTION
Backups fail if some of the attachments are downloaded but exist in AppGroup instead of app's own cache folder