### PR TITLE
web: show better error message on invalid recovery key

### DIFF
--- a/apps/web/src/views/recovery.tsx
+++ b/apps/web/src/views/recovery.tsx
@@ -330,13 +330,16 @@ function RecoveryKeyMethod(props: BaseRecoveryComponentProps<"method:key">) {
         subtitle: strings.keyRecoveryProgressDesc()
       }}
       onSubmit={async (form) => {
+        const recoveryKey = form.recoveryKey;
+        if (recoveryKey.length < 40) {
+          throw new Error(strings.invalidRecoveryKey());
+        }
+
         setProgress(0);
 
         const user = await db.user.getUser();
         if (!user) throw new Error(strings.notLoggedIn());
-        await useKeyStore
-          .getState()
-          .setValue("userEncryptionKey", form.recoveryKey);
+        await useKeyStore.getState().setValue("userEncryptionKey", recoveryKey);
         navigate("new", form);
       }}
     >
@@ -358,7 +361,7 @@ function RecoveryKeyMethod(props: BaseRecoveryComponentProps<"method:key">) {
         >
           {strings.back()}
         </Button>
-      <SubmitButton text={strings.startAccountRecovery()} />
+        <SubmitButton text={strings.startAccountRecovery()} />
       </Flex>
 
       <Button
@@ -398,18 +401,29 @@ function NewPassword(props: BaseRecoveryComponentProps<"new">) {
         subtitle: strings.resetPasswordWait()
       }}
       onSubmit={async (form) => {
-        setProgress(0);
+        try {
+          setProgress(0);
 
-        if (form.password !== form.confirmPassword)
-          throw new Error("Passwords do not match.");
+          if (form.password !== form.confirmPassword)
+            throw new Error("Passwords do not match.");
 
-        if (formData?.userResetRequired && !(await db.user.resetUser()))
-          throw new Error("Failed to reset user.");
+          if (formData?.userResetRequired && !(await db.user.resetUser()))
+            throw new Error("Failed to reset user.");
 
-        if (!(await db.user.resetPassword(form.password)))
-          throw new Error("Could not reset account password.");
+          if (!(await db.user.resetPassword(form.password)))
+            throw new Error("Could not reset account password.");
 
-        navigate("final");
+          navigate("final");
+        } catch (e) {
+          if ((e as Error).message === "invalid input") {
+            console.error(e);
+            throw new Error(
+              "Password reset failed because of invalid recovery key"
+            );
+          }
+
+          throw e;
+        }
       }}
     >
       {(form?: NewPasswordFormData) => (
@@ -443,7 +457,7 @@ function NewPassword(props: BaseRecoveryComponentProps<"new">) {
             >
               {strings.back()}
             </Button>
-          <SubmitButton text={strings.continue()} />
+            <SubmitButton text={strings.continue()} />
           </Flex>
         </>
       )}
@@ -545,7 +559,7 @@ export function RecoveryForm<T extends RecoveryRoutes>(
         {subtitle}
       </Text>
       {typeof children === "function" ? children(form) : children}
-      <ErrorText error={error} />
+      <ErrorText error={error} sx={{ mt: 2 }} />
     </Flex>
   );
 }

--- a/packages/intl/locale/en.po
+++ b/packages/intl/locale/en.po
@@ -3448,6 +3448,10 @@ msgstr "Invalid CORS proxy url"
 msgid "Invalid email"
 msgstr "Invalid email"
 
+#: src/strings.ts:2642
+msgid "Invalid recovery key. Make sure to input your account recovery key, not a 2FA recovery code."
+msgstr "Invalid recovery key. Make sure to input your account recovery key, not a 2FA recovery code."
+
 #: src/strings.ts:224
 msgid "Issue created"
 msgstr "Issue created"

--- a/packages/intl/locale/pseudo-LOCALE.po
+++ b/packages/intl/locale/pseudo-LOCALE.po
@@ -3428,6 +3428,10 @@ msgstr ""
 msgid "Invalid email"
 msgstr ""
 
+#: src/strings.ts:2642
+msgid "Invalid recovery key. Make sure to input your account recovery key, not a 2FA recovery code."
+msgstr ""
+
 #: src/strings.ts:224
 msgid "Issue created"
 msgstr ""

--- a/packages/intl/src/strings.ts
+++ b/packages/intl/src/strings.ts
@@ -2637,5 +2637,7 @@ Use this if changes from other devices are not appearing on this device. This wi
   failedToAttachFile: () => t`Failed to attach file`,
   unlockNoteToMergeConflicts: () => t`Unlock note to merge conflicts`,
   confirmationEmailSent: () => t`Confirmation email sent`,
-  back: () => t`Back`
+  back: () => t`Back`,
+  invalidRecoveryKey: () =>
+    t`Invalid recovery key. Make sure to input your account recovery key, not a 2FA recovery code.`
 };


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

<img width="736" height="718" alt="image" src="https://github.com/user-attachments/assets/8066aaa8-0ef6-46f8-8b6c-191bbff076d3" />

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [X] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [ ] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
