### PR TITLE
web: All tabs closed when any note is deleted.

### DIFF
--- a/apps/web/src/stores/editor-store.ts
+++ b/apps/web/src/stores/editor-store.ts
@@ -286,15 +286,7 @@ class EditorStore extends BaseStore<EditorStore> {
         const clearIds: string[] = [];
         for (const session of sessions) {
           if (session.type === "new") continue;
-          if (session.note.id !== item.id) continue;
-          const noteId = isDeleted(item)
-            ? null
-            : item.type === "note"
-            ? item.id
-            : item.type === "tiptap"
-            ? item.noteId
-            : null;
-          if (noteId && session.note.id !== noteId) continue;
+          if (session.note.id !== item.id && session.note.contentId !== item.id) continue;
           if (isDeleted(item) || isTrashItem(item))
             clearIds.push(session.tabId);
           // if a note becomes conflicted, reopen the session


### PR DESCRIPTION
The logic was missing a check to ensure that only the tabs that correspond to the recently deleted object were being marked for closure. The lack of this check meant that for any deleted note item, all tabs would pass the `if (isDeleted(item) || isTrashItem(item))` check since the open tab loop runs on every tab for every item.

