### PR TITLE
Generate all user keys on sign up

### DIFF
--- a/packages/core/src/api/user-manager.ts
+++ b/packages/core/src/api/user-manager.ts
@@ -106,6 +106,14 @@ class UserManager {
       dataEncryptionKey: await this.keyManager.wrapKey(
         await this.db.crypto().generateRandomKey(),
         masterKey
+      ),
+      attachmentsKey: await this.keyManager.wrapKey(
+        await this.db.crypto().generateRandomKey(),
+        masterKey
+      ),
+      monographPasswordsKey: await this.keyManager.wrapKey(
+        await this.db.crypto().generateRandomKey(),
+        masterKey
       )
     });
 


### PR DESCRIPTION
## Description

This pull request moves additional encryption keys generation to the user creation process. Now, when a new user is created, their attachments & other encryption keys are generated upfront instead of on-demand. This should prevent any possibility of multiple encryption keys getting generated.

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why

Tested manually

## Platform
<!-- Describe which platforms this PR is related to -->

- [x] Web
- [x] Mobile
- [x] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
