### PR TITLE
Field based search

### DIFF
--- a/packages/core/src/utils/query-transformer.ts
+++ b/packages/core/src/utils/query-transformer.ts
@@ -72,8 +72,8 @@ const SUPPORTED_FIELDS = {
   readonly: (ast) => parseBooleanField("readonly", ast),
   favorite: (ast) => parseBooleanField("favorite", ast),
   archived: (ast) => parseBooleanField("archived", ast),
-  untagged: (ast) => parseBooleanField("untagged", ast),
-  uncolored: (ast) => parseBooleanField("uncolored", ast),
+  tagged: (ast) => parseBooleanField("tagged", ast),
+  colored: (ast) => parseBooleanField("colored", ast),
   in_notebook: (ast) => parseBooleanField("in_notebook", ast)
 } satisfies Record<string, (ast: (QueryNode | FieldPhraseNode)[]) => unknown>;
 

--- a/packages/core/src/utils/query-transformer.ts
+++ b/packages/core/src/utils/query-transformer.ts
@@ -70,9 +70,11 @@ const SUPPORTED_FIELDS = {
   pinned: (ast) => parseBooleanField("pinned", ast),
   locked: (ast) => parseBooleanField("locked", ast),
   readonly: (ast) => parseBooleanField("readonly", ast),
-  local_only: (ast) => parseBooleanField("local_only", ast),
   favorite: (ast) => parseBooleanField("favorite", ast),
-  archived: (ast) => parseBooleanField("archived", ast)
+  archived: (ast) => parseBooleanField("archived", ast),
+  untagged: (ast) => parseBooleanField("untagged", ast),
+  uncolored: (ast) => parseBooleanField("uncolored", ast),
+  in_notebook: (ast) => parseBooleanField("in_notebook", ast)
 } satisfies Record<string, (ast: (QueryNode | FieldPhraseNode)[]) => unknown>;
 
 function isFieldSupported(field: string) {


### PR DESCRIPTION
This PR adds support for searching based on fields. Currently, only the following fields are supported:

- `content:`
- `title:`
- `favorite:`
- `pinned:`
- `locked:`
- `archived:`
- `tag:`
- `color:`
- `edited_after:`
- `created_after:`
- `created_before:`
- `edited_before:`


