### PR TITLE
editor: fade all nodes inside a checklist item except for a nested checklist

### DIFF
--- a/packages/editor/styles/styles.css
+++ b/packages/editor/styles/styles.css
@@ -761,9 +761,10 @@ p > *::selection {
   mask-size: cover;
 }
 
-.simple-checklist > li.checked p {
+.simple-checklist > li.checked > :not(.simple-checklist) {
   opacity: 0.8;
 }
+
 
 /* Callout */
 .ProseMirror div.callout {


### PR DESCRIPTION
fade all nodes inside a checklist item except for a nested checklist

<img width="794" height="693" alt="image" src="https://github.com/user-attachments/assets/3f8f5e39-7e15-4c63-bec1-b665c119e9d0" />
