### PR TITLE
web: fix attachment not marked as uploaded when app locked & unlocked

### DIFF
--- a/apps/web/src/root.tsx
+++ b/apps/web/src/root.tsx
@@ -105,9 +105,6 @@ function RouteWrapper(props: {
       setIsMigrating(name === "notesnook")
     );
     EV.subscribe(EVENTS.migrationFinished, () => setIsMigrating(false));
-    return () => {
-      EV.unsubscribeAll();
-    };
   }, []);
 
   const result = usePromise(async () => {


### PR DESCRIPTION
When RouteWrapper was unmounted, it would unsub all events including the ones subbed during db initialization (db.init()). Since db isn't initialized again when app is locked & unlocked, those events weren't subbed again. One of these event subscription (fileUploaded event) is responsible for marking an attachment as uploaded. There is no need to unsubscribe all events on RouteWrapper unmount.

Closes https://github.com/streetwriters/notesnook/issues/8564
Closes https://github.com/streetwriters/notesnook/issues/8970