### PR TITLE
editor: fix crash in heading plugin when pasting markdown content

### DIFF
--- a/packages/editor/src/extensions/heading/heading.ts
+++ b/packages/editor/src/extensions/heading/heading.ts
@@ -365,6 +365,8 @@ const headingUpdatePlugin = new Plugin({
 
     newDoc.descendants((newNode, pos) => {
       if (newNode.type.name === "heading") {
+        if (pos >= oldDoc.content.size) return;
+
         const oldNode = oldDoc.nodeAt(pos);
         if (
           oldNode &&


### PR DESCRIPTION
Closes https://github.com/streetwriters/notesnook/issues/8901
Closes https://github.com/streetwriters/notesnook/issues/8903
Closes https://github.com/streetwriters/notesnook/issues/8899