### PR TITLE
web: add title size settings for list and editor views

### DIFF
--- a/apps/web/__e2e__/models/settings-view.model.ts
+++ b/apps/web/__e2e__/models/settings-view.model.ts
@@ -152,6 +152,30 @@ export class SettingsViewModel {
     await imageCompressionDropdown.selectOption(option);
   }
 
+  async selectListTitleFontSize(option: { value: string; label: string }) {
+    const item = await this.navigation.findItem("Appearance");
+    await item?.click();
+
+    // Find the actual select element inside the setting container
+    const listTitleFontSize = this.page
+      .locator(getTestId("setting-list-font-size"))
+      .locator("select");
+
+    await listTitleFontSize.selectOption(option);
+  }
+
+  async selectEditorTitleFontSize(option: { value: string; label: string }) {
+    const item = await this.navigation.findItem("Appearance");
+    await item?.click();
+
+    // Find the actual select element inside the setting container
+    const editorTitleFontSize = this.page
+      .locator(getTestId("setting-editor-font-size"))
+      .locator("select");
+
+    await editorTitleFontSize.selectOption(option);
+  }
+
   async enableAppLock(userPassword: string, appLockPassword: string) {
     const item = await this.navigation.findItem("App lock");
     await item?.click();

--- a/apps/web/__e2e__/settings.test.ts
+++ b/apps/web/__e2e__/settings.test.ts
@@ -77,3 +77,45 @@ test("do not ask for image compression during image upload when 'Image Compressi
 
   await expect(page.getByText("Enable compression")).toBeHidden();
 });
+
+test("change title size in settings affects note list titles", async ({
+  page
+}) => {
+  const app = new AppModel(page);
+  await app.goto();
+
+  const notes = await app.goToNotes();
+  await notes.createNote(NOTE);
+
+  const settings = await app.goToSettings();
+  await settings.selectListTitleFontSize({ value: "large", label: "Large" });
+  await settings.close();
+
+  const noteItem = page.locator('[data-test-id="list-item"]').first();
+  const titleElement = noteItem.locator('[data-test-id="title"]');
+
+  const fontSize = await titleElement.evaluate(
+    (el) => window.getComputedStyle(el).fontSize
+  );
+  console.log(fontSize);
+
+  expect(parseFloat(fontSize)).toBeGreaterThan(12);
+});
+
+test("change title size affects editor title", async ({ page }) => {
+  const app = new AppModel(page);
+  await app.goto();
+
+  const settings = await app.goToSettings();
+  await settings.selectEditorTitleFontSize({ value: "small", label: "Small" });
+  await settings.close();
+
+  const notes = await app.goToNotes();
+  await notes.createNote(NOTE);
+
+  const editorTitle = page.locator('[data-test-id="editor-title"]');
+  const fontSize = await editorTitle.evaluate(
+    (el) => window.getComputedStyle(el).fontSize
+  );
+  expect(parseFloat(fontSize)).toBeLessThan(50);
+});

--- a/apps/web/src/components/editor/title-box.tsx
+++ b/apps/web/src/components/editor/title-box.tsx
@@ -28,6 +28,8 @@ import { useStore as useSettingsStore } from "../../stores/setting-store";
 import { AppEventManager, AppEvents } from "../../common/app-events";
 import { strings } from "@notesnook/intl";
 import { NEWLINE_STRIP_REGEX } from "@notesnook/core";
