### PR TITLE
web: escape html in note title in diff viewer

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -54,6 +54,7 @@
         "dayjs": "1.11.13",
         "diffblazer": "^1.0.1",
         "electron-trpc": "0.7.1",
+        "entities": "^7.0.1",
         "event-source-polyfill": "1.0.31",
         "fflate": "^0.8.0",
         "file-saver": "^2.0.5",
@@ -507,7 +508,7 @@
     },
     "../desktop": {
       "name": "@notesnook/desktop",
-      "version": "3.3.9-beta.2",
+      "version": "3.3.10",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {
@@ -2924,6 +2925,18 @@
         "zod": "^3.22.4"
       }
     },
+    "node_modules/@notesnook-importer/core/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/@notesnook-importer/core/node_modules/fflate": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
@@ -4161,6 +4174,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/gregberge"
+      }
+    },
+    "node_modules/@svgr/hast-util-to-babel-ast/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/@svgr/plugin-jsx": {
@@ -6687,6 +6713,18 @@
         "htmlparser2": "^9.0.0"
       }
     },
+    "node_modules/diffblazer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/diffblazer/node_modules/htmlparser2": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
@@ -6718,6 +6756,18 @@
       },
       "funding": {
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/domelementtype": {
@@ -6920,9 +6970,9 @@
       }
     },
     "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -8263,6 +8313,18 @@
         "domhandler": "^5.0.3",
         "domutils": "^3.0.1",
         "entities": "^4.4.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/http-cache-semantics": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -52,6 +52,7 @@
     "dayjs": "1.11.13",
     "diffblazer": "^1.0.1",
     "electron-trpc": "0.7.1",
+    "entities": "^7.0.1",
     "event-source-polyfill": "1.0.31",
     "fflate": "^0.8.0",
     "file-saver": "^2.0.5",

--- a/apps/web/src/components/diff-viewer/index.tsx
+++ b/apps/web/src/components/diff-viewer/index.tsx
@@ -35,6 +35,7 @@ import { UnlockView } from "../unlock";
 import { getFormattedDate } from "@notesnook/common";
 import { diff } from "diffblazer";
 import { strings } from "@notesnook/intl";
+import { escapeUTF8 } from "entities";
 
 type DiffViewerProps = { session: ConflictedEditorSession | DiffEditorSession };
 function DiffViewer(props: DiffViewerProps) {
@@ -103,11 +104,13 @@ function DiffViewer(props: DiffViewerProps) {
           paddingTop: 10
         }}
         dangerouslySetInnerHTML={{
-          __html: escapeHtml(
+          __html:
             session.type === "diff" && session.oldTitle
-              ? diff(session.oldTitle || "", session.note.title)
-              : session.note.title
-          )
+              ? diff(
+                  escapeUTF8(session.oldTitle || ""),
+                  escapeUTF8(session.note.title)
+                )
+              : escapeUTF8(session.note.title)
         }}
       ></Text>
       <Flex mt={1} sx={{ alignSelf: "center", justifySelf: "center" }}>
@@ -419,13 +422,4 @@ async function createCopy(note: Note, content: ContentItem, title?: string) {
       title: title || note.title + " (COPY)"
     });
   }
-}
-
-function escapeHtml(s: string) {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
 }


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Fixes https://github.com/streetwriters/notesnook/security/advisories/GHSA-45g3-cv93-q59v

We should escape html in note title in diff viewer because of `dangerouslySetInnerHTML`

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [X] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [ ] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
