### PR TITLE
core: simplify fuzzy separator regex

### DIFF
--- a/packages/core/src/utils/__tests__/fuzzy.test.ts
+++ b/packages/core/src/utils/__tests__/fuzzy.test.ts
@@ -98,20 +98,35 @@ describe("lookup.fuzzy", () => {
     const items = [
       { id: "1", title: "file search.jpg" },
       { id: "2", title: "file-search.jpg" },
-      { id: "3", title: "file_search.jpg" }
+      { id: "3", title: "file_search.jpg" },
+      { id: "4", title: "file____search-393.jpg" },
+      { id: "5", title: "note-393.jpg" }
     ];
 
     test("query with space matches all separator variants", () => {
-      const result = fuzzy("file search", items, (i) => i.id, { title: 1 });
-      expect(result).toStrictEqual(items);
+      const result = fuzzy("fl srch", items, (i) => i.id, { title: 1 });
+      expect(result).toStrictEqual(items.slice(0, 4));
+    });
+
+    test("variants with only separators should match", () => {
+      const result = fuzzy(
+        "---",
+        [
+          { id: "1", title: "--------.jpg" },
+          { id: "2", title: "abc.jpg" }
+        ],
+        (i) => i.id,
+        { title: 1 }
+      );
+      expect(result).toStrictEqual([{ id: "1", title: "--------.jpg" }]);
     });
 
     test("query with special character between words matches all separator variants", () => {
       let result = fuzzy("file_search", items, (i) => i.id, { title: 1 });
-      expect(result).toStrictEqual(items);
+      expect(result).toStrictEqual([items[2], items[3], items[0], items[1]]);
 
       result = fuzzy("file-search", items, (i) => i.id, { title: 1 });
-      expect(result).toStrictEqual(items);
+      expect(result).toStrictEqual([items[1], items[0], items[2], items[3]]);
     });
   });
 });

--- a/packages/core/src/utils/fuzzy.ts
+++ b/packages/core/src/utils/fuzzy.ts
@@ -20,18 +20,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import { match, surround } from "fuzzyjs";
 import { clone } from "./clone.js";
 
-const SEPARATORS = /\w([^a-zA-Z0-9])\w/g;
-
-function normalizeSeparators(str: string): string {
-  return str.replace(SEPARATORS, (m) => m[0] + " " + m[m.length - 1]);
-}
-
-function hasSeparator(str: string): boolean {
-  const result = SEPARATORS.test(str);
-  SEPARATORS.lastIndex = 0;
-  return result;
-}
-
 export function fuzzy<T>(
   query: string,
   items: T[],
@@ -43,6 +31,50 @@ export function fuzzy<T>(
     suffix?: string;
   } = {}
 ): T[] {
+  const results = fuzzyMatch(query, items, getIdentifier, fields, options);
+  if (results.size === 0) return [];
+
+  // if the query contains spaces & other non-alphanumeric characters, then we
+  // should search again with a sanitized query to catch more matches.
+  const sanitizedQuery = sanitize(query);
+  if (sanitizedQuery !== query) {
+    for (const [key, value] of fuzzyMatch(
+      sanitizedQuery,
+      items,
+      getIdentifier,
+      fields,
+      options
+    )) {
+      const matchInFirstSearch = results.get(key);
+      if (matchInFirstSearch) {
+        // just give it an extra bump because matches from first search
+        // must always be higher as they probably match much more closely
+        // with the query given by the user.
+        matchInFirstSearch.score += value.score;
+        continue;
+      }
+      results.set(key, value);
+    }
+  }
+
+  const matches = Array.from(results.entries())
+    .sort((a, b) => b[1].score - a[1].score)
+    .map((item) => item[1].item);
+
+  return matches;
+}
+
+function fuzzyMatch<T>(
+  query: string,
+  items: T[],
+  getIdentifier: (item: T) => string,
+  fields: Partial<Record<keyof T, number>>,
+  options: {
+    limit?: number;
+    prefix?: string;
+    suffix?: string;
+  } = {}
+) {
   const results: Map<
     string,
     {
@@ -51,9 +83,6 @@ export function fuzzy<T>(
     }
   > = new Map();
 
-  const shouldNormalize = hasSeparator(query);
-  const finalQuery = shouldNormalize ? normalizeSeparators(query) : query;
-
   for (const item of items) {
     if (options.limit && results.size >= options.limit) break;
 
@@ -61,10 +90,7 @@ export function fuzzy<T>(
 
     for (const field in fields) {
       const value = `${item[field]}`;
-      const result = match(
-        finalQuery,
-        shouldNormalize ? normalizeSeparators(value) : value
-      );
+      const result = match(query, value);
       if (!result.match) continue;
 
       const oldMatch = results.get(identifier);
@@ -87,11 +113,10 @@ export function fuzzy<T>(
       }
     }
   }
+  return results;
+}
 
-  if (results.size === 0) return [];
-
-  const sorted = Array.from(results.entries());
-  sorted.sort((a, b) => b[1].score - a[1].score);
-
-  return sorted.map((item) => item[1].item);
+const SEPARATORS = /[^a-zA-Z0-9]+/g;
+function sanitize(str: string): string {
+  return str.replace(SEPARATORS, "").trim() || str;
 }


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Using newer regex features breaks the editor on older iOS versions.

* remove lookahead and lookbehind

Closes [https://github.com/streetwriters/notesnook/issues/9630](https://github.com/streetwriters/notesnook/issues/9630)

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [X] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
