### PR TITLE
editor: fix disappearing nodes under collapsed headings if heading is edited

### DIFF
--- a/packages/editor/src/extensions/callout/callout.ts
+++ b/packages/editor/src/extensions/callout/callout.ts
@@ -258,10 +258,10 @@ export const Callout = Node.create({
       container.onmousedown = onClick;
       container.ontouchstart = onClick;
 
-      if (node.attrs.hiddenUnder) {
-        container.dataset.hiddenUnder = node.attrs.hiddenUnder;
+      if (node.attrs.hidden) {
+        container.dataset.hidden = node.attrs.hidden;
       } else {
-        delete container.dataset.hiddenUnder;
+        delete container.dataset.hidden;
       }
 
       return {
@@ -275,9 +275,9 @@ export const Callout = Node.create({
           if (updatedNode.attrs.collapsed) container.classList.add("collapsed");
           else container.classList.remove("collapsed");
 
-          if (updatedNode.attrs.hiddenUnder)
-            container.dataset.hiddenUnder = updatedNode.attrs.hiddenUnder;
-          else delete container.dataset.hiddenUnder;
+          if (updatedNode.attrs.hidden)
+            container.dataset.hidden = updatedNode.attrs.hidden;
+          else delete container.dataset.hidden;
 
           return true;
         }

--- a/packages/editor/src/extensions/code-block/code-block.ts
+++ b/packages/editor/src/extensions/code-block/code-block.ts
@@ -555,7 +555,7 @@ export const CodeBlock = Node.create<CodeBlockOptions>({
           compareCaretPosition(prev.caretPosition, next.caretPosition) ||
           prev.language !== next.language ||
           prev.indentType !== next.indentType ||
-          prev.hiddenUnder !== next.hiddenUnder
+          prev.hidden !== next.hidden
         );
       }
     });

--- a/packages/editor/src/extensions/math/plugin/math-node-view.ts
+++ b/packages/editor/src/extensions/math/plugin/math-node-view.ts
@@ -125,10 +125,10 @@ export class MathView implements NodeView, ICursorPosObserver {
     if (options.className) this.dom.classList.add(options.className);
     this.dom.classList.add("math-node");
 
-    if (node.attrs.hiddenUnder) {
-      this.dom.dataset.hiddenUnder = node.attrs.hiddenUnder;
+    if (node.attrs.hidden) {
+      this.dom.dataset.hidden = node.attrs.hidden;
     } else {
-      delete this.dom.dataset.hiddenUnder;
+      delete this.dom.dataset.hidden;
     }
 
     this._mathRenderElt = document.createElement("span");

--- a/packages/editor/src/extensions/react/react-node-view.tsx
+++ b/packages/editor/src/extensions/react/react-node-view.tsx
@@ -112,10 +112,10 @@ export class ReactNodeView<P extends ReactNodeViewProps> implements NodeView {
       return;
     }
 
-    if (this.node.attrs.hiddenUnder) {
-      this.domRef.dataset.hiddenUnder = this.node.attrs.hiddenUnder;
+    if (this.node.attrs.hidden) {
+      this.domRef.dataset.hidden = this.node.attrs.hidden;
     } else {
-      delete this.domRef.dataset.hiddenUnder;
+      delete this.domRef.dataset.hidden;
     }
 
     portalProviderAPI.render(this.Component, this.domRef);

--- a/packages/editor/styles/styles.css
+++ b/packages/editor/styles/styles.css
@@ -978,7 +978,7 @@ del.diffdel {
   display: none;
 }
 
-[data-hidden-under] {
+[data-hidden="true"] {
   display: none !important;
 }
 


### PR DESCRIPTION
* design flaw in using the hiddenUnder attribute on hidden nodes, a hidden attribute should be sufficient