### PR TITLE
web: reduce snapSize of nav & list panes

### DIFF
--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -196,7 +196,7 @@ function DesktopAppContents() {
               id="nav-pane"
               initialSize={isTablet ? 0 : 250}
               className={`nav-pane`}
-              snapSize={160}
+              snapSize={150}
               minSize={50}
               maxSize={isTablet ? 0 : 500}
               style={{
@@ -212,7 +212,7 @@ function DesktopAppContents() {
               id="list-pane"
               initialSize={380}
               style={{ flex: 1, display: "flex" }}
-              snapSize={200}
+              snapSize={120}
               maxSize={500}
               className="list-pane"
             >


### PR DESCRIPTION
Signed-off-by: 01zulfi <85733202+01zulfi@users.noreply.github.com>

Closes #7884 

I think there's some room for the nav & list panes to have lesser width before snapping. For the list pane, the UI still breaks a little at `120`, but still usable. We should let the user decide if they want to go to this width. 

Anything lesser than these widths, the UI breaks a lot. This is where we can step in and not allow the user to go to this width (i.e. snap the pane)