### PR TITLE
editor: Add keybindings for highlighting the currently selected text

### DIFF
--- a/docs/help/contents/keyboard-shortcuts.md
+++ b/docs/help/contents/keyboard-shortcuts.md
@@ -76,3 +76,4 @@ The following keyboard shortcuts will help you navigate Notesnook faster.
 | Text align left | Ctrl ⇧ L | Ctrl ⇧ L | ⌘ ⇧ L |
 | Text align right | Ctrl ⇧ R | Ctrl ⇧ R | ⌘ ⇧ R |
 | Underline | Ctrl U | Ctrl U | ⌘ U |
+| Toggle highlight | Ctrl Alt H / Ctrl ⇧ H | Ctrl Alt H / Ctrl ⇧ H | ⌘ ⌥ H / ⌘ ⇧ H |

--- a/packages/common/src/utils/keybindings.ts
+++ b/packages/common/src/utils/keybindings.ts
@@ -388,6 +388,12 @@ export const tiptapKeys = {
     description: "Underline",
     category: "Editor",
     type: "tiptap"
+  },
+  toggleHighlight: {
+    keys: ["ctrl+alt+h", "ctrl+shift+h"],
+    description: "Toggle highlight",
+    category: "Editor",
+    type: "tiptap"
   }
 } satisfies Record<string, TipTapKey>;
 

--- a/packages/editor/src/extensions/highlight/highlight.ts
+++ b/packages/editor/src/extensions/highlight/highlight.ts
@@ -19,6 +19,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import "@tiptap/extension-text-style";
 import { Extension } from "@tiptap/core";
+import { config } from "../../utils/config.js";
+import { tiptapKeys } from "@notesnook/common";
 
 export interface HighlightOptions {
   types: string[];
@@ -99,11 +101,16 @@ export const Highlight = Extension.create<HighlightOptions>({
             .run();
         }
     };
-  }
+  },
 
-  // addKeyboardShortcuts() {
-  //   return {
-  //     "Mod-Shift-h": () => this.editor.commands.toggleHighlight(),
-  //   };
-  // },
+  addKeyboardShortcuts() {
+    return {
+      [tiptapKeys.toggleHighlight.keys[0]]: () => this.editor.commands.toggleHighlight(getCurrentHighlightColor()),
+      [tiptapKeys.toggleHighlight.keys[1]]: () => this.editor.commands.toggleHighlight(getCurrentHighlightColor())
+    };
+  }
 });
+
+function getCurrentHighlightColor() {
+  return config.get<"string">("highlight") || "yellow";
+}


### PR DESCRIPTION
Add the following keybindings for highlighting the currently selected text in the editor:
- Mod + Shift + H
- Mod + Alt + H