### PR TITLE
mobile: fix resetting navigation

### DIFF
--- a/apps/mobile/app/components/auth/common.js
+++ b/apps/mobile/app/components/auth/common.js
@@ -33,9 +33,6 @@ export function hideAuth() {
   eSendEvent(eCloseLoginDialog);
   if (initialAuthMode.current === AuthMode.welcomeSignup) {
     Navigation.replace("FluidPanelsView");
-    setTimeout(() => {
-      Navigation.resetRootState();
-    }, 300);
   } else {
     Navigation.goBack();
   }

--- a/apps/mobile/app/components/auth/index.js
+++ b/apps/mobile/app/components/auth/index.js
@@ -89,9 +89,6 @@ const Auth = ({ navigation, route }) => {
               onPress={() => {
                 if (initialAuthMode.current === 2) {
                   Navigation.replace("FluidPanelsView");
-                  setTimeout(() => {
-                    Navigation.resetRootState();
-                  }, 300);
                 } else {
                   Navigation.goBack();
                 }

--- a/apps/mobile/app/components/list-items/search-result/index.tsx
+++ b/apps/mobile/app/components/list-items/search-result/index.tsx
@@ -153,7 +153,6 @@ export const SearchResult = (props: SearchResultProps) => {
               for (let i = 0; i <= index; i++) {
                 activeIndex += props.item.content[i].length;
               }
-              console.log(activeIndex);
               openNote(activeIndex);
             }}
           >

--- a/apps/mobile/app/components/sheet-provider/index.js
+++ b/apps/mobile/app/components/sheet-provider/index.js
@@ -95,8 +95,6 @@ const SheetProvider = ({ context = "global" }) => {
     [context]
   );
 
-  console.log(data?.keyboardHandlerDisabled);
-
   return !visible || !data ? null : (
     <SheetWrapper
       fwdRef={actionSheetRef}

--- a/apps/mobile/app/components/sheets/user/index.tsx
+++ b/apps/mobile/app/components/sheets/user/index.tsx
@@ -312,7 +312,6 @@ export const UserSheet = () => {
             icon: "logout",
             title: strings.logout(),
             onPress: async () => {
-              console.log("logout");
               ref.current?.hide();
               await sleep(300);
               logoutUser();

--- a/apps/mobile/app/components/ui/sheet/index.js
+++ b/apps/mobile/app/components/ui/sheet/index.js
@@ -64,8 +64,6 @@ const SheetWrapper = ({
   const isGestureNavigationEnabled =
     NotesnookModule.isGestureNavigationEnabled();
 
-  console.log(isGestureNavigationEnabled);
-
   const style = React.useMemo(() => {
     return {
       width: largeTablet || smallTablet ? width : "100%",

--- a/apps/mobile/app/navigation/navigation-stack.tsx
+++ b/apps/mobile/app/navigation/navigation-stack.tsx
@@ -30,6 +30,7 @@ import useNavigationStore, {
 import { useSelectionStore } from "../stores/use-selection-store";
 import { useSettingStore } from "../stores/use-setting-store";
 import { rootNavigatorRef } from "../utils/global-refs";
+import Navigation from "../services/navigation";
 
 const RootStack = createNativeStackNavigator();
 const AppStack = createNativeStackNavigator();
@@ -255,12 +256,17 @@ export const RootNavigation = () => {
     (state) => state.settings.introCompleted
   );
   const clearSelection = useSelectionStore((state) => state.clearSelection);
-  const onStateChange = React.useCallback(() => {
-    if (useSelectionStore.getState().selectionMode) {
-      clearSelection();
-    }
-    hideAllTooltips();
-  }, [clearSelection]);
+  const onStateChange = React.useCallback(
+    (state: any) => {
+      if (useSelectionStore.getState().selectionMode) {
+        clearSelection();
+      }
+      console.log(state);
+      Navigation.resetRootState(state);
+      hideAllTooltips();
+    },
+    [clearSelection]
+  );
 
   return (
     <NavigationContainer onStateChange={onStateChange} ref={rootNavigatorRef}>

--- a/apps/mobile/app/navigation/navigation-stack.tsx
+++ b/apps/mobile/app/navigation/navigation-stack.tsx
@@ -261,8 +261,9 @@ export const RootNavigation = () => {
       if (useSelectionStore.getState().selectionMode) {
         clearSelection();
       }
-      console.log(state);
-      Navigation.resetRootState(state);
+      setTimeout(() => {
+        Navigation.resetRootState(state);
+      }, 1000);
       hideAllTooltips();
     },
     [clearSelection]

--- a/apps/mobile/app/screens/editor/tiptap/use-editor-events.tsx
+++ b/apps/mobile/app/screens/editor/tiptap/use-editor-events.tsx
@@ -131,7 +131,6 @@ const showActionsheet = async () => {
     .getState()
     .getNoteIdForTab(useTabStore.getState().currentTab!);
   if (noteId) {
-    console.log("OPEN NOTE");
     const note = await db.notes?.note(noteId);
     Properties.present(note, false);
   } else {

--- a/apps/mobile/app/screens/editor/tiptap/use-editor.ts
+++ b/apps/mobile/app/screens/editor/tiptap/use-editor.ts
@@ -875,7 +875,6 @@ export const useEditor = (
               }
 
               lastContentChangeTime.current[note.id] = note.dateEdited;
-              console.log(tab.session?.selection);
               await postMessage(
                 NativeEvents.updatehtml,
                 {

--- a/apps/mobile/app/services/navigation.ts
+++ b/apps/mobile/app/services/navigation.ts
@@ -176,13 +176,11 @@ function resetRootState(
 
   const routes = state.routes.filter(
     (route) =>
-      route.name !== "Auth" &&
-      route.name !== "Welcome" &&
-      route.key != focusedRoute.key
+      (route.name !== "Auth" && route.name !== "Welcome") ||
+      route.key === focusedRoute.key
   );
 
   if (routes.length === state.routes.length) return;
-  console.log("ROOT STATE RESET");
   if (routes.length === 0) {
     routes.push(focusedRoute);
   }

--- a/apps/mobile/app/services/navigation.ts
+++ b/apps/mobile/app/services/navigation.ts
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { StackActions } from "@react-navigation/native";
+import { NavigationHelpers, StackActions } from "@react-navigation/native";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { useFavoriteStore } from "../stores/use-favorite-store";
 import useNavigationStore, {
@@ -166,13 +166,27 @@ function closeDrawer() {
   fluidTabsRef.current?.closeDrawer();
 }
 
-function resetRootState() {
-  const state = rootNavigatorRef.getState();
-  const focusedRouteKey = state.routes[state.index].key;
+function resetRootState(
+  _state?: ReturnType<NavigationHelpers<any, any>["getState"]>
+) {
+  const state = _state || rootNavigatorRef.getState();
+  const focusedRoute = state.routes[state.index];
+
+  if (state.routes.length < 2) return;
+
   const routes = state.routes.filter(
-    (route) => route.name !== "Auth" && route.name !== "Welcome"
+    (route) =>
+      route.name !== "Auth" &&
+      route.name !== "Welcome" &&
+      route.key != focusedRoute.key
   );
-  const newIndex = routes.findIndex((route) => route.key === focusedRouteKey);
+
+  if (routes.length === state.routes.length) return;
+  console.log("ROOT STATE RESET");
+  if (routes.length === 0) {
+    routes.push(focusedRoute);
+  }
+  const newIndex = routes.findIndex((route) => route.key === focusedRoute.key);
   rootNavigatorRef.reset({
     ...state,
     routes: routes,

--- a/apps/mobile/patches/@react-navigation+core+6.4.8.patch
+++ b/apps/mobile/patches/@react-navigation+core+6.4.8.patch
@@ -1,0 +1,39 @@
+diff --git a/node_modules/@react-navigation/core/lib/commonjs/useNavigationCache.js b/node_modules/@react-navigation/core/lib/commonjs/useNavigationCache.js
+index c7f1df6..0141f28 100644
+--- a/node_modules/@react-navigation/core/lib/commonjs/useNavigationCache.js
++++ b/node_modules/@react-navigation/core/lib/commonjs/useNavigationCache.js
+@@ -109,7 +109,7 @@ function useNavigationCache(_ref) {
+         })),
+         isFocused: () => {
+           const state = getState();
+-          if (state.routes[state.index].key !== route.key) {
++          if (state.routes[state.index]?.key !== route.key) {
+             return false;
+           }
+ 
+diff --git a/node_modules/@react-navigation/core/lib/module/useNavigationCache.js b/node_modules/@react-navigation/core/lib/module/useNavigationCache.js
+index c4d65c6..89abe63 100644
+--- a/node_modules/@react-navigation/core/lib/module/useNavigationCache.js
++++ b/node_modules/@react-navigation/core/lib/module/useNavigationCache.js
+@@ -100,7 +100,7 @@ export default function useNavigationCache(_ref) {
+         })),
+         isFocused: () => {
+           const state = getState();
+-          if (state.routes[state.index].key !== route.key) {
++          if (state.routes[state.index]?.key !== route.key) {
+             return false;
+           }
+ 
+diff --git a/node_modules/@react-navigation/core/src/useNavigationCache.tsx b/node_modules/@react-navigation/core/src/useNavigationCache.tsx
+index 390120a..1b0f2d1 100644
+--- a/node_modules/@react-navigation/core/src/useNavigationCache.tsx
++++ b/node_modules/@react-navigation/core/src/useNavigationCache.tsx
+@@ -157,7 +157,7 @@ export default function useNavigationCache<
+         isFocused: () => {
+           const state = getState();
+ 
+-          if (state.routes[state.index].key !== route.key) {
++          if (state.routes[state.index]?.key !== route.key) {
+             return false;
+           }
+ 


### PR DESCRIPTION
Reset navigation in `onStateChange` callback to prevent invalid state.
Closes #8511