### PR TITLE
editor: remove vertical offset on link hover popup

### DIFF
--- a/packages/editor/src/toolbar/floating-menus/hover-popup/index.tsx
+++ b/packages/editor/src/toolbar/floating-menus/hover-popup/index.tsx
@@ -125,7 +125,7 @@ export function HoverPopupHandler(props: FloatingMenuProps) {
                 align: "start",
                 location: "top",
                 isTargetAbsolute: true,
-                yOffset: -10,
+                yOffset: 0,
                 xOffset: -30
               }
             });


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Back in April last year, we moved the y offset of the hover popup from 10 to -10: https://github.com/streetwriters/notesnook/pull/8011

This was done so that when the hover popup opened, the link text wasn't obstructed and remained visible to the user. But, this offset adds an issue as reported in this issue https://github.com/streetwriters/notesnook/issues/9422: from certain positions the offset is so much that navigation onto the popup before it disappearing becomes a challenge. I remember facing this issue back when working on comments https://github.com/streetwriters/notesnook/pull/8984, so I set the offset to 0.

I'm doing the same in this PR, setting the offset to 0. I also wonder if we should add a delay (100ms or something) between navigating away from the element and closing the popup?

Screenshot of hovering from bottom of the link:

**before**

<img width="755" height="288" alt="image" src="https://github.com/user-attachments/assets/fcc32d12-7f09-4be1-b5aa-5842b223943c" />

**after**

<img width="743" height="257" alt="image" src="https://github.com/user-attachments/assets/9b973625-ee79-4354-9d86-67142afc29b1" />


## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [X] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [ ] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
