### PR TITLE
web: fix pdf viewer's search dialog unreadable UI in dark mode

### DIFF
--- a/apps/web/src/components/pdf-preview/index.tsx
+++ b/apps/web/src/components/pdf-preview/index.tsx
@@ -80,12 +80,30 @@ export function PdfPreview(props: PdfPreviewProps) {
 
                     ".rpv-search__popover label, .rpv-search__popover span": {
                       fontFamily: "body",
-                      fontSize: "body"
+                      fontSize: "body",
+                      color: "paragraph"
                     },
 
                     ".rpv-core__popover-body, .rpv-core__arrow": {
                       bg: "background",
-                      borderColor: "border"
+                      borderColor: "border",
+                      color: "paragraph"
+                    },
+
+                    ".rpv-search__popover .rpv-core__minimal-button": {
+                      color: "icon",
+                      ":hover": {
+                        bg: "hover"
+                      }
+                    },
+
+                    ".rpv-search__popover .rpv-core__button": {
+                      bg: "background-secondary",
+                      color: "paragraph",
+                      border: "none",
+                      ":hover": {
+                        bg: "hover"
+                      }
                     },
 
                     ".rpv-search__popover-label-checkbox": {

--- a/apps/web/src/components/pdf-preview/index.tsx
+++ b/apps/web/src/components/pdf-preview/index.tsx
@@ -22,6 +22,7 @@ import "@react-pdf-viewer/core/lib/styles/index.css";
 import { ToolbarSlot, toolbarPlugin } from "@react-pdf-viewer/toolbar";
 import { Button, Flex, Text } from "@theme-ui/components";
 import { searchPlugin } from "@react-pdf-viewer/search";
+import "@react-pdf-viewer/search/lib/styles/index.css";
 import {
   ChevronDown,
   ChevronUp,
@@ -130,6 +131,10 @@ export function PdfPreview(props: PdfPreviewProps) {
                       ":hover:not(:focus)": {
                         outline: "1.5px solid var(--accent)"
                       }
+                    },
+
+                    ".rpv-search__popover .rpv-core__textbox": {
+                      width: "85% !important"
                     }
                   }}
                 >


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Closes https://github.com/streetwriters/notesnook/issues/6300

<img width="257" height="224" alt="image" src="https://github.com/user-attachments/assets/95ad2c1d-30d5-488d-aef2-5ebb94194fbe" />

## QA Scope

Needs to be tested only on web.

## Type of Change
- [ ] Bug fix
- [ ] Feature

## Visuals
- [X] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [ ] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
