### PR TITLE
web: fix editor title temporary flicker on tab switch

### DIFF
--- a/apps/web/src/components/editor/index.tsx
+++ b/apps/web/src/components/editor/index.tsx
@@ -711,12 +711,12 @@ function EditorChrome(props: PropsWithChildren<EditorProps>) {
         }
       });
 
-      const editorTitle = document.querySelector("#editor-title");
+      const editorTitle = document.querySelector(`#editor-title-${id}`);
       if (editorTitle instanceof HTMLTextAreaElement) {
         resizeTextarea(editorTitle);
       }
     }
-    const observer = new ResizeObserver(debounce(onResize, 500));
+    const observer = new ResizeObserver(onResize);
     observer.observe(editorScrollRef.current);
     return () => {
       observer.disconnect();

--- a/apps/web/src/components/editor/title-box.tsx
+++ b/apps/web/src/components/editor/title-box.tsx
@@ -100,7 +100,7 @@ function TitleBox(props: TitleBoxProps) {
     <Textarea
       ref={inputRef}
       variant="clean"
-      id="editor-title"
+      id={`editor-title-${id}`}
       data-test-id="editor-title"
       className="editorTitle"
       placeholder={strings.noteTitle()}
@@ -157,6 +157,8 @@ export default React.memo(TitleBox, (prevProps, nextProps) => {
 });
 
 export function resizeTextarea(input: HTMLTextAreaElement) {
+  if (input.scrollHeight === 0) return;
+
   input.style.height = "auto";
   requestAnimationFrame(() => {
     input.style.height = input.scrollHeight + "px";


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

fix editor title temporary flicker on tab switch
also remove debounce on editor's resize observer

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [X] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [ ] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
