### PR TITLE
web: handle crash on preview attachment

### DIFF
--- a/apps/web/src/components/editor/index.tsx
+++ b/apps/web/src/components/editor/index.tsx
@@ -572,12 +572,13 @@ export function Editor(props: EditorProps) {
         onDownloadAttachment={(attachment) => saveAttachment(attachment.hash)}
         onPreviewAttachment={async (data) => {
           try {
-            const { hash, type, mime } = data;
+            const { hash, type } = data;
             const attachment = await db.attachments.attachment(hash);
-            if (attachment && mime.startsWith("image/")) {
+            if (!attachment)
+              throw new Error("No attachment found with hash: " + hash);
+            if (attachment.mimeType.startsWith("image/")) {
               await previewImageAttachment(attachment);
             } else if (
-              attachment &&
               onPreviewDocument &&
               type === "file" &&
               attachment.mimeType.startsWith("application/pdf")
@@ -590,11 +591,19 @@ export function Editor(props: EditorProps) {
               }
               onPreviewDocument({ url: URL.createObjectURL(blob), hash });
             } else {
+              logger.info("Attachment cannot be previewed", {
+                hash,
+                type,
+                mimeType: attachment?.mimeType
+              });
               showToast("error", strings.attachmentPreviewFailed());
             }
           } catch (e) {
-            logger.error(e as Error, "Failed to preview attachment");
-            showToast("error", strings.attachmentPreviewFailed());
+            logger.error(e, "Failed to preview attachment", { data });
+            showToast(
+              "error",
+              (e as Error).message || strings.attachmentPreviewFailed()
+            );
           }
         }}
         onInsertAttachment={async (type) => {


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Closes https://github.com/streetwriters/notesnook/issues/9538

The crash occurs because for some reason `mime` is `undefined`. I haven't been able to reproduce this case, nor am I am able to figure out how it is undefined.

In the meantime, I've added try/catch handling to prevent app crash


## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [X] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [ ] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
