### PR TITLE
web: fix plans page being cut-off from top

### DIFF
--- a/apps/web/src/views/plans.tsx
+++ b/apps/web/src/views/plans.tsx
@@ -74,7 +74,7 @@ function Plans() {
               flexDirection: "column",
               flex: 1,
               px: 25,
-              height: "100vh",
+              minHeight: "100vh",
               justifyContent: "center"
             }}
           >


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Fix plans page being cut-off from top

### before

<img width="1919" height="728" alt="image" src="https://github.com/user-attachments/assets/c84219f6-42f8-4134-aa57-6cb27346649f" />

### after

<img width="1919" height="721" alt="image" src="https://github.com/user-attachments/assets/17a6f7bd-d76d-4997-ad67-051021823216" />

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [X] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [x] Web
- [ ] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
