### PR TITLE
mobile: fix top bar item page width and count

### DIFF
--- a/apps/mobile/app/components/properties/items.tsx
+++ b/apps/mobile/app/components/properties/items.tsx
@@ -326,8 +326,9 @@ export const Items = ({
 
   const getTopBarItemChunksOfFour = () => {
     const chunks = [];
-    for (let i = 0; i < topBarItems.length; i += 5) {
-      chunks.push(topBarItems.slice(i, i + 5));
+    const itemCount = shouldShrink ? 4 : 5;
+    for (let i = 0; i < topBarItems.length; i += itemCount) {
+      chunks.push(topBarItems.slice(i, i + itemCount));
     }
     return chunks;
   };
@@ -375,10 +376,7 @@ export const Items = ({
                     flexDirection: "row",
                     paddingHorizontal: DefaultAppStyles.GAP,
                     gap: 5,
-                    /**
-                     * ((columnItemWidth + gap) * noOfItems) - padding
-                     */
-                    width: (columnItemWidth + 5) * 5 - 12
+                    width: width
                   }}
                 >
                   {item.map(renderTopBarItem)}


### PR DESCRIPTION
## Description
Fixed top bar items in note properties show irregular space and do not follow pagination rules. Each page should fill the whole width of the available space.

<img width="389" height="198" alt="Screenshot 2026-03-11 at 12 40 17 PM" src="https://github.com/user-attachments/assets/09647d8a-b5bc-4c95-a7b6-9711da5e31b6" />

Closes https://github.com/streetwriters/notesnook/issues/9459

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [x] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [x] QA passed
- [ ] UI/UX passed
