### PR TITLE
mobile: fix app crash when trying to restore an invalid file

### DIFF
--- a/apps/mobile/app/screens/settings/restore-backup/index.tsx
+++ b/apps/mobile/app/screens/settings/restore-backup/index.tsx
@@ -95,6 +95,15 @@ const restoreBackup = async (options: {
   deleteFile?: boolean;
 }) => {
   try {
+    if (
+      !options.uri.endsWith(".nnbackup") &&
+      !options.uri.endsWith(".nnbackupz")
+    ) {
+      throw new Error(
+        `Invalid backup file selected. Only .nnbackup and .nnbackupz files can be restored.`
+      );
+    }
+
     const isLegacyBackup = options.uri.endsWith(".nnbackup");
 
     startProgress({


### PR DESCRIPTION
Gracefully handle files other than `.nnbackup` and `.nnbackupz` when restoring backup and how the user error.
Closes #9115