### PR TITLE
web: make dates text reactive to date format setting

### DIFF
--- a/apps/web/src/components/note/index.tsx
+++ b/apps/web/src/components/note/index.tsx
@@ -21,7 +21,7 @@ import {
   NoteResolvedData,
   areFeaturesAvailable,
   exportContent,
-  getFormattedDate,
+  formatDate,
   getFormattedReminderTime
 } from "@notesnook/common";
 import {
@@ -56,6 +56,7 @@ import { store as selectionStore } from "../../stores/selection-store";
 import { store as tagStore } from "../../stores/tag-store";
 import { store as userstore } from "../../stores/user-store";
 import { store as appStore } from "../../stores/app-store";
+import { useStore as useSettingStore } from "../../stores/setting-store";
 import { writeToClipboard } from "../../utils/clipboard";
 import { showToast } from "../../utils/toast";
 import IconTag from "../icon-tag";
@@ -103,7 +104,6 @@ import ListItem from "../list-item";
 import { PublishDialog } from "../publish-view";
 import TimeAgo from "../time-ago";
 import { NoteExpiryDateDialog } from "../../dialogs/note-expiry-date-dialog";
-import { withFeatureCheck } from "../../common";
 
 type NoteProps = NoteResolvedData & {
   item: NoteType;
@@ -129,6 +129,7 @@ function Note(props: NoteProps) {
 
   const isOpened = useEditorStore((store) => store.isNoteOpen(item.id));
   const primary: SchemeColors = color ? color.colorCode : "accent-selected";
+  const dateFormat = useSettingStore((store) => store.dateFormat);
 
   return (
     <ListItem
@@ -164,7 +165,9 @@ function Note(props: NoteProps) {
       }
       header={
         <Flex sx={{ alignItems: "center", mb: 1 }}>
-          <Text variant="subBody">{getFormattedDate(date, "date")}</Text>
+          <Text variant="subBody">
+            {formatDate(date, { type: "date", dateFormat })}
+          </Text>
         </Flex>
       }
       footer={
@@ -280,7 +283,10 @@ function Note(props: NoteProps) {
               {note.expiryDate?.value && (
                 <IconTag
                   icon={Destruct}
-                  text={getFormattedDate(note.expiryDate.value, "date")}
+                  text={formatDate(note.expiryDate.value, {
+                    type: "date",
+                    dateFormat
+                  })}
                 />
               )}
             </>

--- a/apps/web/src/components/notebook-header.tsx
+++ b/apps/web/src/components/notebook-header.tsx
@@ -31,10 +31,10 @@ import {
 } from "./icons";
 import { useStore as useNotebookStore } from "../stores/notebook-store";
 import { db } from "../common/db";
-import { getFormattedDate } from "@notesnook/common";
+import { formatDate } from "@notesnook/common";
+import { useStore as useSettingStore } from "../stores/setting-store";
 import { strings } from "@notesnook/intl";
 import { Notebook } from "@notesnook/core";
-import { TITLE_BAR_HEIGHT } from "./title-bar";
 import { Menu } from "../hooks/use-menu";
 
 export function NotebookHeader(props: {
@@ -49,6 +49,7 @@ export function NotebookHeader(props: {
   const [isShortcut, setIsShortcut] = useState(false);
   const shortcuts = useAppStore((store) => store.shortcuts);
   const addToShortcuts = useAppStore((store) => store.addToShortcuts);
+  const dateFormat = useSettingStore((store) => store.dateFormat);
 
   useEffect(() => {
     setIsShortcut(shortcuts.findIndex((p) => p.id === props.notebook.id) > -1);
@@ -100,7 +101,9 @@ export function NotebookHeader(props: {
       {description && <Text variant="body">{description}</Text>}
       <Flex sx={{ alignItems: "center", justifyContent: "space-between" }}>
         <Flex sx={{ alignItems: "center", gap: 2 }}>
-          <Text variant="subBody">{getFormattedDate(dateEdited, "date")}</Text>
+          <Text variant="subBody">
+            {formatDate(dateEdited, { type: "date", dateFormat })}
+          </Text>
           <Text variant="subBody">{strings.notes(totalNotes || 0)}</Text>
         </Flex>
         <Flex sx={{ alignItems: "center", gap: 1 }}>

--- a/apps/web/src/components/properties/index.tsx
+++ b/apps/web/src/components/properties/index.tsx
@@ -48,11 +48,12 @@ import Toggle from "./toggle";
 import { EditNoteCreationDateDialog } from "../../dialogs/edit-note-creation-date-dialog";
 import ScrollContainer from "../scroll-container";
 import {
-  getFormattedDate,
+  formatDate,
   usePromise,
   ResolvedItem,
   useUnresolvedItem
 } from "@notesnook/common";
+import { useStore as useSettingStore } from "../../stores/setting-store";
 import { ScopedThemeProvider } from "../theme-provider";
 import { ListItemWrapper } from "../list-container/list-profiles";
 import { VirtualizedList } from "../virtualized-list";
@@ -103,25 +104,34 @@ type MetadataItem<T extends "dateCreated" | "dateEdited"> = {
   value: (value: number) => string;
 };
 
-const metadataItems = [
-  {
-    key: "dateCreated",
-    label: strings.createdAt(),
-    value: (date) => getFormattedDate(date || Date.now())
-  } as MetadataItem<"dateCreated">,
-  {
-    key: "dateEdited",
-    label: strings.lastEditedAt(),
-    value: (date) => (date ? getFormattedDate(date) : "never")
-  } as MetadataItem<"dateEdited">
-];
-
 type EditorPropertiesProps = {
   sessionId: string;
 };
 function EditorProperties(props: EditorPropertiesProps) {
   const toggleProperties = useEditorStore((store) => store.toggleProperties);
   const isFocusMode = useAppStore((store) => store.isFocusMode);
+  const dateFormat = useSettingStore((store) => store.dateFormat);
+  const timeFormat = useSettingStore((store) => store.timeFormat);
+  const metadataItems = [
+    {
+      key: "dateCreated",
+      label: strings.createdAt(),
+      value: (date: number) =>
+        formatDate(date || Date.now(), {
+          type: "date-time",
+          dateFormat,
+          timeFormat
+        })
+    } as MetadataItem<"dateCreated">,
+    {
+      key: "dateEdited",
+      label: strings.lastEditedAt(),
+      value: (date: number) =>
+        date
+          ? formatDate(date, { type: "date-time", dateFormat, timeFormat })
+          : "never"
+    } as MetadataItem<"dateEdited">
+  ];
   const session = useEditorStore((store) =>
     store.getSession(props.sessionId, [
       "default",

--- a/apps/web/src/components/reminder/index.tsx
+++ b/apps/web/src/components/reminder/index.tsx
@@ -32,12 +32,12 @@ import {
   Trash
 } from "../icons";
 import IconTag from "../icon-tag";
-import { isReminderToday } from "@notesnook/core";
+import { isReminderToday, formatReminderTime } from "@notesnook/core";
 import { hashNavigate } from "../../navigation";
 import { Multiselect } from "../../common/multi-select";
 import { store } from "../../stores/reminder-store";
 import { db } from "../../common/db";
-import { getFormattedReminderTime } from "@notesnook/common";
+import { useStore as useSettingStore } from "../../stores/setting-store";
 import { MenuItem } from "@notesnook/ui";
 import { Reminder as ReminderType } from "@notesnook/core";
 import { ConfirmDialog } from "../../dialogs/confirm";
@@ -67,6 +67,8 @@ function Reminder(props: ReminderProps) {
   const { item, compact } = props;
   const reminder = item as unknown as ReminderType;
   const PriorityIcon = PRIORITY_ICON_MAP[reminder.priority];
+  const dateFormat = useSettingStore((store) => store.dateFormat);
+  const timeFormat = useSettingStore((store) => store.timeFormat);
   return (
     <ListItem
       item={item}
@@ -103,7 +105,10 @@ function Reminder(props: ReminderProps) {
           ) : (
             <IconTag
               icon={Clock}
-              text={getFormattedReminderTime(reminder)}
+              text={formatReminderTime(reminder, false, {
+                dateFormat,
+                timeFormat
+              })}
               highlight={isReminderToday(reminder)}
               testId={"reminder-time"}
             />


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

the following dates text are now reactive:
* dates in note list item
* date in notebook header
* dates in properties panel

## QA Scope

Needs to be only tested on web.
When the date format setting is changed, the dates in the above list should be immediately changed to the new format

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [X] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [ ] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
