### PR TITLE
web: fix toc headings alignment

### DIFF
--- a/apps/web/src/components/editor/table-of-contents.tsx
+++ b/apps/web/src/components/editor/table-of-contents.tsx
@@ -201,7 +201,14 @@ function TableOfContents(props: TableOfContentsProps) {
                     {item.hasChildren ? (
                       <Button
                         variant="secondary"
-                        sx={{ bg: "transparent", p: 0, borderRadius: 100 }}
+                        sx={{
+                          bg: "transparent",
+                          p: 0,
+                          borderRadius: 100,
+                          width: 14,
+                          height: 14,
+                          flexShrink: 0
+                        }}
                         onClick={(e) => {
                           e.stopPropagation();
                           expanded ? collapse() : expand();
@@ -214,7 +221,17 @@ function TableOfContents(props: TableOfContentsProps) {
                         )}
                       </Button>
                     ) : (
-                      <Circle size={5} color="icon-secondary" />
+                      <Flex
+                        sx={{
+                          width: 14,
+                          height: 14,
+                          alignItems: "center",
+                          justifyContent: "center",
+                          flexShrink: 0
+                        }}
+                      >
+                        <Circle size={5} color="icon-secondary" />
+                      </Flex>
                     )}
                     {item.data.title}
                   </Button>


### PR DESCRIPTION
# before

<img width="373" height="345" alt="image" src="https://github.com/user-attachments/assets/32f82764-307d-4efd-bee7-0d56d25b7aed" />

# after

<img width="354" height="320" alt="image" src="https://github.com/user-attachments/assets/6e5faa77-67f7-4386-a0a4-6c9a566e4bcc" />
