### PR TITLE
docker: improvement of the monograph container build process

### DIFF
--- a/.github/workflows/monograph.publish.yml
+++ b/.github/workflows/monograph.publish.yml
@@ -24,22 +24,11 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
-      - name: Setup Node
-        uses: ./.github/actions/setup-node-with-cache
-
-      - name: Install packages
-        run: |
-          npm ci --ignore-scripts --prefer-offline --no-audit
-          npm run bootstrap -- --scope=monograph
-
       - name: Collect package metadata
         id: package_metadata
         working-directory: ./apps/monograph
         run: |
           echo ::set-output name=app_version::$(cat package.json | jq -r .version)
-
-      - name: Generate build
-        run: npm run tx @notesnook/monograph:build
 
       # Setup Buildx
       - name: Docker Setup Buildx
@@ -74,7 +63,7 @@ jobs:
         id: push
         uses: docker/build-push-action@v6
         with:
-          context: apps/monograph
+          context: .
           file: apps/monograph/Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64

--- a/apps/monograph/Dockerfile
+++ b/apps/monograph/Dockerfile
@@ -1,14 +1,39 @@
+# Build stage
+FROM node:22.20.0-alpine AS build
 
-FROM oven/bun:1.3.14-slim
+# Install dependencies for gyp to work
+RUN --mount=type=cache,target=/var/cache/apk,sharing=locked apk add --update build-base git python3 py3-setuptools
 
-RUN mkdir -p /home/bun/app && chown -R bun:bun /home/bun/app
+WORKDIR /app
 
+# Copy files
+COPY . .
+
+# Install dependencies
+RUN --mount=type=cache,target=/root/.npm npm ci --ignore-scripts --prefer-offline --no-audit
+
+# Bootstrap the project
+RUN --mount=type=cache,target=/root/.npm npm run bootstrap -- --scope=monograph
+
+# Build the application
+RUN --mount=type=cache,target=/root/.npm npm run tx @notesnook/monograph:build
+
+# Production stage
+FROM oven/bun:1.3.14-slim AS production
+
+# Copy built files from build stage
 WORKDIR /home/bun/app
+COPY --chown=bun:bun --from=build /app/apps/monograph/output .
 
+# Set the user to bun
+RUN chown -R bun:bun /home/bun/app
 USER bun
 
-COPY --chown=bun:bun output .
+# Mark current environment as production
+ENV NODE_ENV=production
+ENV HOST=0.0.0.0
 
+# Install server dependencies
 RUN bun install
 
 CMD [ "bun", "run", "start" ]

--- a/apps/monograph/package-lock.json
+++ b/apps/monograph/package-lock.json
@@ -2952,6 +2952,22 @@
         "@styled-system/css": "^5.1.5"
       }
     },
+    "node_modules/@theme-ui/color-modes": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@theme-ui/color-modes/-/color-modes-0.16.2.tgz",
+      "integrity": "sha512-jWEWx53lxNgWCT38i/kwLV2rsvJz8lVZgi5oImnVwYba9VejXD23q1ckbNFJHosQ8KKXY87ht0KPC6BQFIiHtQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@theme-ui/core": "^0.16.2",
+        "@theme-ui/css": "^0.16.2",
+        "deepmerge": "^4.2.2"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.11.1",
+        "react": ">=18"
+      }
+    },
     "node_modules/@theme-ui/components": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@theme-ui/components/-/components-0.16.2.tgz",
@@ -2995,6 +3011,22 @@
       },
       "peerDependencies": {
         "@emotion/react": "^11.11.1"
+      }
+    },
+    "node_modules/@theme-ui/theme-provider": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@theme-ui/theme-provider/-/theme-provider-0.16.2.tgz",
+      "integrity": "sha512-LRnVevODcGqO0JyLJ3wht+PV3ZoZcJ7XXLJAJWDoGeII4vZcPQKwVy4Lpz/juHsZppQxKcB3U+sQDGBnP25irQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@theme-ui/color-modes": "^0.16.2",
+        "@theme-ui/core": "^0.16.2",
+        "@theme-ui/css": "^0.16.2"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.11.1",
+        "react": ">=18"
       }
     },
     "node_modules/@types/acorn": {
@@ -3126,14 +3158,14 @@
       "version": "15.7.13",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
       "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.10.tgz",
       "integrity": "sha512-02sAAlBnP39JgXwkAq3PeU9DVaaGpZyF3MGcC0MKgQVkZor5IiiDAipVaxQHtDJAmO4GIy/rVBy/LzVj76Cyqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -12241,7 +12273,7 @@
       "version": "3.23.8",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
       "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"


### PR DESCRIPTION
Previously, before building a container, it was necessary to install the dependencies on the host and build the monograph itself.
Now this process is written in the Dockerfile itself, so the end user does not need to carry out preliminary preparations.
Just `git clone ...; docker build` and you're done.

#8107