### PR TITLE
editor: improve blockquote style to fit heading collapse icon

### DIFF
--- a/packages/editor/styles/styles.css
+++ b/packages/editor/styles/styles.css
@@ -338,7 +338,7 @@ img.ProseMirror-separator {
 
 .ProseMirror blockquote {
   border-inline-start: 5px solid var(--border);
-  padding-inline-start: 15px;
+  padding-inline-start: 18px;
 }
 
 @media screen and (max-width: 480px) {


### PR DESCRIPTION
# before

<img width="585" height="517" alt="image" src="https://github.com/user-attachments/assets/2bb57260-352c-4f84-8765-099f7d67e55a" />


# after

<img width="562" height="566" alt="image" src="https://github.com/user-attachments/assets/e788b658-71a4-4dd1-a24a-abe8afae0c82" />
