### PR TITLE
web: add delete data option for not logged in user

### DIFF
--- a/apps/web/src/dialogs/settings/profile-settings.ts
+++ b/apps/web/src/dialogs/settings/profile-settings.ts
@@ -35,6 +35,7 @@ import { EmailChangeDialog } from "../email-change-dialog";
 import { RecoveryKeyDialog } from "../recovery-key-dialog";
 import { UserProfile } from "./components/user-profile";
 import { SettingsGroup } from "./types";
+import Config from "../../utils/config";
 
 export const ProfileSettings: SettingsGroup[] = [
   {
@@ -86,6 +87,29 @@ export const ProfileSettings: SettingsGroup[] = [
             variant: "secondary",
             action: async () => {
               if (await verifyAccount()) await RecoveryKeyDialog.show({});
+            }
+          }
+        ]
+      },
+      {
+        key: "delete-data-for-not-logged-in-user",
+        title: strings.deleteData(),
+        description: strings.deleteAccountDesc(),
+        keywords: [
+          strings.deleteData(),
+          strings.deleteAccount(),
+          strings.clear()
+        ],
+        isHidden: () => Boolean(useUserStore.getState().isLoggedIn),
+        components: [
+          {
+            type: "button",
+            variant: "error",
+            title: strings.deleteData(),
+            action: async () => {
+              Config.clear();
+              await db.reset();
+              window.location.reload();
             }
           }
         ]

--- a/packages/intl/src/strings.ts
+++ b/packages/intl/src/strings.ts
@@ -2441,5 +2441,7 @@ Use this if changes from other devices are not appearing on this device. This wi
   zoom: () => t`Zoom`,
   toggleFocusMode: () => t`Toggle focus mode`,
   fontLigatures: () => t`Font ligatures`,
-  fontLigaturesDesc: () => t`Enable ligatures for common symbols like →, ←, etc`
+  fontLigaturesDesc: () =>
+    t`Enable ligatures for common symbols like →, ←, etc`,
+  deleteData: () => t`Delete data`
 };


### PR DESCRIPTION
Signed-off-by: 01zulfi <85733202+01zulfi@users.noreply.github.com>

I sometimes need to clear all data when working locally so I'm adding this. I think it might be handy for not logged in users as well