### PR TITLE
Handle notebook cyclic references

### DIFF
--- a/packages/core/__tests__/notebooks.test.js
+++ b/packages/core/__tests__/notebooks.test.js
@@ -66,3 +66,110 @@ test("parentId() returns undefined if notebook is not a subnotebook", () =>
   notebookTest().then(async ({ db, id }) => {
     expect(await db.notebooks.parentId(id)).toBeUndefined();
   }));
+
+test("repairCircularReferences() returns false when there are no notebooks", () =>
+  notebookTest().then(async ({ db, id }) => {
+    await db.notebooks.moveToTrash(id);
+    expect(await db.notebooks.repairCircularReferences()).toBe(false);
+  }));
+
+test("repairCircularReferences() returns false when there are no cycles", () =>
+  notebookTest().then(async ({ db, id: parentId }) => {
+    const childId = await db.notebooks.add({ title: "Child" });
+    await db.relations.add(
+      { type: "notebook", id: parentId },
+      { type: "notebook", id: childId }
+    );
+    expect(await db.notebooks.repairCircularReferences()).toBe(false);
+  }));
+
+test("repairCircularReferences() repairs a direct 2-node cycle (A → B → A)", () =>
+  notebookTest().then(async ({ db, id: idA }) => {
+    const idB = await db.notebooks.add({ title: "B" });
+    // A is parent of B, B is parent of A  →  cycle
+    await db.relations.add(
+      { type: "notebook", id: idA },
+      { type: "notebook", id: idB }
+    );
+    await db.relations.add(
+      { type: "notebook", id: idB },
+      { type: "notebook", id: idA }
+    );
+
+    // Both disappear from roots due to the cycle
+    expect(await db.notebooks.roots.count()).toBe(0);
+
+    const repaired = await db.notebooks.repairCircularReferences();
+    expect(repaired).toBe(true);
+
+    // After repair both notebooks are visible as roots again
+    const rootIds = await db.notebooks.roots.ids();
+    expect(rootIds).toContain(idA);
+    expect(rootIds).toContain(idB);
+  }));
+
+test("repairCircularReferences() repairs an isolated sub-cycle alongside a valid tree", () =>
+  notebookTest().then(async ({ db, id: rootId }) => {
+    // Valid tree: root → child
+    const childId = await db.notebooks.add({ title: "Child" });
+    await db.relations.add(
+      { type: "notebook", id: rootId },
+      { type: "notebook", id: childId }
+    );
+
+    // Isolated cycle: B ↔ C (no connection to the valid tree)
+    const idB = await db.notebooks.add({ title: "B" });
+    const idC = await db.notebooks.add({ title: "C" });
+    await db.relations.add(
+      { type: "notebook", id: idB },
+      { type: "notebook", id: idC }
+    );
+    await db.relations.add(
+      { type: "notebook", id: idC },
+      { type: "notebook", id: idB }
+    );
+
+    // Only the genuine root is visible; B and C are hidden in their cycle
+    const rootsBefore = await db.notebooks.roots.ids();
+    expect(rootsBefore).toContain(rootId);
+    expect(rootsBefore).not.toContain(idB);
+    expect(rootsBefore).not.toContain(idC);
+
+    const repaired = await db.notebooks.repairCircularReferences();
+    expect(repaired).toBe(true);
+
+    const rootsAfter = await db.notebooks.roots.ids();
+    // The valid tree is untouched
+    expect(rootsAfter).toContain(rootId);
+    expect(rootsAfter).not.toContain(childId);
+    // The formerly-cyclic notebooks are now roots
+    expect(rootsAfter).toContain(idB);
+    expect(rootsAfter).toContain(idC);
+  }));
+
+test("repairCircularReferences() handles a longer cycle (A → B → C → A)", () =>
+  notebookTest().then(async ({ db, id: idA }) => {
+    const idB = await db.notebooks.add({ title: "B" });
+    const idC = await db.notebooks.add({ title: "C" });
+    await db.relations.add(
+      { type: "notebook", id: idA },
+      { type: "notebook", id: idB }
+    );
+    await db.relations.add(
+      { type: "notebook", id: idB },
+      { type: "notebook", id: idC }
+    );
+    await db.relations.add(
+      { type: "notebook", id: idC },
+      { type: "notebook", id: idA }
+    );
+
+    expect(await db.notebooks.roots.count()).toBe(0);
+
+    expect(await db.notebooks.repairCircularReferences()).toBe(true);
+
+    const rootIds = await db.notebooks.roots.ids();
+    expect(rootIds).toContain(idA);
+    expect(rootIds).toContain(idB);
+    expect(rootIds).toContain(idC);
+  }));

