### PR TITLE
Harden cmd function in scripts/build.mjs against command injection

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -84,7 +84,11 @@ await Promise.all([
 ]);
 
 async function cmd(...command) {
-  let p = spawn(command[0], command.slice(1), { shell: true });
+  // WARNING: shell: true can allow injection if commands include untrusted input.
+  // Switching to shell: false may break commands using pipes, &&, or globs,
+  // Test needed for this channge and comment can be removed after test.
+  
+  let p = spawn(command[0], command.slice(1), { shell: false });
   console.time(command.join(" "));
   await new Promise((resolveFunc) => {
     p.stdout.on("data", (x) => {


### PR DESCRIPTION
Updated the cmd function in scripts/build.mjs.

shell: true can allow command injection if arguments include untrusted input.

Switching to shell: false is safer, but may break commands using shell features like pipes (|), chaining (&&), or glob patterns (*.js).

Testing is required before merging the switch to make sure it doesn't break.
