### PR TITLE
web: Beta release track unset after browser exit

### DIFF
--- a/apps/web/src/dialogs/settings/other-settings.ts
+++ b/apps/web/src/dialogs/settings/other-settings.ts
@@ -417,6 +417,6 @@ async function switchReleaseTrack(track: string) {
   if (!registration) return;
   await registration.unregister();
   for (const key of await caches.keys()) await caches.delete(key);
-  document.cookie = `release-track=${track}; Secure; Path=/`;
+  document.cookie = `release-track=${track}; Secure; Path=/; max-age=2147483647`;
   window.location.reload();
 }

--- a/apps/web/src/utils/updater.ts
+++ b/apps/web/src/utils/updater.ts
@@ -27,6 +27,12 @@ export async function checkForUpdate(checkOnDesktop = true) {
   }
 
   if (!IS_DESKTOP_APP) {
+    const releaseTrack = document.cookie.split("; ")
+    .find((row) => row.startsWith(`release-track=`))
+    ?.split("=").slice(1).join("=")
+    if (releaseTrack){
+      document.cookie = `release-track=${releaseTrack}; Secure; Path=/; max-age=2147483647`;
+    }
     AppEventManager.publish(AppEvents.checkingForUpdate);
 
     const registrations =


### PR DESCRIPTION
## Description
Release track cookies are set to expire after the session ends, which means update checks in the future (for example, the user puts their computer to sleep, but leaves the web app open) can erroneously suggest the latest stable while the user is on the beta release track.

Editing to add: Release track is also cleared when the browser exits normally (I just hadn't noticed), so yeah this fixes that too lol

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
How do you test browser-only edge cases like this? Testing shouldn't be needed anyway, since the cookies should now persist.

## Platform
<!-- Describe which platforms this PR is related to -->

- [x] Web
- [ ] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
