### PR TITLE
web: improve note title size and spacing

### DIFF
--- a/apps/web/src/components/editor/title-box.tsx
+++ b/apps/web/src/components/editor/title-box.tsx
@@ -110,9 +110,9 @@ function TitleBox(props: TitleBoxProps) {
       rows={1}
       sx={{
         m: 0,
-        p: 0,
+        p: "0.3em 0 0.1em",
         fontFamily,
-        fontSize: ["1.625em", "1.625em", "2.625em"],
+        fontSize: ["1.625em", "1.625em", "1.8em"],
         fontWeight: "heading",
         width: "100%",
         fieldSizing: "content",


### PR DESCRIPTION
The note title font size is currently unreasonably large, making it stand out from the overall design. This makes the top area look a bit off. This PR is trying to address it. Please see the screenshots.

## Before
<img width="1345" height="556" alt="before" src="https://github.com/user-attachments/assets/d9edc082-347e-467e-b658-76425009acb3" />

## After
<img width="1338" height="556" alt="after" src="https://github.com/user-attachments/assets/8f5d5503-9b0e-40c0-8bfa-2635d96085a2" />
