### PR TITLE
editor: improve inline code styling

### DIFF
--- a/packages/editor/styles/styles.css
+++ b/packages/editor/styles/styles.css
@@ -54,10 +54,10 @@
   border: 1px solid var(--border);
   color: var(--paragraph-secondary);
   border-radius: 5px;
-  padding: 0px 5px 0px 5px;
+  padding: 2px 5px 2px 5px;
   font-family: ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono,
     Menlo, monospace !important;
-  font-size: 10pt !important;
+  font-size: 85%;
 }
 
 .ProseMirror code > span {


### PR DESCRIPTION
# before

<img width="1048" height="195" alt="image" src="https://github.com/user-attachments/assets/e63a5fe5-7100-4084-b911-3d8bfc2405d9" />


# after

<img width="843" height="241" alt="image" src="https://github.com/user-attachments/assets/bd0e6410-d672-4fd8-8e9e-f4da70364f88" />
