### PR TITLE
web: reduce note title size & improve padding

### DIFF
--- a/apps/web/src/components/editor/title-box.tsx
+++ b/apps/web/src/components/editor/title-box.tsx
@@ -110,9 +110,10 @@ function TitleBox(props: TitleBoxProps) {
       rows={1}
       sx={{
         m: 0,
-        p: 0,
+        py: 1,
+        px: 0,
         fontFamily,
-        fontSize: ["1.625em", "1.625em", "2.625em"],
+        fontSize: ["1.625em", "1.625em", "1.8em"],
         fontWeight: "heading",
         width: "100%",
         fieldSizing: "content",


### PR DESCRIPTION
# before

<img width="585" height="445" alt="image" src="https://github.com/user-attachments/assets/886481ec-119d-4ec4-9ce4-d22e8c3ec286" />

# after

<img width="497" height="428" alt="image" src="https://github.com/user-attachments/assets/25c6cd91-c281-4ac1-a724-72c460e0e048" />
