### PR TITLE
Fix keyboard in iPad split view

### DIFF
--- a/apps/mobile/app/hooks/use-is-floating-keyboard.ts
+++ b/apps/mobile/app/hooks/use-is-floating-keyboard.ts
@@ -26,12 +26,14 @@ import { useCallback } from "react";
  * @returns Is keyboard floating or not
  */
 const useIsFloatingKeyboard = () => {
-  const { width } = useWindowDimensions();
+  const { width, height } = useWindowDimensions();
 
   const [floating, setFloating] = useState<boolean>(false);
   const onKeyboardWillChangeFrame = useCallback(
     (event: KeyboardEvent) => {
-      setFloating(event.endCoordinates.width < width);
+      setFloating(
+        event.endCoordinates.width === 0 || event.endCoordinates.width < width
+      );
     },
     [width]
   );
@@ -41,8 +43,13 @@ const useIsFloatingKeyboard = () => {
       "keyboardWillChangeFrame",
       onKeyboardWillChangeFrame
     );
+    const sub2 = Keyboard.addListener(
+      "keyboardWillShow",
+      onKeyboardWillChangeFrame
+    );
     return () => {
       sub1?.remove();
+      sub2?.remove();
     };
   }, [onKeyboardWillChangeFrame, width]);
 

--- a/apps/mobile/patches/react-native+0.77.2.patch
+++ b/apps/mobile/patches/react-native+0.77.2.patch
@@ -1,3 +1,24 @@
+diff --git a/node_modules/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js b/node_modules/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+index 77c81f0..be34558 100644
+--- a/node_modules/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
++++ b/node_modules/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+@@ -156,7 +156,8 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
+ 
+     if (
+       Platform.OS === 'ios' &&
+-      this._windowWidth !== this._keyboardEvent.endCoordinates.width
++      this._windowWidth !== this._keyboardEvent.endCoordinates.width && 
++      this._windowWidth > this._keyboardEvent.endCoordinates.width
+     ) {
+       // The keyboard is not the standard bottom-of-the-screen keyboard. For example, floating keyboard on iPadOS.
+       this._setBottom(0);
+diff --git a/node_modules/react-native/scripts/.packager.env b/node_modules/react-native/scripts/.packager.env
+new file mode 100644
+index 0000000..361f5fb
+--- /dev/null
++++ b/node_modules/react-native/scripts/.packager.env
+@@ -0,0 +1 @@
++export RCT_METRO_PORT=8081
 diff --git a/node_modules/react-native/scripts/packager.sh b/node_modules/react-native/scripts/packager.sh
 index 00d6ebc..6846832 100755
 --- a/node_modules/react-native/scripts/packager.sh


### PR DESCRIPTION
Content does not shift upwards when Keyboard is opened on iPad when using iOS Split View.