### PR TITLE
mobile: fix file size check shows error but continues uploading the file

### DIFF
--- a/apps/mobile/app/common/filesystem/upload.ts
+++ b/apps/mobile/app/common/filesystem/upload.ts
@@ -35,6 +35,8 @@ import Upload from "@ammarahmed/react-native-upload";
 import { CloudUploader } from "react-native-nitro-cloud-uploader";
 import { useUserStore } from "../../stores/use-user-store";
 import { sleep } from "../../utils/time";
+import { isFeatureAvailable } from "@notesnook/common";
+import { strings } from "@notesnook/intl";
 
 // Upload constants
 const CHUNK_SIZE = 10 * 1024 * 1024; // 10 MB
@@ -198,6 +200,20 @@ export async function uploadFile(
 
     const remoteFileSize = await getUploadedFileSize(filename);
     if (remoteFileSize === FileSizeResult.Error) return false;
+
+    const featureResult = await isFeatureAvailable(
+      "fileSize",
+      fileInfo.size || 0
+    );
+
+    if (!featureResult.isAllowed) {
+      ToastManager.show({
+        heading: strings.fileTooLarge(),
+        message: featureResult.error,
+        type: "error"
+      });
+      return false;
+    }
 
     if (
       remoteFileSize > FileSizeResult.Empty &&

--- a/apps/mobile/app/screens/editor/tiptap/picker.ts
+++ b/apps/mobile/app/screens/editor/tiptap/picker.ts
@@ -90,6 +90,7 @@ const file = async (fileOptions: PickerOptions) => {
         message: featureResult.error,
         type: "error"
       });
+      return;
     }
 
     if (fileCopyUri.status === "error") {
@@ -272,6 +273,7 @@ const handleImageResponse = async (
         message: featureResult.error,
         type: "error"
       });
+      return;
     }
 
     const b64 = `data:${image.mime};base64, ` + image.data;


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->
Fix uploading file bigger than allowed on a plan does not prevent file from being added to the editor. File does not get uploaded but the app constantly keeps trying to upload it indefinitely until the file is deleted.

- Adds a check before file upload to ensure file size is allowed to prevent unnecessary data usage
- Ensures user cannot add a file bigger than what is allowed on the plan

Closes [https://github.com/streetwriters/notesnook/issues/9615](https://github.com/streetwriters/notesnook/issues/9615)

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
