### PR TITLE
Enable CSC_FOR_PULL_REQUEST for desktop preview builds

### DIFF
--- a/.github/workflows/desktop.preview.yml
+++ b/.github/workflows/desktop.preview.yml
@@ -107,6 +107,7 @@ jobs:
           APPLE_API_KEY: ~/private_keys/AuthKey_${{ secrets.api_key_id }}.p8
           APPLE_API_KEY_ID: ${{ secrets.api_key_id }}
           APPLE_API_ISSUER: ${{ secrets.api_key_issuer_id }}
+          CSC_FOR_PULL_REQUEST: true
         run: |
           npm run tx @notesnook/desktop:release
           cd apps/desktop


### PR DESCRIPTION
## Description

Without `CSC_FOR_PULL_REQUEST` macOS desktop builds are not signed which makes them unable to open without jumping through a lot of hoops. Since the desktop preview CI workflow only runs for pull requests in the main repo (no forks allowed), it is a safe workaround.
