### PR TITLE
web: release space taken by properties pane for new note/tab

### DIFF
--- a/apps/web/src/components/editor/index.tsx
+++ b/apps/web/src/components/editor/index.tsx
@@ -226,11 +226,13 @@ export default function TabsView() {
               <TableOfContents sessionId={activeSession.id} />
             </Pane>
           ) : null}
-          {arePropertiesVisible && activeSession && (
-            <Pane id="properties-pane" initialSize={250} minSize={250}>
-              <Properties sessionId={activeSession.id} />
-            </Pane>
-          )}
+          {arePropertiesVisible &&
+            activeSession &&
+            activeSession.type !== "new" && (
+              <Pane id="properties-pane" initialSize={250} minSize={250}>
+                <Properties sessionId={activeSession.id} />
+              </Pane>
+            )}
         </SplitPane>
         <DropZone overlayRef={overlayRef} />
       </ScopedThemeProvider>


### PR DESCRIPTION
<img width="1288" height="412" alt="image" src="https://github.com/user-attachments/assets/52d440a8-dba5-4c79-ba51-f8febf0734ad" />

Properties pane is not shown for new note/tab, but the pane still claims this space when it doesn't need to. Plus, the toggle button is disabled, so we can't have that space back. 