### PR TITLE
editor: fix checklist & blockquote indent so text starts at same pos as other lists

### DIFF
--- a/packages/editor/styles/styles.css
+++ b/packages/editor/styles/styles.css
@@ -393,6 +393,8 @@ img.ProseMirror-separator {
 .ProseMirror blockquote {
   border-inline-start: 5px solid var(--border);
   padding-inline-start: 15px;
+  margin-inline-start: 20px;
+  margin-inline-end: 0px;
 }
 
 @media screen and (max-width: 480px) {
@@ -720,7 +722,7 @@ p > *::selection {
 .ProseMirror ul.simple-checklist {
   list-style: none;
   padding-inline: 0px !important;
-  padding-inline-start: 24px !important;
+  padding-inline-start: 40px !important;
 }
 
 .ProseMirror li.nested > ul.simple-checklist {


### PR DESCRIPTION
related https://github.com/streetwriters/notesnook/issues/9336

# before

<img width="1088" height="614" alt="image" src="https://github.com/user-attachments/assets/e86bfc50-1521-41a5-bb74-8d186f8d49b2" />

# after

<img width="1151" height="654" alt="image" src="https://github.com/user-attachments/assets/506fd9e4-c48e-4be9-ba29-f13535591fcf" />
