### PR TITLE
editor: fix crash when app is unlocked after a relock

### DIFF
--- a/packages/editor/src/hooks/use-editor.ts
+++ b/packages/editor/src/hooks/use-editor.ts
@@ -121,6 +121,7 @@ export const useEditor = (
 function destroyView(view: EditorView) {
   // we override all the methods to prevent any further interaction with the
   // editor, otherwise we'll get errors.
+  view.focus = () => {};
   view.dispatch = () => {};
   view.update = () => {};
   view.updateState = () => {};


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Closes https://github.com/streetwriters/notesnook/issues/9688

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [X] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [ ] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