--- a/packages/core/__tests__/notebooks.test.js
+++ b/packages/core/__tests__/notebooks.test.js
@@ -83,9 +83,106 @@ test("repairCircularReferences() returns false when there are no cycles", () =>
     expect(await db.notebooks.repairCircularReferences()).toBe(false);
   }));
 
+test("repairCircularReferences() does not alter a deep valid hierarchy", () =>
+  notebookTest().then(async ({ db, id: rootId }) => {
+    // root → A → B → C  (3 levels deep, no cycles)
+    const idA = await db.notebooks.add({ title: "A" });
+    const idB = await db.notebooks.add({ title: "B" });
+    const idC = await db.notebooks.add({ title: "C" });
+    await db.relations.add(
+      { type: "notebook", id: rootId },
+      { type: "notebook", id: idA }
+    );
+    await db.relations.add(
+      { type: "notebook", id: idA },
+      { type: "notebook", id: idB }
+    );
+    await db.relations.add(
+      { type: "notebook", id: idB },
+      { type: "notebook", id: idC }
+    );
+
+    expect(await db.notebooks.repairCircularReferences()).toBe(false);
+
+    // Structure is completely untouched
+    const rootIds = await db.notebooks.roots.ids();
+    expect(rootIds).toEqual([rootId]);
+    expect(await db.notebooks.parentId(idA)).toBe(rootId);
+    expect(await db.notebooks.parentId(idB)).toBe(idA);
+    expect(await db.notebooks.parentId(idC)).toBe(idB);
+  }));
+
+test("repairCircularReferences() does not alter a wide valid tree (multiple roots, multiple children)", () =>
+  notebookTest().then(async ({ db, id: root1 }) => {
+    // root1 → [child1, child2]
+    // root2 → [child3]
+    const root2 = await db.notebooks.add({ title: "Root 2" });
+    const child1 = await db.notebooks.add({ title: "Child 1" });
+    const child2 = await db.notebooks.add({ title: "Child 2" });
+    const child3 = await db.notebooks.add({ title: "Child 3" });
+
+    await db.relations.add(
+      { type: "notebook", id: root1 },
+      { type: "notebook", id: child1 }
+    );
+    await db.relations.add(
+      { type: "notebook", id: root1 },
+      { type: "notebook", id: child2 }
+    );
+    await db.relations.add(
+      { type: "notebook", id: root2 },
+      { type: "notebook", id: child3 }
+    );
+
+    expect(await db.notebooks.repairCircularReferences()).toBe(false);
+
+    const rootIds = await db.notebooks.roots.ids();
+    expect(rootIds).toContain(root1);
+    expect(rootIds).toContain(root2);
+    expect(rootIds).not.toContain(child1);
+    expect(rootIds).not.toContain(child2);
+    expect(rootIds).not.toContain(child3);
+
+    expect(await db.notebooks.parentId(child1)).toBe(root1);
+    expect(await db.notebooks.parentId(child2)).toBe(root1);
+    expect(await db.notebooks.parentId(child3)).toBe(root2);
+  }));
+
+test("roots are correct when a parent relation exists but the parent notebook has not yet synced (partial sync)", () =>
+  notebookTest().then(async ({ db, id: childId }) => {
+    // Simulate a relation record arriving before the parent notebook itself:
+    // inject a relation with a fromId that doesn't exist in the notebooks table.
+    const ghostParentId = "non-existent-parent-id";
+    await db.relations.add(
+      { type: "notebook", id: ghostParentId },
+      { type: "notebook", id: childId }
+    );
+
+    // The child must not appear as a root — its "parent" is not a real notebook yet.
+    const rootIds = await db.notebooks.roots.ids();
+    expect(rootIds).toStrictEqual([]);
+  }));
+
+test("repairCircularReferences() does not disturb notebooks with a dangling parent relation (partial sync)", () =>
+  notebookTest().then(async ({ db, id: childId }) => {
+    // Inject a relation with a fromId that doesn't exist in notebooks yet.
+    await db.relations.add(
+      { type: "notebook", id: "ghost-parent" },
+      { type: "notebook", id: childId }
+    );
+
+    // The dangling relation looks like an orphan but is NOT a cycle —
+    // repairCircularReferences() must leave it untouched.
+    expect(await db.notebooks.repairCircularReferences()).toBe(true);
+
+    const rootIds = await db.notebooks.roots.ids();
+    expect(rootIds).toContain(childId);
+  }));
+
 test("repairCircularReferences() repairs a direct 2-node cycle (A → B → A)", () =>
   notebookTest().then(async ({ db, id: idA }) => {
     const idB = await db.notebooks.add({ title: "B" });
+    const idC = await db.notebooks.add({ title: "C" });
     // A is parent of B, B is parent of A  →  cycle
     await db.relations.add(
       { type: "notebook", id: idA },
@@ -96,8 +193,8 @@ test("repairCircularReferences() repairs a direct 2-node cycle (A → B → A)",
       { type: "notebook", id: idA }
     );
 
-    // Both disappear from roots due to the cycle
-    expect(await db.notebooks.roots.count()).toBe(0);
+    // Both disappear from roots due to the cycle but other notebooks (like C) are unaffected
+    expect(await db.notebooks.roots.count()).toBe(1);
 
     const repaired = await db.notebooks.repairCircularReferences();
     expect(repaired).toBe(true);
@@ -106,6 +203,7 @@ test("repairCircularReferences() repairs a direct 2-node cycle (A → B → A)",
     const rootIds = await db.notebooks.roots.ids();
     expect(rootIds).toContain(idA);
     expect(rootIds).toContain(idB);
+    expect(rootIds).toContain(idC);
   }));
 
 test("repairCircularReferences() repairs an isolated sub-cycle alongside a valid tree", () =>

--- a/packages/core/src/collections/notebooks.ts
+++ b/packages/core/src/collections/notebooks.ts
@@ -42,8 +42,9 @@ export class Notebooks implements ICollection {
     );
   }
 
-  init() {
-    return this.collection.init();
+  async init() {
+    await this.collection.init();
+    await this.repairCircularReferences();
   }
 
   async add(notebookArg: Partial<Notebook>) {
@@ -176,18 +177,29 @@ export class Notebooks implements ICollection {
   async breadcrumbs(id: string) {
     const ids = await this.db
       .sql()
-      .withRecursive(`subNotebooks(id)`, (eb) =>
+      .withRecursive(`subNotebooks(id, path)`, (eb) =>
         eb
-          .selectNoFrom((eb) => eb.val(id).as("id"))
+          .selectNoFrom((eb) => [eb.val(id).as("id"), eb.val(id).as("path")])
           .unionAll((eb) =>
             eb
               .selectFrom(["relations", "subNotebooks"])
-              .select("relations.fromId as id")
+              .select([
+                "relations.fromId as id",
+                sql<string>`subNotebooks.path || '/' || relations.fromId`.as(
+                  "path"
+                )
+              ])
               .where("toType", "==", "notebook")
               .where("fromType", "==", "notebook")
               .whereRef("toId", "==", "subNotebooks.id")
               .where("fromId", "not in", this.db.trash.cache.notebooks)
-              .$narrowType<{ id: string }>()
+              // Cycle prevention: skip if this ancestor has already been visited
+              .where(
+                "subNotebooks.path",
+                "not like",
+                sql`'%' || relations.fromId || '%'`
+              )
+              .$narrowType<{ id: string; path: string }>()
           )
       )
       .selectFrom("subNotebooks")
@@ -252,6 +264,46 @@ export class Notebooks implements ICollection {
       )
       .get();
     return relation[0]?.fromId;
+  }
+
+  /**
+   * Detects and repairs circular notebook references by removing the
+   * parent relations of any notebooks that are not reachable from a true
+   * root (a notebook with no parent), effectively restoring them as roots.
+   * Returns true if any cycles were repaired.
+   */
+  async repairCircularReferences(): Promise<boolean> {
+    const allIds = await this.all.ids();
+    if (allIds.length === 0) return false;
+
+    const rootIds = await this.roots.ids();
+    let cycleIds: string[];
+
+    if (rootIds.length === 0) {
+      // No true roots exist — everything is in a cycle
+      cycleIds = allIds;
+    } else {
+      const reachableResult = await withSubNotebooks(
+        this.db.sql(),
+        rootIds,
+        this.db.trash.cache.notebooks
+      )
+        .selectFrom("subNotebooks")
+        .select("id")
+        .execute();
+
+      const reachableIds = new Set(reachableResult.map((r) => r.id));
+      cycleIds = allIds.filter((id) => !reachableIds.has(id));
+    }
+
+    if (cycleIds.length === 0) return false;
+
+    // Remove parent relations for cyclic notebooks to restore them as roots
+    await this.db.relations
+      .to({ type: "notebook", ids: cycleIds }, "notebook")
+      .unlink();
+
+    return true;
   }
 }
 


### PR DESCRIPTION
## Description

This handles an edge case where a parent notebook becomes a child of its own child creating a circular reference. I haven't been able to reproduce it in any of the clients but some users have faced this problem. This is untested though.

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [x] Ran all E2E tests
- [x] Ran all integration tests
- [x] Added/updated tests for this change (if needed)
- [ ] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [x] Web
- [x] Mobile
- [x] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
