### PR TITLE
core: add fallback to return the note if search highlighting returns empty values

### DIFF
--- a/packages/core/src/api/lookup.ts
+++ b/packages/core/src/api/lookup.ts
@@ -401,6 +401,28 @@ export default class Lookup {
           );
         }
 
+        /**
+         * If both title and content is missing in the result object, then someting went wrong in the highlighting process.
+         * Instead of returning empty values, fetch the title so the matched note is still returned,
+         * even if highlighting information is unavailable.
+         */
+        const missingTitleAndContentResults = results.filter(
+          (r) => !r.content.length && !r.title.length
+        );
+        if (missingTitleAndContentResults.length > 0) {
+          const ids = missingTitleAndContentResults.map((r) => r.id);
+          const notes = await db
+            .selectFrom("notes")
+            .where("id", "in", ids)
+            .select(["id", "title"])
+            .execute();
+          for (const note of notes) {
+            const result = results.find((r) => r.id === note.id);
+            if (!result || !note.title) continue;
+            result.title = stringToMatch(note.title);
+          }
+        }
+
         return {
           ids: results.map((c) => c.id),
           items: results


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Related https://github.com/streetwriters/notesnook/issues/9421

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [X] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [X] Mobile
- [X] Desktop

## Sign-off
- [X] QA passed
- [ ] UI/UX passed
