### PR TITLE
editor: check for permission before pasting images

### DIFF
--- a/packages/editor/src/extensions/clipboard/clipboard-dom-parser.ts
+++ b/packages/editor/src/extensions/clipboard/clipboard-dom-parser.ts
@@ -42,7 +42,7 @@ export class ClipboardDOMParser extends ProsemirrorDOMParser {
       convertGoogleDocsChecklist(dom);
       formatCodeblocks(dom);
       convertBrToSingleSpacedParagraphs(dom);
-      removePremiumFeatures(dom);
+      removeRestrictedFeatures(dom);
       removeBlockId(dom);
     }
     return super.parseSlice(dom, options);
@@ -53,7 +53,7 @@ export class ClipboardDOMParser extends ProsemirrorDOMParser {
       convertGoogleDocsChecklist(dom);
       formatCodeblocks(dom);
       convertBrToSingleSpacedParagraphs(dom);
-      removePremiumFeatures(dom);
+      removeRestrictedFeatures(dom);
       removeBlockId(dom);
     }
     return super.parse(dom, options);
@@ -154,7 +154,7 @@ export function convertGoogleDocsChecklist(dom: HTMLElement | Document) {
   }
 }
 
-const premiumFeatures = [
+const restrictedFeatures = [
   {
     selector: "div.callout",
     permission: "setCallout"
@@ -166,11 +166,15 @@ const premiumFeatures = [
   {
     selector: "ul.checklist",
     permission: "toggleTaskList"
+  },
+  {
+    selector: "img",
+    permission: "insertAttachment"
   }
 ] as const;
 
-function removePremiumFeatures(dom: HTMLElement | Document) {
-  for (const feature of premiumFeatures) {
+function removeRestrictedFeatures(dom: HTMLElement | Document) {
+  for (const feature of restrictedFeatures) {
     const elements = dom.querySelectorAll(feature.selector);
     if (elements.length === 0) continue;
 


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

we need to check for permission before pasting images

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [X] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [X] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
