### PR TITLE
mobile: fix parent notebook can be moved into it's child notebooks.

### DIFF
--- a/apps/mobile/app/components/side-menu/index.tsx
+++ b/apps/mobile/app/components/side-menu/index.tsx
@@ -432,6 +432,7 @@ const TabBar = (props: SimpleTabBarProps) => {
                       name="plus"
                       testID="sidebar-add-button"
                       size={AppFontSize.lg - 2}
+                       top={10}
                       color={colors.primary.icon}
                       onPress={async () => {
                         if (props.navigationState.index === 1) {
@@ -485,6 +486,7 @@ const TabBar = (props: SimpleTabBarProps) => {
                           ? "sort-ascending"
                           : "sort-descending"
                       }
+                      top={10}
                       testID="sidebar-sort-button"
                       color={colors.primary.icon}
                       onPress={() => {
@@ -520,6 +522,7 @@ const TabBar = (props: SimpleTabBarProps) => {
                         width: 28,
                         height: 28
                       }}
+                      top={10}
                       testID="sidebar-theme-button"
                       color={colors.primary.icon}
                       name={isDark ? "weather-night" : "weather-sunny"}

--- a/apps/mobile/app/components/side-menu/notebook-item.tsx
+++ b/apps/mobile/app/components/side-menu/notebook-item.tsx
@@ -24,7 +24,8 @@ import { StoreApi, UseBoundStore } from "zustand";
 import { useTotalNotes } from "../../hooks/use-db-item";
 import {
   eSubscribeEvent,
-  eUnSubscribeEvent
+  eUnSubscribeEvent,
+  ToastManager
 } from "../../services/event-manager";
 import { TreeItem } from "../../stores/create-notebook-tree-stores";
 import { SelectionStore } from "../../stores/item-selection-store";
@@ -101,7 +102,8 @@ export const NotebookItem = ({
             ? 15 * item.depth
             : 15 * 5,
         width: "100%",
-        marginTop: 2
+        marginTop: 2,
+        opacity: item.disabled ? 0.5 : 1
       }}
     >
       <Pressable

--- a/apps/mobile/app/components/toast/index.tsx
+++ b/apps/mobile/app/components/toast/index.tsx
@@ -120,10 +120,9 @@ export const Toast = ({ context = "global" }) => {
         alignItems: "center",
         alignSelf: "center",
         bottom:
-          Platform.OS === "android"
-            ? Math.max(insets.bottom, 40)
-            : Math.max(insets.bottom, 40) +
-              (keyboard.keyboardShown ? keyboard.keyboardHeight : 0),
+          insets.bottom +
+          15 +
+          (keyboard.keyboardShown ? Math.max(0, keyboard.keyboardHeight) : 0),
         position: "absolute",
         zIndex: 999,
         elevation: 15
@@ -158,22 +157,22 @@ export const Toast = ({ context = "global" }) => {
               toastOptions.icon
                 ? toastOptions.icon
                 : toastOptions.type === "success"
-                ? "check"
-                : toastOptions.type === "info"
-                ? "information"
-                : "close"
+                  ? "check"
+                  : toastOptions.type === "info"
+                    ? "information"
+                    : "close"
             }
             size={isFullToastMessage ? AppFontSize.xxxl : AppFontSize.xl}
             color={
               toastOptions?.icon
                 ? toastOptions?.icon
                 : toastOptions.type === "error"
-                ? colors.error.icon
-                : toastOptions.type === "info"
-                ? isDark
-                  ? colors.static.white
-                  : colors.static.black
-                : colors.success.icon
+                  ? colors.error.icon
+                  : toastOptions.type === "info"
+                    ? isDark
+                      ? colors.static.white
+                      : colors.static.black
+                    : colors.success.icon
             }
           />
 

--- a/apps/mobile/app/screens/move-notebook/index.tsx
+++ b/apps/mobile/app/screens/move-notebook/index.tsx
@@ -46,6 +46,7 @@ import {
 import {
   checkParentSelected,
   findRootNotebookId,
+  getAllNotebookChildren,
   getParentNotebookId
 } from "../../utils/notebooks";
 import { DefaultAppStyles } from "../../utils/styles";
@@ -124,17 +125,25 @@ export const MoveNotebook = (props: NavigationProps<"MoveNotebook">) => {
   useEffect(() => {
     async function filterNotebooks() {
       const excludedItems: string[] = [];
+      const disabledItems: string[] = [];
       for (const notebook of selectedNotebooks) {
+        const children = await getAllNotebookChildren(notebook.id, []);
+        excludedItems.push(...children);
         const parent = await getParentNotebookId(notebook.id);
-        if (!excludedItems.includes(parent)) {
-          excludedItems.push(parent);
+        if (!disabledItems.includes(parent)) {
+          disabledItems.push(parent);
         }
         excludedItems.push(notebook.id);
       }
-      const filtered = tree.filter(
-        (treeItem) => !excludedItems.includes(treeItem.notebook.id)
+      // Exclude and disable items as needed
+      const filtered = tree.filter(item => !excludedItems.includes(item.notebook.id)).map(
+        (treeItem) => {
+          return {
+            ...treeItem,
+            disabled: disabledItems.includes(treeItem.notebook.id)
+          }
+        }
       );
-
       return filtered;
     }
     filterNotebooks().then((filtered) => {
@@ -149,6 +158,13 @@ export const MoveNotebook = (props: NavigationProps<"MoveNotebook">) => {
           index={index}
           item={item}
           onPress={async () => {
+             if (item.disabled) {
+                        ToastManager.show({
+                          type: "info",
+                          "message": "You cannot move the selected notebook(s) here"
+                        })
+            return;
+            }
             const selectedNotebook = item.notebook;
             presentDialog({
               title: strings.moveNotebooks(selectedNotebooks.length),

--- a/apps/mobile/app/screens/move-notebook/index.tsx
+++ b/apps/mobile/app/screens/move-notebook/index.tsx
@@ -255,6 +255,7 @@ export const MoveNotebook = (props: NavigationProps<"MoveNotebook">) => {
                   updateNotebooks();
                 }, 300);
               }}
+              testID="move-notebook-search"
               button={{
                 icon: "plus",
                 onPress: async () => {

--- a/apps/mobile/app/stores/create-notebook-tree-stores.ts
+++ b/apps/mobile/app/stores/create-notebook-tree-stores.ts
@@ -28,6 +28,7 @@ export type TreeItem = {
   notebook: Notebook;
   depth: number;
   hasChildren: boolean;
+  disabled?: boolean;
 };
 
 function removeTreeItem(tree: TreeItem[], id: string) {

--- a/apps/mobile/app/utils/notebooks.ts
+++ b/apps/mobile/app/utils/notebooks.ts
@@ -61,6 +61,25 @@ export async function checkParentSelected(
   }
 }
 
+export async function getAllNotebookChildren(id: string, childrenIds: string[] = []) {
+  const relation = await db.relations
+    .from(
+      {
+        id,
+        type: "notebook"
+      },
+      "notebook"
+    )
+    .get()
+  childrenIds.push(...relation.map(rel => rel.toId))
+
+  for (let rel of relation) {
+    await getAllNotebookChildren(rel.toId, childrenIds)
+  }
+  return childrenIds
+
+}
+
 export async function getParentNotebookId(id: string) {
   const relation = await db.relations
     .to(

--- a/apps/mobile/e2e/tests/notebook.e2e.ts
+++ b/apps/mobile/e2e/tests/notebook.e2e.ts
@@ -68,6 +68,32 @@ describe("NOTEBOOKS", () => {
       .run();
   });
 
+  it("Moving notebook should not be moved to child notebook", async () => {
+    await TestBuilder.create()
+      .prepare()
+      .openSideMenu()
+      .waitAndTapById("tab-notebooks")
+      .waitAndTapById("sidebar-add-button")
+      .createNotebook("Notebook 1", true)
+      .wait(500)
+      .longPressByText("Notebook 1")
+      .wait(500)
+      .waitAndTapByText("Add notebook")
+      .createNotebook("Sub notebook", true)
+      .wait(500)
+      .waitAndTapById("expand-notebook-0")
+      .isVisibleByText("Sub notebook")
+      .longPressByText("Notebook 1")
+      .wait(500)
+      .waitAndTapByText("Move notebook")
+      .wait(500)
+      .isNotVisibleByText("Sub notebook")
+      .typeTextById("move-notebook-search", "Sub notebook")
+      .wait(500)
+      .isNotVisibleByText("Sub notebook")
+      .run();
+  });
+
   it("Edit notebook", async () => {
     await TestBuilder.create()
       .prepare()


### PR DESCRIPTION
## Description

Fix parent notebook can be moved into it's child notebooks resulting in cycling references which leads to notebook's disappearing.

1. Ensure notebook that is being moved and all it's children are not visible in move-notebook dialog
2. Ensure child cannot be moved into it's parent and vice versa
3. Ensure child can be moved into it's sibling notebooks
4. Ensure that notebook tree above the notebook that is being moved is visible but disabled where needed.

Closes [https://github.com/streetwriters/notesnook/issues/9644](https://github.com/streetwriters/notesnook/issues/9644)

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [ ] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
