### PR TITLE
mobile: fix restore button is hidden in history preview item

### DIFF
--- a/apps/mobile/app/components/note-history/preview.js
+++ b/apps/mobile/app/components/note-history/preview.js
@@ -117,7 +117,8 @@ export default function NotePreview({ session, content, note }) {
       {!session?.locked && !locked ? (
         <View
           style={{
-            flex: 1
+            flex: 1,
+            backgroundColor: colors.primary.background
           }}
         >
           <ReadonlyEditor


### PR DESCRIPTION
Closes https://github.com/streetwriters/notesnook/issues/8811