### PR TITLE
editor: fix callout first heading being collapsed/expanded if clicked towards right of it

### DIFF
--- a/packages/editor/src/extensions/callout/callout.ts
+++ b/packages/editor/src/extensions/callout/callout.ts
@@ -27,7 +27,7 @@ import {
   mergeAttributes
 } from "@tiptap/core";
 import { Paragraph } from "../paragraph/index.js";
-import { Heading } from "../heading/index.js";
+import { Heading, toggleNodesUnderPos } from "../heading/index.js";
 import { TextSelection } from "@tiptap/pm/state";
 import { Fragment } from "@tiptap/pm/model";
 import { hasPermission } from "../../types.js";
@@ -250,6 +250,24 @@ export const Callout = Node.create({
               "collapsed",
               !container.classList.contains("collapsed")
             );
+
+            /**
+             * Due to a bug in heading extension, the first callout heading
+             * was able to be expanded/collapsed. This caused the callout
+             * content to be hidden without the callout itself being collapsed.
+             * The bug is fixed, but we still need to handle the case
+             * where the first callout heading was previously collapsed.
+             */
+            if (node.firstChild?.attrs.collapsed) {
+              tr.setNodeAttribute(pos + 1, "collapsed", false);
+              toggleNodesUnderPos(
+                tr,
+                pos + 1,
+                node.firstChild?.attrs.level,
+                false
+              );
+            }
+
             return true;
           });
         }

--- a/packages/editor/src/extensions/heading/heading.ts
+++ b/packages/editor/src/extensions/heading/heading.ts
@@ -205,7 +205,7 @@ export const Heading = TiptapHeading.extend({
           (node) => node.type.name === Callout.name
         );
         // the first callout heading's collapsibility is handled by callout itself
-        if (callout?.node.firstChild === node) {
+        if (callout?.node.firstChild?.attrs.blockId === node.attrs.blockId) {
           return;
         }
 


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [X] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [ ] Mobile
- [x] Desktop

## Sign-off
- [x] QA passed
- [ ] UI/UX passed
