### PR TITLE
editor: handle crash on inserting incorrect syntax in math nodes

### DIFF
--- a/packages/editor/src/extensions/math/plugin/math-node-view.ts
+++ b/packages/editor/src/extensions/math/plugin/math-node-view.ts
@@ -276,6 +276,8 @@ export class MathView implements NodeView, ICursorPosObserver {
       while (this._mathRenderElt.firstChild) {
         this._mathRenderElt.firstChild.remove();
       }
+      this._mathRenderElt.classList.remove("parse-error");
+      this.dom.setAttribute("title", "");
       // do not render empty math
       return;
     } else {

--- a/packages/editor/src/extensions/math/plugin/renderers/katex.ts
+++ b/packages/editor/src/extensions/math/plugin/renderers/katex.ts
@@ -32,20 +32,32 @@ async function loadKatex() {
 export const KatexRenderer: MathRenderer = {
   inline: (text, element) => {
     loadKatex().then((katex) => {
-      katex.render(text, element, {
-        displayMode: false,
-        globalGroup: true,
-        throwOnError: false
-      });
+      try {
+        katex.render(text, element, {
+          displayMode: false,
+          globalGroup: true,
+          throwOnError: false
+        });
+      } catch (err) {
+        console.error(err);
+        element.classList.add("parse-error");
+        element.setAttribute("title", err instanceof Error ? err.message : String(err));
+      }
     });
   },
   block: (text, element) => {
     loadKatex().then((katex) => {
-      katex.render(text, element, {
-        displayMode: true,
-        globalGroup: true,
-        throwOnError: false
-      });
+      try {
+        katex.render(text, element, {
+          displayMode: true,
+          globalGroup: true,
+          throwOnError: false
+        });
+      } catch (err) {
+        console.error(err);
+        element.classList.add("parse-error");
+        element.setAttribute("title", err instanceof Error ? err.message : String(err));
+      }
     });
   }
 };


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Closes https://github.com/streetwriters/notesnook/issues/6864

entering `\begin\array` will now show this:
<img width="675" height="97" alt="image" src="https://github.com/user-attachments/assets/f1c63629-0109-4fc4-905d-7a466f5e1212" />


## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [X] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [X] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
