### PR TITLE
web: Fix reminder dialog subtext formatting.

### DIFF
--- a/apps/web/src/dialogs/add-reminder-dialog.tsx
+++ b/apps/web/src/dialogs/add-reminder-dialog.tsx
@@ -509,7 +509,7 @@ export const AddReminderDialog = DialogManager.register(
           </Text>
         ) : (
           <Text variant="subBody" sx={{ mt: 1 }}>
-            {strings.reminderStarts(date.toString(), date.format(timeFormat()))}
+            {strings.reminderStarts(date.format(db.settings.getDateFormat()), date.format(timeFormat()))}
           </Text>
         )}
       </Dialog>


### PR DESCRIPTION
Changes the subtext at the bottom of the create reminder dialog to use the date format configured in settings.
Before:
<img width="972" height="400" alt="image" src="https://github.com/user-attachments/assets/f103e1d8-e2fc-4288-b8e8-976bf088ad67" />
After:
<img width="972" height="400" alt="image" src="https://github.com/user-attachments/assets/c857cfc0-e458-4dfd-bdb5-1b99088e7820" />
