### PR TITLE
mobile: fix cursor bug on ios

### DIFF
--- a/apps/mobile/app/screens/editor/tiptap/use-editor-events.tsx
+++ b/apps/mobile/app/screens/editor/tiptap/use-editor-events.tsx
@@ -177,7 +177,7 @@ export const useEditorEvents = (
   useEffect(() => {
     const handleKeyboardDidShow: KeyboardEventListener = () => {
       editor.commands.keyboardShown(true);
-      //editor.postMessage(NativeEvents.keyboardShown, undefined);
+      editor.postMessage(NativeEvents.keyboardShown, undefined);
     };
     const handleKeyboardDidHide: KeyboardEventListener = () => {
       editor.commands.keyboardShown(false);

--- a/packages/editor-mobile/src/components/tiptap.tsx
+++ b/packages/editor-mobile/src/components/tiptap.tsx
@@ -43,7 +43,11 @@ export default function TiptapEditorWrapper(props: {
             sx={{
               display: props.settings.noToolbar ? "none" : "flex",
               overflowY: "hidden",
-              minHeight: "50px"
+              minHeight: "50px",
+              position: "absolute",
+              bottom: 0,
+              left: 0,
+              right: 0
             }}
             editor={editor}
             location="bottom"

--- a/packages/editor-mobile/src/hooks/useEditorController.ts
+++ b/packages/editor-mobile/src/hooks/useEditorController.ts
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { Editor, scrollIntoViewById } from "@notesnook/editor";
+import { keepLastLineInView } from "@notesnook/editor/extensions/keep-in-view/keep-in-view.js";
 import { strings } from "@notesnook/intl";
 import {
   ThemeDefinition,
@@ -66,38 +67,12 @@ type Timers = {
   scroll: NodeJS.Timeout | null;
 };
 
-function isInViewport(element: any) {
-  const rect = element.getBoundingClientRect();
-  return (
-    rect.top >= 0 &&
-    rect.left >= 0 &&
-    rect.bottom <=
-      (window.innerHeight || document.documentElement.clientHeight) &&
-    rect.right <= (window.innerWidth || document.documentElement.clientWidth)
-  );
-}
-
 function scrollIntoView(editor: Editor) {
+  if (__PLATFORM__ == "android") return;
   setTimeout(() => {
-    try {
-      const node = editor?.state.selection.$from;
-      const dom = node ? editor?.view?.domAtPos?.(node.pos) : null;
-      let domNode = dom?.node;
-
-      if (domNode) {
-        if (domNode.nodeType === Node.TEXT_NODE && domNode.parentNode) {
-          domNode = domNode.parentNode;
-        }
-        if (isInViewport(domNode)) return;
-        (domNode as HTMLElement).scrollIntoView({
-          behavior: "smooth",
-          block: "end"
-        });
-      }
-    } catch (e) {
-      /* empty */
-    }
-  }, 100);
+    if (!editor.isFocused) return;
+    keepLastLineInView(editor);
+  }, 1);
 }
 
 export type EditorController = {

--- a/packages/editor/src/extensions/keep-in-view/keep-in-view.ts
+++ b/packages/editor/src/extensions/keep-in-view/keep-in-view.ts
@@ -71,7 +71,7 @@ export const KeepInView = Extension.create<
 
 export function keepLastLineInView(
   editor: Editor,
-  THRESHOLD = 80,
+  THRESHOLD = 90,
   SCROLL_THRESHOLD = 100
 ) {
   if (


### PR DESCRIPTION
Fix cursor renders at wrong position on ios when tying long texts.