### PR TITLE
fix: unable to change zoom level back to 1.0

### DIFF
--- a/apps/web/src/dialogs/settings/index.tsx
+++ b/apps/web/src/dialogs/settings/index.tsx
@@ -581,6 +581,7 @@ function SettingItem(props: { item: Setting }) {
               case "input":
                 return component.inputType === "number" ? (
                   <Input
+                    key={component.defaultValue()}
                     type={"number"}
                     min={component.min}
                     max={component.max}
@@ -597,6 +598,16 @@ function SettingItem(props: { item: Setting }) {
                           : value;
                       component.onChange(value);
                     }, 500)}
+                    onBlur={(e) => {
+                      let value = e.target.valueAsNumber;
+                      value =
+                        Number.isNaN(value) || value < component.min
+                          ? component.min
+                          : value > component.max
+                          ? component.max
+                          : value;
+                      component.onChange(value);
+                    }}
                   />
                 ) : (
                   <Input
@@ -607,6 +618,7 @@ function SettingItem(props: { item: Setting }) {
                       (e) => component.onChange(e.target.value),
                       500
                     )}
+                    onBlur={(e) => component.onChange(e.target.value)}
                   />
                 );
               case "icon":


### PR DESCRIPTION
## Summary
Fixed the issue where users couldn't change the zoom level back to 1.0 after changing it to another value.

## Root Cause
The number input for zoom factor used:
1. `defaultValue` (uncontrolled) - which doesn't update the displayed value when the store changes
2. 500ms debounced `onChange` - which doesn't commit the value if the user clicks away quickly

This caused a race condition where:
1. User types 1.0, the visual zoom changes
2. User clicks away before 500ms passes
3. The debounced onChange never fires, value isn't saved
4. On settings refresh, the old value is loaded back

## Fix
1. **Added `onBlur` handler** - Immediately commits the value when the input loses focus, ensuring values are saved even if the user navigates away before the debounce fires
2. **Added `key` prop** - Forces re-render when the stored value changes, ensuring the input always reflects the actual persisted value

Also applied the same fix to text inputs for consistency.

Fixes #4035