### PR TITLE
web: don't remove properties pane when editor is refocused

### DIFF
--- a/apps/web/src/components/editor/index.tsx
+++ b/apps/web/src/components/editor/index.tsx
@@ -252,7 +252,6 @@ function EditorView({
   const lastChangedTime = useRef<number>(0);
   const root = useRef<HTMLDivElement>(null);
 
-  const toggleProperties = useEditorStore((store) => store.toggleProperties);
   const isFocusMode = useAppStore((store) => store.isFocusMode);
   const editor = useEditorManager((store) => store.editors[session.id]?.editor);
 
@@ -376,7 +375,6 @@ function EditorView({
         }}
         options={{
           readonly: session?.type === "readonly" || session?.type === "deleted",
-          onRequestFocus: () => toggleProperties(false),
           focusMode: isFocusMode
         }}
       />


### PR DESCRIPTION
Signed-off-by: 01zulfi <85733202+01zulfi@users.noreply.github.com>

Closes #7770 