### PR TITLE
editor: don't show open & copy tools for empty links

### DIFF
--- a/packages/editor/src/toolbar/tools/link.tsx
+++ b/packages/editor/src/toolbar/tools/link.tsx
@@ -196,6 +196,7 @@ export function OpenLink(props: ToolProps) {
   const link = node ? findMark(node, "link") : null;
   if (!link) return null;
   const href = link?.attrs.href;
+  if (!href) return null;
 
   return (
     <Flex sx={{ alignItems: "center" }}>
@@ -245,6 +246,7 @@ export function CopyLink(props: ToolProps) {
   const link = node ? findMark(node, "link") : null;
   if (!link) return null;
   const href = link?.attrs.href;
+  if (!href) return null;
 
   return (
     <ToolButton


### PR DESCRIPTION
Closes https://github.com/streetwriters/notesnook/issues/8505