### PR TITLE
docs: clarify internal note links limitation in Evernote importer

### DIFF
--- a/docs/help/contents/importing-notes/import-notes-from-evernote.md
+++ b/docs/help/contents/importing-notes/import-notes-from-evernote.md
@@ -41,6 +41,6 @@ Notesnook Importer is one of the most robust Evernote importers, supporting almo
 - [x] Images
 - [x] Rich text (bold, italic, lists etc.)
 - [ ] Reminders
-- [x] Internal note links
+- [x] Internal note links (limitation: links only resolve correctly if the link text exactly matches the Evernote note title)
 - [x] Notebooks
 - [x] Tags


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Closes #9422

NN importer relies on the link text to match exactly with the Evernote title to be able to resolve internal links. Unfortunately, there's no other way to figure out the internal link reference in the .enex file

## Type of Change
- [ ] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [X] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [ ] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
