### PR TITLE
web: fix RCE via stored XSS in note html export

### DIFF
--- a/apps/web/src/common/export.ts
+++ b/apps/web/src/common/export.ts
@@ -54,6 +54,7 @@ export async function exportToPDF(
     iframe.style.height = "0";
     iframe.style.border = "0";
     iframe.loading = "eager";
+    iframe.sandbox.add("allow-same-origin", "allow-modals");
 
     iframe.onload = async () => {
       if (!iframe.contentWindow) return;

--- a/packages/core/src/utils/templates/html/template.ts
+++ b/packages/core/src/utils/templates/html/template.ts
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import { TemplateData } from "../index.js";
 import { formatDate } from "../../date.js";
+import { escapeUTF8 } from "entities";
 
 export function template(data: TemplateData) {
   return `<!DOCTYPE html>
@@ -28,19 +29,23 @@ export function template(data: TemplateData) {
     <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1" />
     <meta
       name="description"
-      content="${data.headline}"
+      content="${escapeUTF8(data.headline || "")}"
     />
-    <title>${data.title}</title>
+    <title>${escapeUTF8(data.title)}</title>
     <meta name="created-at" content="${formatDate(data.dateCreated)}" />
     <meta name="updated-at" content="${formatDate(data.dateEdited)}" />
     ${data.pinned ? `<meta name="pinned" content="${data.pinned}" />` : ""}
     ${
       data.favorite ? `<meta name="favorite" content="${data.favorite}" />` : ""
     }
-    ${data.color ? `<meta name="color" content="${data.color}" />` : ""}
+    ${
+      data.color
+        ? `<meta name="color" content="${escapeUTF8(data.color)}" />`
+        : ""
+    }
     ${
       data.tags && data.tags.length
-        ? `<meta name="tags" content="${data.tags.join(", ")}" />`
+        ? `<meta name="tags" content="${escapeUTF8(data.tags.join(", "))}" />`
         : ""
     }
     <link rel="stylesheet" href="https://app.notesnook.com/assets/editor-styles.css?d=1690887574068">
@@ -207,7 +212,7 @@ export function template(data: TemplateData) {
     </style>
   </head>
   <body>
-    <h1>${data.title}</h1>
+    <h1>${escapeUTF8(data.title)}</h1>
     ${data.content}
   </body>
 </html>


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Fixes https://github.com/streetwriters/notesnook/security/advisories/GHSA-fjm8-jg78-89h4

* sandbox the export iframe
* escape fields when building html template

## QA Scope

Should be tested on both web and mobile.

If a note's title and headline is a HTML, it should be correctly exported as HTML.
For example, set `RCE test <img onerror="alert('hello');" src=""/> again` as note's title and headline and export the note as PDF/HTML.

Also use similar HTML strings to name colors and tags and then link them to the note. Then export the note as PDF/HTML and it should work as expected

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [X] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [X] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
