### PR TITLE
core: fix crash because of bracket in note search query

### DIFF
--- a/packages/core/__tests__/lookup.test.js
+++ b/packages/core/__tests__/lookup.test.js
@@ -153,4 +153,17 @@ describe("notesWithHighlighting", () => {
       const item = await filtered.item(0);
       expect(item.item).toBeDefined();
     }));
+
+  test("search notes with brackets in query should load the item", () =>
+    noteTest({
+      title: "[with brackets]"
+    }).then(async ({ db }) => {
+      await db.notes.add(TEST_NOTE);
+      const filtered = await db.lookup.notesWithHighlighting(
+        "[with brackets]",
+        db.notes.all
+      );
+      const item = await filtered.item(0);
+      expect(item.item).toBeDefined();
+    }));
 });

--- a/packages/core/src/api/lookup.ts
+++ b/packages/core/src/api/lookup.ts
@@ -1154,7 +1154,7 @@ function textContainsTokens(text: string, tokens: QueryTokens) {
   const lowerCasedText = text.toLowerCase();
 
   const createTagPattern = (token: string) => {
-    const escapedToken = token.replace(/[()]/g, "\\$&");
+    const escapedToken = token.replace(/[()[\]]/g, "\\$&");
     return `<${MATCH_TAG_NAME}\\s+id="(.+?)">${escapedToken}<\\/${MATCH_TAG_NAME}>`;
   };
 


### PR DESCRIPTION
Related https://github.com/streetwriters/notesnook/issues/9421