### PR TITLE
mobile: fix wrong trial end date shown in settings

### DIFF
--- a/apps/mobile/app/screens/settings/settings-data.tsx
+++ b/apps/mobile/app/screens/settings/settings-data.tsx
@@ -143,21 +143,20 @@ export const settingsGroups: SettingSection[] = [
             "dddd, MMMM D, YYYY h:mm A"
           );
 
+          const trialEndDate = dayjs(user?.subscription?.start)
+            .add(
+              user?.subscription?.productId?.includes("monthly") ? 7 : 14,
+              "day"
+            )
+            .format("dddd, MMMM D, YYYY h:mm A");
+
           if (
             user.subscription?.plan !== SubscriptionPlan.FREE &&
             user.subscription?.productId
           ) {
             const status = user.subscription?.status;
             return status === SubscriptionStatus.TRIAL
-              ? strings.trialEndsOn(
-                  dayjs(user?.subscription?.start)
-                    .add(
-                      user?.subscription?.productId?.includes("monthly")
-                        ? 7
-                        : 14
-                    )
-                    .format("dddd, MMMM D, YYYY h:mm A")
-                )
+              ? strings.trialOnGoing(trialEndDate)
               : status === SubscriptionStatus.ACTIVE
                 ? strings.subRenewOn(expiryDate)
                 : status === SubscriptionStatus.CANCELED ||

--- a/packages/intl/locale/en.po
+++ b/packages/intl/locale/en.po
@@ -7471,6 +7471,10 @@ msgstr "Your free trial has started"
 msgid "Your free trial is ending soon"
 msgstr "Your free trial is ending soon"
 
+#: src/strings.ts:2614
+msgid "Your free trial is on-going. Your subscription will start on {trialExpiryDate}"
+msgstr "Your free trial is on-going. Your subscription will start on {trialExpiryDate}"
+
 #: src/strings.ts:1777
 msgid "Your full name"
 msgstr "Your full name"

--- a/packages/intl/locale/pseudo-LOCALE.po
+++ b/packages/intl/locale/pseudo-LOCALE.po
@@ -7417,6 +7417,10 @@ msgstr ""
 msgid "Your free trial is ending soon"
 msgstr ""
 
+#: src/strings.ts:2614
+msgid "Your free trial is on-going. Your subscription will start on {trialExpiryDate}"
+msgstr ""
+
 #: src/strings.ts:1777
 msgid "Your full name"
 msgstr ""

--- a/packages/intl/src/strings.ts
+++ b/packages/intl/src/strings.ts
@@ -2609,5 +2609,7 @@ Use this if changes from other devices are not appearing on this device. This wi
   views: () => t`Views`,
   clickToUpdate: () => t`Click to update`,
   noPassword: () => t`No password`,
-  publishToTheWeb: () => t`Publish to the web`
+  publishToTheWeb: () => t`Publish to the web`,
+  trialOnGoing: (trialExpiryDate: string) =>
+    t`Your free trial is on-going. Your subscription will start on ${trialExpiryDate}`
 };


### PR DESCRIPTION
Closes #9106