### PR TITLE
web: align check icon inside note's color in properties panel

### DIFF
--- a/apps/web/src/components/properties/index.tsx
+++ b/apps/web/src/components/properties/index.tsx
@@ -676,7 +676,7 @@ function Colors({ noteId, color }: { noteId: string; color?: string }) {
                 <Checkmark
                   color="white"
                   size={18}
-                  sx={{ position: "absolute", left: "8px" }}
+                  sx={{ position: "absolute", left: "4px" }}
                 />
               )}
             </Flex>


### PR DESCRIPTION
# before

<img width="367" height="162" alt="image" src="https://github.com/user-attachments/assets/0bfef84e-f307-44a9-b5d8-1c83c7720e59" />

# after

<img width="334" height="170" alt="image" src="https://github.com/user-attachments/assets/2d238efb-3092-4792-a2d7-3201785e0318" />
