### PR TITLE
mobile: fix notes title edit issue

### DIFF
--- a/packages/core/src/collections/notes.ts
+++ b/packages/core/src/collections/notes.ts
@@ -164,7 +164,6 @@ export class Notes implements ICollection {
           item.title = titleFormat.replace(HEADLINE_REGEX, headlineTitle);
         } else if (item.title === "")
           item.title = currentNoteTitleFields?.title || "Untitled";
-        }
       }
 
       if (isUpdating) {


### PR DESCRIPTION
## Description


https://github.com/user-attachments/assets/81a0bf00-8b0a-4b9e-bb45-23a692fa3aa6



Not sure if bug but please fix the need to double delete a note title. Easy to recreate go into any note delete the existing title for example in order to put a new one in and bam it auto inserts date time so have to delete again . App should recognise that if I delete a title it's because I'm going to put a new one

closes #8437

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [x] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [x] QA passed
- [x] UI/UX passed
