### PR TITLE
core: Fix reminder sorting.

### DIFF
--- a/packages/core/src/collections/reminders.ts
+++ b/packages/core/src/collections/reminders.ts
@@ -326,8 +326,8 @@ export function createIsReminderActiveQuery(now = "now") {
   return sql`IIF(
     (disabled IS NULL OR disabled = 0)
     AND (mode != 'once'
-      OR datetime(date / 1000, 'unixepoch', 'localtime') > datetime(${now})
+      OR datetime(date / 1000, 'unixepoch', 'localtime') > datetime(${now}, 'localtime')
       OR (snoozeUntil IS NOT NULL
-        AND datetime(snoozeUntil / 1000, 'unixepoch', 'localtime') > datetime(${now}))
+        AND datetime(snoozeUntil / 1000, 'unixepoch', 'localtime') > datetime(${now}, 'localtime'))
     ), 1, 0)`.$castTo<boolean>();
 }


### PR DESCRIPTION
Reminders are now properly sorted. This prevents reminders that are in the future from being sorted in the past:
<img width="776" height="536" alt="Screenshot From 2026-01-19 00-28-55" src="https://github.com/user-attachments/assets/b8280f94-5e71-4032-90c2-b664e290fe5b" />
After:
<img width="776" height="536" alt="Screenshot From 2026-01-19 00-28-51" src="https://github.com/user-attachments/assets/6a23c526-838a-4494-b1d0-cf4c4b1603e3" />

And it also seems to fix this other issue, where inactive reminders can sort ahead of the active reminders:
<img width="774" height="578" alt="Screenshot From 2026-01-19 00-11-24" src="https://github.com/user-attachments/assets/ee7f465a-83cf-4fb5-95fe-cd34f556cc8a" />

Edit to add (I forgot): The sort is by due date, with earliest first order.