### PR TITLE
web: enable toc toggle on new notes

### DIFF
--- a/apps/web/src/components/editor/action-bar.tsx
+++ b/apps/web/src/components/editor/action-bar.tsx
@@ -163,7 +163,6 @@ export function EditorActionBar() {
       icon: TableOfContents,
       enabled:
         activeSession &&
-        activeSession.type !== "new" &&
         activeSession.type !== "locked" &&
         activeSession.type !== "diff" &&
         activeSession.type !== "conflicted",


### PR DESCRIPTION
I think we can keep the toc toggle enabled on new notes. Mostly because when the toc is open and user creates a new note, the toc panel takes up space that cannot be released. 