### PR TITLE
editor: skip markdown clipboard parsing if markdown shortcuts is disabled

### DIFF
--- a/packages/editor/src/extensions/clipboard/clipboard-text-parser.ts
+++ b/packages/editor/src/extensions/clipboard/clipboard-text-parser.ts
@@ -27,9 +27,10 @@ export function clipboardTextParser(
   text: string,
   $context: ResolvedPos,
   plain: boolean,
-  view: EditorView
+  view: EditorView,
+  parseMarkdownOnPaste = true
 ): Slice {
-  if (!plain && isProbablyMarkdown(text)) {
+  if (!plain && parseMarkdownOnPaste && isProbablyMarkdown(text)) {
     const node = ClipboardDOMParser.fromSchema(view.state.schema).parse(
       new DOMParser().parseFromString(
         markdowntoHTML(text, { allowDangerousHtml: false }),

--- a/packages/editor/src/extensions/clipboard/clipboard.ts
+++ b/packages/editor/src/extensions/clipboard/clipboard.ts
@@ -30,6 +30,12 @@ import { EditorView } from "prosemirror-view";
 export const Clipboard = Extension.create({
   name: "clipboard",
 
+  addOptions() {
+    return {
+      parseMarkdownOnPaste: true
+    };
+  },
+
   addProseMirrorPlugins() {
     return [
       new Plugin({
@@ -40,7 +46,14 @@ export const Clipboard = Extension.create({
             this.editor.schema
           ),
           transformCopied,
-          clipboardTextParser,
+          clipboardTextParser: (text, $context, plain, view) =>
+            clipboardTextParser(
+              text,
+              $context,
+              plain,
+              view,
+              this.options.parseMarkdownOnPaste
+            ),
           clipboardTextSerializer
         }
       })

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -286,7 +286,9 @@ const useTiptap = (
           allowTableNodeSelection: true,
           cellMinWidth: 50
         }),
-        Clipboard,
+        Clipboard.configure({
+          parseMarkdownOnPaste: options.enableInputRules
+        }),
         TableRow,
         TableCell,
         TableHeader,


### PR DESCRIPTION
Closes https://github.com/streetwriters/notesnook/issues/8597