### PR TITLE
web: refresh user on change email && run timer on sending change email for first time

### DIFF
--- a/apps/web/src/dialogs/email-change-dialog.tsx
+++ b/apps/web/src/dialogs/email-change-dialog.tsx
@@ -26,6 +26,7 @@ import { Loading } from "../components/icons";
 import Dialog from "../components/dialog";
 import { BaseDialogProps, DialogManager } from "../common/dialog-manager";
 import { strings } from "@notesnook/intl";
+import { useStore as useUserStore } from "../stores/user-store";
 
 type EmailChangeState = {
   newEmail: string;
@@ -104,6 +105,7 @@ export const EmailChangeDialog = DialogManager.register(
                   emailChangeState.password,
                   code
                 );
+                await useUserStore.getState().refreshUser();
                 props.onClose(true);
                 return;
               }
@@ -116,6 +118,7 @@ export const EmailChangeDialog = DialogManager.register(
               }
 
               await db.user.sendVerificationEmail(newEmail);
+              setEnabled(false);
               setEmailChangeState({ newEmail, password });
             } catch (e) {
               if (e instanceof Error) setError(e.message);


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Fixes [NN-82]


https://github.com/user-attachments/assets/debc2c14-b0e9-4ff4-824c-d211c3983046



## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [X] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [ ] Mobile
- [X] Desktop

## Sign-off
- [x] QA passed
- [ ] UI/UX passed
