### PR TITLE
core: fix notes search results having mismatched references

### DIFF
--- a/packages/core/src/api/lookup.ts
+++ b/packages/core/src/api/lookup.ts
@@ -295,7 +295,7 @@ export default class Lookup {
       async (start, end) => {
         const items = await selector.items(ids.slice(start, end), sortOptions);
         return {
-          ids: ids.slice(start, end),
+          ids: items.map((i) => i.id),
           items
         };
       }


### PR DESCRIPTION
* ids and items had different orders

Closes #7907 