### PR TITLE
web: show spaces in note,notebook,tag,reminder list item titles

### DIFF
--- a/apps/web/src/components/list-item/index.tsx
+++ b/apps/web/src/components/list-item/index.tsx
@@ -202,7 +202,7 @@ function ListItem<TItem extends Item, TContext>(
           data-test-id={`title`}
           variant={"body"}
           sx={{
-            whiteSpace: "nowrap",
+            whiteSpace: "pre",
             overflow: "hidden",
             textOverflow: "ellipsis",
             fontWeight: isCompact ? "body" : "medium",

--- a/apps/web/src/components/notebook/index.tsx
+++ b/apps/web/src/components/notebook/index.tsx
@@ -153,7 +153,7 @@ export function Notebook(props: NotebookProps) {
             variant={"body"}
             color={isOpened ? "paragraph-selected" : "paragraph"}
             sx={{
-              whiteSpace: "nowrap",
+              whiteSpace: "pre",
               overflow: "hidden",
               textOverflow: "ellipsis",
               fontWeight: "body",

--- a/apps/web/src/components/tag/index.tsx
+++ b/apps/web/src/components/tag/index.tsx
@@ -67,7 +67,7 @@ function Tag(props: TagProps) {
             variant={"body"}
             color={isSelected ? "paragraph-selected" : "paragraph"}
             sx={{
-              whiteSpace: "nowrap",
+              whiteSpace: "pre",
               overflow: "hidden",
               textOverflow: "ellipsis",
               fontWeight: "body",


### PR DESCRIPTION
I'm not sure why these list item titles are `nowrap`. I think we should render the spaces in the titles as that's what the user intended