### PR TITLE
web: fix update & vault status items vertical alignment

### DIFF
--- a/apps/web/src/components/status-bar/index.tsx
+++ b/apps/web/src/components/status-bar/index.tsx
@@ -156,7 +156,8 @@ function StatusBar() {
                 ml: 1,
                 alignItems: "center",
                 justifyContent: "center",
-                display: "flex"
+                display: "flex",
+                height: "100%"
               }}
             >
               <Update
@@ -182,7 +183,8 @@ function StatusBar() {
               sx={{
                 alignItems: "center",
                 justifyContent: "center",
-                display: "flex"
+                display: "flex",
+                height: "100%"
               }}
               data-test-id="vault-unlocked"
             >


### PR DESCRIPTION
### because

<img width="378" height="57" alt="image" src="https://github.com/user-attachments/assets/39dc3a22-d098-45b6-a725-915dedfc2c06" />
