### PR TITLE
core: Duplicating a note should copy all the flags

### DIFF
--- a/packages/core/src/collections/notes.ts
+++ b/packages/core/src/collections/notes.ts
@@ -177,6 +177,7 @@ export class Notes implements ICollection {
           localOnly: item.localOnly,
           conflicted: item.conflicted,
           readonly: item.readonly,
+          archived: item.archived,
 
           dateCreated: item.dateCreated,
           dateEdited: item.dateEdited || dateEdited,
@@ -197,6 +198,7 @@ export class Notes implements ICollection {
           localOnly: item.localOnly,
           conflicted: item.conflicted,
           readonly: item.readonly,
+          archived: item.archived,
 
           dateCreated: item.dateCreated || Date.now(),
           dateEdited: item.dateEdited || dateEdited || Date.now(),
@@ -432,9 +434,7 @@ export class Notes implements ICollection {
       const duplicateId = await this.db.notes.add({
         ...clone(note),
         id: undefined,
-        readonly: false,
-        favorite: false,
-        pinned: false,
+        isGeneratedTitle: false,
         contentId: undefined,
         title: note.title + " (Copy)",
         dateEdited: undefined,


### PR DESCRIPTION
Duplicating an item should copy the item flags. Duplication implies you are making an identical copy, and not copying the item flags means that this item isn't an exact duplicate.

This issue also causes a usability UX problem when duplicating an item that is archived, because it won't show up in the archived section, which may confuse users and cause them to create multiple duplicates of the same note as they could think that the first time the action did not occur. They would have to notice that the note count (in the regular notes section) has indeed gone up.

Other notes: Expiring note expiry dates aren't copied over, but I think that's a good thing as users may forget to change (or remove) it otherwise.