### PR TITLE
mobile: fix glitch when opening note, flickery behaviour

### DIFF
--- a/apps/mobile/app/components/list-items/note/wrapper.tsx
+++ b/apps/mobile/app/components/list-items/note/wrapper.tsx
@@ -32,9 +32,11 @@ import { eOnLoadNote, eShowMergeDialog } from "../../../utils/events";
 import { fluidTabsRef } from "../../../utils/global-refs";
 
 import { NotebooksWithDateEdited, TagsWithDateEdited } from "@notesnook/common";
+import { useTabStore } from "../../../screens/editor/tiptap/use-tab-store";
+import { editorController } from "../../../screens/editor/tiptap/utils";
+import { RouteParams } from "../../../stores/use-navigation-store";
 import NotePreview from "../../note-history/preview";
 import SelectionWrapper, { selectItem } from "../selection-wrapper";
-import { RouteParams } from "../../../stores/use-navigation-store";
 
 export const openNote = async (
   item: Note,
@@ -63,11 +65,19 @@ export const openNote = async (
       component: <NotePreview note={item} content={content} />
     });
   } else {
+    if (!useTabStore.getState().hasTabForNote(note.id!)) {
+      editorController.current.commands.setLoading(
+        true,
+        useTabStore.getState().currentTab
+      );
+    }
     eSendEvent(eOnLoadNote, {
       item: note
     });
     if (!DDS.isTab) {
-      fluidTabsRef.current?.goToPage("editor");
+      setTimeout(() => {
+        fluidTabsRef.current?.goToPage("editor");
+      }, 32);
     }
   }
 };

--- a/packages/editor-mobile/src/components/editor.tsx
+++ b/packages/editor-mobile/src/components/editor.tsx
@@ -285,7 +285,7 @@ const Tiptap = ({
             restoreNoteSelection(scrollTop, selection);
           }
         }, 300);
-      }, 1);
+      }, 150);
     },
     [restoreNoteSelection]
   );


### PR DESCRIPTION
## Description
Fix note glitch and flicker when switching between notes on mobile. It is noticeable with animations disabled or on tablets where editor is always visible.

### Before
![note-glitch-before](https://github.com/user-attachments/assets/dc05f675-3235-4fdc-86c2-fdfa51cf3047)

### After
![note-glitch-after](https://github.com/user-attachments/assets/74b3c6fc-0c8e-47f7-9d00-39543540e675) 

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [x] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
