### PR TITLE
editor: fix crash on task list toggle & drag

### DIFF
--- a/packages/editor/src/extensions/table/prosemirror-tables/columnresizing.ts
+++ b/packages/editor/src/extensions/table/prosemirror-tables/columnresizing.ts
@@ -168,7 +168,7 @@ function handleMouseDown(
   if (!pluginState || pluginState.dragging) return false;
 
   if (
-    event.target instanceof HTMLElement &&
+    event.target instanceof Element &&
     event.target.closest(".column-resize-handle") == null
   ) {
     console.log("No handle target");


### PR DESCRIPTION
* make sure column resizing's handleMouseDown correctly checks for handle element

Closes https://github.com/streetwriters/notesnook/issues/9074

the column resizing logic gets executed when toggling/dragging task list, relevant stack trace:
```txt
RangeError: Position -1 outside of fragment (<paragraph("a task list"), taskList(taskItem(paragraph)), paragraph>)
RangeError: Position -1 outside of fragment (<paragraph("a task list"), taskList(taskItem(paragraph)), paragraph>)
    at _Fragment.findIndex (http://localhost:3000/@fs/home/zulfi/code/notesnook/notesnook/apps/web/node_modules/.vite/deps/chunk-2HGS27MN.js?v=2477a7c3:390:13)
    at _Node.nodeAt (http://localhost:3000/@fs/home/zulfi/code/notesnook/notesnook/apps/web/node_modules/.vite/deps/chunk-2HGS27MN.js?v=2477a7c3:1325:44)
    at handleMouseDown (http://localhost:3000/@fs/home/zulfi/code/notesnook/notesnook/packages/editor/dist/esm/extensions/table/prosemirror-tables/columnresizing.js:106:33)
    at Plugin.mousedown (http://localhost:3000/@fs/home/zulfi/code/notesnook/notesnook/packages/editor/dist/esm/extensions/table/prosemirror-tables/columnresizing.js:57:21)
    at http://localhost:3000/@fs/home/zulfi/code/notesnook/notesnook/apps/web/node_modules/.vite/deps/chunk-HVCBY5OO.js?v=2477a7c3:2752:22
    at EditorView.someProp (http://localhost:3000/@fs/home/zulfi/code/notesnook/notesnook/apps/web/node_modules/.vite/deps/chunk-HVCBY5OO.js?v=2477a7c3:4840:43)
    at runCustomHandler (http://localhost:3000/@fs/home/zulfi/code/notesnook/notesnook/apps/web/node_modules/.vite/deps/chunk-HVCBY5OO.js?v=2477a7c3:2750:15)
    at view.dom.addEventListener.view.input.eventHandlers.<computed> (http://localhost:3000/@fs/home/zulfi/code/notesnook/notesnook/apps/web/node_modules/.vite/deps/chunk-HVCBY5OO.js?v=2477a7c3:2723:48)
```