+import { useTitleSize } from "../../hooks/use-title-size";
+import { titleSizeToTextAreaFontSize } from "../../utils/title-size";
 
 type TitleBoxProps = {
   id: string;
@@ -46,11 +48,20 @@ function TitleBox(props: TitleBoxProps) {
   const { editorConfig } = useEditorConfig();
   const dateFormat = useSettingsStore((store) => store.dateFormat);
   const timeFormat = useSettingsStore((store) => store.timeFormat);
+  const { detailViewTitleSize } = useTitleSize();
 
   const fontFamily = useMemo(
     () => getFontById(editorConfig.fontFamily)?.font || "heading",
     [editorConfig.fontFamily]
   );
+
+  useEffect(() => {
+    setTimeout(() => {
+      if (inputRef.current) {
+        resizeTextarea(inputRef.current);
+      }
+    }, 0);
+  }, [detailViewTitleSize]);
 
   useLayoutEffect(() => {
     const session = useEditorStore.getState().getSession(id);
@@ -112,7 +123,7 @@ function TitleBox(props: TitleBoxProps) {
         m: 0,
         p: 0,
         fontFamily,
-        fontSize: ["1.625em", "1.625em", "2.625em"],
+        fontSize: titleSizeToTextAreaFontSize(detailViewTitleSize),
         fontWeight: "heading",
         width: "100%",
         fieldSizing: "content",

--- a/apps/web/src/components/list-item/index.tsx
+++ b/apps/web/src/components/list-item/index.tsx
@@ -30,6 +30,8 @@ import { MenuItem } from "@notesnook/ui";
 import { alpha } from "@theme-ui/color";
 import { Item } from "@notesnook/core";
 import { setDragData } from "../../utils/data-transfer";
+import { useTitleSize } from "../../hooks/use-title-size";
+import { titleSizeToVariant } from "../../utils/title-size";
 
 type ListItemProps<TItem extends Item, TContext> = {
   colors?: {
@@ -91,6 +93,7 @@ function ListItem<TItem extends Item, TContext>(
   const listItemRef = useRef<HTMLDivElement>(null);
   const { openMenu, target } = useMenuTrigger();
   const isMenuTarget = target && target === listItemRef.current;
+  const { listViewTitleSize } = useTitleSize();
 
   const isSelected = useSelectionStore((store) => {
     const isInSelection = store.selectedItems.includes(props.item.id);
@@ -200,7 +203,7 @@ function ListItem<TItem extends Item, TContext>(
         <Text
           dir="auto"
           data-test-id={`title`}
-          variant={"body"}
+          variant={titleSizeToVariant(listViewTitleSize) || "body"}
           sx={{
             whiteSpace: "nowrap",
             overflow: "hidden",

--- a/apps/web/src/dialogs/settings/appearance-settings.ts
+++ b/apps/web/src/dialogs/settings/appearance-settings.ts
@@ -18,7 +18,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { SettingsGroup } from "./types";
-import { useStore as useSettingStore } from "../../stores/setting-store";
+import {
+  TitleSize,
+  useStore as useSettingStore
+} from "../../stores/setting-store";
 import { useStore as useThemeStore } from "../../stores/theme-store";
 import { ThemesSelector } from "./components/themes-selector";
 import { strings } from "@notesnook/intl";
@@ -87,6 +90,50 @@ export const AppearanceSettings: SettingsGroup[] = [
                   .getState()
                   .setColorScheme(value as "dark" | "light");
             }
+          }
+        ]
+      },
+      {
+        key: "list-font-size",
+        title: strings.listTitle(),
+        onStateChange: (listener) =>
+          useSettingStore.subscribe((s) => [s.listViewTitleSize], listener),
+        components: [
+          {
+            type: "dropdown",
+            options: [
+              { title: "Small", value: "small" },
+              { title: "Medium", value: "medium" },
+              { title: "Large", value: "large" }
+            ],
+            selectedOption: () =>
+              useSettingStore.getState().listViewTitleSize || "small",
+            onSelectionChanged: (value) =>
+              useSettingStore
+                .getState()
+                .setListViewTitleSize(value as TitleSize)
+          }
+        ]
+      },
+      {
+        key: "editor-font-size",
+        title: strings.editorTitle(),
+        onStateChange: (listener) =>
+          useSettingStore.subscribe((s) => [s.detailViewTitleSize], listener),
+        components: [
+          {
+            type: "dropdown",
+            options: [
+              { title: "Small", value: "small" },
+              { title: "Medium", value: "medium" },
+              { title: "Large", value: "large" }
+            ],
+            selectedOption: () =>
+              useSettingStore.getState().detailViewTitleSize || "small",
+            onSelectionChanged: (value) =>
+              useSettingStore
+                .getState()
+                .setDetailViewTitleSize(value as TitleSize)
           }
         ]
       },

--- a/apps/web/src/hooks/use-title-size.ts
+++ b/apps/web/src/hooks/use-title-size.ts
@@ -1,0 +1,29 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { useStore as useSettingStore } from "../stores/setting-store";
+
+export const useTitleSize = () => {
+  const listViewTitleSize = useSettingStore((store) => store.listViewTitleSize);
+  const detailViewTitleSize = useSettingStore(
+    (store) => store.detailViewTitleSize
+  );
+
+  return { listViewTitleSize, detailViewTitleSize };
+};

--- a/apps/web/src/stores/setting-store.ts
+++ b/apps/web/src/stores/setting-store.ts
@@ -47,6 +47,8 @@ export type HomePage = {
   id: string;
 };
 
+export type TitleSize = "small" | "medium" | "large";
+
 class SettingStore extends BaseStore<SettingStore> {
   encryptBackups = Config.get("encryptBackups", false);
   backupReminderOffset = Config.get("backupReminderOffset", 0);
@@ -70,6 +72,8 @@ class SettingStore extends BaseStore<SettingStore> {
   timeFormat: TimeFormat = "12-hour";
   titleFormat = "Note $date$ $time$";
   profile?: Profile;
+  listViewTitleSize?: TitleSize = Config.get("listViewTitleSize", "small");
+  detailViewTitleSize?: TitleSize = Config.get("detailViewTitleSize", "medium");
 
   trashCleanupInterval: TrashCleanupInterval = 7;
   homepage = Config.get<HomePage>("homepage-v2", {
@@ -122,6 +126,16 @@ class SettingStore extends BaseStore<SettingStore> {
   setTitleFormat = async (titleFormat: string) => {
     await db.settings.setTitleFormat(titleFormat);
     this.set({ titleFormat });
+  };
+
+  setListViewTitleSize = (listViewTitleSize: TitleSize) => {
+    this.set({ listViewTitleSize });
+    Config.set("listViewTitleSize", listViewTitleSize);
+  };
+
+  setDetailViewTitleSize = (detailViewTitleSize: TitleSize) => {
+    this.set({ detailViewTitleSize });
+    Config.set("detailViewTitleSize", detailViewTitleSize);
   };
 
   setTrashCleanupInterval = async (

--- a/apps/web/src/utils/title-size.ts
+++ b/apps/web/src/utils/title-size.ts
@@ -1,0 +1,47 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { TitleSize } from "../stores/setting-store";
+
+export function titleSizeToVariant(size: TitleSize | undefined): string {
+  switch (size) {
+    case "small":
+      return "body";
+    case "medium":
+      return "subtitle";
+    case "large":
+      return "title";
+    default:
+      return "body";
+  }
+}
+export function titleSizeToTextAreaFontSize(
+  size: TitleSize | undefined
+): string[] {
+  switch (size) {
+    case "small":
+      return ["1.25em", "1.25em", "1.875em"];
+    case "medium":
+      return ["1.625em", "1.625em", "2.625em"];
+    case "large":
+      return ["2em", "2em", "3.125em"];
+    default:
+      return ["1.625em", "1.625em", "2.625em"];
+  }
+}

--- a/packages/intl/locale/en.po
+++ b/packages/intl/locale/en.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/strings.ts:2410
+#: src/strings.ts:2412
 msgid " \"Notebook > Notes\""
 msgstr " \"Notebook > Notes\""
 
@@ -288,7 +288,7 @@ msgstr "{count, plural, one {Item restored} other {# items restored}}"
 msgid "{count, plural, one {Item unpublished} other {# items unpublished}}"
 msgstr "{count, plural, one {Item unpublished} other {# items unpublished}}"
 
-#: src/strings.ts:2427
+#: src/strings.ts:2429
 msgid "{count, plural, one {Move all notes in this notebook to trash} other {Move all notes in these notebooks to trash}}"
 msgstr "{count, plural, one {Move all notes in this notebook to trash} other {Move all notes in these notebooks to trash}}"
 
@@ -563,7 +563,7 @@ msgstr "{platform, select, android {{name} saved to selected path} other {{name}
 msgid "{platform, select, android {Backup file saved in \"Notesnook backups\" folder on your phone.} other {Backup file is saved in File Manager/Notesnook folder}}"
 msgstr "{platform, select, android {Backup file saved in \"Notesnook backups\" folder on your phone.} other {Backup file is saved in File Manager/Notesnook folder}}"
 
-#: src/strings.ts:2357
+#: src/strings.ts:2359
 msgid "{selected} selected"
 msgstr "{selected} selected"
 
@@ -643,15 +643,15 @@ msgstr "Account"
 msgid "Account password"
 msgstr "Account password"
 
-#: src/strings.ts:2452
+#: src/strings.ts:2454
 msgid "Actions for note: {title}"
 msgstr "Actions for note: {title}"
 
-#: src/strings.ts:2453
+#: src/strings.ts:2455
 msgid "Actions for notebook: {title}"
 msgstr "Actions for notebook: {title}"
 
-#: src/strings.ts:2454
+#: src/strings.ts:2456
 msgid "Actions for tag: {title}"
 msgstr "Actions for tag: {title}"
 
@@ -687,7 +687,7 @@ msgstr "Add color"
 msgid "Add notebook"
 msgstr "Add notebook"
 
-#: src/strings.ts:2479
+#: src/strings.ts:2481
 msgid "Add notes"
 msgstr "Add notes"
 
@@ -715,11 +715,11 @@ msgstr "Add tags"
 msgid "Add tags to multiple notes at once"
 msgstr "Add tags to multiple notes at once"
 
-#: src/strings.ts:2243
+#: src/strings.ts:2245
 msgid "Add to dictionary"
 msgstr "Add to dictionary"
 
-#: src/strings.ts:2477
+#: src/strings.ts:2479
 msgid "Add to notebook"
 msgstr "Add to notebook"
 
@@ -731,7 +731,7 @@ msgstr "Add your first note"
 msgid "Add your first notebook"
 msgstr "Add your first notebook"
 
-#: src/strings.ts:2170
+#: src/strings.ts:2172
 msgid "Advanced"
 msgstr "Advanced"
 
@@ -739,15 +739,15 @@ msgstr "Advanced"
 msgid "After scanning the QR code image, the app will display a code that you can enter below."
 msgstr "After scanning the QR code image, the app will display a code that you can enter below."
 
-#: src/strings.ts:2308
+#: src/strings.ts:2310
 msgid "Align left"
 msgstr "Align left"
 
-#: src/strings.ts:2309
+#: src/strings.ts:2311
 msgid "Align right"
 msgstr "Align right"
 
-#: src/strings.ts:2278
+#: src/strings.ts:2280
 msgid "Alignment"
 msgstr "Alignment"
 
@@ -759,7 +759,7 @@ msgstr "All"
 msgid "All attachments are end-to-end encrypted."
 msgstr "All attachments are end-to-end encrypted."
 
-#: src/strings.ts:2404
+#: src/strings.ts:2406
 msgid "All cached attachments have been cleared."
 msgstr "All cached attachments have been cleared."
 
@@ -787,7 +787,7 @@ msgstr "All server urls are required."
 msgid "All the data in your account will be overwritten with the data in the backup file. There is no way to reverse this action."
 msgstr "All the data in your account will be overwritten with the data in the backup file. There is no way to reverse this action."
 
-#: src/strings.ts:2150
+#: src/strings.ts:2152
 msgid "All the source code for Notesnook is available & open for everyone on GitHub."
 msgstr "All the source code for Notesnook is available & open for everyone on GitHub."
 
@@ -815,7 +815,7 @@ msgstr "All your data will be removed permanently. Make sure you have saved back
 msgid "Already have an account?"
 msgstr "Already have an account?"
 
-#: src/strings.ts:2220
+#: src/strings.ts:2222
 msgid "Amount"
 msgstr "Amount"
 
@@ -882,7 +882,7 @@ msgid "Applying changes"
 msgstr "Applying changes"
 
 #: src/strings.ts:1529
-#: src/strings.ts:2484
+#: src/strings.ts:2486
 msgid "Archive"
 msgstr "Archive"
 
@@ -934,7 +934,7 @@ msgstr "Assign to..."
 msgid "Atleast 8 characters required"
 msgstr "Atleast 8 characters required"
 
-#: src/strings.ts:2346
+#: src/strings.ts:2348
 msgid "Attach image from URL"
 msgstr "Attach image from URL"
 
@@ -947,11 +947,11 @@ msgid "attachment"
 msgstr "attachment"
 
 #: src/strings.ts:300
-#: src/strings.ts:2343
+#: src/strings.ts:2345
 msgid "Attachment"
 msgstr "Attachment"
 
-#: src/strings.ts:2447
+#: src/strings.ts:2449
 msgid "Attachment manager"
 msgstr "Attachment manager"
 
@@ -959,11 +959,11 @@ msgstr "Attachment manager"
 msgid "Attachment preview failed"
 msgstr "Attachment preview failed"
 
-#: src/strings.ts:2397
+#: src/strings.ts:2399
 msgid "Attachment recheck cancelled"
 msgstr "Attachment recheck cancelled"
 
-#: src/strings.ts:2314
+#: src/strings.ts:2316
 msgid "Attachment settings"
 msgstr "Attachment settings"
 
@@ -980,7 +980,7 @@ msgstr "Attachments"
 msgid "Attachments cache cleared!"
 msgstr "Attachments cache cleared!"
 
-#: src/strings.ts:2399
+#: src/strings.ts:2401
 msgid "Attachments recheck complete"
 msgstr "Attachments recheck complete"
 
@@ -1000,7 +1000,7 @@ msgstr "Authenticated as {email}"
 msgid "Authenticating user"
 msgstr "Authenticating user"
 
-#: src/strings.ts:2133
+#: src/strings.ts:2135
 msgid "Authentication"
 msgstr "Authentication"
 
@@ -1016,7 +1016,7 @@ msgstr "Authentication cancelled by user"
 msgid "Authentication failed"
 msgstr "Authentication failed"
 
-#: src/strings.ts:2096
+#: src/strings.ts:2098
 msgid "Auto"
 msgstr "Auto"
 
@@ -1024,7 +1024,7 @@ msgstr "Auto"
 msgid "Auto save: off"
 msgstr "Auto save: off"
 
-#: src/strings.ts:2110
+#: src/strings.ts:2112
 msgid "Auto start on system startup"
 msgstr "Auto start on system startup"
 
@@ -1045,7 +1045,7 @@ msgstr "Automatic backups disabled"
 msgid "Automatic backups with attachments"
 msgstr "Automatic backups with attachments"
 
-#: src/strings.ts:2106
+#: src/strings.ts:2108
 msgid "Automatic updates"
 msgstr "Automatic updates"
 
@@ -1053,7 +1053,7 @@ msgstr "Automatic updates"
 msgid "Automatically clear trash after a certain period of time"
 msgstr "Automatically clear trash after a certain period of time"
 
-#: src/strings.ts:2108
+#: src/strings.ts:2110
 msgid "Automatically download & install updates in the background without prompting first."
 msgstr "Automatically download & install updates in the background without prompting first."
 
@@ -1065,15 +1065,15 @@ msgstr "Automatically lock the app after a certain period"
 msgid "Automatically switch between light and dark themes based on your system settings"
 msgstr "Automatically switch between light and dark themes based on your system settings"
 
-#: src/strings.ts:2153
+#: src/strings.ts:2155
 msgid "Available on iOS"
 msgstr "Available on iOS"
 
-#: src/strings.ts:2154
+#: src/strings.ts:2156
 msgid "Available on iOS & Android"
 msgstr "Available on iOS & Android"
 
-#: src/strings.ts:2301
+#: src/strings.ts:2303
 msgid "Background color"
 msgstr "Background color"
 
@@ -1081,11 +1081,11 @@ msgstr "Background color"
 msgid "Background sync (experimental)"
 msgstr "Background sync (experimental)"
 
-#: src/strings.ts:2102
+#: src/strings.ts:2104
 msgid "Backup"
 msgstr "Backup"
 
-#: src/strings.ts:2140
+#: src/strings.ts:2142
 msgid "Backup & export"
 msgstr "Backup & export"
 
@@ -1137,7 +1137,7 @@ msgstr "Backup saved at {path}"
 msgid "Backup successful"
 msgstr "Backup successful"
 
-#: src/strings.ts:2103
+#: src/strings.ts:2105
 msgid "Backup with attachments"
 msgstr "Backup with attachments"
 
@@ -1157,23 +1157,23 @@ msgstr "Because where's the fun in nookin' alone?"
 msgid "Behavior"
 msgstr "Behavior"
 
-#: src/strings.ts:2135
+#: src/strings.ts:2137
 msgid "Behaviour"
 msgstr "Behaviour"
 
-#: src/strings.ts:2471
+#: src/strings.ts:2473
 msgid "Believer plan"
 msgstr "Believer plan"
 
-#: src/strings.ts:2460
+#: src/strings.ts:2462
 msgid "Beta"
 msgstr "Beta"
 
-#: src/strings.ts:2259
+#: src/strings.ts:2261
 msgid "Bi-directional note link"
 msgstr "Bi-directional note link"
 
-#: src/strings.ts:2201
+#: src/strings.ts:2203
 msgid "Billing history"
 msgstr "Billing history"
 
@@ -1197,11 +1197,11 @@ msgstr "Biometrics authentication failed. Please try again."
 msgid "Biometrics not enrolled"
 msgstr "Biometrics not enrolled"
 
-#: src/strings.ts:2255
+#: src/strings.ts:2257
 msgid "Bold"
 msgstr "Bold"
 
-#: src/strings.ts:2409
+#: src/strings.ts:2411
 msgid "Boost your productivity with Notebooks and organize your notes."
 msgstr "Boost your productivity with Notebooks and organize your notes."
 
@@ -1209,7 +1209,7 @@ msgstr "Boost your productivity with Notebooks and organize your notes."
 msgid "Browse"
 msgstr "Browse"
 
-#: src/strings.ts:2272
+#: src/strings.ts:2274
 msgid "Bullet list"
 msgstr "Bullet list"
 
@@ -1221,7 +1221,7 @@ msgstr "By"
 msgid "By signing up, you agree to our "
 msgstr "By signing up, you agree to our "
 
-#: src/strings.ts:2334
+#: src/strings.ts:2336
 msgid "Callout"
 msgstr "Callout"
 
@@ -1245,24 +1245,24 @@ msgstr "Cancel subscription"
 msgid "Cancel upload"
 msgstr "Cancel upload"
 
-#: src/strings.ts:2300
+#: src/strings.ts:2302
 msgid "Cell background color"
 msgstr "Cell background color"
 
-#: src/strings.ts:2302
+#: src/strings.ts:2304
 msgid "Cell border color"
 msgstr "Cell border color"
 
-#: src/strings.ts:2304
-#: src/strings.ts:2305
+#: src/strings.ts:2306
+#: src/strings.ts:2307
 msgid "Cell border width"
 msgstr "Cell border width"
 
-#: src/strings.ts:2286
+#: src/strings.ts:2288
 msgid "Cell properties"
 msgstr "Cell properties"
 
-#: src/strings.ts:2303
+#: src/strings.ts:2305
 msgid "Cell text color"
 msgstr "Cell text color"
 
@@ -1298,7 +1298,7 @@ msgstr "Change email address"
 msgid "Change how the app behaves in different situations"
 msgstr "Change how the app behaves in different situations"
 
-#: src/strings.ts:2352
+#: src/strings.ts:2354
 msgid "Change language"
 msgstr "Change language"
 
@@ -1314,11 +1314,11 @@ msgstr "Change password"
 msgid "Change profile picture"
 msgstr "Change profile picture"
 
-#: src/strings.ts:2179
+#: src/strings.ts:2181
 msgid "Change proxy"
 msgstr "Change proxy"
 
-#: src/strings.ts:2200
+#: src/strings.ts:2202
 msgid "Change the payment method you used to purchase this subscription."
 msgstr "Change the payment method you used to purchase this subscription."
 
@@ -1362,7 +1362,7 @@ msgstr "Check for updates"
 msgid "Check for updates automatically"
 msgstr "Check for updates automatically"
 
-#: src/strings.ts:2152
+#: src/strings.ts:2154
 msgid "Check roadmap"
 msgstr "Check roadmap"
 
@@ -1370,7 +1370,7 @@ msgstr "Check roadmap"
 msgid "Check your spam folder if you haven't received an email yet."
 msgstr "Check your spam folder if you haven't received an email yet."
 
-#: src/strings.ts:2401
+#: src/strings.ts:2403
 msgid "Checking all attachments"
 msgstr "Checking all attachments"
 
@@ -1382,15 +1382,15 @@ msgstr "Checking for new version"
 msgid "Checking for updates"
 msgstr "Checking for updates"
 
-#: src/strings.ts:2400
+#: src/strings.ts:2402
 msgid "Checking note attachments"
 msgstr "Checking note attachments"
 
-#: src/strings.ts:2274
+#: src/strings.ts:2276
 msgid "Checklist"
 msgstr "Checklist"
 
-#: src/strings.ts:2329
+#: src/strings.ts:2331
 msgid "Choose a block to insert"
 msgstr "Choose a block to insert"
 
@@ -1398,11 +1398,11 @@ msgstr "Choose a block to insert"
 msgid "Choose a recovery method"
 msgstr "Choose a recovery method"
 
-#: src/strings.ts:2101
+#: src/strings.ts:2103
 msgid "Choose backup format"
 msgstr "Choose backup format"
 
-#: src/strings.ts:2365
+#: src/strings.ts:2367
 msgid "Choose custom color"
 msgstr "Choose custom color"
 
@@ -1446,7 +1446,7 @@ msgstr "Clear"
 msgid "Clear all cached attachments. Current cache size: {cacheSize}"
 msgstr "Clear all cached attachments. Current cache size: {cacheSize}"
 
-#: src/strings.ts:2268
+#: src/strings.ts:2270
 msgid "Clear all formatting"
 msgstr "Clear all formatting"
 
@@ -1458,7 +1458,7 @@ msgstr "Clear attachments cache?"
 msgid "Clear cache"
 msgstr "Clear cache"
 
-#: src/strings.ts:2363
+#: src/strings.ts:2365
 msgid "Clear completed tasks"
 msgstr "Clear completed tasks"
 
@@ -1474,7 +1474,7 @@ msgstr "Clear default notebook"
 msgid "Clear logs"
 msgstr "Clear logs"
 
-#: src/strings.ts:2195
+#: src/strings.ts:2197
 msgid "clear sessions"
 msgstr "clear sessions"
 
@@ -1528,7 +1528,7 @@ msgstr "Click to preview"
 msgid "Click to remove"
 msgstr "Click to remove"
 
-#: src/strings.ts:2392
+#: src/strings.ts:2394
 msgid "Click to reset {title}"
 msgstr "Click to reset {title}"
 
@@ -1540,11 +1540,11 @@ msgstr "Close"
 msgid "Close all"
 msgstr "Close all"
 
-#: src/strings.ts:2450
+#: src/strings.ts:2452
 msgid "Close all tabs"
 msgstr "Close all tabs"
 
-#: src/strings.ts:2449
+#: src/strings.ts:2451
 msgid "Close current tab"
 msgstr "Close current tab"
 
@@ -1552,7 +1552,7 @@ msgstr "Close current tab"
 msgid "Close others"
 msgstr "Close others"
 
-#: src/strings.ts:2119
+#: src/strings.ts:2121
 msgid "Close to system tray"
 msgstr "Close to system tray"
 
@@ -1564,15 +1564,15 @@ msgstr "Close to the left"
 msgid "Close to the right"
 msgstr "Close to the right"
 
-#: src/strings.ts:2266
+#: src/strings.ts:2268
 msgid "Code"
 msgstr "Code"
 
-#: src/strings.ts:2331
+#: src/strings.ts:2333
 msgid "Code block"
 msgstr "Code block"
 
-#: src/strings.ts:2267
+#: src/strings.ts:2269
 msgid "Code remove"
 msgstr "Code remove"
 
@@ -1609,11 +1609,11 @@ msgstr "colors"
 msgid "Colors"
 msgstr "Colors"
 
-#: src/strings.ts:2284
+#: src/strings.ts:2286
 msgid "Column properties"
 msgstr "Column properties"
 
-#: src/strings.ts:2441
+#: src/strings.ts:2443
 msgid "Command palette"
 msgstr "Command palette"
 
@@ -1637,11 +1637,11 @@ msgstr "Compress images before uploading"
 msgid "Compressed images are uploaded in Full HD resolution and usually are good enough for most use cases."
 msgstr "Compressed images are uploaded in Full HD resolution and usually are good enough for most use cases."
 
-#: src/strings.ts:2250
+#: src/strings.ts:2252
 msgid "Configure"
 msgstr "Configure"
 
-#: src/strings.ts:2406
+#: src/strings.ts:2408
 msgid "Configure server URLs for Notesnook"
 msgstr "Configure server URLs for Notesnook"
 
@@ -1710,7 +1710,7 @@ msgstr "Copy as{0}"
 msgid "Copy codes"
 msgstr "Copy codes"
 
-#: src/strings.ts:2246
+#: src/strings.ts:2248
 msgid "Copy image"
 msgstr "Copy image"
 
@@ -1718,7 +1718,7 @@ msgstr "Copy image"
 msgid "Copy link"
 msgstr "Copy link"
 
-#: src/strings.ts:2245
+#: src/strings.ts:2247
 msgid "Copy link text"
 msgstr "Copy link text"
 
@@ -1814,7 +1814,7 @@ msgstr "Create vault"
 msgid "Create your account"
 msgstr "Create your account"
 
-#: src/strings.ts:2228
+#: src/strings.ts:2230
 msgid "Created at"
 msgstr "Created at"
 
@@ -1859,7 +1859,7 @@ msgstr "CURRENT PLAN"
 msgid "Custom"
 msgstr "Custom"
 
-#: src/strings.ts:2130
+#: src/strings.ts:2132
 msgid "Custom dictionary words"
 msgstr "Custom dictionary words"
 
@@ -1883,7 +1883,7 @@ msgstr "Customize the toolbar in the note editor"
 msgid "Customize toolbar"
 msgstr "Customize toolbar"
 
-#: src/strings.ts:2244
+#: src/strings.ts:2246
 msgid "Cut"
 msgstr "Cut"
 
@@ -1900,7 +1900,7 @@ msgstr "Dark"
 msgid "Dark mode"
 msgstr "Dark mode"
 
-#: src/strings.ts:2095
+#: src/strings.ts:2097
 msgid "Dark or light, we won't judge."
 msgstr "Dark or light, we won't judge."
 
@@ -1912,7 +1912,7 @@ msgstr "Database setup failed, could not get database key"
 msgid "Date"
 msgstr "Date"
 
-#: src/strings.ts:2104
+#: src/strings.ts:2106
 msgid "Date & time"
 msgstr "Date & time"
 
@@ -1964,7 +1964,7 @@ msgstr "Debug logs downloaded"
 msgid "Debugging"
 msgstr "Debugging"
 
-#: src/strings.ts:2394
+#: src/strings.ts:2396
 msgid "Decrease {title}"
 msgstr "Decrease {title}"
 
@@ -1997,7 +1997,7 @@ msgstr "Default notebook cleared"
 msgid "Default screen to open on app launch"
 msgstr "Default screen to open on app launch"
 
-#: src/strings.ts:2481
+#: src/strings.ts:2483
 msgid "Default sidebar tab"
 msgstr "Default sidebar tab"
 
@@ -2021,7 +2021,7 @@ msgstr "Delete account"
 msgid "Delete collapsed section"
 msgstr "Delete collapsed section"
 
-#: src/strings.ts:2291
+#: src/strings.ts:2293
 msgid "Delete column"
 msgstr "Delete column"
 
@@ -2029,7 +2029,7 @@ msgstr "Delete column"
 msgid "Delete group"
 msgstr "Delete group"
 
-#: src/strings.ts:2366
+#: src/strings.ts:2368
 msgid "Delete mode"
 msgstr "Delete mode"
 
@@ -2041,11 +2041,11 @@ msgstr "Delete notes in this vault"
 msgid "Delete permanently"
 msgstr "Delete permanently"
 
-#: src/strings.ts:2298
+#: src/strings.ts:2300
 msgid "Delete row"
 msgstr "Delete row"
 
-#: src/strings.ts:2299
+#: src/strings.ts:2301
 msgid "Delete table"
 msgstr "Delete table"
 
@@ -2069,11 +2069,11 @@ msgstr "Deleting"
 msgid "Description"
 msgstr "Description"
 
-#: src/strings.ts:2105
+#: src/strings.ts:2107
 msgid "Desktop app"
 msgstr "Desktop app"
 
-#: src/strings.ts:2109
+#: src/strings.ts:2111
 msgid "Desktop integration"
 msgstr "Desktop integration"
 
@@ -2125,7 +2125,7 @@ msgstr "Disputed"
 msgid "Do you enjoy using Notesnook?"
 msgstr "Do you enjoy using Notesnook?"
 
-#: src/strings.ts:2227
+#: src/strings.ts:2229
 msgid "Do you want to clear the trash?"
 msgstr "Do you want to clear the trash?"
 
@@ -2189,7 +2189,7 @@ msgstr "Download"
 msgid "Download all attachments"
 msgstr "Download all attachments"
 
-#: src/strings.ts:2315
+#: src/strings.ts:2317
 msgid "Download attachment"
 msgstr "Download attachment"
 
@@ -2201,7 +2201,7 @@ msgstr "Download backup file"
 msgid "Download cancelled"
 msgstr "Download cancelled"
 
-#: src/strings.ts:2207
+#: src/strings.ts:2209
 msgid "Download everything including attachments on sync"
 msgstr "Download everything including attachments on sync"
 
@@ -2266,7 +2266,7 @@ msgstr "Duplicate"
 msgid "Earliest first"
 msgstr "Earliest first"
 
-#: src/strings.ts:2418
+#: src/strings.ts:2420
 msgid "Easy access"
 msgstr "Easy access"
 
@@ -2278,12 +2278,12 @@ msgstr "Edit"
 msgid "Edit internal link"
 msgstr "Edit internal link"
 
-#: src/strings.ts:2233
-#: src/strings.ts:2261
+#: src/strings.ts:2235
+#: src/strings.ts:2263
 msgid "Edit link"
 msgstr "Edit link"
 
-#: src/strings.ts:2474
+#: src/strings.ts:2476
 msgid "Edit profile"
 msgstr "Edit profile"
 
@@ -2304,7 +2304,7 @@ msgstr "Editor"
 msgid "Email"
 msgstr "Email"
 
-#: src/strings.ts:2431
+#: src/strings.ts:2433
 msgid "Email copied"
 msgstr "Email copied"
 
@@ -2328,15 +2328,15 @@ msgstr "Email support"
 msgid "Email updated to {email}"
 msgstr "Email updated to {email}"
 
-#: src/strings.ts:2341
+#: src/strings.ts:2343
 msgid "Embed"
 msgstr "Embed"
 
-#: src/strings.ts:2321
+#: src/strings.ts:2323
 msgid "Embed properties"
 msgstr "Embed properties"
 
-#: src/strings.ts:2317
+#: src/strings.ts:2319
 msgid "Embed settings"
 msgstr "Embed settings"
 
@@ -2356,15 +2356,15 @@ msgstr "Enable app lock"
 msgid "Enable editor margins"
 msgstr "Enable editor margins"
 
-#: src/strings.ts:2465
+#: src/strings.ts:2467
 msgid "Enable ligatures for common symbols like →, ←, etc"
 msgstr "Enable ligatures for common symbols like →, ←, etc"
 
-#: src/strings.ts:2381
+#: src/strings.ts:2383
 msgid "Enable regex"
 msgstr "Enable regex"
 
-#: src/strings.ts:2126
+#: src/strings.ts:2128
 msgid "Enable spell checker"
 msgstr "Enable spell checker"
 
@@ -2380,7 +2380,7 @@ msgstr "Encrypt your backups for added security"
 msgid "Encrypted and synced"
 msgstr "Encrypted and synced"
 
-#: src/strings.ts:2240
+#: src/strings.ts:2242
 msgid "Encrypted backup"
 msgstr "Encrypted backup"
 
@@ -2432,7 +2432,7 @@ msgstr "Enter code from authenticator app"
 msgid "Enter email address"
 msgstr "Enter email address"
 
-#: src/strings.ts:2369
+#: src/strings.ts:2371
 msgid "Enter embed source URL"
 msgstr "Enter embed source URL"
 
@@ -2476,7 +2476,7 @@ msgstr "Enter the 6 digit code sent to your email to continue logging in"
 msgid "Enter the 6 digit code sent to your phone number to continue logging in"
 msgstr "Enter the 6 digit code sent to your phone number to continue logging in"
 
-#: src/strings.ts:2433
+#: src/strings.ts:2435
 msgid "Enter the gift code to redeem your subscription."
 msgstr "Enter the gift code to redeem your subscription."
 
@@ -2496,7 +2496,7 @@ msgstr "Enter your new email"
 msgid "Enter your username"
 msgstr "Enter your username"
 
-#: src/strings.ts:2425
+#: src/strings.ts:2427
 msgid "Error"
 msgstr "Error"
 
@@ -2532,7 +2532,7 @@ msgstr "Errors"
 msgid "Errors in {count} attachments"
 msgstr "Errors in {count} attachments"
 
-#: src/strings.ts:2470
+#: src/strings.ts:2472
 msgid "Essential plan"
 msgstr "Essential plan"
 
@@ -2540,23 +2540,23 @@ msgstr "Essential plan"
 msgid "Events server"
 msgstr "Events server"
 
-#: src/strings.ts:2411
+#: src/strings.ts:2413
 msgid "Every Notebook can have notes and sub notebooks."
 msgstr "Every Notebook can have notes and sub notebooks."
 
-#: src/strings.ts:2413
+#: src/strings.ts:2415
 msgid "Everything related to my job in one place."
 msgstr "Everything related to my job in one place."
 
-#: src/strings.ts:2422
+#: src/strings.ts:2424
 msgid "Everything related to my school in one place."
 msgstr "Everything related to my school in one place."
 
-#: src/strings.ts:2439
+#: src/strings.ts:2441
 msgid "Execute"
 msgstr "Execute"
 
-#: src/strings.ts:2438
+#: src/strings.ts:2440
 msgid "Execute a command..."
 msgstr "Execute a command..."
 
@@ -2564,11 +2564,11 @@ msgstr "Execute a command..."
 msgid "Exit fullscreen"
 msgstr "Exit fullscreen"
 
-#: src/strings.ts:2373
+#: src/strings.ts:2375
 msgid "Expand"
 msgstr "Expand"
 
-#: src/strings.ts:2466
+#: src/strings.ts:2468
 msgid "Expand sidebar"
 msgstr "Expand sidebar"
 
@@ -2617,7 +2617,7 @@ msgstr "EXTREMELY DANGEROUS! This action is irreversible. All your data includin
 msgid "Faced an issue or have a suggestion? Click here to create a bug report"
 msgstr "Faced an issue or have a suggestion? Click here to create a bug report"
 
-#: src/strings.ts:2403
+#: src/strings.ts:2405
 msgid "Failed"
 msgstr "Failed"
 
@@ -2673,11 +2673,11 @@ msgstr "Failed to send verification email"
 msgid "Failed to subscribe"
 msgstr "Failed to subscribe"
 
-#: src/strings.ts:2202
+#: src/strings.ts:2204
 msgid "Failed to take backup"
 msgstr "Failed to take backup"
 
-#: src/strings.ts:2204
+#: src/strings.ts:2206
 msgid "Failed to take backup of your data. Do you want to continue logging out?"
 msgstr "Failed to take backup of your data. Do you want to continue logging out?"
 
@@ -2702,11 +2702,11 @@ msgstr "Favorite"
 msgid "Favorites"
 msgstr "Favorites"
 
-#: src/strings.ts:2415
+#: src/strings.ts:2417
 msgid "February 2022 Week 2"
 msgstr "February 2022 Week 2"
 
-#: src/strings.ts:2416
+#: src/strings.ts:2418
 msgid "February 2022 Week 3"
 msgstr "February 2022 Week 3"
 
@@ -2750,7 +2750,7 @@ msgstr "Filter languages"
 msgid "Fix it"
 msgstr "Fix it"
 
-#: src/strings.ts:2310
+#: src/strings.ts:2312
 msgid "Float image"
 msgstr "Float image"
 
@@ -2758,7 +2758,7 @@ msgstr "Float image"
 msgid "Focus mode"
 msgstr "Focus mode"
 
-#: src/strings.ts:2162
+#: src/strings.ts:2164
 msgid "Follow"
 msgstr "Follow"
 
@@ -2778,17 +2778,25 @@ msgstr "Follow us on X"
 msgid "Follow us on X for updates and news about Notesnook"
 msgstr "Follow us on X for updates and news about Notesnook"
 
-#: src/strings.ts:2275
+#: src/strings.ts:2277
 msgid "Font family"
 msgstr "Font family"
 
-#: src/strings.ts:2463
+#: src/strings.ts:2465
 msgid "Font ligatures"
 msgstr "Font ligatures"
 
-#: src/strings.ts:2276
+#: src/strings.ts:2278
 msgid "Font size"
 msgstr "Font size"
+
+#: src/strings.ts:2096
+msgid "Font Size(Editor Title)"
+msgstr "Font Size(Editor Title)"
+
+#: src/strings.ts:2095
+msgid "Font Size(List Title)"
+msgstr "Font Size(List Title)"
 
 #: src/strings.ts:1685
 msgid "For a more integrated user experience, try out Notesnook for {platform}"
@@ -2798,7 +2806,7 @@ msgstr "For a more integrated user experience, try out Notesnook for {platform}"
 msgid "for help regarding how to use the Notesnook Importer."
 msgstr "for help regarding how to use the Notesnook Importer."
 
-#: src/strings.ts:2194
+#: src/strings.ts:2196
 msgid "Force logout from all your other logged in devices."
 msgstr "Force logout from all your other logged in devices."
 
@@ -2810,7 +2818,7 @@ msgstr "Force pull changes"
 msgid "Force push changes"
 msgstr "Force push changes"
 
-#: src/strings.ts:2211
+#: src/strings.ts:2213
 msgid ""
 "Force push:\n"
 "Use this if changes made on this device are not appearing on other devices. This will overwrite the data on the server with the data from this device.\n"
@@ -2832,7 +2840,7 @@ msgstr ""
 msgid "Forgot password?"
 msgstr "Forgot password?"
 
-#: src/strings.ts:2468
+#: src/strings.ts:2470
 msgid "Free plan"
 msgstr "Free plan"
 
@@ -2844,11 +2852,11 @@ msgstr "Fri"
 msgid "Friday"
 msgstr "Friday"
 
-#: src/strings.ts:2371
+#: src/strings.ts:2373
 msgid "From code"
 msgstr "From code"
 
-#: src/strings.ts:2368
+#: src/strings.ts:2370
 msgid "From URL"
 msgstr "From URL"
 
@@ -2856,11 +2864,11 @@ msgstr "From URL"
 msgid "Full name updated"
 msgstr "Full name updated"
 
-#: src/strings.ts:2205
+#: src/strings.ts:2207
 msgid "Full offline mode"
 msgstr "Full offline mode"
 
-#: src/strings.ts:2323
+#: src/strings.ts:2325
 msgid "Full screen"
 msgstr "Full screen"
 
@@ -2876,11 +2884,11 @@ msgstr "Get helpful debug info about the app to help us find bugs."
 msgid "Get Notesnook app on your desktop and access all notes"
 msgstr "Get Notesnook app on your desktop and access all notes"
 
-#: src/strings.ts:2156
+#: src/strings.ts:2158
 msgid "Get Notesnook app on your iPhone and access all your notes on the go."
 msgstr "Get Notesnook app on your iPhone and access all your notes on the go."
 
-#: src/strings.ts:2158
+#: src/strings.ts:2160
 msgid "Get Notesnook app on your iPhone or Android device and access all your notes on the go."
 msgstr "Get Notesnook app on your iPhone or Android device and access all your notes on the go."
 
@@ -2892,7 +2900,7 @@ msgstr "Get Notesnook Pro"
 msgid "Get Notesnook Pro to enable automatic backups"
 msgstr "Get Notesnook Pro to enable automatic backups"
 
-#: src/strings.ts:2407
+#: src/strings.ts:2409
 msgid "Get Priority support"
 msgstr "Get Priority support"
 
@@ -2916,23 +2924,23 @@ msgstr "Getting information"
 msgid "Getting recovery codes"
 msgstr "Getting recovery codes"
 
-#: src/strings.ts:2161
+#: src/strings.ts:2163
 msgid "GNU GENERAL PUBLIC LICENSE Version 3"
 msgstr "GNU GENERAL PUBLIC LICENSE Version 3"
 
-#: src/strings.ts:2446
+#: src/strings.ts:2448
 msgid "Go back in tab"
 msgstr "Go back in tab"
 
-#: src/strings.ts:2224
+#: src/strings.ts:2226
 msgid "Go back to notebooks"
 msgstr "Go back to notebooks"
 
-#: src/strings.ts:2225
+#: src/strings.ts:2227
 msgid "Go back to tags"
 msgstr "Go back to tags"
 
-#: src/strings.ts:2445
+#: src/strings.ts:2447
 msgid "Go forward in tab"
 msgstr "Go forward in tab"
 
@@ -2976,19 +2984,19 @@ msgstr "Group by"
 msgid "Hash copied"
 msgstr "Hash copied"
 
-#: src/strings.ts:2208
+#: src/strings.ts:2210
 msgid "Having problems with sync?"
 msgstr "Having problems with sync?"
 
-#: src/strings.ts:2349
+#: src/strings.ts:2351
 msgid "Heading {level}"
 msgstr "Heading {level}"
 
-#: src/strings.ts:2277
+#: src/strings.ts:2279
 msgid "Headings"
 msgstr "Headings"
 
-#: src/strings.ts:2384
+#: src/strings.ts:2386
 msgid "Height"
 msgstr "Height"
 
@@ -3008,11 +3016,11 @@ msgstr "Hide"
 msgid "Hide app contents when you switch to other apps. This will also disable screenshot taking in the app."
 msgstr "Hide app contents when you switch to other apps. This will also disable screenshot taking in the app."
 
-#: src/strings.ts:2167
+#: src/strings.ts:2169
 msgid "Hide note title"
 msgstr "Hide note title"
 
-#: src/strings.ts:2280
+#: src/strings.ts:2282
 msgid "Highlight"
 msgstr "Highlight"
 
@@ -3032,7 +3040,7 @@ msgstr "Homepage"
 msgid "Homepage changed to {name}"
 msgstr "Homepage changed to {name}"
 
-#: src/strings.ts:2330
+#: src/strings.ts:2332
 msgid "Horizontal rule"
 msgstr "Horizontal rule"
 
@@ -3072,11 +3080,11 @@ msgstr "I have a recovery code"
 msgid "I have saved my key"
 msgstr "I have saved my key"
 
-#: src/strings.ts:2424
+#: src/strings.ts:2426
 msgid "I love cooking and collecting recipes."
 msgstr "I love cooking and collecting recipes."
 
-#: src/strings.ts:2209
+#: src/strings.ts:2211
 msgid "I understand"
 msgstr "I understand"
 
@@ -3092,11 +3100,11 @@ msgstr "If the editor fails to load even after reloading. Try restarting the app
 msgid "If this continues to happen, please reach out to us via"
 msgstr "If this continues to happen, please reach out to us via"
 
-#: src/strings.ts:2112
+#: src/strings.ts:2114
 msgid "If true, Notesnook will automatically start up when you turn on & login to your system."
 msgstr "If true, Notesnook will automatically start up when you turn on & login to your system."
 
-#: src/strings.ts:2115
+#: src/strings.ts:2117
 msgid "If true, Notesnook will start minimized to either the system tray or your system taskbar/dock. This setting only works with Auto start on system startup is enabled."
 msgstr "If true, Notesnook will start minimized to either the system tray or your system taskbar/dock. This setting only works with Auto start on system startup is enabled."
 
@@ -3124,7 +3132,7 @@ msgstr "If you face any issue, you can reach out to us anytime."
 msgid "If you want to ask something in general or need some assistance, we would suggest that you"
 msgstr "If you want to ask something in general or need some assistance, we would suggest that you"
 
-#: src/strings.ts:2335
+#: src/strings.ts:2337
 msgid "Image"
 msgstr "Image"
 
@@ -3132,11 +3140,11 @@ msgstr "Image"
 msgid "Image Compression"
 msgstr "Image Compression"
 
-#: src/strings.ts:2311
+#: src/strings.ts:2313
 msgid "Image properties"
 msgstr "Image properties"
 
-#: src/strings.ts:2306
+#: src/strings.ts:2308
 msgid "Image settings"
 msgstr "Image settings"
 
@@ -3156,7 +3164,7 @@ msgstr "Images uploaded without compression are slow to load and take more bandw
 msgid "Immediately"
 msgstr "Immediately"
 
-#: src/strings.ts:2139
+#: src/strings.ts:2141
 msgid "Import & export"
 msgstr "Import & export"
 
@@ -3180,47 +3188,47 @@ msgstr "Incoming note"
 msgid "Incorrect {type}"
 msgstr "Incorrect {type}"
 
-#: src/strings.ts:2393
+#: src/strings.ts:2395
 msgid "Increase {title}"
 msgstr "Increase {title}"
 
-#: src/strings.ts:2234
+#: src/strings.ts:2236
 msgid "Insert"
 msgstr "Insert"
 
-#: src/strings.ts:2390
+#: src/strings.ts:2392
 msgid "Insert a {rows}x{columns} table"
 msgstr "Insert a {rows}x{columns} table"
 
-#: src/strings.ts:2340
+#: src/strings.ts:2342
 msgid "Insert a table"
 msgstr "Insert a table"
 
-#: src/strings.ts:2342
+#: src/strings.ts:2344
 msgid "Insert an embed"
 msgstr "Insert an embed"
 
-#: src/strings.ts:2336
+#: src/strings.ts:2338
 msgid "Insert an image"
 msgstr "Insert an image"
 
-#: src/strings.ts:2287
+#: src/strings.ts:2289
 msgid "Insert column left"
 msgstr "Insert column left"
 
-#: src/strings.ts:2288
+#: src/strings.ts:2290
 msgid "Insert column right"
 msgstr "Insert column right"
 
-#: src/strings.ts:2232
+#: src/strings.ts:2234
 msgid "Insert link"
 msgstr "Insert link"
 
-#: src/strings.ts:2294
+#: src/strings.ts:2296
 msgid "Insert row above"
 msgstr "Insert row above"
 
-#: src/strings.ts:2295
+#: src/strings.ts:2297
 msgid "Insert row below"
 msgstr "Insert row below"
 
@@ -3228,7 +3236,7 @@ msgstr "Insert row below"
 msgid "Install Notesnook"
 msgstr "Install Notesnook"
 
-#: src/strings.ts:2147
+#: src/strings.ts:2149
 msgid "Install update"
 msgstr "Install update"
 
@@ -3265,7 +3273,7 @@ msgstr "It seems that your changes could not be saved. What to do next:"
 msgid "It took us a year to bring Notesnook to life. Share your experience and suggestions to help us improve it."
 msgstr "It took us a year to bring Notesnook to life. Share your experience and suggestions to help us improve it."
 
-#: src/strings.ts:2256
+#: src/strings.ts:2258
 msgid "Italic"
 msgstr "Italic"
 
@@ -3286,7 +3294,7 @@ msgstr "items"
 msgid "Items"
 msgstr "Items"
 
-#: src/strings.ts:2159
+#: src/strings.ts:2161
 msgid "Join community"
 msgstr "Join community"
 
@@ -3330,11 +3338,11 @@ msgstr "Keep open"
 msgid "Keep your data safe"
 msgstr "Keep your data safe"
 
-#: src/strings.ts:2127
+#: src/strings.ts:2129
 msgid "Languages"
 msgstr "Languages"
 
-#: src/strings.ts:2229
+#: src/strings.ts:2231
 msgid "Last edited at"
 msgstr "Last edited at"
 
@@ -3374,7 +3382,7 @@ msgstr "Legal"
 msgid "Let us know if you have faced any issue/bug while using Notesnook. We will try to fix it as soon as possible."
 msgstr "Let us know if you have faced any issue/bug while using Notesnook. We will try to fix it as soon as possible."
 
-#: src/strings.ts:2160
+#: src/strings.ts:2162
 msgid "License"
 msgstr "License"
 
@@ -3382,7 +3390,7 @@ msgstr "License"
 msgid "Licensed under {license}"
 msgstr "Licensed under {license}"
 
-#: src/strings.ts:2326
+#: src/strings.ts:2328
 msgid "Lift list item"
 msgstr "Lift list item"
 
@@ -3390,7 +3398,7 @@ msgstr "Lift list item"
 msgid "Light"
 msgstr "Light"
 
-#: src/strings.ts:2356
+#: src/strings.ts:2358
 msgid "Line {line}, Column {column}"
 msgstr "Line {line}, Column {column}"
 
@@ -3398,7 +3406,7 @@ msgstr "Line {line}, Column {column}"
 msgid "Line spacing changed"
 msgstr "Line spacing changed"
 
-#: src/strings.ts:2260
+#: src/strings.ts:2262
 msgid "Link"
 msgstr "Link"
 
@@ -3410,15 +3418,15 @@ msgstr "Link copied"
 msgid "Link notebooks"
 msgstr "Link notebooks"
 
-#: src/strings.ts:2475
+#: src/strings.ts:2477
 msgid "Link notes"
 msgstr "Link notes"
 
-#: src/strings.ts:2265
+#: src/strings.ts:2267
 msgid "Link settings"
 msgstr "Link settings"
 
-#: src/strings.ts:2386
+#: src/strings.ts:2388
 msgid "Link text"
 msgstr "Link text"
 
@@ -3523,7 +3531,7 @@ msgstr "Locked notes cannot be pinned"
 msgid "Locked notes cannot be published"
 msgstr "Locked notes cannot be published"
 
-#: src/strings.ts:2192
+#: src/strings.ts:2194
 msgid "Log out from all other devices"
 msgstr "Log out from all other devices"
 
@@ -3583,7 +3591,7 @@ msgstr "Logout from this device"
 msgid "Long press on any item in list to enter multi-select mode."
 msgstr "Long press on any item in list to enter multi-select mode."
 
-#: src/strings.ts:2361
+#: src/strings.ts:2363
 msgid "Make task list readonly"
 msgstr "Make task list readonly"
 
@@ -3635,19 +3643,19 @@ msgstr "Markdown shortcuts"
 msgid "Marketing emails"
 msgstr "Marketing emails"
 
-#: src/strings.ts:2374
+#: src/strings.ts:2376
 msgid "Match case"
 msgstr "Match case"
 
-#: src/strings.ts:2375
+#: src/strings.ts:2377
 msgid "Match whole word"
 msgstr "Match whole word"
 
-#: src/strings.ts:2282
+#: src/strings.ts:2284
 msgid "Math (inline)"
 msgstr "Math (inline)"
 
-#: src/strings.ts:2333
+#: src/strings.ts:2335
 msgid "Math & formulas"
 msgstr "Math & formulas"
 
@@ -3659,7 +3667,7 @@ msgstr "Maximize"
 msgid "Meet other privacy-minded people & talk to us directly about your concerns, issues and suggestions."
 msgstr "Meet other privacy-minded people & talk to us directly about your concerns, issues and suggestions."
 
-#: src/strings.ts:2417
+#: src/strings.ts:2419
 msgid "Meetings"
 msgstr "Meetings"
 
@@ -3667,7 +3675,7 @@ msgstr "Meetings"
 msgid "Member since {date}"
 msgstr "Member since {date}"
 
-#: src/strings.ts:2293
+#: src/strings.ts:2295
 msgid "Merge cells"
 msgstr "Merge cells"
 
@@ -3693,7 +3701,7 @@ msgstr "Minimal"
 msgid "Minimize"
 msgstr "Minimize"
 
-#: src/strings.ts:2116
+#: src/strings.ts:2118
 msgid "Minimize to system tray"
 msgstr "Minimize to system tray"
 
@@ -3744,7 +3752,7 @@ msgstr "Month"
 msgid "Monthly"
 msgstr "Monthly"
 
-#: src/strings.ts:2313
+#: src/strings.ts:2315
 msgid "More"
 msgstr "More"
 
@@ -3756,15 +3764,15 @@ msgstr "Most relevant first"
 msgid "Move"
 msgstr "Move"
 
-#: src/strings.ts:2362
+#: src/strings.ts:2364
 msgid "Move all checked tasks to bottom"
 msgstr "Move all checked tasks to bottom"
 
-#: src/strings.ts:2289
+#: src/strings.ts:2291
 msgid "Move column left"
 msgstr "Move column left"
 
-#: src/strings.ts:2290
+#: src/strings.ts:2292
 msgid "Move column right"
 msgstr "Move column right"
 
@@ -3776,11 +3784,11 @@ msgstr "Move notebook"
 msgid "Move notes"
 msgstr "Move notes"
 
-#: src/strings.ts:2297
+#: src/strings.ts:2299
 msgid "Move row down"
 msgstr "Move row down"
 
-#: src/strings.ts:2296
+#: src/strings.ts:2298
 msgid "Move row up"
 msgstr "Move row up"
 
@@ -3808,7 +3816,7 @@ msgstr "Name"
 msgid "Native high-performance encryption"
 msgstr "Native high-performance encryption"
 
-#: src/strings.ts:2442
+#: src/strings.ts:2444
 msgid "Navigate"
 msgstr "Navigate"
 
@@ -3868,7 +3876,7 @@ msgstr "New reminder"
 msgid "New tab"
 msgstr "New tab"
 
-#: src/strings.ts:2448
+#: src/strings.ts:2450
 msgid "New tag"
 msgstr "New tag"
 
@@ -3892,11 +3900,11 @@ msgstr "Newly created notes will be uncategorized"
 msgid "Next"
 msgstr "Next"
 
-#: src/strings.ts:2378
+#: src/strings.ts:2380
 msgid "Next match"
 msgstr "Next match"
 
-#: src/strings.ts:2443
+#: src/strings.ts:2445
 msgid "Next tab"
 msgstr "Next tab"
 
@@ -3952,7 +3960,7 @@ msgstr "No links found"
 msgid "No note history available for this device."
 msgstr "No note history available for this device."
 
-#: src/strings.ts:2489
+#: src/strings.ts:2491
 msgid "No notebooks selected to move"
 msgstr "No notebooks selected to move"
 
@@ -4050,7 +4058,7 @@ msgstr "notebook"
 msgid "Notebook"
 msgstr "Notebook"
 
-#: src/strings.ts:2478
+#: src/strings.ts:2480
 msgid "Notebook added"
 msgstr "Notebook added"
 
@@ -4068,7 +4076,7 @@ msgstr "Notebooks"
 msgid "NOTEBOOKS"
 msgstr "NOTEBOOKS"
 
-#: src/strings.ts:2239
+#: src/strings.ts:2241
 msgid "Notebooks are the best way to organize your notes."
 msgstr "Notebooks are the best way to organize your notes."
 
@@ -4093,7 +4101,7 @@ msgstr "notes imported"
 msgid "Notesnook encrypts everything offline before syncing to your other devices. This means that no one can read your notes except you. Not even us."
 msgstr "Notesnook encrypts everything offline before syncing to your other devices. This means that no one can read your notes except you. Not even us."
 
-#: src/strings.ts:2141
+#: src/strings.ts:2143
 msgid "Notesnook Importer"
 msgstr "Notesnook Importer"
 
@@ -4101,7 +4109,7 @@ msgstr "Notesnook Importer"
 msgid "Notesnook Pro"
 msgstr "Notesnook Pro"
 
-#: src/strings.ts:2173
+#: src/strings.ts:2175
 msgid ""
 "Notesnook uses the following DNS providers:\n"
 "\n"
@@ -4125,7 +4133,7 @@ msgstr "Notesnook will send you a 2FA code on your email when prompted"
 msgid "Notesnook will send you an SMS with a 2FA code when prompted"
 msgstr "Notesnook will send you an SMS with a 2FA code when prompted"
 
-#: src/strings.ts:2136
+#: src/strings.ts:2138
 msgid "Notifications"
 msgstr "Notifications"
 
@@ -4133,7 +4141,7 @@ msgstr "Notifications"
 msgid "Notifications disabled"
 msgstr "Notifications disabled"
 
-#: src/strings.ts:2273
+#: src/strings.ts:2275
 msgid "Numbered list"
 msgstr "Numbered list"
 
@@ -4149,7 +4157,7 @@ msgstr "Off"
 msgid "Offline"
 msgstr "Offline"
 
-#: src/strings.ts:2226
+#: src/strings.ts:2228
 msgid "Okay"
 msgstr "Okay"
 
@@ -4193,7 +4201,7 @@ msgstr "Open in browser"
 msgid "Open in browser to manage subscription"
 msgstr "Open in browser to manage subscription"
 
-#: src/strings.ts:2324
+#: src/strings.ts:2326
 msgid "Open in new tab"
 msgstr "Open in new tab"
 
@@ -4201,7 +4209,7 @@ msgstr "Open in new tab"
 msgid "Open issue"
 msgstr "Open issue"
 
-#: src/strings.ts:2263
+#: src/strings.ts:2265
 msgid "Open link"
 msgstr "Open link"
 
@@ -4213,7 +4221,7 @@ msgstr "Open note"
 msgid "Open settings"
 msgstr "Open settings"
 
-#: src/strings.ts:2325
+#: src/strings.ts:2327
 msgid "Open source"
 msgstr "Open source"
 
@@ -4245,7 +4253,7 @@ msgstr "or email us at"
 msgid "Order by"
 msgstr "Order by"
 
-#: src/strings.ts:2219
+#: src/strings.ts:2221
 msgid "Order ID"
 msgstr "Order ID"
 
@@ -4254,19 +4262,19 @@ msgstr "Order ID"
 msgid "Orphaned"
 msgstr "Orphaned"
 
-#: src/strings.ts:2144
+#: src/strings.ts:2146
 msgid "Other"
 msgstr "Other"
 
-#: src/strings.ts:2345
+#: src/strings.ts:2347
 msgid "Outline list"
 msgstr "Outline list"
 
-#: src/strings.ts:2348
+#: src/strings.ts:2350
 msgid "Paragraph"
 msgstr "Paragraph"
 
-#: src/strings.ts:2100
+#: src/strings.ts:2102
 msgid "Partial backups contain all your data except attachments. They are created from data already available on your device and do not require an Internet connection."
 msgstr "Partial backups contain all your data except attachments. They are created from data already available on your device and do not require an Internet connection."
 
@@ -4274,7 +4282,7 @@ msgstr "Partial backups contain all your data except attachments. They are creat
 msgid "Partially refunded"
 msgstr "Partially refunded"
 
-#: src/strings.ts:2402
+#: src/strings.ts:2404
 msgid "Passed"
 msgstr "Passed"
 
@@ -4314,27 +4322,27 @@ msgstr "Password updated"
 msgid "Password/pin"
 msgstr "Password/pin"
 
-#: src/strings.ts:2247
+#: src/strings.ts:2249
 msgid "Paste"
 msgstr "Paste"
 
-#: src/strings.ts:2248
+#: src/strings.ts:2250
 msgid "Paste and match style"
 msgstr "Paste and match style"
 
-#: src/strings.ts:2370
+#: src/strings.ts:2372
 msgid "Paste embed code here. Only iframes are supported."
 msgstr "Paste embed code here. Only iframes are supported."
 
-#: src/strings.ts:2385
+#: src/strings.ts:2387
 msgid "Paste image URL here"
 msgstr "Paste image URL here"
 
-#: src/strings.ts:2249
+#: src/strings.ts:2251
 msgid "Paste without formatting"
 msgstr "Paste without formatting"
 
-#: src/strings.ts:2198
+#: src/strings.ts:2200
 msgid "Payment method"
 msgstr "Payment method"
 
@@ -4379,7 +4387,7 @@ msgid "Please confirm your identity by entering a recovery code."
 msgstr "Please confirm your identity by entering a recovery code."
 
 #: src/strings.ts:980
-#: src/strings.ts:2231
+#: src/strings.ts:2233
 msgid "Please confirm your identity by entering the authentication code from your authenticator app."
 msgstr "Please confirm your identity by entering the authentication code from your authenticator app."
 
@@ -4416,7 +4424,7 @@ msgstr "Please enter a valid URL"
 msgid "Please enter password of this backup file"
 msgstr "Please enter password of this backup file"
 
-#: src/strings.ts:2242
+#: src/strings.ts:2244
 msgid "Please enter the password to decrypt and restore this backup."
 msgstr "Please enter the password to decrypt and restore this backup."
 
@@ -4476,7 +4484,7 @@ msgstr "Please select the day to repeat the reminder on"
 msgid "please send us an email from your registered email address"
 msgstr "please send us an email from your registered email address"
 
-#: src/strings.ts:2391
+#: src/strings.ts:2393
 msgid "Please set a table size"
 msgstr "Please set a table size"
 
@@ -4574,19 +4582,19 @@ msgstr "Preparing to restore backup file..."
 msgid "PRESETS"
 msgstr "PRESETS"
 
-#: src/strings.ts:2118
+#: src/strings.ts:2120
 msgid "Pressing \"—\" will hide the app in your system tray."
 msgstr "Pressing \"—\" will hide the app in your system tray."
 
-#: src/strings.ts:2121
+#: src/strings.ts:2123
 msgid "Pressing \"X\" will hide the app in your system tray."
 msgstr "Pressing \"X\" will hide the app in your system tray."
 
-#: src/strings.ts:2169
+#: src/strings.ts:2171
 msgid "Prevent note title from appearing in tab/window title."
 msgstr "Prevent note title from appearing in tab/window title."
 
-#: src/strings.ts:2312
+#: src/strings.ts:2314
 msgid "Preview attachment"
 msgstr "Preview attachment"
 
@@ -4594,11 +4602,11 @@ msgstr "Preview attachment"
 msgid "Preview not available, content is encrypted."
 msgstr "Preview not available, content is encrypted."
 
-#: src/strings.ts:2379
+#: src/strings.ts:2381
 msgid "Previous match"
 msgstr "Previous match"
 
-#: src/strings.ts:2444
+#: src/strings.ts:2446
 msgid "Previous tab"
 msgstr "Previous tab"
 
@@ -4606,7 +4614,7 @@ msgstr "Previous tab"
 msgid "Print"
 msgstr "Print"
 
-#: src/strings.ts:2143
+#: src/strings.ts:2145
 msgid "Privacy"
 msgstr "Privacy"
 
@@ -4650,7 +4658,7 @@ msgstr "privileged few"
 msgid "Pro"
 msgstr "Pro"
 
-#: src/strings.ts:2469
+#: src/strings.ts:2471
 msgid "Pro plan"
 msgstr "Pro plan"
 
@@ -4666,7 +4674,7 @@ msgstr "Processing..."
 msgid "Productivity"
 msgstr "Productivity"
 
-#: src/strings.ts:2132
+#: src/strings.ts:2134
 msgid "Profile"
 msgstr "Profile"
 
@@ -4682,7 +4690,7 @@ msgstr "Properties"
 msgid "Protect your notes"
 msgstr "Protect your notes"
 
-#: src/strings.ts:2180
+#: src/strings.ts:2182
 msgid "Proxy"
 msgstr "Proxy"
 
@@ -4726,7 +4734,7 @@ msgstr "Quick note notification"
 msgid "Quick note widgets"
 msgstr "Quick note widgets"
 
-#: src/strings.ts:2440
+#: src/strings.ts:2442
 msgid "Quick open"
 msgstr "Quick open"
 
@@ -4734,7 +4742,7 @@ msgstr "Quick open"
 msgid "Quickly create a note from the notification"
 msgstr "Quickly create a note from the notification"
 
-#: src/strings.ts:2332
+#: src/strings.ts:2334
 msgid "Quote"
 msgstr "Quote"
 
@@ -4774,7 +4782,7 @@ msgstr "Read the terms of service"
 msgid "Reading backup file..."
 msgstr "Reading backup file..."
 
-#: src/strings.ts:2222
+#: src/strings.ts:2224
 msgid "Receipt"
 msgstr "Receipt"
 
@@ -4782,11 +4790,11 @@ msgstr "Receipt"
 msgid "RECENT BACKUPS"
 msgstr "RECENT BACKUPS"
 
-#: src/strings.ts:2455
+#: src/strings.ts:2457
 msgid "Recents"
 msgstr "Recents"
 
-#: src/strings.ts:2398
+#: src/strings.ts:2400
 msgid "Recheck all"
 msgstr "Recheck all"
 
@@ -4794,7 +4802,7 @@ msgstr "Recheck all"
 msgid "Rechecking failed"
 msgstr "Rechecking failed"
 
-#: src/strings.ts:2423
+#: src/strings.ts:2425
 msgid "Recipes"
 msgstr "Recipes"
 
@@ -4838,15 +4846,15 @@ msgstr "Recovery key text file saved"
 msgid "Recovery successful!"
 msgstr "Recovery successful!"
 
-#: src/strings.ts:2435
+#: src/strings.ts:2437
 msgid "Redeem"
 msgstr "Redeem"
 
-#: src/strings.ts:2432
+#: src/strings.ts:2434
 msgid "Redeem gift code"
 msgstr "Redeem gift code"
 
-#: src/strings.ts:2434
+#: src/strings.ts:2436
 msgid "Redeeming gift code"
 msgstr "Redeeming gift code"
 
@@ -4874,7 +4882,7 @@ msgstr "Register"
 msgid "Release notes"
 msgstr "Release notes"
 
-#: src/strings.ts:2457
+#: src/strings.ts:2459
 msgid "Release track"
 msgstr "Release track"
 
@@ -4968,7 +4976,7 @@ msgstr "Remove app lock pin, app lock will be disabled if no other security meth
 msgid "Remove as default"
 msgstr "Remove as default"
 
-#: src/strings.ts:2316
+#: src/strings.ts:2318
 msgid "Remove attachment"
 msgstr "Remove attachment"
 
@@ -4980,7 +4988,7 @@ msgstr "Remove from all"
 msgid "Remove from notebook"
 msgstr "Remove from notebook"
 
-#: src/strings.ts:2456
+#: src/strings.ts:2458
 msgid "Remove from recents"
 msgstr "Remove from recents"
 
@@ -4988,7 +4996,7 @@ msgstr "Remove from recents"
 msgid "Remove full name"
 msgstr "Remove full name"
 
-#: src/strings.ts:2262
+#: src/strings.ts:2264
 msgid "Remove link"
 msgstr "Remove link"
 
@@ -5020,15 +5028,15 @@ msgstr "Reorder"
 msgid "Repeats daily at {date}"
 msgstr "Repeats daily at {date}"
 
-#: src/strings.ts:2376
+#: src/strings.ts:2378
 msgid "Replace"
 msgstr "Replace"
 
-#: src/strings.ts:2377
+#: src/strings.ts:2379
 msgid "Replace all"
 msgstr "Replace all"
 
-#: src/strings.ts:2163
+#: src/strings.ts:2165
 msgid "Report"
 msgstr "Report"
 
@@ -5061,7 +5069,7 @@ msgstr "Reset"
 msgid "Reset account password"
 msgstr "Reset account password"
 
-#: src/strings.ts:2483
+#: src/strings.ts:2485
 msgid "Reset homepage"
 msgstr "Reset homepage"
 
@@ -5113,7 +5121,7 @@ msgstr "Restore"
 msgid "Restore backup"
 msgstr "Restore backup"
 
-#: src/strings.ts:2405
+#: src/strings.ts:2407
 msgid "Restore backup?"
 msgstr "Restore backup?"
 
@@ -5193,7 +5201,7 @@ msgstr "Rotate left"
 msgid "Rotate right"
 msgstr "Rotate right"
 
-#: src/strings.ts:2285
+#: src/strings.ts:2287
 msgid "Row properties"
 msgstr "Row properties"
 
@@ -5273,11 +5281,11 @@ msgstr "Save your data recovery key in a safe place. You will need it to recover
 msgid "Save your recovery codes in a safe place. You will need them to recover your account in case you lose access to your two-factor authentication methods."
 msgstr "Save your recovery codes in a safe place. You will need them to recover your account in case you lose access to your two-factor authentication methods."
 
-#: src/strings.ts:2395
+#: src/strings.ts:2397
 msgid "Saved"
 msgstr "Saved"
 
-#: src/strings.ts:2396
+#: src/strings.ts:2398
 msgid "Saving"
 msgstr "Saving"
 
@@ -5297,15 +5305,15 @@ msgstr "Saving zip file. Please wait..."
 msgid "Scan the QR code with your authenticator app"
 msgstr "Scan the QR code with your authenticator app"
 
-#: src/strings.ts:2421
+#: src/strings.ts:2423
 msgid "School work"
 msgstr "School work"
 
-#: src/strings.ts:2491
+#: src/strings.ts:2493
 msgid "Scroll to bottom"
 msgstr "Scroll to bottom"
 
-#: src/strings.ts:2490
+#: src/strings.ts:2492
 msgid "Scroll to top"
 msgstr "Scroll to top"
 
@@ -5322,7 +5330,7 @@ msgstr "Search a note"
 msgid "Search a note to link to"
 msgstr "Search a note to link to"
 
-#: src/strings.ts:2437
+#: src/strings.ts:2439
 msgid "Search for notes, notebooks, and tags..."
 msgstr "Search for notes, notebooks, and tags..."
 
@@ -5378,7 +5386,7 @@ msgstr "Search in Tags"
 msgid "Search in Trash"
 msgstr "Search in Trash"
 
-#: src/strings.ts:2358
+#: src/strings.ts:2360
 msgid "Search languages"
 msgstr "Search languages"
 
@@ -5402,7 +5410,7 @@ msgstr "Searching for {query}..."
 msgid "sec"
 msgstr "sec"
 
-#: src/strings.ts:2142
+#: src/strings.ts:2144
 msgid "Security & privacy"
 msgstr "Security & privacy"
 
@@ -5426,11 +5434,11 @@ msgstr "Select"
 msgid "Select a backup file from your device to restore backup"
 msgstr "Select a backup file from your device to restore backup"
 
-#: src/strings.ts:2488
+#: src/strings.ts:2490
 msgid "Select a notebook to move this notebook into, or unselect to move it to the root level."
 msgstr "Select a notebook to move this notebook into, or unselect to move it to the root level."
 
-#: src/strings.ts:2097
+#: src/strings.ts:2099
 msgid "Select a theme"
 msgstr "Select a theme"
 
@@ -5470,7 +5478,7 @@ msgstr "Select folder with backup files"
 msgid "Select how you would like to recieve the code"
 msgstr "Select how you would like to recieve the code"
 
-#: src/strings.ts:2353
+#: src/strings.ts:2355
 msgid "Select language"
 msgstr "Select language"
 
@@ -5486,7 +5494,7 @@ msgstr "Select notebooks"
 msgid "Select notebooks you want to add note(s) to."
 msgstr "Select notebooks you want to add note(s) to."
 
-#: src/strings.ts:2476
+#: src/strings.ts:2478
 msgid "Select notes to link to \"{title}\""
 msgstr "Select notes to link to \"{title}\""
 
@@ -5498,7 +5506,7 @@ msgstr "Select nth day of the month to repeat the reminder."
 msgid "Select profile picture"
 msgstr "Select profile picture"
 
-#: src/strings.ts:2482
+#: src/strings.ts:2484
 msgid "Select the default sidebar tab"
 msgstr "Select the default sidebar tab"
 
@@ -5506,11 +5514,11 @@ msgstr "Select the default sidebar tab"
 msgid "Select the folder that includes your backup files to list them here."
 msgstr "Select the folder that includes your backup files to list them here."
 
-#: src/strings.ts:2129
+#: src/strings.ts:2131
 msgid "Select the languages the spell checker should check in."
 msgstr "Select the languages the spell checker should check in."
 
-#: src/strings.ts:2458
+#: src/strings.ts:2460
 msgid "Select the release track for Notesnook."
 msgstr "Select the release track for Notesnook."
 
@@ -5522,7 +5530,7 @@ msgstr "SELECTED NOTE"
 msgid "Self destruct"
 msgstr "Self destruct"
 
-#: src/strings.ts:2164
+#: src/strings.ts:2166
 msgid "Send"
 msgstr "Send"
 
@@ -5574,11 +5582,11 @@ msgstr "Server used to sync your notes & other data between devices."
 msgid "Server with host {host} not found."
 msgstr "Server with host {host} not found."
 
-#: src/strings.ts:2137
+#: src/strings.ts:2139
 msgid "Servers"
 msgstr "Servers"
 
-#: src/strings.ts:2138
+#: src/strings.ts:2140
 msgid "Servers configuration"
 msgstr "Servers configuration"
 
@@ -5586,7 +5594,7 @@ msgstr "Servers configuration"
 msgid "Session expired"
 msgstr "Session expired"
 
-#: src/strings.ts:2190
+#: src/strings.ts:2192
 msgid "Sessions"
 msgstr "Sessions"
 
@@ -5602,7 +5610,7 @@ msgstr "Set as dark theme"
 msgid "Set as default"
 msgstr "Set as default"
 
-#: src/strings.ts:2480
+#: src/strings.ts:2482
 msgid "Set as homepage"
 msgstr "Set as homepage"
 
@@ -5656,7 +5664,7 @@ msgstr "Setup a password to lock the app"
 msgid "Setup a pin to lock the app"
 msgstr "Setup a pin to lock the app"
 
-#: src/strings.ts:2182
+#: src/strings.ts:2184
 msgid ""
 "Setup an HTTP/HTTPS/SOCKS proxy.\n"
 "\n"
@@ -5760,7 +5768,7 @@ msgstr "Signup failed"
 msgid "Silent"
 msgstr "Silent"
 
-#: src/strings.ts:2327
+#: src/strings.ts:2329
 msgid "Sink list item"
 msgstr "Sink list item"
 
@@ -5800,23 +5808,23 @@ msgstr "Sort"
 msgid "Sort by"
 msgstr "Sort by"
 
-#: src/strings.ts:2148
+#: src/strings.ts:2150
 msgid "Source code"
 msgstr "Source code"
 
-#: src/strings.ts:2354
+#: src/strings.ts:2356
 msgid "Spaces"
 msgstr "Spaces"
 
-#: src/strings.ts:2125
+#: src/strings.ts:2127
 msgid "Spell check"
 msgstr "Spell check"
 
-#: src/strings.ts:2292
+#: src/strings.ts:2294
 msgid "Split cells"
 msgstr "Split cells"
 
-#: src/strings.ts:2459
+#: src/strings.ts:2461
 msgid "Stable"
 msgstr "Stable"
 
@@ -5836,7 +5844,7 @@ msgstr "Start import"
 msgid "Start importing now"
 msgstr "Start importing now"
 
-#: src/strings.ts:2113
+#: src/strings.ts:2115
 msgid "Start minimized"
 msgstr "Start minimized"
 
@@ -5856,11 +5864,11 @@ msgstr "Start writing to save your note."
 msgid "Start writing your note..."
 msgstr "Start writing your note..."
 
-#: src/strings.ts:2221
+#: src/strings.ts:2223
 msgid "Status"
 msgstr "Status"
 
-#: src/strings.ts:2472
+#: src/strings.ts:2474
 msgid "Storage"
 msgstr "Storage"
 
@@ -5868,11 +5876,11 @@ msgstr "Storage"
 msgid "Streaming not supported"
 msgstr "Streaming not supported"
 
-#: src/strings.ts:2258
+#: src/strings.ts:2260
 msgid "Strikethrough"
 msgstr "Strikethrough"
 
-#: src/strings.ts:2223
+#: src/strings.ts:2225
 msgid "Subgroup 1"
 msgstr "Subgroup 1"
 
@@ -5908,7 +5916,7 @@ msgstr "Subscribed on Web"
 msgid "Subscribed using gift card"
 msgstr "Subscribed using gift card"
 
-#: src/strings.ts:2269
+#: src/strings.ts:2271
 msgid "Subscript"
 msgstr "Subscript"
 
@@ -5932,7 +5940,7 @@ msgstr "Sun"
 msgid "Sunday"
 msgstr "Sunday"
 
-#: src/strings.ts:2270
+#: src/strings.ts:2272
 msgid "Superscript"
 msgstr "Superscript"
 
@@ -5940,7 +5948,7 @@ msgstr "Superscript"
 msgid "Switch to search/replace mode"
 msgstr "Switch to search/replace mode"
 
-#: src/strings.ts:2134
+#: src/strings.ts:2136
 msgid "Sync"
 msgstr "Sync"
 
@@ -5988,7 +5996,7 @@ msgstr "Syncing your data"
 msgid "Syncing your notes"
 msgstr "Syncing your notes"
 
-#: src/strings.ts:2339
+#: src/strings.ts:2341
 msgid "Table"
 msgstr "Table"
 
@@ -5996,7 +6004,7 @@ msgstr "Table"
 msgid "Table of contents"
 msgstr "Table of contents"
 
-#: src/strings.ts:2283
+#: src/strings.ts:2285
 msgid "Table settings"
 msgstr "Table settings"
 
@@ -6033,7 +6041,7 @@ msgstr "Take a full backup of your data with all attachments"
 msgid "Take a partial backup of your data that does not include attachments"
 msgstr "Take a partial backup of your data that does not include attachments"
 
-#: src/strings.ts:2338
+#: src/strings.ts:2340
 msgid "Take a photo using camera"
 msgstr "Take a photo using camera"
 
@@ -6093,11 +6101,11 @@ msgstr "Tap to try again"
 msgid "Tap twice to confirm you have saved the recovery key."
 msgstr "Tap twice to confirm you have saved the recovery key."
 
-#: src/strings.ts:2344
+#: src/strings.ts:2346
 msgid "Task list"
 msgstr "Task list"
 
-#: src/strings.ts:2414
+#: src/strings.ts:2416
 msgid "Tasks"
 msgstr "Tasks"
 
@@ -6143,11 +6151,11 @@ msgstr "Test connection"
 msgid "Test connection before changing server urls"
 msgstr "Test connection before changing server urls"
 
-#: src/strings.ts:2281
+#: src/strings.ts:2283
 msgid "Text color"
 msgstr "Text color"
 
-#: src/strings.ts:2279
+#: src/strings.ts:2281
 msgid "Text direction"
 msgstr "Text direction"
 
@@ -6207,7 +6215,7 @@ msgstr "Themes"
 msgid "There are no blocks in this note."
 msgstr "There are no blocks in this note."
 
-#: src/strings.ts:2236
+#: src/strings.ts:2238
 msgid "These items will be **kept in your Trash for {interval} days** after which they will be permanently deleted."
 msgstr "These items will be **kept in your Trash for {interval} days** after which they will be permanently deleted."
 
@@ -6321,23 +6329,23 @@ msgstr "To use app lock, you must enable biometrics such as Fingerprint lock or 
 msgid "Toggle dark/light mode"
 msgstr "Toggle dark/light mode"
 
-#: src/strings.ts:2462
+#: src/strings.ts:2464
 msgid "Toggle focus mode"
 msgstr "Toggle focus mode"
 
-#: src/strings.ts:2351
+#: src/strings.ts:2353
 msgid "Toggle indentation mode"
 msgstr "Toggle indentation mode"
 
-#: src/strings.ts:2380
+#: src/strings.ts:2382
 msgid "Toggle replace"
 msgstr "Toggle replace"
 
-#: src/strings.ts:2451
+#: src/strings.ts:2453
 msgid "Toggle theme"
 msgstr "Toggle theme"
 
-#: src/strings.ts:2131
+#: src/strings.ts:2133
 msgid "Toolbar"
 msgstr "Toolbar"
 
@@ -6422,11 +6430,11 @@ msgstr "Unable to resolve download url"
 msgid "Unable to send 2FA code"
 msgstr "Unable to send 2FA code"
 
-#: src/strings.ts:2486
+#: src/strings.ts:2488
 msgid "Unarchive"
 msgstr "Unarchive"
 
-#: src/strings.ts:2257
+#: src/strings.ts:2259
 msgid "Underline"
 msgstr "Underline"
 
@@ -6512,7 +6520,7 @@ msgid "Unregister"
 msgstr "Unregister"
 
 #: src/strings.ts:210
-#: src/strings.ts:2360
+#: src/strings.ts:2362
 msgid "Untitled"
 msgstr "Untitled"
 
@@ -6548,7 +6556,7 @@ msgstr "Upgrade to Pro"
 msgid "Upload"
 msgstr "Upload"
 
-#: src/strings.ts:2337
+#: src/strings.ts:2339
 msgid "Upload from disk"
 msgstr "Upload from disk"
 
@@ -6574,7 +6582,7 @@ msgstr "Uploads"
 msgid "Urgent"
 msgstr "Urgent"
 
-#: src/strings.ts:2387
+#: src/strings.ts:2389
 msgid "URL"
 msgstr "URL"
 
@@ -6602,7 +6610,7 @@ msgstr "Use account password"
 msgid "Use an authenticator app to generate 2FA codes."
 msgstr "Use an authenticator app to generate 2FA codes."
 
-#: src/strings.ts:2171
+#: src/strings.ts:2173
 msgid "Use custom DNS"
 msgstr "Use custom DNS"
 
@@ -6618,11 +6626,11 @@ msgstr "Use encryption key"
 msgid "Use markdown shortcuts in the editor"
 msgstr "Use markdown shortcuts in the editor"
 
-#: src/strings.ts:2124
+#: src/strings.ts:2126
 msgid "Use native OS titlebar instead of replacing it with a custom one. Requires app restart for changes to take effect."
 msgstr "Use native OS titlebar instead of replacing it with a custom one. Requires app restart for changes to take effect."
 
-#: src/strings.ts:2122
+#: src/strings.ts:2124
 msgid "Use native titlebar"
 msgstr "Use native titlebar"
 
@@ -6662,7 +6670,7 @@ msgstr "Use this if changes from other devices are not appearing on this device.
 msgid "Use this if changes made on this device are not appearing on other devices. This will overwrite the data on the server with the data from this device."
 msgstr "Use this if changes made on this device are not appearing on other devices. This will overwrite the data on the server with the data from this device."
 
-#: src/strings.ts:2473
+#: src/strings.ts:2475
 msgid "used"
 msgstr "used"
 
@@ -6670,11 +6678,11 @@ msgstr "used"
 msgid "User verification failed"
 msgstr "User verification failed"
 
-#: src/strings.ts:2253
+#: src/strings.ts:2255
 msgid "Using {instance} (v{version})"
 msgstr "Using {instance} (v{version})"
 
-#: src/strings.ts:2251
+#: src/strings.ts:2253
 msgid "Using official Notesnook instance"
 msgstr "Using official Notesnook instance"
 
@@ -6762,7 +6770,7 @@ msgstr "View receipt"
 msgid "View recovery codes"
 msgstr "View recovery codes"
 
-#: src/strings.ts:2151
+#: src/strings.ts:2153
 msgid "View source code"
 msgstr "View source code"
 
@@ -6794,7 +6802,7 @@ msgstr "We are sorry, it seems that the app crashed due to an error. You can sub
 msgid "We have sent you an email confirmation link. Please check your email inbox. If you cannot find the email, check your spam folder."
 msgstr "We have sent you an email confirmation link. Please check your email inbox. If you cannot find the email, check your spam folder."
 
-#: src/strings.ts:2166
+#: src/strings.ts:2168
 msgid "We send you occasional promotional offers & product updates on your email (once every month)."
 msgstr "We send you occasional promotional offers & product updates on your email (once every month)."
 
@@ -6806,7 +6814,7 @@ msgstr "We will send you occasional promotional offers & product updates on your
 msgid "We would love to know what you think!"
 msgstr "We would love to know what you think!"
 
-#: src/strings.ts:2322
+#: src/strings.ts:2324
 msgid "Web clip settings"
 msgstr "Web clip settings"
 
@@ -6851,11 +6859,11 @@ msgstr "What do I do if I am not getting the email?"
 msgid "What went wrong?"
 msgstr "What went wrong?"
 
-#: src/strings.ts:2383
+#: src/strings.ts:2385
 msgid "Width"
 msgstr "Width"
 
-#: src/strings.ts:2412
+#: src/strings.ts:2414
 msgid "Work & Office"
 msgstr "Work & Office"
 
@@ -6892,7 +6900,7 @@ msgstr "Yes"
 msgid "You also agree to recieve marketing emails from us which you can opt-out of from app settings."
 msgstr "You also agree to recieve marketing emails from us which you can opt-out of from app settings."
 
-#: src/strings.ts:2238
+#: src/strings.ts:2240
 msgid "You are editing \"{notebookTitle}\"."
 msgstr "You are editing \"{notebookTitle}\"."
 
@@ -6924,7 +6932,7 @@ msgstr "You can also link a note to multiple Notebooks. Tap and hold any noteboo
 msgid "You can change the theme at any time from Settings or the side menu."
 msgstr "You can change the theme at any time from Settings or the side menu."
 
-#: src/strings.ts:2420
+#: src/strings.ts:2422
 msgid "You can create shortcuts of frequently accessed notebooks in the side menu"
 msgstr "You can create shortcuts of frequently accessed notebooks in the side menu"
 
@@ -6982,11 +6990,11 @@ msgstr "You can view & restore older versions of any note by going to its proper
 msgid "You have {count} custom dictionary words."
 msgstr "You have {count} custom dictionary words."
 
-#: src/strings.ts:2197
+#: src/strings.ts:2199
 msgid "You have been logged out from all other devices."
 msgstr "You have been logged out from all other devices."
 
-#: src/strings.ts:2191
+#: src/strings.ts:2193
 msgid "You have been logged out."
 msgstr "You have been logged out."
 
@@ -7083,7 +7091,7 @@ msgstr "Your account will be downgraded in {days} days"
 msgid "Your archive"
 msgstr "Your archive"
 
-#: src/strings.ts:2485
+#: src/strings.ts:2487
 msgid "Your archive is empty"
 msgstr "Your archive is empty"
 
@@ -7099,7 +7107,7 @@ msgstr "Your changes could not be saved"
 msgid "Your changes have been saved and will be reflected after the app has refreshed."
 msgstr "Your changes have been saved and will be reflected after the app has refreshed."
 
-#: src/strings.ts:2098
+#: src/strings.ts:2100
 msgid "Your current 2FA method is {method}"
 msgstr "Your current 2FA method is {method}"
 
@@ -7219,7 +7227,7 @@ msgstr "Z to A"
 msgid "Zipping"
 msgstr "Zipping"
 
-#: src/strings.ts:2461
+#: src/strings.ts:2463
 msgid "Zoom"
 msgstr "Zoom"
 

--- a/packages/intl/locale/pseudo-LOCALE.po
+++ b/packages/intl/locale/pseudo-LOCALE.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/strings.ts:2410
+#: src/strings.ts:2412
 msgid " \"Notebook > Notes\""
 msgstr ""
 
@@ -288,7 +288,7 @@ msgstr ""
 msgid "{count, plural, one {Item unpublished} other {# items unpublished}}"
 msgstr ""
 
-#: src/strings.ts:2427
+#: src/strings.ts:2429
 msgid "{count, plural, one {Move all notes in this notebook to trash} other {Move all notes in these notebooks to trash}}"
 msgstr ""
 
@@ -563,7 +563,7 @@ msgstr ""
 msgid "{platform, select, android {Backup file saved in \"Notesnook backups\" folder on your phone.} other {Backup file is saved in File Manager/Notesnook folder}}"
 msgstr ""
 
-#: src/strings.ts:2357
+#: src/strings.ts:2359
 msgid "{selected} selected"
 msgstr ""
 
@@ -643,15 +643,15 @@ msgstr ""
 msgid "Account password"
 msgstr ""
 
-#: src/strings.ts:2452
+#: src/strings.ts:2454
 msgid "Actions for note: {title}"
 msgstr ""
 
-#: src/strings.ts:2453
+#: src/strings.ts:2455
 msgid "Actions for notebook: {title}"
 msgstr ""
 
-#: src/strings.ts:2454
+#: src/strings.ts:2456
 msgid "Actions for tag: {title}"
 msgstr ""
 
@@ -687,7 +687,7 @@ msgstr ""
 msgid "Add notebook"
 msgstr ""
 
-#: src/strings.ts:2479
+#: src/strings.ts:2481
 msgid "Add notes"
 msgstr ""
 
@@ -715,11 +715,11 @@ msgstr ""
 msgid "Add tags to multiple notes at once"
 msgstr ""
 
-#: src/strings.ts:2243
+#: src/strings.ts:2245
 msgid "Add to dictionary"
 msgstr ""
 
-#: src/strings.ts:2477
+#: src/strings.ts:2479
 msgid "Add to notebook"
 msgstr ""
 
@@ -731,7 +731,7 @@ msgstr ""
 msgid "Add your first notebook"
 msgstr ""
 
-#: src/strings.ts:2170
+#: src/strings.ts:2172
 msgid "Advanced"
 msgstr ""
 
@@ -739,15 +739,15 @@ msgstr ""
 msgid "After scanning the QR code image, the app will display a code that you can enter below."
 msgstr ""
 
-#: src/strings.ts:2308
+#: src/strings.ts:2310
 msgid "Align left"
 msgstr ""
 
-#: src/strings.ts:2309
+#: src/strings.ts:2311
 msgid "Align right"
 msgstr ""
 
-#: src/strings.ts:2278
+#: src/strings.ts:2280
 msgid "Alignment"
 msgstr ""
 
@@ -759,7 +759,7 @@ msgstr ""
 msgid "All attachments are end-to-end encrypted."
 msgstr ""
 
-#: src/strings.ts:2404
+#: src/strings.ts:2406
 msgid "All cached attachments have been cleared."
 msgstr ""
 
@@ -787,7 +787,7 @@ msgstr ""
 msgid "All the data in your account will be overwritten with the data in the backup file. There is no way to reverse this action."
 msgstr ""
 
-#: src/strings.ts:2150
+#: src/strings.ts:2152
 msgid "All the source code for Notesnook is available & open for everyone on GitHub."
 msgstr ""
 
@@ -815,7 +815,7 @@ msgstr ""
 msgid "Already have an account?"
 msgstr ""
 
-#: src/strings.ts:2220
+#: src/strings.ts:2222
 msgid "Amount"
 msgstr ""
 
@@ -882,7 +882,7 @@ msgid "Applying changes"
 msgstr ""
 
 #: src/strings.ts:1529
-#: src/strings.ts:2484
+#: src/strings.ts:2486
 msgid "Archive"
 msgstr ""
 
@@ -934,7 +934,7 @@ msgstr ""
 msgid "Atleast 8 characters required"
 msgstr ""
 
-#: src/strings.ts:2346
+#: src/strings.ts:2348
 msgid "Attach image from URL"
 msgstr ""
 
@@ -947,11 +947,11 @@ msgid "attachment"
 msgstr ""
 
 #: src/strings.ts:300
-#: src/strings.ts:2343
+#: src/strings.ts:2345
 msgid "Attachment"
 msgstr ""
 
-#: src/strings.ts:2447
+#: src/strings.ts:2449
 msgid "Attachment manager"
 msgstr ""
 
@@ -959,11 +959,11 @@ msgstr ""
 msgid "Attachment preview failed"
 msgstr ""
 
-#: src/strings.ts:2397
+#: src/strings.ts:2399
 msgid "Attachment recheck cancelled"
 msgstr ""
 
-#: src/strings.ts:2314
+#: src/strings.ts:2316
 msgid "Attachment settings"
 msgstr ""
 
@@ -980,7 +980,7 @@ msgstr ""
 msgid "Attachments cache cleared!"
 msgstr ""
 
-#: src/strings.ts:2399
+#: src/strings.ts:2401
 msgid "Attachments recheck complete"
 msgstr ""
 
@@ -1000,7 +1000,7 @@ msgstr ""
 msgid "Authenticating user"
 msgstr ""
 
-#: src/strings.ts:2133
+#: src/strings.ts:2135
 msgid "Authentication"
 msgstr ""
 
@@ -1016,7 +1016,7 @@ msgstr ""
 msgid "Authentication failed"
 msgstr ""
 
-#: src/strings.ts:2096
+#: src/strings.ts:2098
 msgid "Auto"
 msgstr ""
 
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Auto save: off"
 msgstr ""
 
-#: src/strings.ts:2110
+#: src/strings.ts:2112
 msgid "Auto start on system startup"
 msgstr ""
 
@@ -1045,7 +1045,7 @@ msgstr ""
 msgid "Automatic backups with attachments"
 msgstr ""
 
-#: src/strings.ts:2106
+#: src/strings.ts:2108
 msgid "Automatic updates"
 msgstr ""
 
@@ -1053,7 +1053,7 @@ msgstr ""
 msgid "Automatically clear trash after a certain period of time"
 msgstr ""
 
-#: src/strings.ts:2108
+#: src/strings.ts:2110
 msgid "Automatically download & install updates in the background without prompting first."
 msgstr ""
 
@@ -1065,15 +1065,15 @@ msgstr ""
 msgid "Automatically switch between light and dark themes based on your system settings"
 msgstr ""
 
-#: src/strings.ts:2153
+#: src/strings.ts:2155
 msgid "Available on iOS"
 msgstr ""
 
-#: src/strings.ts:2154
+#: src/strings.ts:2156
 msgid "Available on iOS & Android"
 msgstr ""
 
-#: src/strings.ts:2301
+#: src/strings.ts:2303
 msgid "Background color"
 msgstr ""
 
@@ -1081,11 +1081,11 @@ msgstr ""
 msgid "Background sync (experimental)"
 msgstr ""
 
-#: src/strings.ts:2102
+#: src/strings.ts:2104
 msgid "Backup"
 msgstr ""
 
-#: src/strings.ts:2140
+#: src/strings.ts:2142
 msgid "Backup & export"
 msgstr ""
 
@@ -1137,7 +1137,7 @@ msgstr ""
 msgid "Backup successful"
 msgstr ""
 
-#: src/strings.ts:2103
+#: src/strings.ts:2105
 msgid "Backup with attachments"
 msgstr ""
 
@@ -1157,23 +1157,23 @@ msgstr ""
 msgid "Behavior"
 msgstr ""
 
-#: src/strings.ts:2135
+#: src/strings.ts:2137
 msgid "Behaviour"
 msgstr ""
 
-#: src/strings.ts:2471
+#: src/strings.ts:2473
 msgid "Believer plan"
 msgstr ""
 
-#: src/strings.ts:2460
+#: src/strings.ts:2462
 msgid "Beta"
 msgstr ""
 
-#: src/strings.ts:2259
+#: src/strings.ts:2261
 msgid "Bi-directional note link"
 msgstr ""
 
-#: src/strings.ts:2201
+#: src/strings.ts:2203
 msgid "Billing history"
 msgstr ""
 
@@ -1197,11 +1197,11 @@ msgstr ""
 msgid "Biometrics not enrolled"
 msgstr ""
 
-#: src/strings.ts:2255
+#: src/strings.ts:2257
 msgid "Bold"
 msgstr ""
 
-#: src/strings.ts:2409
+#: src/strings.ts:2411
 msgid "Boost your productivity with Notebooks and organize your notes."
 msgstr ""
 
@@ -1209,7 +1209,7 @@ msgstr ""
 msgid "Browse"
 msgstr ""
 
-#: src/strings.ts:2272
+#: src/strings.ts:2274
 msgid "Bullet list"
 msgstr ""
 
@@ -1221,7 +1221,7 @@ msgstr ""
 msgid "By signing up, you agree to our "
 msgstr ""
 
-#: src/strings.ts:2334
+#: src/strings.ts:2336
 msgid "Callout"
 msgstr ""
 
@@ -1245,24 +1245,24 @@ msgstr ""
 msgid "Cancel upload"
 msgstr ""
 
-#: src/strings.ts:2300
+#: src/strings.ts:2302
 msgid "Cell background color"
 msgstr ""
 
-#: src/strings.ts:2302
+#: src/strings.ts:2304
 msgid "Cell border color"
 msgstr ""
 
-#: src/strings.ts:2304
-#: src/strings.ts:2305
+#: src/strings.ts:2306
+#: src/strings.ts:2307
 msgid "Cell border width"
 msgstr ""
 
-#: src/strings.ts:2286
+#: src/strings.ts:2288
 msgid "Cell properties"
 msgstr ""
 
-#: src/strings.ts:2303
+#: src/strings.ts:2305
 msgid "Cell text color"
 msgstr ""
 
@@ -1298,7 +1298,7 @@ msgstr ""
 msgid "Change how the app behaves in different situations"
 msgstr ""
 
-#: src/strings.ts:2352
+#: src/strings.ts:2354
 msgid "Change language"
 msgstr ""
 
@@ -1314,11 +1314,11 @@ msgstr ""
 msgid "Change profile picture"
 msgstr ""
 
-#: src/strings.ts:2179
+#: src/strings.ts:2181
 msgid "Change proxy"
 msgstr ""
 
-#: src/strings.ts:2200
+#: src/strings.ts:2202
 msgid "Change the payment method you used to purchase this subscription."
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgstr ""
 msgid "Check for updates automatically"
 msgstr ""
 
-#: src/strings.ts:2152
+#: src/strings.ts:2154
 msgid "Check roadmap"
 msgstr ""
 
@@ -1370,7 +1370,7 @@ msgstr ""
 msgid "Check your spam folder if you haven't received an email yet."
 msgstr ""
 
-#: src/strings.ts:2401
+#: src/strings.ts:2403
 msgid "Checking all attachments"
 msgstr ""
 
@@ -1382,15 +1382,15 @@ msgstr ""
 msgid "Checking for updates"
 msgstr ""
 
-#: src/strings.ts:2400
+#: src/strings.ts:2402
 msgid "Checking note attachments"
 msgstr ""
 
-#: src/strings.ts:2274
+#: src/strings.ts:2276
 msgid "Checklist"
 msgstr ""
 
-#: src/strings.ts:2329
+#: src/strings.ts:2331
 msgid "Choose a block to insert"
 msgstr ""
 
@@ -1398,11 +1398,11 @@ msgstr ""
 msgid "Choose a recovery method"
 msgstr ""
 
-#: src/strings.ts:2101
+#: src/strings.ts:2103
 msgid "Choose backup format"
 msgstr ""
 
-#: src/strings.ts:2365
+#: src/strings.ts:2367
 msgid "Choose custom color"
 msgstr ""
 
@@ -1446,7 +1446,7 @@ msgstr ""
 msgid "Clear all cached attachments. Current cache size: {cacheSize}"
 msgstr ""
 
-#: src/strings.ts:2268
+#: src/strings.ts:2270
 msgid "Clear all formatting"
 msgstr ""
 
@@ -1458,7 +1458,7 @@ msgstr ""
 msgid "Clear cache"
 msgstr ""
 
-#: src/strings.ts:2363
+#: src/strings.ts:2365
 msgid "Clear completed tasks"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Clear logs"
 msgstr ""
 
-#: src/strings.ts:2195
+#: src/strings.ts:2197
 msgid "clear sessions"
 msgstr ""
 
@@ -1517,7 +1517,7 @@ msgstr ""
 msgid "Click to remove"
 msgstr ""
 
-#: src/strings.ts:2392
+#: src/strings.ts:2394
 msgid "Click to reset {title}"
 msgstr ""
 
@@ -1529,11 +1529,11 @@ msgstr ""
 msgid "Close all"
 msgstr ""
 
-#: src/strings.ts:2450
+#: src/strings.ts:2452
 msgid "Close all tabs"
 msgstr ""
 
-#: src/strings.ts:2449
+#: src/strings.ts:2451
 msgid "Close current tab"
 msgstr ""
 
@@ -1541,7 +1541,7 @@ msgstr ""
 msgid "Close others"
 msgstr ""
 
-#: src/strings.ts:2119
+#: src/strings.ts:2121
 msgid "Close to system tray"
 msgstr ""
 
@@ -1553,15 +1553,15 @@ msgstr ""
 msgid "Close to the right"
 msgstr ""
 
-#: src/strings.ts:2266
+#: src/strings.ts:2268
 msgid "Code"
 msgstr ""
 
-#: src/strings.ts:2331
+#: src/strings.ts:2333
 msgid "Code block"
 msgstr ""
 
-#: src/strings.ts:2267
+#: src/strings.ts:2269
 msgid "Code remove"
 msgstr ""
 
@@ -1598,11 +1598,11 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
-#: src/strings.ts:2284
+#: src/strings.ts:2286
 msgid "Column properties"
 msgstr ""
 
-#: src/strings.ts:2441
+#: src/strings.ts:2443
 msgid "Command palette"
 msgstr ""
 
@@ -1626,11 +1626,11 @@ msgstr ""
 msgid "Compressed images are uploaded in Full HD resolution and usually are good enough for most use cases."
 msgstr ""
 
-#: src/strings.ts:2250
+#: src/strings.ts:2252
 msgid "Configure"
 msgstr ""
 
-#: src/strings.ts:2406
+#: src/strings.ts:2408
 msgid "Configure server URLs for Notesnook"
 msgstr ""
 
@@ -1699,7 +1699,7 @@ msgstr ""
 msgid "Copy codes"
 msgstr ""
 
-#: src/strings.ts:2246
+#: src/strings.ts:2248
 msgid "Copy image"
 msgstr ""
 
@@ -1707,7 +1707,7 @@ msgstr ""
 msgid "Copy link"
 msgstr ""
 
-#: src/strings.ts:2245
+#: src/strings.ts:2247
 msgid "Copy link text"
 msgstr ""
 
@@ -1803,7 +1803,7 @@ msgstr ""
 msgid "Create your account"
 msgstr ""
 
-#: src/strings.ts:2228
+#: src/strings.ts:2230
 msgid "Created at"
 msgstr ""
 
@@ -1848,7 +1848,7 @@ msgstr ""
 msgid "Custom"
 msgstr ""
 
-#: src/strings.ts:2130
+#: src/strings.ts:2132
 msgid "Custom dictionary words"
 msgstr ""
 
@@ -1872,7 +1872,7 @@ msgstr ""
 msgid "Customize toolbar"
 msgstr ""
 
-#: src/strings.ts:2244
+#: src/strings.ts:2246
 msgid "Cut"
 msgstr ""
 
@@ -1889,7 +1889,7 @@ msgstr ""
 msgid "Dark mode"
 msgstr ""
 
-#: src/strings.ts:2095
+#: src/strings.ts:2097
 msgid "Dark or light, we won't judge."
 msgstr ""
 
@@ -1901,7 +1901,7 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: src/strings.ts:2104
+#: src/strings.ts:2106
 msgid "Date & time"
 msgstr ""
 
@@ -1953,7 +1953,7 @@ msgstr ""
 msgid "Debugging"
 msgstr ""
 
-#: src/strings.ts:2394
+#: src/strings.ts:2396
 msgid "Decrease {title}"
 msgstr ""
 
@@ -1986,7 +1986,7 @@ msgstr ""
 msgid "Default screen to open on app launch"
 msgstr ""
 
-#: src/strings.ts:2481
+#: src/strings.ts:2483
 msgid "Default sidebar tab"
 msgstr ""
 
@@ -2010,7 +2010,7 @@ msgstr ""
 msgid "Delete collapsed section"
 msgstr ""
 
-#: src/strings.ts:2291
+#: src/strings.ts:2293
 msgid "Delete column"
 msgstr ""
 
@@ -2018,7 +2018,7 @@ msgstr ""
 msgid "Delete group"
 msgstr ""
 
-#: src/strings.ts:2366
+#: src/strings.ts:2368
 msgid "Delete mode"
 msgstr ""
 
@@ -2030,11 +2030,11 @@ msgstr ""
 msgid "Delete permanently"
 msgstr ""
 
-#: src/strings.ts:2298
+#: src/strings.ts:2300
 msgid "Delete row"
 msgstr ""
 
-#: src/strings.ts:2299
+#: src/strings.ts:2301
 msgid "Delete table"
 msgstr ""
 
@@ -2058,11 +2058,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: src/strings.ts:2105
+#: src/strings.ts:2107
 msgid "Desktop app"
 msgstr ""
 
-#: src/strings.ts:2109
+#: src/strings.ts:2111
 msgid "Desktop integration"
 msgstr ""
 
@@ -2114,7 +2114,7 @@ msgstr ""
 msgid "Do you enjoy using Notesnook?"
 msgstr ""
 
-#: src/strings.ts:2227
+#: src/strings.ts:2229
 msgid "Do you want to clear the trash?"
 msgstr ""
 
@@ -2178,7 +2178,7 @@ msgstr ""
 msgid "Download all attachments"
 msgstr ""
 
-#: src/strings.ts:2315
+#: src/strings.ts:2317
 msgid "Download attachment"
 msgstr ""
 
@@ -2190,7 +2190,7 @@ msgstr ""
 msgid "Download cancelled"
 msgstr ""
 
-#: src/strings.ts:2207
+#: src/strings.ts:2209
 msgid "Download everything including attachments on sync"
 msgstr ""
 
@@ -2255,7 +2255,7 @@ msgstr ""
 msgid "Earliest first"
 msgstr ""
 
-#: src/strings.ts:2418
+#: src/strings.ts:2420
 msgid "Easy access"
 msgstr ""
 
@@ -2267,12 +2267,12 @@ msgstr ""
 msgid "Edit internal link"
 msgstr ""
 
-#: src/strings.ts:2233
-#: src/strings.ts:2261
+#: src/strings.ts:2235
+#: src/strings.ts:2263
 msgid "Edit link"
 msgstr ""
 
-#: src/strings.ts:2474
+#: src/strings.ts:2476
 msgid "Edit profile"
 msgstr ""
 
@@ -2293,7 +2293,7 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: src/strings.ts:2431
+#: src/strings.ts:2433
 msgid "Email copied"
 msgstr ""
 
@@ -2317,15 +2317,15 @@ msgstr ""
 msgid "Email updated to {email}"
 msgstr ""
 
-#: src/strings.ts:2341
+#: src/strings.ts:2343
 msgid "Embed"
 msgstr ""
 
-#: src/strings.ts:2321
+#: src/strings.ts:2323
 msgid "Embed properties"
 msgstr ""
 
-#: src/strings.ts:2317
+#: src/strings.ts:2319
 msgid "Embed settings"
 msgstr ""
 
@@ -2345,15 +2345,15 @@ msgstr ""
 msgid "Enable editor margins"
 msgstr ""
 
-#: src/strings.ts:2465
+#: src/strings.ts:2467
 msgid "Enable ligatures for common symbols like →, ←, etc"
 msgstr ""
 
-#: src/strings.ts:2381
+#: src/strings.ts:2383
 msgid "Enable regex"
 msgstr ""
 
-#: src/strings.ts:2126
+#: src/strings.ts:2128
 msgid "Enable spell checker"
 msgstr ""
 
@@ -2369,7 +2369,7 @@ msgstr ""
 msgid "Encrypted and synced"
 msgstr ""
 
-#: src/strings.ts:2240
+#: src/strings.ts:2242
 msgid "Encrypted backup"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Enter email address"
 msgstr ""
 
-#: src/strings.ts:2369
+#: src/strings.ts:2371
 msgid "Enter embed source URL"
 msgstr ""
 
@@ -2465,7 +2465,7 @@ msgstr ""
 msgid "Enter the 6 digit code sent to your phone number to continue logging in"
 msgstr ""
 
-#: src/strings.ts:2433
+#: src/strings.ts:2435
 msgid "Enter the gift code to redeem your subscription."
 msgstr ""
 
@@ -2485,7 +2485,7 @@ msgstr ""
 msgid "Enter your username"
 msgstr ""
 
-#: src/strings.ts:2425
+#: src/strings.ts:2427
 msgid "Error"
 msgstr ""
 
@@ -2521,7 +2521,7 @@ msgstr ""
 msgid "Errors in {count} attachments"
 msgstr ""
 
-#: src/strings.ts:2470
+#: src/strings.ts:2472
 msgid "Essential plan"
 msgstr ""
 
@@ -2529,23 +2529,23 @@ msgstr ""
 msgid "Events server"
 msgstr ""
 
-#: src/strings.ts:2411
+#: src/strings.ts:2413
 msgid "Every Notebook can have notes and sub notebooks."
 msgstr ""
 
-#: src/strings.ts:2413
+#: src/strings.ts:2415
 msgid "Everything related to my job in one place."
 msgstr ""
 
-#: src/strings.ts:2422
+#: src/strings.ts:2424
 msgid "Everything related to my school in one place."
 msgstr ""
 
-#: src/strings.ts:2439
+#: src/strings.ts:2441
 msgid "Execute"
 msgstr ""
 
-#: src/strings.ts:2438
+#: src/strings.ts:2440
 msgid "Execute a command..."
 msgstr ""
 
@@ -2553,11 +2553,11 @@ msgstr ""
 msgid "Exit fullscreen"
 msgstr ""
 
-#: src/strings.ts:2373
+#: src/strings.ts:2375
 msgid "Expand"
 msgstr ""
 
-#: src/strings.ts:2466
+#: src/strings.ts:2468
 msgid "Expand sidebar"
 msgstr ""
 
@@ -2606,7 +2606,7 @@ msgstr ""
 msgid "Faced an issue or have a suggestion? Click here to create a bug report"
 msgstr ""
 
-#: src/strings.ts:2403
+#: src/strings.ts:2405
 msgid "Failed"
 msgstr ""
 
@@ -2662,11 +2662,11 @@ msgstr ""
 msgid "Failed to subscribe"
 msgstr ""
 
-#: src/strings.ts:2202
+#: src/strings.ts:2204
 msgid "Failed to take backup"
 msgstr ""
 
-#: src/strings.ts:2204
+#: src/strings.ts:2206
 msgid "Failed to take backup of your data. Do you want to continue logging out?"
 msgstr ""
 
@@ -2691,11 +2691,11 @@ msgstr ""
 msgid "Favorites"
 msgstr ""
 
-#: src/strings.ts:2415
+#: src/strings.ts:2417
 msgid "February 2022 Week 2"
 msgstr ""
 
-#: src/strings.ts:2416
+#: src/strings.ts:2418
 msgid "February 2022 Week 3"
 msgstr ""
 
@@ -2739,7 +2739,7 @@ msgstr ""
 msgid "Fix it"
 msgstr ""
 
-#: src/strings.ts:2310
+#: src/strings.ts:2312
 msgid "Float image"
 msgstr ""
 
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "Focus mode"
 msgstr ""
 
-#: src/strings.ts:2162
+#: src/strings.ts:2164
 msgid "Follow"
 msgstr ""
 
@@ -2767,16 +2767,24 @@ msgstr ""
 msgid "Follow us on X for updates and news about Notesnook"
 msgstr ""
 
-#: src/strings.ts:2275
+#: src/strings.ts:2277
 msgid "Font family"
 msgstr ""
 
-#: src/strings.ts:2463
+#: src/strings.ts:2465
 msgid "Font ligatures"
 msgstr ""
 
-#: src/strings.ts:2276
+#: src/strings.ts:2278
 msgid "Font size"
+msgstr ""
+
+#: src/strings.ts:2096
+msgid "Font Size(Editor Title)"
+msgstr ""
+
+#: src/strings.ts:2095
+msgid "Font Size(List Title)"
 msgstr ""
 
 #: src/strings.ts:1685
@@ -2787,7 +2795,7 @@ msgstr ""
 msgid "for help regarding how to use the Notesnook Importer."
 msgstr ""
 
-#: src/strings.ts:2194
+#: src/strings.ts:2196
 msgid "Force logout from all your other logged in devices."
 msgstr ""
 
@@ -2799,7 +2807,7 @@ msgstr ""
 msgid "Force push changes"
 msgstr ""
 
-#: src/strings.ts:2211
+#: src/strings.ts:2213
 msgid ""
 "Force push:\n"
 "Use this if changes made on this device are not appearing on other devices. This will overwrite the data on the server with the data from this device.\n"
@@ -2814,7 +2822,7 @@ msgstr ""
 msgid "Forgot password?"
 msgstr ""
 
-#: src/strings.ts:2468
+#: src/strings.ts:2470
 msgid "Free plan"
 msgstr ""
 
@@ -2826,11 +2834,11 @@ msgstr ""
 msgid "Friday"
 msgstr ""
 
-#: src/strings.ts:2371
+#: src/strings.ts:2373
 msgid "From code"
 msgstr ""
 
-#: src/strings.ts:2368
+#: src/strings.ts:2370
 msgid "From URL"
 msgstr ""
 
@@ -2838,11 +2846,11 @@ msgstr ""
 msgid "Full name updated"
 msgstr ""
 
-#: src/strings.ts:2205
+#: src/strings.ts:2207
 msgid "Full offline mode"
 msgstr ""
 
-#: src/strings.ts:2323
+#: src/strings.ts:2325
 msgid "Full screen"
 msgstr ""
 
@@ -2858,11 +2866,11 @@ msgstr ""
 msgid "Get Notesnook app on your desktop and access all notes"
 msgstr ""
 
-#: src/strings.ts:2156
+#: src/strings.ts:2158
 msgid "Get Notesnook app on your iPhone and access all your notes on the go."
 msgstr ""
 
-#: src/strings.ts:2158
+#: src/strings.ts:2160
 msgid "Get Notesnook app on your iPhone or Android device and access all your notes on the go."
 msgstr ""
 
@@ -2874,7 +2882,7 @@ msgstr ""
 msgid "Get Notesnook Pro to enable automatic backups"
 msgstr ""
 
-#: src/strings.ts:2407
+#: src/strings.ts:2409
 msgid "Get Priority support"
 msgstr ""
 
@@ -2898,23 +2906,23 @@ msgstr ""
 msgid "Getting recovery codes"
 msgstr ""
 
-#: src/strings.ts:2161
+#: src/strings.ts:2163
 msgid "GNU GENERAL PUBLIC LICENSE Version 3"
 msgstr ""
 
-#: src/strings.ts:2446
+#: src/strings.ts:2448
 msgid "Go back in tab"
 msgstr ""
 
-#: src/strings.ts:2224
+#: src/strings.ts:2226
 msgid "Go back to notebooks"
 msgstr ""
 
-#: src/strings.ts:2225
+#: src/strings.ts:2227
 msgid "Go back to tags"
 msgstr ""
 
-#: src/strings.ts:2445
+#: src/strings.ts:2447
 msgid "Go forward in tab"
 msgstr ""
 
@@ -2958,19 +2966,19 @@ msgstr ""
 msgid "Hash copied"
 msgstr ""
 
-#: src/strings.ts:2208
+#: src/strings.ts:2210
 msgid "Having problems with sync?"
 msgstr ""
 
-#: src/strings.ts:2349
+#: src/strings.ts:2351
 msgid "Heading {level}"
 msgstr ""
 
-#: src/strings.ts:2277
+#: src/strings.ts:2279
 msgid "Headings"
 msgstr ""
 
-#: src/strings.ts:2384
+#: src/strings.ts:2386
 msgid "Height"
 msgstr ""
 
@@ -2990,11 +2998,11 @@ msgstr ""
 msgid "Hide app contents when you switch to other apps. This will also disable screenshot taking in the app."
 msgstr ""
 
-#: src/strings.ts:2167
+#: src/strings.ts:2169
 msgid "Hide note title"
 msgstr ""
 
-#: src/strings.ts:2280
+#: src/strings.ts:2282
 msgid "Highlight"
 msgstr ""
 
@@ -3014,7 +3022,7 @@ msgstr ""
 msgid "Homepage changed to {name}"
 msgstr ""
 
-#: src/strings.ts:2330
+#: src/strings.ts:2332
 msgid "Horizontal rule"
 msgstr ""
 
@@ -3054,11 +3062,11 @@ msgstr ""
 msgid "I have saved my key"
 msgstr ""
 
-#: src/strings.ts:2424
+#: src/strings.ts:2426
 msgid "I love cooking and collecting recipes."
 msgstr ""
 
-#: src/strings.ts:2209
+#: src/strings.ts:2211
 msgid "I understand"
 msgstr ""
 
@@ -3074,11 +3082,11 @@ msgstr ""
 msgid "If this continues to happen, please reach out to us via"
 msgstr ""
 
-#: src/strings.ts:2112
+#: src/strings.ts:2114
 msgid "If true, Notesnook will automatically start up when you turn on & login to your system."
 msgstr ""
 
-#: src/strings.ts:2115
+#: src/strings.ts:2117
 msgid "If true, Notesnook will start minimized to either the system tray or your system taskbar/dock. This setting only works with Auto start on system startup is enabled."
 msgstr ""
 
@@ -3104,7 +3112,7 @@ msgstr ""
 msgid "If you want to ask something in general or need some assistance, we would suggest that you"
 msgstr ""
 
-#: src/strings.ts:2335
+#: src/strings.ts:2337
 msgid "Image"
 msgstr ""
 
@@ -3112,11 +3120,11 @@ msgstr ""
 msgid "Image Compression"
 msgstr ""
 
-#: src/strings.ts:2311
+#: src/strings.ts:2313
 msgid "Image properties"
 msgstr ""
 
-#: src/strings.ts:2306
+#: src/strings.ts:2308
 msgid "Image settings"
 msgstr ""
 
@@ -3136,7 +3144,7 @@ msgstr ""
 msgid "Immediately"
 msgstr ""
 
-#: src/strings.ts:2139
+#: src/strings.ts:2141
 msgid "Import & export"
 msgstr ""
 
@@ -3160,47 +3168,47 @@ msgstr ""
 msgid "Incorrect {type}"
 msgstr ""
 
-#: src/strings.ts:2393
+#: src/strings.ts:2395
 msgid "Increase {title}"
 msgstr ""
 
-#: src/strings.ts:2234
+#: src/strings.ts:2236
 msgid "Insert"
 msgstr ""
 
-#: src/strings.ts:2390
+#: src/strings.ts:2392
 msgid "Insert a {rows}x{columns} table"
 msgstr ""
 
-#: src/strings.ts:2340
+#: src/strings.ts:2342
 msgid "Insert a table"
 msgstr ""
 
-#: src/strings.ts:2342
+#: src/strings.ts:2344
 msgid "Insert an embed"
 msgstr ""
 
-#: src/strings.ts:2336
+#: src/strings.ts:2338
 msgid "Insert an image"
 msgstr ""
 
-#: src/strings.ts:2287
+#: src/strings.ts:2289
 msgid "Insert column left"
 msgstr ""
 
-#: src/strings.ts:2288
+#: src/strings.ts:2290
 msgid "Insert column right"
 msgstr ""
 
-#: src/strings.ts:2232
+#: src/strings.ts:2234
 msgid "Insert link"
 msgstr ""
 
-#: src/strings.ts:2294
+#: src/strings.ts:2296
 msgid "Insert row above"
 msgstr ""
 
-#: src/strings.ts:2295
+#: src/strings.ts:2297
 msgid "Insert row below"
 msgstr ""
 
@@ -3208,7 +3216,7 @@ msgstr ""
 msgid "Install Notesnook"
 msgstr ""
 
-#: src/strings.ts:2147
+#: src/strings.ts:2149
 msgid "Install update"
 msgstr ""
 
@@ -3245,7 +3253,7 @@ msgstr ""
 msgid "It took us a year to bring Notesnook to life. Share your experience and suggestions to help us improve it."
 msgstr ""
 
-#: src/strings.ts:2256
+#: src/strings.ts:2258
 msgid "Italic"
 msgstr ""
 
@@ -3266,7 +3274,7 @@ msgstr ""
 msgid "Items"
 msgstr ""
 
-#: src/strings.ts:2159
+#: src/strings.ts:2161
 msgid "Join community"
 msgstr ""
 
@@ -3310,11 +3318,11 @@ msgstr ""
 msgid "Keep your data safe"
 msgstr ""
 
-#: src/strings.ts:2127
+#: src/strings.ts:2129
 msgid "Languages"
 msgstr ""
 
-#: src/strings.ts:2229
+#: src/strings.ts:2231
 msgid "Last edited at"
 msgstr ""
 
@@ -3354,7 +3362,7 @@ msgstr ""
 msgid "Let us know if you have faced any issue/bug while using Notesnook. We will try to fix it as soon as possible."
 msgstr ""
 
-#: src/strings.ts:2160
+#: src/strings.ts:2162
 msgid "License"
 msgstr ""
 
@@ -3362,7 +3370,7 @@ msgstr ""
 msgid "Licensed under {license}"
 msgstr ""
 
-#: src/strings.ts:2326
+#: src/strings.ts:2328
 msgid "Lift list item"
 msgstr ""
 
@@ -3370,7 +3378,7 @@ msgstr ""
 msgid "Light"
 msgstr ""
 
-#: src/strings.ts:2356
+#: src/strings.ts:2358
 msgid "Line {line}, Column {column}"
 msgstr ""
 
@@ -3378,7 +3386,7 @@ msgstr ""
 msgid "Line spacing changed"
 msgstr ""
 
-#: src/strings.ts:2260
+#: src/strings.ts:2262
 msgid "Link"
 msgstr ""
 
@@ -3390,15 +3398,15 @@ msgstr ""
 msgid "Link notebooks"
 msgstr ""
 
-#: src/strings.ts:2475
+#: src/strings.ts:2477
 msgid "Link notes"
 msgstr ""
 
-#: src/strings.ts:2265
+#: src/strings.ts:2267
 msgid "Link settings"
 msgstr ""
 
-#: src/strings.ts:2386
+#: src/strings.ts:2388
 msgid "Link text"
 msgstr ""
 
@@ -3503,7 +3511,7 @@ msgstr ""
 msgid "Locked notes cannot be published"
 msgstr ""
 
-#: src/strings.ts:2192
+#: src/strings.ts:2194
 msgid "Log out from all other devices"
 msgstr ""
 
@@ -3563,7 +3571,7 @@ msgstr ""
 msgid "Long press on any item in list to enter multi-select mode."
 msgstr ""
 
-#: src/strings.ts:2361
+#: src/strings.ts:2363
 msgid "Make task list readonly"
 msgstr ""
 
@@ -3615,19 +3623,19 @@ msgstr ""
 msgid "Marketing emails"
 msgstr ""
 
-#: src/strings.ts:2374
+#: src/strings.ts:2376
 msgid "Match case"
 msgstr ""
 
-#: src/strings.ts:2375
+#: src/strings.ts:2377
 msgid "Match whole word"
 msgstr ""
 
-#: src/strings.ts:2282
+#: src/strings.ts:2284
 msgid "Math (inline)"
 msgstr ""
 
-#: src/strings.ts:2333
+#: src/strings.ts:2335
 msgid "Math & formulas"
 msgstr ""
 
@@ -3639,7 +3647,7 @@ msgstr ""
 msgid "Meet other privacy-minded people & talk to us directly about your concerns, issues and suggestions."
 msgstr ""
 
-#: src/strings.ts:2417
+#: src/strings.ts:2419
 msgid "Meetings"
 msgstr ""
 
@@ -3647,7 +3655,7 @@ msgstr ""
 msgid "Member since {date}"
 msgstr ""
 
-#: src/strings.ts:2293
+#: src/strings.ts:2295
 msgid "Merge cells"
 msgstr ""
 
@@ -3673,7 +3681,7 @@ msgstr ""
 msgid "Minimize"
 msgstr ""
 
-#: src/strings.ts:2116
+#: src/strings.ts:2118
 msgid "Minimize to system tray"
 msgstr ""
 
@@ -3724,7 +3732,7 @@ msgstr ""
 msgid "Monthly"
 msgstr ""
 
-#: src/strings.ts:2313
+#: src/strings.ts:2315
 msgid "More"
 msgstr ""
 
@@ -3736,15 +3744,15 @@ msgstr ""
 msgid "Move"
 msgstr ""
 
-#: src/strings.ts:2362
+#: src/strings.ts:2364
 msgid "Move all checked tasks to bottom"
 msgstr ""
 
-#: src/strings.ts:2289
+#: src/strings.ts:2291
 msgid "Move column left"
 msgstr ""
 
-#: src/strings.ts:2290
+#: src/strings.ts:2292
 msgid "Move column right"
 msgstr ""
 
@@ -3756,11 +3764,11 @@ msgstr ""
 msgid "Move notes"
 msgstr ""
 
-#: src/strings.ts:2297
+#: src/strings.ts:2299
 msgid "Move row down"
 msgstr ""
 
-#: src/strings.ts:2296
+#: src/strings.ts:2298
 msgid "Move row up"
 msgstr ""
 
@@ -3788,7 +3796,7 @@ msgstr ""
 msgid "Native high-performance encryption"
 msgstr ""
 
-#: src/strings.ts:2442
+#: src/strings.ts:2444
 msgid "Navigate"
 msgstr ""
 
@@ -3848,7 +3856,7 @@ msgstr ""
 msgid "New tab"
 msgstr ""
 
-#: src/strings.ts:2448
+#: src/strings.ts:2450
 msgid "New tag"
 msgstr ""
 
@@ -3872,11 +3880,11 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
-#: src/strings.ts:2378
+#: src/strings.ts:2380
 msgid "Next match"
 msgstr ""
 
-#: src/strings.ts:2443
+#: src/strings.ts:2445
 msgid "Next tab"
 msgstr ""
 
@@ -3932,7 +3940,7 @@ msgstr ""
 msgid "No note history available for this device."
 msgstr ""
 
-#: src/strings.ts:2489
+#: src/strings.ts:2491
 msgid "No notebooks selected to move"
 msgstr ""
 
@@ -4030,7 +4038,7 @@ msgstr ""
 msgid "Notebook"
 msgstr ""
 
-#: src/strings.ts:2478
+#: src/strings.ts:2480
 msgid "Notebook added"
 msgstr ""
 
@@ -4048,7 +4056,7 @@ msgstr ""
 msgid "NOTEBOOKS"
 msgstr ""
 
-#: src/strings.ts:2239
+#: src/strings.ts:2241
 msgid "Notebooks are the best way to organize your notes."
 msgstr ""
 
@@ -4073,7 +4081,7 @@ msgstr ""
 msgid "Notesnook encrypts everything offline before syncing to your other devices. This means that no one can read your notes except you. Not even us."
 msgstr ""
 
-#: src/strings.ts:2141
+#: src/strings.ts:2143
 msgid "Notesnook Importer"
 msgstr ""
 
@@ -4081,7 +4089,7 @@ msgstr ""
 msgid "Notesnook Pro"
 msgstr ""
 
-#: src/strings.ts:2173
+#: src/strings.ts:2175
 msgid ""
 "Notesnook uses the following DNS providers:\n"
 "\n"
@@ -4099,7 +4107,7 @@ msgstr ""
 msgid "Notesnook will send you an SMS with a 2FA code when prompted"
 msgstr ""
 
-#: src/strings.ts:2136
+#: src/strings.ts:2138
 msgid "Notifications"
 msgstr ""
 
@@ -4107,7 +4115,7 @@ msgstr ""
 msgid "Notifications disabled"
 msgstr ""
 
-#: src/strings.ts:2273
+#: src/strings.ts:2275
 msgid "Numbered list"
 msgstr ""
 
@@ -4123,7 +4131,7 @@ msgstr ""
 msgid "Offline"
 msgstr ""
 
-#: src/strings.ts:2226
+#: src/strings.ts:2228
 msgid "Okay"
 msgstr ""
 
@@ -4167,7 +4175,7 @@ msgstr ""
 msgid "Open in browser to manage subscription"
 msgstr ""
 
-#: src/strings.ts:2324
+#: src/strings.ts:2326
 msgid "Open in new tab"
 msgstr ""
 
@@ -4175,7 +4183,7 @@ msgstr ""
 msgid "Open issue"
 msgstr ""
 
-#: src/strings.ts:2263
+#: src/strings.ts:2265
 msgid "Open link"
 msgstr ""
 
@@ -4187,7 +4195,7 @@ msgstr ""
 msgid "Open settings"
 msgstr ""
 
-#: src/strings.ts:2325
+#: src/strings.ts:2327
 msgid "Open source"
 msgstr ""
 
@@ -4219,7 +4227,7 @@ msgstr ""
 msgid "Order by"
 msgstr ""
 
-#: src/strings.ts:2219
+#: src/strings.ts:2221
 msgid "Order ID"
 msgstr ""
 
@@ -4228,19 +4236,19 @@ msgstr ""
 msgid "Orphaned"
 msgstr ""
 
-#: src/strings.ts:2144
+#: src/strings.ts:2146
 msgid "Other"
 msgstr ""
 
-#: src/strings.ts:2345
+#: src/strings.ts:2347
 msgid "Outline list"
 msgstr ""
 
-#: src/strings.ts:2348
+#: src/strings.ts:2350
 msgid "Paragraph"
 msgstr ""
 
-#: src/strings.ts:2100
+#: src/strings.ts:2102
 msgid "Partial backups contain all your data except attachments. They are created from data already available on your device and do not require an Internet connection."
 msgstr ""
 
@@ -4248,7 +4256,7 @@ msgstr ""
 msgid "Partially refunded"
 msgstr ""
 
-#: src/strings.ts:2402
+#: src/strings.ts:2404
 msgid "Passed"
 msgstr ""
 
@@ -4288,27 +4296,27 @@ msgstr ""
 msgid "Password/pin"
 msgstr ""
 
-#: src/strings.ts:2247
+#: src/strings.ts:2249
 msgid "Paste"
 msgstr ""
 
-#: src/strings.ts:2248
+#: src/strings.ts:2250
 msgid "Paste and match style"
 msgstr ""
 
-#: src/strings.ts:2370
+#: src/strings.ts:2372
 msgid "Paste embed code here. Only iframes are supported."
 msgstr ""
 
-#: src/strings.ts:2385
+#: src/strings.ts:2387
 msgid "Paste image URL here"
 msgstr ""
 
-#: src/strings.ts:2249
+#: src/strings.ts:2251
 msgid "Paste without formatting"
 msgstr ""
 
-#: src/strings.ts:2198
+#: src/strings.ts:2200
 msgid "Payment method"
 msgstr ""
 
@@ -4353,7 +4361,7 @@ msgid "Please confirm your identity by entering a recovery code."
 msgstr ""
 
 #: src/strings.ts:980
-#: src/strings.ts:2231
+#: src/strings.ts:2233
 msgid "Please confirm your identity by entering the authentication code from your authenticator app."
 msgstr ""
 
@@ -4390,7 +4398,7 @@ msgstr ""
 msgid "Please enter password of this backup file"
 msgstr ""
 
-#: src/strings.ts:2242
+#: src/strings.ts:2244
 msgid "Please enter the password to decrypt and restore this backup."
 msgstr ""
 
@@ -4450,7 +4458,7 @@ msgstr ""
 msgid "please send us an email from your registered email address"
 msgstr ""
 
-#: src/strings.ts:2391
+#: src/strings.ts:2393
 msgid "Please set a table size"
 msgstr ""
 
@@ -4548,19 +4556,19 @@ msgstr ""
 msgid "PRESETS"
 msgstr ""
 
-#: src/strings.ts:2118
+#: src/strings.ts:2120
 msgid "Pressing \"—\" will hide the app in your system tray."
 msgstr ""
 
-#: src/strings.ts:2121
+#: src/strings.ts:2123
 msgid "Pressing \"X\" will hide the app in your system tray."
 msgstr ""
 
-#: src/strings.ts:2169
+#: src/strings.ts:2171
 msgid "Prevent note title from appearing in tab/window title."
 msgstr ""
 
-#: src/strings.ts:2312
+#: src/strings.ts:2314
 msgid "Preview attachment"
 msgstr ""
 
@@ -4568,11 +4576,11 @@ msgstr ""
 msgid "Preview not available, content is encrypted."
 msgstr ""
 
-#: src/strings.ts:2379
+#: src/strings.ts:2381
 msgid "Previous match"
 msgstr ""
 
-#: src/strings.ts:2444
+#: src/strings.ts:2446
 msgid "Previous tab"
 msgstr ""
 
@@ -4580,7 +4588,7 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: src/strings.ts:2143
+#: src/strings.ts:2145
 msgid "Privacy"
 msgstr ""
 
@@ -4624,7 +4632,7 @@ msgstr ""
 msgid "Pro"
 msgstr ""
 
-#: src/strings.ts:2469
+#: src/strings.ts:2471
 msgid "Pro plan"
 msgstr ""
 
@@ -4640,7 +4648,7 @@ msgstr ""
 msgid "Productivity"
 msgstr ""
 
-#: src/strings.ts:2132
+#: src/strings.ts:2134
 msgid "Profile"
 msgstr ""
 
@@ -4656,7 +4664,7 @@ msgstr ""
 msgid "Protect your notes"
 msgstr ""
 
-#: src/strings.ts:2180
+#: src/strings.ts:2182
 msgid "Proxy"
 msgstr ""
 
@@ -4700,7 +4708,7 @@ msgstr ""
 msgid "Quick note widgets"
 msgstr ""
 
-#: src/strings.ts:2440
+#: src/strings.ts:2442
 msgid "Quick open"
 msgstr ""
 
@@ -4708,7 +4716,7 @@ msgstr ""
 msgid "Quickly create a note from the notification"
 msgstr ""
 
-#: src/strings.ts:2332
+#: src/strings.ts:2334
 msgid "Quote"
 msgstr ""
 
@@ -4748,7 +4756,7 @@ msgstr ""
 msgid "Reading backup file..."
 msgstr ""
 
-#: src/strings.ts:2222
+#: src/strings.ts:2224
 msgid "Receipt"
 msgstr ""
 
@@ -4756,11 +4764,11 @@ msgstr ""
 msgid "RECENT BACKUPS"
 msgstr ""
 
-#: src/strings.ts:2455
+#: src/strings.ts:2457
 msgid "Recents"
 msgstr ""
 
-#: src/strings.ts:2398
+#: src/strings.ts:2400
 msgid "Recheck all"
 msgstr ""
 
@@ -4768,7 +4776,7 @@ msgstr ""
 msgid "Rechecking failed"
 msgstr ""
 
-#: src/strings.ts:2423
+#: src/strings.ts:2425
 msgid "Recipes"
 msgstr ""
 
@@ -4812,15 +4820,15 @@ msgstr ""
 msgid "Recovery successful!"
 msgstr ""
 
-#: src/strings.ts:2435
+#: src/strings.ts:2437
 msgid "Redeem"
 msgstr ""
 
-#: src/strings.ts:2432
+#: src/strings.ts:2434
 msgid "Redeem gift code"
 msgstr ""
 
-#: src/strings.ts:2434
+#: src/strings.ts:2436
 msgid "Redeeming gift code"
 msgstr ""
 
@@ -4848,7 +4856,7 @@ msgstr ""
 msgid "Release notes"
 msgstr ""
 
-#: src/strings.ts:2457
+#: src/strings.ts:2459
 msgid "Release track"
 msgstr ""
 
@@ -4942,7 +4950,7 @@ msgstr ""
 msgid "Remove as default"
 msgstr ""
 
-#: src/strings.ts:2316
+#: src/strings.ts:2318
 msgid "Remove attachment"
 msgstr ""
 
@@ -4954,7 +4962,7 @@ msgstr ""
 msgid "Remove from notebook"
 msgstr ""
 
-#: src/strings.ts:2456
+#: src/strings.ts:2458
 msgid "Remove from recents"
 msgstr ""
 
@@ -4962,7 +4970,7 @@ msgstr ""
 msgid "Remove full name"
 msgstr ""
 
-#: src/strings.ts:2262
+#: src/strings.ts:2264
 msgid "Remove link"
 msgstr ""
 
@@ -4994,15 +5002,15 @@ msgstr ""
 msgid "Repeats daily at {date}"
 msgstr ""
 
-#: src/strings.ts:2376
+#: src/strings.ts:2378
 msgid "Replace"
 msgstr ""
 
-#: src/strings.ts:2377
+#: src/strings.ts:2379
 msgid "Replace all"
 msgstr ""
 
-#: src/strings.ts:2163
+#: src/strings.ts:2165
 msgid "Report"
 msgstr ""
 
@@ -5035,7 +5043,7 @@ msgstr ""
 msgid "Reset account password"
 msgstr ""
 
-#: src/strings.ts:2483
+#: src/strings.ts:2485
 msgid "Reset homepage"
 msgstr ""
 
@@ -5087,7 +5095,7 @@ msgstr ""
 msgid "Restore backup"
 msgstr ""
 
-#: src/strings.ts:2405
+#: src/strings.ts:2407
 msgid "Restore backup?"
 msgstr ""
 
@@ -5167,7 +5175,7 @@ msgstr ""
 msgid "Rotate right"
 msgstr ""
 
-#: src/strings.ts:2285
+#: src/strings.ts:2287
 msgid "Row properties"
 msgstr ""
 
@@ -5247,11 +5255,11 @@ msgstr ""
 msgid "Save your recovery codes in a safe place. You will need them to recover your account in case you lose access to your two-factor authentication methods."
 msgstr ""
 
-#: src/strings.ts:2395
+#: src/strings.ts:2397
 msgid "Saved"
 msgstr ""
 
-#: src/strings.ts:2396
+#: src/strings.ts:2398
 msgid "Saving"
 msgstr ""
 
@@ -5271,15 +5279,15 @@ msgstr ""
 msgid "Scan the QR code with your authenticator app"
 msgstr ""
 
-#: src/strings.ts:2421
+#: src/strings.ts:2423
 msgid "School work"
 msgstr ""
 
-#: src/strings.ts:2491
+#: src/strings.ts:2493
 msgid "Scroll to bottom"
 msgstr ""
 
-#: src/strings.ts:2490
+#: src/strings.ts:2492
 msgid "Scroll to top"
 msgstr ""
 
@@ -5296,7 +5304,7 @@ msgstr ""
 msgid "Search a note to link to"
 msgstr ""
 
-#: src/strings.ts:2437
+#: src/strings.ts:2439
 msgid "Search for notes, notebooks, and tags..."
 msgstr ""
 
@@ -5352,7 +5360,7 @@ msgstr ""
 msgid "Search in Trash"
 msgstr ""
 
-#: src/strings.ts:2358
+#: src/strings.ts:2360
 msgid "Search languages"
 msgstr ""
 
@@ -5376,7 +5384,7 @@ msgstr ""
 msgid "sec"
 msgstr ""
 
-#: src/strings.ts:2142
+#: src/strings.ts:2144
 msgid "Security & privacy"
 msgstr ""
 
@@ -5400,11 +5408,11 @@ msgstr ""
 msgid "Select a backup file from your device to restore backup"
 msgstr ""
 
-#: src/strings.ts:2488
+#: src/strings.ts:2490
 msgid "Select a notebook to move this notebook into, or unselect to move it to the root level."
 msgstr ""
 
-#: src/strings.ts:2097
+#: src/strings.ts:2099
 msgid "Select a theme"
 msgstr ""
 
@@ -5444,7 +5452,7 @@ msgstr ""
 msgid "Select how you would like to recieve the code"
 msgstr ""
 
-#: src/strings.ts:2353
+#: src/strings.ts:2355
 msgid "Select language"
 msgstr ""
 
@@ -5460,7 +5468,7 @@ msgstr ""
 msgid "Select notebooks you want to add note(s) to."
 msgstr ""
 
-#: src/strings.ts:2476
+#: src/strings.ts:2478
 msgid "Select notes to link to \"{title}\""
 msgstr ""
 
@@ -5472,7 +5480,7 @@ msgstr ""
 msgid "Select profile picture"
 msgstr ""
 
-#: src/strings.ts:2482
+#: src/strings.ts:2484
 msgid "Select the default sidebar tab"
 msgstr ""
 
@@ -5480,11 +5488,11 @@ msgstr ""
 msgid "Select the folder that includes your backup files to list them here."
 msgstr ""
 
-#: src/strings.ts:2129
+#: src/strings.ts:2131
 msgid "Select the languages the spell checker should check in."
 msgstr ""
 
-#: src/strings.ts:2458
+#: src/strings.ts:2460
 msgid "Select the release track for Notesnook."
 msgstr ""
 
@@ -5496,7 +5504,7 @@ msgstr ""
 msgid "Self destruct"
 msgstr ""
 
-#: src/strings.ts:2164
+#: src/strings.ts:2166
 msgid "Send"
 msgstr ""
 
@@ -5548,11 +5556,11 @@ msgstr ""
 msgid "Server with host {host} not found."
 msgstr ""
 
-#: src/strings.ts:2137
+#: src/strings.ts:2139
 msgid "Servers"
 msgstr ""
 
-#: src/strings.ts:2138
+#: src/strings.ts:2140
 msgid "Servers configuration"
 msgstr ""
 
@@ -5560,7 +5568,7 @@ msgstr ""
 msgid "Session expired"
 msgstr ""
 
-#: src/strings.ts:2190
+#: src/strings.ts:2192
 msgid "Sessions"
 msgstr ""
 
@@ -5576,7 +5584,7 @@ msgstr ""
 msgid "Set as default"
 msgstr ""
 
-#: src/strings.ts:2480
+#: src/strings.ts:2482
 msgid "Set as homepage"
 msgstr ""
 
@@ -5630,7 +5638,7 @@ msgstr ""
 msgid "Setup a pin to lock the app"
 msgstr ""
 
-#: src/strings.ts:2182
+#: src/strings.ts:2184
 msgid ""
 "Setup an HTTP/HTTPS/SOCKS proxy.\n"
 "\n"
@@ -5726,7 +5734,7 @@ msgstr ""
 msgid "Silent"
 msgstr ""
 
-#: src/strings.ts:2327
+#: src/strings.ts:2329
 msgid "Sink list item"
 msgstr ""
 
@@ -5766,23 +5774,23 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: src/strings.ts:2148
+#: src/strings.ts:2150
 msgid "Source code"
 msgstr ""
 
-#: src/strings.ts:2354
+#: src/strings.ts:2356
 msgid "Spaces"
 msgstr ""
 
-#: src/strings.ts:2125
+#: src/strings.ts:2127
 msgid "Spell check"
 msgstr ""
 
-#: src/strings.ts:2292
+#: src/strings.ts:2294
 msgid "Split cells"
 msgstr ""
 
-#: src/strings.ts:2459
+#: src/strings.ts:2461
 msgid "Stable"
 msgstr ""
 
@@ -5802,7 +5810,7 @@ msgstr ""
 msgid "Start importing now"
 msgstr ""
 
-#: src/strings.ts:2113
+#: src/strings.ts:2115
 msgid "Start minimized"
 msgstr ""
 
@@ -5822,11 +5830,11 @@ msgstr ""
 msgid "Start writing your note..."
 msgstr ""
 
-#: src/strings.ts:2221
+#: src/strings.ts:2223
 msgid "Status"
 msgstr ""
 
-#: src/strings.ts:2472
+#: src/strings.ts:2474
 msgid "Storage"
 msgstr ""
 
@@ -5834,11 +5842,11 @@ msgstr ""
 msgid "Streaming not supported"
 msgstr ""
 
-#: src/strings.ts:2258
+#: src/strings.ts:2260
 msgid "Strikethrough"
 msgstr ""
 
-#: src/strings.ts:2223
+#: src/strings.ts:2225
 msgid "Subgroup 1"
 msgstr ""
 
@@ -5874,7 +5882,7 @@ msgstr ""
 msgid "Subscribed using gift card"
 msgstr ""
 
-#: src/strings.ts:2269
+#: src/strings.ts:2271
 msgid "Subscript"
 msgstr ""
 
@@ -5898,7 +5906,7 @@ msgstr ""
 msgid "Sunday"
 msgstr ""
 
-#: src/strings.ts:2270
+#: src/strings.ts:2272
 msgid "Superscript"
 msgstr ""
 
@@ -5906,7 +5914,7 @@ msgstr ""
 msgid "Switch to search/replace mode"
 msgstr ""
 
-#: src/strings.ts:2134
+#: src/strings.ts:2136
 msgid "Sync"
 msgstr ""
 
@@ -5954,7 +5962,7 @@ msgstr ""
 msgid "Syncing your notes"
 msgstr ""
 
-#: src/strings.ts:2339
+#: src/strings.ts:2341
 msgid "Table"
 msgstr ""
 
@@ -5962,7 +5970,7 @@ msgstr ""
 msgid "Table of contents"
 msgstr ""
 
-#: src/strings.ts:2283
+#: src/strings.ts:2285
 msgid "Table settings"
 msgstr ""
 
@@ -5999,7 +6007,7 @@ msgstr ""
 msgid "Take a partial backup of your data that does not include attachments"
 msgstr ""
 
-#: src/strings.ts:2338
+#: src/strings.ts:2340
 msgid "Take a photo using camera"
 msgstr ""
 
@@ -6059,11 +6067,11 @@ msgstr ""
 msgid "Tap twice to confirm you have saved the recovery key."
 msgstr ""
 
-#: src/strings.ts:2344
+#: src/strings.ts:2346
 msgid "Task list"
 msgstr ""
 
-#: src/strings.ts:2414
+#: src/strings.ts:2416
 msgid "Tasks"
 msgstr ""
 
@@ -6102,11 +6110,11 @@ msgstr ""
 msgid "Test connection before changing server urls"
 msgstr ""
 
-#: src/strings.ts:2281
+#: src/strings.ts:2283
 msgid "Text color"
 msgstr ""
 
-#: src/strings.ts:2279
+#: src/strings.ts:2281
 msgid "Text direction"
 msgstr ""
 
@@ -6166,7 +6174,7 @@ msgstr ""
 msgid "There are no blocks in this note."
 msgstr ""
 
-#: src/strings.ts:2236
+#: src/strings.ts:2238
 msgid "These items will be **kept in your Trash for {interval} days** after which they will be permanently deleted."
 msgstr ""
 
@@ -6280,23 +6288,23 @@ msgstr ""
 msgid "Toggle dark/light mode"
 msgstr ""
 
-#: src/strings.ts:2462
+#: src/strings.ts:2464
 msgid "Toggle focus mode"
 msgstr ""
 
-#: src/strings.ts:2351
+#: src/strings.ts:2353
 msgid "Toggle indentation mode"
 msgstr ""
 
-#: src/strings.ts:2380
+#: src/strings.ts:2382
 msgid "Toggle replace"
 msgstr ""
 
-#: src/strings.ts:2451
+#: src/strings.ts:2453
 msgid "Toggle theme"
 msgstr ""
 
-#: src/strings.ts:2131
+#: src/strings.ts:2133
 msgid "Toolbar"
 msgstr ""
 
@@ -6381,11 +6389,11 @@ msgstr ""
 msgid "Unable to send 2FA code"
 msgstr ""
 
-#: src/strings.ts:2486
+#: src/strings.ts:2488
 msgid "Unarchive"
 msgstr ""
 
-#: src/strings.ts:2257
+#: src/strings.ts:2259
 msgid "Underline"
 msgstr ""
 
@@ -6471,7 +6479,7 @@ msgid "Unregister"
 msgstr ""
 
 #: src/strings.ts:210
-#: src/strings.ts:2360
+#: src/strings.ts:2362
 msgid "Untitled"
 msgstr ""
 
@@ -6507,7 +6515,7 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: src/strings.ts:2337
+#: src/strings.ts:2339
 msgid "Upload from disk"
 msgstr ""
 
@@ -6533,7 +6541,7 @@ msgstr ""
 msgid "Urgent"
 msgstr ""
 
-#: src/strings.ts:2387
+#: src/strings.ts:2389
 msgid "URL"
 msgstr ""
 
@@ -6561,7 +6569,7 @@ msgstr ""
 msgid "Use an authenticator app to generate 2FA codes."
 msgstr ""
 
-#: src/strings.ts:2171
+#: src/strings.ts:2173
 msgid "Use custom DNS"
 msgstr ""
 
@@ -6577,11 +6585,11 @@ msgstr ""
 msgid "Use markdown shortcuts in the editor"
 msgstr ""
 
-#: src/strings.ts:2124
+#: src/strings.ts:2126
 msgid "Use native OS titlebar instead of replacing it with a custom one. Requires app restart for changes to take effect."
 msgstr ""
 
-#: src/strings.ts:2122
+#: src/strings.ts:2124
 msgid "Use native titlebar"
 msgstr ""
 
@@ -6613,7 +6621,7 @@ msgstr ""
 msgid "Use this if changes made on this device are not appearing on other devices. This will overwrite the data on the server with the data from this device."
 msgstr ""
 
-#: src/strings.ts:2473
+#: src/strings.ts:2475
 msgid "used"
 msgstr ""
 
@@ -6621,11 +6629,11 @@ msgstr ""
 msgid "User verification failed"
 msgstr ""
 
-#: src/strings.ts:2253
+#: src/strings.ts:2255
 msgid "Using {instance} (v{version})"
 msgstr ""
 
-#: src/strings.ts:2251
+#: src/strings.ts:2253
 msgid "Using official Notesnook instance"
 msgstr ""
 
@@ -6713,7 +6721,7 @@ msgstr ""
 msgid "View recovery codes"
 msgstr ""
 
-#: src/strings.ts:2151
+#: src/strings.ts:2153
 msgid "View source code"
 msgstr ""
 
@@ -6745,7 +6753,7 @@ msgstr ""
 msgid "We have sent you an email confirmation link. Please check your email inbox. If you cannot find the email, check your spam folder."
 msgstr ""
 
-#: src/strings.ts:2166
+#: src/strings.ts:2168
 msgid "We send you occasional promotional offers & product updates on your email (once every month)."
 msgstr ""
 
@@ -6757,7 +6765,7 @@ msgstr ""
 msgid "We would love to know what you think!"
 msgstr ""
 
-#: src/strings.ts:2322
+#: src/strings.ts:2324
 msgid "Web clip settings"
 msgstr ""
 
@@ -6802,11 +6810,11 @@ msgstr ""
 msgid "What went wrong?"
 msgstr ""
 
-#: src/strings.ts:2383
+#: src/strings.ts:2385
 msgid "Width"
 msgstr ""
 
-#: src/strings.ts:2412
+#: src/strings.ts:2414
 msgid "Work & Office"
 msgstr ""
 
@@ -6843,7 +6851,7 @@ msgstr ""
 msgid "You also agree to recieve marketing emails from us which you can opt-out of from app settings."
 msgstr ""
 
-#: src/strings.ts:2238
+#: src/strings.ts:2240
 msgid "You are editing \"{notebookTitle}\"."
 msgstr ""
 
@@ -6875,7 +6883,7 @@ msgstr ""
 msgid "You can change the theme at any time from Settings or the side menu."
 msgstr ""
 
-#: src/strings.ts:2420
+#: src/strings.ts:2422
 msgid "You can create shortcuts of frequently accessed notebooks in the side menu"
 msgstr ""
 
@@ -6928,11 +6936,11 @@ msgstr ""
 msgid "You have {count} custom dictionary words."
 msgstr ""
 
-#: src/strings.ts:2197
+#: src/strings.ts:2199
 msgid "You have been logged out from all other devices."
 msgstr ""
 
-#: src/strings.ts:2191
+#: src/strings.ts:2193
 msgid "You have been logged out."
 msgstr ""
 
@@ -7029,7 +7037,7 @@ msgstr ""
 msgid "Your archive"
 msgstr ""
 
-#: src/strings.ts:2485
+#: src/strings.ts:2487
 msgid "Your archive is empty"
 msgstr ""
 
@@ -7045,7 +7053,7 @@ msgstr ""
 msgid "Your changes have been saved and will be reflected after the app has refreshed."
 msgstr ""
 
-#: src/strings.ts:2098
+#: src/strings.ts:2100
 msgid "Your current 2FA method is {method}"
 msgstr ""
 
@@ -7165,7 +7173,7 @@ msgstr ""
 msgid "Zipping"
 msgstr ""
 
-#: src/strings.ts:2461
+#: src/strings.ts:2463
 msgid "Zoom"
 msgstr ""
 

--- a/packages/intl/scripts/generate-strings.mjs
+++ b/packages/intl/scripts/generate-strings.mjs
@@ -121,7 +121,7 @@ const ACTION_CONFIRMATIONS = [
       "tag",
       "color",
       "attachment"
-    ],
+    ]
   },
   {
     action: "permanentlyDelete",

--- a/packages/intl/src/strings.ts
+++ b/packages/intl/src/strings.ts
@@ -2092,6 +2092,8 @@ If your issue is critical (e.g. notes not syncing, crashes etc.), please [join o
   zoomFactor: () => t`Zoom factor`,
   zoomFactorDescription: () => t`Zoom in or out the app content.`,
   colorScheme: () => t`Color scheme`,
+  listTitle: () => t`Font Size(List Title)`,
+  editorTitle: () => t`Font Size(Editor Title)`,
   colorSchemeDescription: () => t`Dark or light, we won't judge.`,
   auto: () => t`Auto`,
   selectTheme: () => t`Select a theme`,

--- a/packages/theme/src/theme/variants/text.ts
+++ b/packages/theme/src/theme/variants/text.ts
@@ -32,6 +32,14 @@ const heading: ThemeUIStyleObject = {
   fontSize: "heading"
 };
 
+const subHeading: ThemeUIStyleObject = {
+  variant: "text.heading",
+  color: "heading",
+  fontFamily: "heading",
+  fontWeight: "bold",
+  fontSize: "subheading"
+};
+
 const title: ThemeUIStyleObject = {
   variant: "text.heading",
   color: "heading",
@@ -63,6 +71,7 @@ const error: ThemeUIStyleObject = {
 export const textVariants = {
   default: defaultVariant,
   heading,
+  subHeading,
   title,
   subtitle,
   body,


### PR DESCRIPTION
Issues addressed: [#8540](https://github.com/streetwriters/notesnook/issues/8540), [#8175](https://github.com/streetwriters/notesnook/issues/8175)

Summary
- Add three font size(small, medium, and large) variants for note titles in list view
- Add the same font size options for note titles in details view
- Add E2E tests for both