### PR TITLE
web: add desktop drag region in auth pages

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -2,7 +2,8 @@
 .titlebarLogo,
 .theme-scope-titleBar,
 .navigation-menu-header,
-.route-container-header {
+.route-container-header,
+.desktop-drag-region {
   -webkit-app-region: drag;
 }
 

--- a/apps/web/src/components/auth-container/index.jsx
+++ b/apps/web/src/components/auth-container/index.jsx
@@ -98,6 +98,15 @@ function AuthContainer(props) {
         }}
       >
         <Box
+          className="desktop-drag-region"
+          sx={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            height: "50%"
+          }}
+        />
+        <Box
           as="svg"
           version="1.1"
           viewBox="0 0 1920 1080"


### PR DESCRIPTION
this part of the auth pages is a drag region now
<img width="1162" height="864" alt="image" src="https://github.com/user-attachments/assets/fb648b95-1e62-4334-a756-f722e0ba2add" />
