### PR TITLE
web: fix feature title margin in feature dialog

### DIFF
--- a/apps/web/src/dialogs/feature-dialog.tsx
+++ b/apps/web/src/dialogs/feature-dialog.tsx
@@ -96,7 +96,7 @@ const features: Record<FeatureKeys, Feature> = {
               "You can now play audio files directly in the editor without needing to download them first."
           },
           {
-            title: "Orphaned attachmetns are now automatically deleted",
+            title: "Orphaned attachments are now automatically deleted",
             subtitle:
               "Attachments that are not linked to any note will now be automatically deleted to save space."
           },
@@ -177,7 +177,11 @@ export const FeatureDialog = DialogManager.register(function FeatureDialog(
           >
             <Flex sx={{ alignItems: "center", justifyContent: "start" }}>
               {feature.icon && <feature.icon size={14} color="accent" />}
-              <Text variant="subtitle" ml={1} sx={{ fontWeight: "normal" }}>
+              <Text
+                variant="subtitle"
+                ml={feature.icon ? 1 : 0}
+                sx={{ fontWeight: "normal" }}
+              >
                 {feature.title}
               </Text>
             </Flex>


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Closes https://github.com/streetwriters/notesnook/issues/9544

# before

<img width="543" height="569" alt="image" src="https://github.com/user-attachments/assets/c8ced32e-68db-4bb3-bb64-c2bd8d2e3940" />


# after

<img width="535" height="536" alt="image" src="https://github.com/user-attachments/assets/394e2767-1618-424f-8a1c-e96bf30f683c" />


## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [X] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [ ] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
