### PR TITLE
Add support for disabling 2FA

### DIFF
--- a/apps/mobile/app/components/auth/two-factor.tsx
+++ b/apps/mobile/app/components/auth/two-factor.tsx
@@ -35,11 +35,13 @@ import Heading from "../ui/typography/heading";
 import Paragraph from "../ui/typography/paragraph";
 import { DefaultAppStyles } from "../../utils/styles";
 import { presentDialog } from "../dialog/functions";
+import { AuthenticatorType } from "@notesnook/core";
 
 type MFAInfo = {
-  primaryMethod: string;
-  secondaryMethod: string;
-  token: string;
+  primaryMethod: AuthenticatorType;
+  secondaryMethod?: AuthenticatorType;
+  phoneNumber?: string;
+  redirect: "mfa";
 };
 
 const TwoFactorVerification = ({
@@ -141,7 +143,7 @@ const TwoFactorVerification = ({
       setSending(false);
       ToastManager.error(e as Error, "Error sending 2FA Code", "local");
     }
-  }, [currentMethod.method, mfaInfo.token, seconds, sending, start]);
+  }, [currentMethod.method, seconds, sending, start]);
 
   useEffect(() => {
     if (currentMethod.method === "sms" || currentMethod.method === "email") {

--- a/apps/mobile/app/components/auth/use-login.ts
+++ b/apps/mobile/app/components/auth/use-login.ts
@@ -79,7 +79,7 @@ export const useLogin = (
           }
           const mfaInfo = await db.user.authenticateEmail(email.current);
 
-          if (mfaInfo) {
+          if (mfaInfo.redirect === "mfa") {
             TwoFactorVerification.present(
               async (mfa: any, callback: (success: boolean) => void) => {
                 try {
@@ -113,6 +113,11 @@ export const useLogin = (
                 setStep(LoginSteps.emailAuth);
               }
             );
+          } else if (mfaInfo.redirect === "password") {
+            setStep(LoginSteps.passwordAuth);
+            setTimeout(() => {
+              passwordInputRef.current?.focus();
+            }, 500);
           } else {
             finishWithError(new Error(strings.unableToSend2faCode()));
           }

--- a/apps/mobile/app/screens/settings/settings-data.tsx
+++ b/apps/mobile/app/screens/settings/settings-data.tsx
@@ -66,6 +66,7 @@ import { useUserStore } from "../../stores/use-user-store";
 import {
   eAfterSync,
   eCloseSheet,
+  eCloseSimpleDialog,
   eOpenRecoveryKeyDialog
 } from "../../utils/events";
 import { NotesnookModule } from "../../utils/notesnook-module";
@@ -207,15 +208,15 @@ export const settingsGroups: SettingSection[] = [
             return status === SubscriptionStatus.TRIAL
               ? strings.trialOnGoing(trialEndDate)
               : status === SubscriptionStatus.ACTIVE
-              ? strings.subRenewOn(expiryDate)
-              : status === SubscriptionStatus.CANCELED ||
-                status === SubscriptionStatus.PAUSED
-              ? strings.subEndsOn(expiryDate)
-              : status === SubscriptionStatus.EXPIRED
-              ? subscriptionDaysLeft.time < -3
-                ? strings.subEnded()
-                : strings.accountDowngradedIn(3)
-              : strings.neverHesitate();
+                ? strings.subRenewOn(expiryDate)
+                : status === SubscriptionStatus.CANCELED ||
+                    status === SubscriptionStatus.PAUSED
+                  ? strings.subEndsOn(expiryDate)
+                  : status === SubscriptionStatus.EXPIRED
+                    ? subscriptionDaysLeft.time < -3
+                      ? strings.subEnded()
+                      : strings.accountDowngradedIn(3)
+                    : strings.neverHesitate();
           }
 
           return strings.neverHesitate();
@@ -356,6 +357,67 @@ export const settingsGroups: SettingSection[] = [
             sections: [
               {
                 id: "enable-2fa",
+                type: "switch",
+                name: strings.twoFactorAuth(),
+                useHook: () => useUserStore((state) => state.user),
+                getter: (current) => !!(current as User)?.mfa?.isEnabled,
+                modifer: async (current) => {
+                  const user =
+                    (current as User) || useUserStore.getState().user;
+                  if (!user?.mfa) return;
+
+                  presentDialog({
+                    title: !user.mfa.isEnabled
+                      ? strings.twoFactorEnable()
+                      : strings.twoFactorAuth(),
+                    paragraph: !user.mfa.isEnabled
+                      ? undefined
+                      : strings.verifySubDesc(),
+                    negativeText: strings.cancel(),
+                    positiveText: user.mfa.isEnabled
+                      ? strings.disable()
+                      : strings.enable(),
+                    positiveType: user.mfa.isEnabled ? "errorShade" : undefined,
+                    input: true,
+                    inputPlaceholder: "Enter account password",
+                    positivePress: async (password) => {
+                      const verified = await db.user.verifyPassword(password);
+                      if (!verified) {
+                        ToastManager.show({
+                          message: strings.passwordIncorrect(),
+                          type: "error"
+                        });
+                        return;
+                      }
+                      try {
+                        if (user.mfa.isEnabled) {
+                          await db.mfa.disable();
+                          ToastManager.show({
+                            heading: strings.twoFactorAuthDisabled(),
+                            type: "success"
+                          });
+                          useUserStore
+                            .getState()
+                            .setUser(await db.user.fetchUser());
+                          return;
+                        }
+                        sleep(500).then(() => {
+                          MFASheet.present();
+                        });
+                      } catch (e) {
+                        ToastManager.error(e as Error);
+                      }
+                      return true;
+                    }
+                  });
+                },
+                description: (current) =>
+                  (current as User)?.mfa?.isEnabled
+                    ? strings.accountIsSecure()
+                    : strings.twoFactorAuthDesc()
+              },
+              {
+                id: "change-2fa-primary-method",
                 name: strings.change2faMethod(),
                 modifer: () => {
                   verifyUser("global", async () => {
@@ -363,6 +425,9 @@ export const settingsGroups: SettingSection[] = [
                   });
                 },
                 useHook: () => useUserStore((state) => state.user),
+                hidden: (user) => {
+                  return !(user as User)?.mfa?.isEnabled;
+                },
                 description: strings.change2faMethodDesc()
               },
               {

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@notesnook/mobile",
-  "version": "3.3.19",
+  "version": "3.4.0-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@notesnook/mobile",
-      "version": "3.3.19",
+      "version": "3.4.0-beta.0",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/apps/web/src/dialogs/settings/auth-settings.ts
+++ b/apps/web/src/dialogs/settings/auth-settings.ts
@@ -87,21 +87,42 @@ export const AuthenticationSettings: SettingsGroup[] = [
     header: strings.twoFactorAuth(),
     key: "2fa",
     section: "auth",
+    onStateChange: (listener) =>
+      useUserStore.subscribe((s) => s.user?.mfa, listener),
     settings: [
       {
         key: "2fa-enabled",
-        title: strings.twoFactorAuthEnabled(),
-        description: strings.accountIsSecure(),
+        title: strings.twoFactorAuth(),
+        description: () =>
+          useUserStore.getState().user?.mfa.isEnabled
+            ? strings.accountIsSecure()
+            : strings.twoFactorAuthDesc(),
         keywords: [],
-        components: []
+        components: [
+          {
+            type: "toggle",
+            isToggled: () => !!useUserStore.getState().user?.mfa.isEnabled,
+            toggle: async () => {
+              if (useUserStore.getState().user?.mfa.isEnabled) {
+                await db.mfa.disable();
+                showToast("success", strings.twoFactorAuthDisabled());
+                await useUserStore.getState().refreshUser();
+              } else {
+                await MultifactorDialog.show({});
+                await useUserStore.getState().refreshUser();
+              }
+            }
+          }
+        ]
       },
       {
         key: "primary-2fa-method",
         title: strings.change2faMethod(),
         keywords: ["primary 2fa method"],
         description: strings.twoFactorAuthDesc(),
-        onStateChange: (listener) =>
-          useUserStore.subscribe((s) => s.user?.mfa.primaryMethod, listener),
+        isHidden: () =>
+          !useUserStore.getState().user?.mfa ||
+          !useUserStore.getState().user?.mfa.isEnabled,
         components: [
           {
             type: "button",
@@ -121,8 +142,9 @@ export const AuthenticationSettings: SettingsGroup[] = [
         title: strings.addFallback2faMethod(),
         description: strings.addFallback2faMethodDesc(),
         keywords: ["backup 2fa methods"],
-        onStateChange: (listener) =>
-          useUserStore.subscribe((s) => s.user?.mfa.secondaryMethod, listener),
+        isHidden: () =>
+          !useUserStore.getState().user?.mfa ||
+          !useUserStore.getState().user?.mfa.isEnabled,
         components: () => [
           {
             type: "button",
@@ -147,6 +169,9 @@ export const AuthenticationSettings: SettingsGroup[] = [
         title: strings.viewRecoveryCodes(),
         description: strings.viewRecoveryCodesDesc(),
         keywords: ["recovery codes"],
+        isHidden: () =>
+          !useUserStore.getState().user?.mfa ||
+          !useUserStore.getState().user?.mfa.isEnabled,
         components: [
           {
             type: "button",

--- a/apps/web/src/views/auth.tsx
+++ b/apps/web/src/views/auth.tsx
@@ -251,16 +251,24 @@ function LoginEmail(props: BaseAuthComponentProps<"login:email">) {
         subtitle: strings.authWait()
       }}
       onSubmit={async (form) => {
-        const { primaryMethod, phoneNumber, secondaryMethod } =
-          (await userstore.login(form)) as MFAErrorData;
+        const loginResult = await userstore.login(form);
+        if (typeof loginResult === "boolean" || !loginResult)
+          throw new Error(strings.loginFailed());
 
-        navigate("mfa:code", {
-          email: form.email,
-          selectedMethod: primaryMethod,
-          primaryMethod,
-          phoneNumber,
-          secondaryMethod
-        });
+        if (loginResult.redirect === "mfa") {
+          navigate("mfa:code", {
+            email: form.email,
+            selectedMethod: loginResult.primaryMethod,
+            primaryMethod: loginResult.primaryMethod,
+            phoneNumber: loginResult.phoneNumber,
+            secondaryMethod: loginResult.secondaryMethod
+          });
+        } else {
+          navigate("login:password", {
+            email: form.email,
+            password: ""
+          });
+        }
       }}
     >
       {(form?: EmailFormData) => (
@@ -472,16 +480,24 @@ function SessionExpiry(props: BaseAuthComponentProps<"sessionExpiry">) {
       onSubmit={async () => {
         if (!user) return;
 
-        const { primaryMethod, phoneNumber, secondaryMethod } =
-          (await userstore.login(user)) as MFAErrorData;
+        const loginResult = await userstore.login(user);
+        if (typeof loginResult === "boolean" || !loginResult)
+          throw new Error(strings.loginFailed());
 
-        navigate("mfa:code", {
-          email: user.email,
-          selectedMethod: primaryMethod,
-          primaryMethod,
-          phoneNumber,
-          secondaryMethod
-        });
+        if (loginResult.redirect === "mfa") {
+          navigate("mfa:code", {
+            email: user.email,
+            selectedMethod: loginResult.primaryMethod,
+            primaryMethod: loginResult.primaryMethod,
+            phoneNumber: loginResult.phoneNumber,
+            secondaryMethod: loginResult.secondaryMethod
+          });
+        } else {
+          navigate("login:password", {
+            email: user.email,
+            password: ""
+          });
+        }
       }}
     >
       <AuthField

--- a/packages/core/src/api/token-manager.ts
+++ b/packages/core/src/api/token-manager.ts
@@ -24,6 +24,7 @@ import { withTimeout, Mutex } from "async-mutex";
 import { logger } from "../logger.js";
 import { KVStorageAccessor } from "../interfaces.js";
 import EventManager from "../utils/event-manager.js";
+import { AuthenticatorType } from "../types.js";
 
 export type Token = {
   access_token: string;
@@ -31,6 +32,11 @@ export type Token = {
   expires_in: number;
   scope: string;
   refresh_token: string;
+  additional_data?: {
+    primaryMethod: AuthenticatorType;
+    secondaryMethod?: AuthenticatorType;
+    phoneNumber?: string;
+  };
 };
 
 type Scope = (typeof SCOPES)[number];

--- a/packages/core/src/api/user-manager.ts
+++ b/packages/core/src/api/user-manager.ts
@@ -20,7 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import { User } from "../types.js";
 import http from "../utils/http.js";
 import constants from "../utils/constants.js";
-import TokenManager from "./token-manager.js";
+import TokenManager, { Token } from "./token-manager.js";
 import { EV, EVENTS } from "../common.js";
 import { HealthCheck } from "./healthcheck.js";
 import Database from "./index.js";
@@ -125,14 +125,22 @@ class UserManager {
 
     email = email.toLowerCase();
 
-    const result = await http.post(`${constants.AUTH_HOST}${ENDPOINTS.token}`, {
-      email,
-      grant_type: "email",
-      client_id: "notesnook"
-    });
+    const result = (await http.post(
+      `${constants.AUTH_HOST}${ENDPOINTS.token}`,
+      {
+        email,
+        grant_type: "email",
+        client_id: "notesnook"
+      }
+    )) as Token;
 
     await this.tokenManager.saveToken(result);
-    return result.additional_data;
+    return result.additional_data
+      ? ({
+          redirect: "mfa",
+          ...result.additional_data
+        } as const)
+      : ({ redirect: "password" } as const);
   }
 
   async authenticateMultiFactorCode(code: string, method: string) {
@@ -142,19 +150,18 @@ class UserManager {
     if (!token || token.scope !== "auth:grant_types:mfa")
       throw new Error("No token found.");
 
-    await this.tokenManager.saveToken(
-      await http.post(
-        `${constants.AUTH_HOST}${ENDPOINTS.token}`,
-        {
-          grant_type: "mfa",
-          client_id: "notesnook",
-          "mfa:code": code,
-          "mfa:method": method
-        },
-        token.access_token
-      )
+    const result = await http.post(
+      `${constants.AUTH_HOST}${ENDPOINTS.token}`,
+      {
+        grant_type: "mfa",
+        client_id: "notesnook",
+        "mfa:code": code,
+        "mfa:method": method
+      },
+      token.access_token
     );
-    return true;
+    await this.tokenManager.saveToken(result);
+    return { redirect: "password" } as const;
   }
 
   async authenticatePassword(

--- a/packages/intl/locale/en.po
+++ b/packages/intl/locale/en.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2025-09-22 09:18+0500\n"
+"POT-Creation-Date: 2026-04-24 10:46+0500\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -2607,6 +2607,10 @@ msgstr "Enable regex"
 #: src/strings.ts:2130
 msgid "Enable spell checker"
 msgstr "Enable spell checker"
+
+#: src/strings.ts:2715
+msgid "Enable two factor authentication"
+msgstr "Enable two factor authentication"
 
 #: src/strings.ts:496
 msgid "Enable two-factor authentication to add an extra layer of security to your account."
@@ -6820,6 +6824,10 @@ msgstr "This username will be used to distinguish between different credentials 
 #: src/strings.ts:1306
 msgid "This version of Notesnook app does not support in-app purchases. Kindly login on the Notesnook web app to make the purchase."
 msgstr "This version of Notesnook app does not support in-app purchases. Kindly login on the Notesnook web app to make the purchase."
+
+#: src/strings.ts:2714
+msgid "This will reset your current two-factor authentication setup. Do you want to proceed?"
+msgstr "This will reset your current two-factor authentication setup. Do you want to proceed?"
 
 #: src/strings.ts:627
 msgid "Thu"

--- a/packages/intl/locale/en.po
+++ b/packages/intl/locale/en.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/strings.ts:2412
+#: src/strings.ts:2413
 msgid " \"Notebook > Notes\""
 msgstr " \"Notebook > Notes\""
 
@@ -21,27 +21,27 @@ msgstr " \"Notebook > Notes\""
 msgid " Unlock with password once to enable biometric access."
 msgstr " Unlock with password once to enable biometric access."
 
-#: src/strings.ts:1943
+#: src/strings.ts:1944
 msgid " Upgrade to Notesnook Pro to add more notebooks."
 msgstr " Upgrade to Notesnook Pro to add more notebooks."
 
-#: src/strings.ts:1946
+#: src/strings.ts:1947
 msgid " Upgrade to Notesnook Pro to customize the toolbar."
 msgstr " Upgrade to Notesnook Pro to customize the toolbar."
 
-#: src/strings.ts:1945
+#: src/strings.ts:1946
 msgid " Upgrade to Notesnook Pro to use custom toolbar presets."
 msgstr " Upgrade to Notesnook Pro to use custom toolbar presets."
 
-#: src/strings.ts:1944
+#: src/strings.ts:1945
 msgid " Upgrade to Notesnook Pro to use the notes vault."
 msgstr " Upgrade to Notesnook Pro to use the notes vault."
 
-#: src/strings.ts:1947
+#: src/strings.ts:1948
 msgid " Upgrade to Notesnook Pro to use this feature."
 msgstr " Upgrade to Notesnook Pro to use this feature."
 
-#: src/strings.ts:828
+#: src/strings.ts:829
 msgid "— not just the"
 msgstr "— not just the"
 
@@ -59,24 +59,24 @@ msgid "{0}"
 msgstr "{0}"
 
 #. placeholder {0}: name || "File"
-#: src/strings.ts:515
+#: src/strings.ts:516
 msgid "{0} downloaded"
 msgstr "{0} downloaded"
 
 #. placeholder {0}: version ? `v${version} ` : "New version"
-#: src/strings.ts:533
+#: src/strings.ts:534
 msgid "{0} Highlights 🎉"
 msgstr "{0} Highlights 🎉"
 
-#: src/strings.ts:1755
+#: src/strings.ts:1756
 msgid "{count, plural, one {# error occured} other {# errors occured}}"
 msgstr "{count, plural, one {# error occured} other {# errors occured}}"
 
-#: src/strings.ts:1761
+#: src/strings.ts:1762
 msgid "{count, plural, one {# file ready for import} other {# files ready for import}}"
 msgstr "{count, plural, one {# file ready for import} other {# files ready for import}}"
 
-#: src/strings.ts:1716
+#: src/strings.ts:1717
 msgid "{count, plural, one {# file} other {# files}}"
 msgstr "{count, plural, one {# file} other {# files}}"
 
@@ -84,11 +84,11 @@ msgstr "{count, plural, one {# file} other {# files}}"
 msgid "{count, plural, one {# note} other {# notes}}"
 msgstr "{count, plural, one {# note} other {# notes}}"
 
-#: src/strings.ts:1580
+#: src/strings.ts:1581
 msgid "{count, plural, one {1 hour} other {# hours}}"
 msgstr "{count, plural, one {1 hour} other {# hours}}"
 
-#: src/strings.ts:1575
+#: src/strings.ts:1576
 msgid "{count, plural, one {1 minute} other {# minutes}}"
 msgstr "{count, plural, one {1 minute} other {# minutes}}"
 
@@ -129,7 +129,7 @@ msgstr "{count, plural, one {Are you sure you want to delete this tag?} other {A
 msgid "{count, plural, one {Are you sure you want to download all attachments of this note?} other {Are you sure you want to download all attachments?}}"
 msgstr "{count, plural, one {Are you sure you want to download all attachments of this note?} other {Are you sure you want to download all attachments?}}"
 
-#: src/strings.ts:863
+#: src/strings.ts:864
 msgid "{count, plural, one {Are you sure you want to move this notebook to {selectedNotebookTitle}?} other {Are you sure you want to move these # notebooks {selectedNotebookTitle}?}}"
 msgstr "{count, plural, one {Are you sure you want to move this notebook to {selectedNotebookTitle}?} other {Are you sure you want to move these # notebooks {selectedNotebookTitle}?}}"
 
@@ -288,11 +288,11 @@ msgstr "{count, plural, one {Item restored} other {# items restored}}"
 msgid "{count, plural, one {Item unpublished} other {# items unpublished}}"
 msgstr "{count, plural, one {Item unpublished} other {# items unpublished}}"
 
-#: src/strings.ts:2429
+#: src/strings.ts:2430
 msgid "{count, plural, one {Move all notes in this notebook to trash} other {Move all notes in these notebooks to trash}}"
 msgstr "{count, plural, one {Move all notes in this notebook to trash} other {Move all notes in these notebooks to trash}}"
 
-#: src/strings.ts:861
+#: src/strings.ts:862
 msgid "{count, plural, one {Move notebook} other {Move # notebooks}}"
 msgstr "{count, plural, one {Move notebook} other {Move # notebooks}}"
 
@@ -336,7 +336,7 @@ msgstr "{count, plural, one {Note restored} other {# notes restored}}"
 msgid "{count, plural, one {Note unpublished} other {# notes unpublished}}"
 msgstr "{count, plural, one {Note unpublished} other {# notes unpublished}}"
 
-#: src/strings.ts:922
+#: src/strings.ts:923
 msgid "{count, plural, one {Note will be automatically deleted from all other devices & any future changes won't get synced. Are you sure you want to continue?} other {# notes will be automatically deleted from all other devices & any future changes won't get synced. Are you sure you want to continue?}}"
 msgstr "{count, plural, one {Note will be automatically deleted from all other devices & any future changes won't get synced. Are you sure you want to continue?} other {# notes will be automatically deleted from all other devices & any future changes won't get synced. Are you sure you want to continue?}}"
 
@@ -390,7 +390,7 @@ msgstr "{count, plural, one {Pin note} other {Pin # notes}}"
 msgid "{count, plural, one {Pin notebook} other {Pin # notebooks}}"
 msgstr "{count, plural, one {Pin notebook} other {Pin # notebooks}}"
 
-#: src/strings.ts:917
+#: src/strings.ts:918
 msgid "{count, plural, one {Prevent note from syncing} other {Prevent # notes from syncing}}"
 msgstr "{count, plural, one {Prevent note from syncing} other {Prevent # notes from syncing}}"
 
@@ -491,15 +491,15 @@ msgstr "{count, plural, one {Unpublish item} other {Unpublish # items}}"
 msgid "{count, plural, one {Unpublish note} other {Unpublish # notes}}"
 msgstr "{count, plural, one {Unpublish note} other {Unpublish # notes}}"
 
-#: src/strings.ts:2499
+#: src/strings.ts:2500
 msgid "{count} characters"
 msgstr "{count} characters"
 
-#: src/strings.ts:1566
+#: src/strings.ts:1567
 msgid "{days, plural, one {1 day} other {# days}}"
 msgstr "{days, plural, one {1 day} other {# days}}"
 
-#: src/strings.ts:2559
+#: src/strings.ts:2560
 msgid "{days} days free"
 msgstr "{days} days free"
 
@@ -531,27 +531,27 @@ msgstr "{key, select, dateCreated {Created at} dateEdited {Last edited at} dateM
 msgid "{mode, select, create {Create app lock {keyboardType}} change {Change app lock {keyboardType}} remove {Remove app lock {keyboardType}} other {}}"
 msgstr "{mode, select, create {Create app lock {keyboardType}} change {Change app lock {keyboardType}} remove {Remove app lock {keyboardType}} other {}}"
 
-#: src/strings.ts:605
+#: src/strings.ts:606
 msgid "{mode, select, day {Daily} week {Weekly} month {Monthly} year {Yearly} other {Unknown mode}}"
 msgstr "{mode, select, day {Daily} week {Weekly} month {Monthly} year {Yearly} other {Unknown mode}}"
 
-#: src/strings.ts:598
+#: src/strings.ts:599
 msgid "{mode, select, repeat {Repeat} once {Once} permanent {Permanent} other {Unknown mode}}"
 msgstr "{mode, select, repeat {Repeat} once {Once} permanent {Permanent} other {Unknown mode}}"
 
-#: src/strings.ts:1978
+#: src/strings.ts:1979
 msgid "{n} {added, plural, one {added to 1 notebook} other {added to # notebooks}} and {removed, plural, one {removed from 1 notebook} other {removed from # notebooks}}."
 msgstr "{n} {added, plural, one {added to 1 notebook} other {added to # notebooks}} and {removed, plural, one {removed from 1 notebook} other {removed from # notebooks}}."
 
-#: src/strings.ts:1973
+#: src/strings.ts:1974
 msgid "{n} {added, plural, one {added to 1 notebook} other {added to # notebooks}}."
 msgstr "{n} {added, plural, one {added to 1 notebook} other {added to # notebooks}}."
 
-#: src/strings.ts:1968
+#: src/strings.ts:1969
 msgid "{n} {removed, plural, one {removed from 1 notebook} other {removed from # notebooks}}."
 msgstr "{n} {removed, plural, one {removed from 1 notebook} other {removed from # notebooks}}."
 
-#: src/strings.ts:1963
+#: src/strings.ts:1964
 msgid "{notes, plural, one {1 note} other {# notes}}"
 msgstr "{notes, plural, one {1 note} other {# notes}}"
 
@@ -559,23 +559,23 @@ msgstr "{notes, plural, one {1 note} other {# notes}}"
 msgid "{notes, plural, one {Export note} other {Export # notes}}"
 msgstr "{notes, plural, one {Export note} other {Export # notes}}"
 
-#: src/strings.ts:1708
+#: src/strings.ts:1709
 msgid "{percentage}% updating..."
 msgstr "{percentage}% updating..."
 
-#: src/strings.ts:2543
+#: src/strings.ts:2544
 msgid "{plan} plan"
 msgstr "{plan} plan"
 
-#: src/strings.ts:743
+#: src/strings.ts:744
 msgid "{platform, select, android {{name} saved to selected path} other {{name} saved to File Manager/Notesnook/downloads}}"
 msgstr "{platform, select, android {{name} saved to selected path} other {{name} saved to File Manager/Notesnook/downloads}}"
 
-#: src/strings.ts:1339
+#: src/strings.ts:1340
 msgid "{platform, select, android {Backup file saved in \"Notesnook backups\" folder on your phone.} other {Backup file is saved in File Manager/Notesnook folder}}"
 msgstr "{platform, select, android {Backup file saved in \"Notesnook backups\" folder on your phone.} other {Backup file is saved in File Manager/Notesnook folder}}"
 
-#: src/strings.ts:2359
+#: src/strings.ts:2360
 msgid "{selected} selected"
 msgstr "{selected} selected"
 
@@ -591,67 +591,75 @@ msgstr "{type, select, other {This list is empty} notebook {No notebooks} tag {N
 msgid "{type, select, upload {Uploading} download {Downloading} sync {Syncing} other {Loading}}"
 msgstr "{type, select, upload {Uploading} download {Downloading} sync {Syncing} other {Loading}}"
 
-#: src/strings.ts:785
+#: src/strings.ts:786
 msgid "{type} does not match"
 msgstr "{type} does not match"
 
-#: src/strings.ts:1601
+#: src/strings.ts:1602
 msgid "{words, plural, one {# word} other {# words}}"
 msgstr "{words, plural, one {# word} other {# words}}"
 
-#: src/strings.ts:1664
+#: src/strings.ts:1665
 msgid "{words, plural, other {# selected}}"
 msgstr "{words, plural, other {# selected}}"
 
-#: src/strings.ts:1792
+#: src/strings.ts:1793
 msgid "#notesnook"
 msgstr "#notesnook"
 
-#: src/strings.ts:2665
+#: src/strings.ts:2666
 msgid "1 day"
 msgstr "1 day"
 
-#: src/strings.ts:2667
+#: src/strings.ts:2668
 msgid "1 month"
 msgstr "1 month"
 
-#: src/strings.ts:2666
+#: src/strings.ts:2667
 msgid "1 week"
 msgstr "1 week"
 
-#: src/strings.ts:2668
+#: src/strings.ts:2669
 msgid "1 year"
 msgstr "1 year"
 
-#: src/strings.ts:1585
+#: src/strings.ts:1586
 msgid "12-hour"
 msgstr "12-hour"
 
-#: src/strings.ts:1586
+#: src/strings.ts:1587
 msgid "24-hour"
 msgstr "24-hour"
 
-#: src/strings.ts:1906
+#: src/strings.ts:1008
+msgid "2FA backup codes copied!"
+msgstr "2FA backup codes copied!"
+
+#: src/strings.ts:1013
+msgid "2FA backup codes saved!"
+msgstr "2FA backup codes saved!"
+
+#: src/strings.ts:1907
 msgid "2FA code is required()"
 msgstr "2FA code is required()"
 
-#: src/strings.ts:1010
+#: src/strings.ts:1011
 msgid "2FA code sent via {method}"
 msgstr "2FA code sent via {method}"
 
-#: src/strings.ts:2583
+#: src/strings.ts:2584
 msgid "5 year plan (One time purchase)"
 msgstr "5 year plan (One time purchase)"
 
-#: src/strings.ts:1847
+#: src/strings.ts:1848
 msgid "6 digit code"
 msgstr "6 digit code"
 
-#: src/strings.ts:1433
+#: src/strings.ts:1434
 msgid "A notebook can have unlimited topics with unlimited notes."
 msgstr "A notebook can have unlimited topics with unlimited notes."
 
-#: src/strings.ts:647
+#: src/strings.ts:648
 msgid "A to Z"
 msgstr "A to Z"
 
@@ -659,71 +667,71 @@ msgstr "A to Z"
 msgid "A vault stores your notes in an encrypted storage."
 msgstr "A vault stores your notes in an encrypted storage."
 
-#: src/strings.ts:662
+#: src/strings.ts:663
 msgid "Abc"
 msgstr "Abc"
 
-#: src/strings.ts:1291
+#: src/strings.ts:1292
 msgid "About"
 msgstr "About"
 
-#: src/strings.ts:1026
+#: src/strings.ts:1027
 msgid "Account"
 msgstr "Account"
 
-#: src/strings.ts:1849
+#: src/strings.ts:1850
 msgid "Account password"
 msgstr "Account password"
 
-#: src/strings.ts:2454
+#: src/strings.ts:2455
 msgid "Actions for note: {title}"
 msgstr "Actions for note: {title}"
 
-#: src/strings.ts:2455
+#: src/strings.ts:2456
 msgid "Actions for notebook: {title}"
 msgstr "Actions for notebook: {title}"
 
-#: src/strings.ts:2456
+#: src/strings.ts:2457
 msgid "Actions for tag: {title}"
 msgstr "Actions for tag: {title}"
 
-#: src/strings.ts:2039
+#: src/strings.ts:2040
 msgid "Activate"
 msgstr "Activate"
 
-#: src/strings.ts:1825
+#: src/strings.ts:1826
 msgid "Activating trial"
 msgstr "Activating trial"
 
-#: src/strings.ts:530
+#: src/strings.ts:531
 msgid "Add"
 msgstr "Add"
 
-#: src/strings.ts:1058
+#: src/strings.ts:1059
 msgid "Add 2FA fallback method"
 msgstr "Add 2FA fallback method"
 
-#: src/strings.ts:1509
+#: src/strings.ts:1510
 msgid "Add a short note"
 msgstr "Add a short note"
 
-#: src/strings.ts:1602
+#: src/strings.ts:1603
 msgid "Add a tag"
 msgstr "Add a tag"
 
-#: src/strings.ts:557
+#: src/strings.ts:558
 msgid "Add color"
 msgstr "Add color"
 
-#: src/strings.ts:2653
+#: src/strings.ts:2654
 msgid "Add key"
 msgstr "Add key"
 
-#: src/strings.ts:895
+#: src/strings.ts:896
 msgid "Add notebook"
 msgstr "Add notebook"
 
-#: src/strings.ts:2481
+#: src/strings.ts:2482
 msgid "Add notes"
 msgstr "Add notes"
 
@@ -731,71 +739,71 @@ msgstr "Add notes"
 msgid "Add notes to {title}"
 msgstr "Add notes to {title}"
 
-#: src/strings.ts:894
+#: src/strings.ts:895
 msgid "Add shortcut"
 msgstr "Add shortcut"
 
-#: src/strings.ts:737
+#: src/strings.ts:738
 msgid "Add shortcuts for notebooks and tags here."
 msgstr "Add shortcuts for notebooks and tags here."
 
-#: src/strings.ts:572
+#: src/strings.ts:573
 msgid "Add tag"
 msgstr "Add tag"
 
-#: src/strings.ts:935
+#: src/strings.ts:936
 msgid "Add tags"
 msgstr "Add tags"
 
-#: src/strings.ts:936
+#: src/strings.ts:937
 msgid "Add tags to multiple notes at once"
 msgstr "Add tags to multiple notes at once"
 
-#: src/strings.ts:2246
+#: src/strings.ts:2247
 msgid "Add to dictionary"
 msgstr "Add to dictionary"
 
-#: src/strings.ts:2616
+#: src/strings.ts:2617
 msgid "Add to home"
 msgstr "Add to home"
 
-#: src/strings.ts:2479
+#: src/strings.ts:2480
 msgid "Add to notebook"
 msgstr "Add to notebook"
 
-#: src/strings.ts:976
+#: src/strings.ts:977
 msgid "Add your first note"
 msgstr "Add your first note"
 
-#: src/strings.ts:977
+#: src/strings.ts:978
 msgid "Add your first notebook"
 msgstr "Add your first notebook"
 
-#: src/strings.ts:2619
+#: src/strings.ts:2620
 msgid "Adjust the line height of the editor"
 msgstr "Adjust the line height of the editor"
 
-#: src/strings.ts:2173
+#: src/strings.ts:2174
 msgid "Advanced"
 msgstr "Advanced"
 
-#: src/strings.ts:1728
+#: src/strings.ts:1729
 msgid "After scanning the QR code image, the app will display a code that you can enter below."
 msgstr "After scanning the QR code image, the app will display a code that you can enter below."
 
-#: src/strings.ts:2311
+#: src/strings.ts:2312
 msgid "Align left"
 msgstr "Align left"
 
-#: src/strings.ts:2312
+#: src/strings.ts:2313
 msgid "Align right"
 msgstr "Align right"
 
-#: src/strings.ts:2281
+#: src/strings.ts:2282
 msgid "Alignment"
 msgstr "Alignment"
 
-#: src/strings.ts:726
+#: src/strings.ts:727
 msgid "All"
 msgstr "All"
 
@@ -803,35 +811,35 @@ msgstr "All"
 msgid "All attachments are end-to-end encrypted."
 msgstr "All attachments are end-to-end encrypted."
 
-#: src/strings.ts:2406
+#: src/strings.ts:2407
 msgid "All cached attachments have been cleared."
 msgstr "All cached attachments have been cleared."
 
-#: src/strings.ts:767
+#: src/strings.ts:768
 msgid "All fields are required"
 msgstr "All fields are required"
 
-#: src/strings.ts:754
+#: src/strings.ts:755
 msgid "All files"
 msgstr "All files"
 
-#: src/strings.ts:1176
+#: src/strings.ts:1177
 msgid "All locked notes will be re-encrypted with the new password."
 msgstr "All locked notes will be re-encrypted with the new password."
 
-#: src/strings.ts:739
+#: src/strings.ts:740
 msgid "All logs are local only and are not sent to any server. You can share the logs from here with us if you face an issue to help us find the root cause."
 msgstr "All logs are local only and are not sent to any server. You can share the logs from here with us if you face an issue to help us find the root cause."
 
-#: src/strings.ts:1639
+#: src/strings.ts:1640
 msgid "All server urls are required."
 msgstr "All server urls are required."
 
-#: src/strings.ts:1908
+#: src/strings.ts:1909
 msgid "All the data in your account will be overwritten with the data in the backup file. There is no way to reverse this action."
 msgstr "All the data in your account will be overwritten with the data in the backup file. There is no way to reverse this action."
 
-#: src/strings.ts:2153
+#: src/strings.ts:2154
 msgid "All the source code for Notesnook is available & open for everyone on GitHub."
 msgstr "All the source code for Notesnook is available & open for everyone on GitHub."
 
@@ -839,15 +847,15 @@ msgstr "All the source code for Notesnook is available & open for everyone on Gi
 msgid "All tools are grouped"
 msgstr "All tools are grouped"
 
-#: src/strings.ts:1323
+#: src/strings.ts:1324
 msgid "All tools in the collapsed section will be removed"
 msgstr "All tools in the collapsed section will be removed"
 
-#: src/strings.ts:1318
+#: src/strings.ts:1319
 msgid "All tools in this group will be removed from the toolbar."
 msgstr "All tools in this group will be removed from the toolbar."
 
-#: src/strings.ts:1348
+#: src/strings.ts:1349
 msgid "All your backups are stored in 'Phone Storage/Notesnook/backups/' folder"
 msgstr "All your backups are stored in 'Phone Storage/Notesnook/backups/' folder"
 
@@ -855,7 +863,7 @@ msgstr "All your backups are stored in 'Phone Storage/Notesnook/backups/' folder
 msgid "Already have an account?"
 msgstr "Already have an account?"
 
-#: src/strings.ts:2223
+#: src/strings.ts:2224
 msgid "Amount"
 msgstr "Amount"
 
@@ -863,7 +871,7 @@ msgstr "Amount"
 msgid "An error occurred while migrating your data. You can logout of your account and try to relogin. However this is not recommended as it may result in some data loss if your data was not synced."
 msgstr "An error occurred while migrating your data. You can logout of your account and try to relogin. However this is not recommended as it may result in some data loss if your data was not synced."
 
-#: src/strings.ts:2577
+#: src/strings.ts:2578
 msgid "and"
 msgstr "and"
 
@@ -871,39 +879,39 @@ msgstr "and"
 msgid "and "
 msgstr "and "
 
-#: src/strings.ts:1793
+#: src/strings.ts:1794
 msgid "and get a chance to win free promo codes."
 msgstr "and get a chance to win free promo codes."
 
-#: src/strings.ts:2536
+#: src/strings.ts:2537
 msgid "and much more."
 msgstr "and much more."
 
-#: src/strings.ts:1399
+#: src/strings.ts:1400
 msgid "and we will manually confirm your account."
 msgstr "and we will manually confirm your account."
 
-#: src/strings.ts:2594
+#: src/strings.ts:2595
 msgid "ANNOUNCEMENT"
 msgstr "ANNOUNCEMENT"
 
-#: src/strings.ts:2683
+#: src/strings.ts:2684
 msgid "API key copied to clipboard"
 msgstr "API key copied to clipboard"
 
-#: src/strings.ts:2661
+#: src/strings.ts:2662
 msgid "API key created successfully"
 msgstr "API key created successfully"
 
-#: src/strings.ts:2688
+#: src/strings.ts:2689
 msgid "API key revoked"
 msgstr "API key revoked"
 
-#: src/strings.ts:2654
+#: src/strings.ts:2655
 msgid "API Keys"
 msgstr "API Keys"
 
-#: src/strings.ts:2675
+#: src/strings.ts:2676
 msgid "API Keys Limit Reached"
 msgstr "API Keys Limit Reached"
 
@@ -911,37 +919,37 @@ msgstr "API Keys Limit Reached"
 msgid "App data has been cleared. Kindly relaunch the app to login again."
 msgstr "App data has been cleared. Kindly relaunch the app to login again."
 
-#: src/strings.ts:1185
-#: src/strings.ts:1695
+#: src/strings.ts:1186
+#: src/strings.ts:1696
 msgid "App lock"
 msgstr "App lock"
 
-#: src/strings.ts:781
-#: src/strings.ts:1211
+#: src/strings.ts:782
+#: src/strings.ts:1212
 msgid "App lock disabled"
 msgstr "App lock disabled"
 
-#: src/strings.ts:1191
+#: src/strings.ts:1192
 msgid "App lock timeout"
 msgstr "App lock timeout"
 
-#: src/strings.ts:1302
+#: src/strings.ts:1303
 msgid "App version"
 msgstr "App version"
 
-#: src/strings.ts:1776
+#: src/strings.ts:1777
 msgid "App will reload in {sec} seconds"
 msgstr "App will reload in {sec} seconds"
 
-#: src/strings.ts:1116
+#: src/strings.ts:1117
 msgid "Appearance"
 msgstr "Appearance"
 
-#: src/strings.ts:539
+#: src/strings.ts:540
 msgid "Applied as dark theme"
 msgstr "Applied as dark theme"
 
-#: src/strings.ts:540
+#: src/strings.ts:541
 msgid "Applied as light theme"
 msgstr "Applied as light theme"
 
@@ -949,60 +957,60 @@ msgstr "Applied as light theme"
 msgid "Apply changes"
 msgstr "Apply changes"
 
-#: src/strings.ts:2046
+#: src/strings.ts:2047
 msgid "Applying changes"
 msgstr "Applying changes"
 
-#: src/strings.ts:1532
-#: src/strings.ts:2486
+#: src/strings.ts:1533
+#: src/strings.ts:2487
 msgid "Archive"
 msgstr "Archive"
 
-#: src/strings.ts:1447
+#: src/strings.ts:1448
 msgid "Are you scrolling a lot to find a specific note? Pin it to the top from Note properties."
 msgstr "Are you scrolling a lot to find a specific note? Pin it to the top from Note properties."
 
-#: src/strings.ts:1018
+#: src/strings.ts:1019
 msgid "Are you sure you want to clear all logs from {key}?"
 msgstr "Are you sure you want to clear all logs from {key}?"
 
-#: src/strings.ts:1326
+#: src/strings.ts:1327
 msgid "Are you sure you want to clear trash?"
 msgstr "Are you sure you want to clear trash?"
 
-#: src/strings.ts:1544
+#: src/strings.ts:1545
 msgid "Are you sure you want to logout and clear all data stored on THIS DEVICE?"
 msgstr "Are you sure you want to logout and clear all data stored on THIS DEVICE?"
 
-#: src/strings.ts:775
+#: src/strings.ts:776
 msgid "Are you sure you want to logout from this device? Any unsynced changes will be lost."
 msgstr "Are you sure you want to logout from this device? Any unsynced changes will be lost."
 
-#: src/strings.ts:1048
+#: src/strings.ts:1049
 msgid "Are you sure you want to remove your name?"
 msgstr "Are you sure you want to remove your name?"
 
-#: src/strings.ts:1045
+#: src/strings.ts:1046
 msgid "Are you sure you want to remove your profile picture?"
 msgstr "Are you sure you want to remove your profile picture?"
 
-#: src/strings.ts:2687
+#: src/strings.ts:2688
 msgid "Are you sure you want to revoke the key \"{name}\"? All inbox actions using this key will stop working immediately."
 msgstr "Are you sure you want to revoke the key \"{name}\"? All inbox actions using this key will stop working immediately."
 
-#: src/strings.ts:1325
+#: src/strings.ts:1326
 msgid "Are you sure?"
 msgstr "Are you sure?"
 
-#: src/strings.ts:1132
+#: src/strings.ts:1133
 msgid "Ask every time"
 msgstr "Ask every time"
 
-#: src/strings.ts:2035
+#: src/strings.ts:2036
 msgid "Assign color"
 msgstr "Assign color"
 
-#: src/strings.ts:934
+#: src/strings.ts:935
 msgid "Assign to..."
 msgstr "Assign to..."
 
@@ -1010,11 +1018,11 @@ msgstr "Assign to..."
 msgid "Atleast 8 characters required"
 msgstr "Atleast 8 characters required"
 
-#: src/strings.ts:2348
+#: src/strings.ts:2349
 msgid "Attach image from URL"
 msgstr "Attach image from URL"
 
-#: src/strings.ts:908
+#: src/strings.ts:909
 msgid "Attached files"
 msgstr "Attached files"
 
@@ -1023,23 +1031,23 @@ msgid "attachment"
 msgstr "attachment"
 
 #: src/strings.ts:300
-#: src/strings.ts:2345
+#: src/strings.ts:2346
 msgid "Attachment"
 msgstr "Attachment"
 
-#: src/strings.ts:2449
+#: src/strings.ts:2450
 msgid "Attachment manager"
 msgstr "Attachment manager"
 
-#: src/strings.ts:1937
+#: src/strings.ts:1938
 msgid "Attachment preview failed"
 msgstr "Attachment preview failed"
 
-#: src/strings.ts:2399
+#: src/strings.ts:2400
 msgid "Attachment recheck cancelled"
 msgstr "Attachment recheck cancelled"
 
-#: src/strings.ts:2316
+#: src/strings.ts:2317
 msgid "Attachment settings"
 msgstr "Attachment settings"
 
@@ -1048,184 +1056,184 @@ msgid "attachments"
 msgstr "attachments"
 
 #: src/strings.ts:320
-#: src/strings.ts:907
+#: src/strings.ts:908
 msgid "Attachments"
 msgstr "Attachments"
 
-#: src/strings.ts:1886
+#: src/strings.ts:1887
 msgid "Attachments cache cleared!"
 msgstr "Attachments cache cleared!"
 
-#: src/strings.ts:2401
+#: src/strings.ts:2402
 msgid "Attachments recheck complete"
 msgstr "Attachments recheck complete"
 
-#: src/strings.ts:760
+#: src/strings.ts:761
 msgid "Audios"
 msgstr "Audios"
 
-#: src/strings.ts:1628
+#: src/strings.ts:1629
 msgid "Auth server"
 msgstr "Auth server"
 
-#: src/strings.ts:2681
+#: src/strings.ts:2682
 msgid "Authenticate"
 msgstr "Authenticate"
 
-#: src/strings.ts:2678
+#: src/strings.ts:2679
 msgid "Authenticate to view API key"
 msgstr "Authenticate to view API key"
 
-#: src/strings.ts:1797
+#: src/strings.ts:1798
 msgid "Authenticated as {email}"
 msgstr "Authenticated as {email}"
 
-#: src/strings.ts:1900
+#: src/strings.ts:1901
 msgid "Authenticating user"
 msgstr "Authenticating user"
 
-#: src/strings.ts:2136
+#: src/strings.ts:2137
 msgid "Authentication"
 msgstr "Authentication"
 
-#: src/strings.ts:1732
+#: src/strings.ts:1733
 msgid "authentication app"
 msgstr "authentication app"
 
-#: src/strings.ts:1353
+#: src/strings.ts:1354
 msgid "Authentication cancelled by user"
 msgstr "Authentication cancelled by user"
 
-#: src/strings.ts:1354
+#: src/strings.ts:1355
 msgid "Authentication failed"
 msgstr "Authentication failed"
 
-#: src/strings.ts:2099
+#: src/strings.ts:2100
 msgid "Auto"
 msgstr "Auto"
 
-#: src/strings.ts:1663
+#: src/strings.ts:1664
 msgid "Auto save: off"
 msgstr "Auto save: off"
 
-#: src/strings.ts:2113
+#: src/strings.ts:2114
 msgid "Auto start on system startup"
 msgstr "Auto start on system startup"
 
-#: src/strings.ts:1220
-#: src/strings.ts:1691
+#: src/strings.ts:1221
+#: src/strings.ts:1692
 msgid "Automatic backups"
 msgstr "Automatic backups"
 
-#: src/strings.ts:1367
+#: src/strings.ts:1368
 msgid "Automatic backups are off"
 msgstr "Automatic backups are off"
 
-#: src/strings.ts:2007
+#: src/strings.ts:2008
 msgid "Automatic backups disabled"
 msgstr "Automatic backups disabled"
 
-#: src/strings.ts:1223
+#: src/strings.ts:1224
 msgid "Automatic backups with attachments"
 msgstr "Automatic backups with attachments"
 
-#: src/strings.ts:2109
+#: src/strings.ts:2110
 msgid "Automatic updates"
 msgstr "Automatic updates"
 
-#: src/strings.ts:1140
+#: src/strings.ts:1141
 msgid "Automatically clear trash after a certain period of time"
 msgstr "Automatically clear trash after a certain period of time"
 
-#: src/strings.ts:2111
+#: src/strings.ts:2112
 msgid "Automatically download & install updates in the background without prompting first."
 msgstr "Automatically download & install updates in the background without prompting first."
 
-#: src/strings.ts:1193
+#: src/strings.ts:1194
 msgid "Automatically lock the app after a certain period"
 msgstr "Automatically lock the app after a certain period"
 
-#: src/strings.ts:1123
+#: src/strings.ts:1124
 msgid "Automatically switch between light and dark themes based on your system settings"
 msgstr "Automatically switch between light and dark themes based on your system settings"
 
-#: src/strings.ts:2156
+#: src/strings.ts:2157
 msgid "Available on iOS"
 msgstr "Available on iOS"
 
-#: src/strings.ts:2157
+#: src/strings.ts:2158
 msgid "Available on iOS & Android"
 msgstr "Available on iOS & Android"
 
-#: src/strings.ts:2706
+#: src/strings.ts:2707
 msgid "Back"
 msgstr "Back"
 
-#: src/strings.ts:2304
+#: src/strings.ts:2305
 msgid "Background color"
 msgstr "Background color"
 
-#: src/strings.ts:1095
+#: src/strings.ts:1096
 msgid "Background sync (experimental)"
 msgstr "Background sync (experimental)"
 
-#: src/strings.ts:2105
+#: src/strings.ts:2106
 msgid "Backup"
 msgstr "Backup"
 
-#: src/strings.ts:2143
+#: src/strings.ts:2144
 msgid "Backup & export"
 msgstr "Backup & export"
 
-#: src/strings.ts:1212
+#: src/strings.ts:1213
 msgid "Backup & restore"
 msgstr "Backup & restore"
 
-#: src/strings.ts:1337
+#: src/strings.ts:1338
 msgid "Backup complete"
 msgstr "Backup complete"
 
-#: src/strings.ts:1563
+#: src/strings.ts:1564
 msgid "Backup directory not selected"
 msgstr "Backup directory not selected"
 
-#: src/strings.ts:1235
+#: src/strings.ts:1236
 msgid "Backup encryption"
 msgstr "Backup encryption"
 
-#: src/strings.ts:1860
+#: src/strings.ts:1861
 msgid "Backup files have .nnbackup extension"
 msgstr "Backup files have .nnbackup extension"
 
-#: src/strings.ts:882
+#: src/strings.ts:883
 msgid "Backup is encrypted"
 msgstr "Backup is encrypted"
 
-#: src/strings.ts:1616
+#: src/strings.ts:1617
 msgid "Backup is encrypted, decrypting..."
 msgstr "Backup is encrypted, decrypting..."
 
-#: src/strings.ts:1214
+#: src/strings.ts:1215
 msgid "Backup now"
 msgstr "Backup now"
 
-#: src/strings.ts:1215
+#: src/strings.ts:1216
 msgid "Backup now with attachments"
 msgstr "Backup now with attachments"
 
-#: src/strings.ts:889
+#: src/strings.ts:890
 msgid "Backup restored"
 msgstr "Backup restored"
 
-#: src/strings.ts:1921
+#: src/strings.ts:1922
 msgid "Backup saved at {path}"
 msgstr "Backup saved at {path}"
 
-#: src/strings.ts:1349
+#: src/strings.ts:1350
 msgid "Backup successful"
 msgstr "Backup successful"
 
-#: src/strings.ts:2106
+#: src/strings.ts:2107
 msgid "Backup with attachments"
 msgstr "Backup with attachments"
 
@@ -1233,83 +1241,83 @@ msgstr "Backup with attachments"
 msgid "Backups"
 msgstr "Backups"
 
-#: src/strings.ts:541
+#: src/strings.ts:542
 msgid "Basic"
 msgstr "Basic"
 
-#: src/strings.ts:1795
+#: src/strings.ts:1796
 msgid "Because where's the fun in nookin' alone?"
 msgstr "Because where's the fun in nookin' alone?"
 
-#: src/strings.ts:1126
+#: src/strings.ts:1127
 msgid "Behavior"
 msgstr "Behavior"
 
-#: src/strings.ts:2138
+#: src/strings.ts:2139
 msgid "Behaviour"
 msgstr "Behaviour"
 
-#: src/strings.ts:2473
+#: src/strings.ts:2474
 msgid "Believer plan"
 msgstr "Believer plan"
 
-#: src/strings.ts:2580
+#: src/strings.ts:2581
 msgid "Best value"
 msgstr "Best value"
 
-#: src/strings.ts:2462
+#: src/strings.ts:2463
 msgid "Beta"
 msgstr "Beta"
 
-#: src/strings.ts:2262
+#: src/strings.ts:2263
 msgid "Bi-directional note link"
 msgstr "Bi-directional note link"
 
-#: src/strings.ts:2556
+#: src/strings.ts:2557
 msgid "billed annually at {price}"
 msgstr "billed annually at {price}"
 
-#: src/strings.ts:2557
+#: src/strings.ts:2558
 msgid "billed monthly at {price}"
 msgstr "billed monthly at {price}"
 
-#: src/strings.ts:2204
+#: src/strings.ts:2205
 msgid "Billing history"
 msgstr "Billing history"
 
-#: src/strings.ts:1179
+#: src/strings.ts:1180
 msgid "Biometric unlocking"
 msgstr "Biometric unlocking"
 
-#: src/strings.ts:812
+#: src/strings.ts:813
 msgid "Biometric unlocking disabled"
 msgstr "Biometric unlocking disabled"
 
-#: src/strings.ts:811
+#: src/strings.ts:812
 msgid "Biometric unlocking enabled"
 msgstr "Biometric unlocking enabled"
 
-#: src/strings.ts:1351
+#: src/strings.ts:1352
 msgid "Biometrics authentication failed. Please try again."
 msgstr "Biometrics authentication failed. Please try again."
 
-#: src/strings.ts:1188
+#: src/strings.ts:1189
 msgid "Biometrics not enrolled"
 msgstr "Biometrics not enrolled"
 
-#: src/strings.ts:2258
+#: src/strings.ts:2259
 msgid "Bold"
 msgstr "Bold"
 
-#: src/strings.ts:2411
+#: src/strings.ts:2412
 msgid "Boost your productivity with Notebooks and organize your notes."
 msgstr "Boost your productivity with Notebooks and organize your notes."
 
-#: src/strings.ts:1811
+#: src/strings.ts:1812
 msgid "Browse"
 msgstr "Browse"
 
-#: src/strings.ts:2275
+#: src/strings.ts:2276
 msgid "Bullet list"
 msgstr "Bullet list"
 
@@ -1317,7 +1325,7 @@ msgstr "Bullet list"
 msgid "By"
 msgstr "By"
 
-#: src/strings.ts:2575
+#: src/strings.ts:2576
 msgid "By joining you agree to our"
 msgstr "By joining you agree to our"
 
@@ -1325,64 +1333,64 @@ msgstr "By joining you agree to our"
 msgid "By signing up, you agree to our "
 msgstr "By signing up, you agree to our "
 
-#: src/strings.ts:2336
+#: src/strings.ts:2337
 msgid "Callout"
 msgstr "Callout"
 
-#: src/strings.ts:2516
+#: src/strings.ts:2517
 msgid "Can I cancel my free trial anytime?"
 msgstr "Can I cancel my free trial anytime?"
 
-#: src/strings.ts:549
+#: src/strings.ts:550
 msgid "Cancel"
 msgstr "Cancel"
 
-#: src/strings.ts:2573
+#: src/strings.ts:2574
 msgid "Cancel anytime, subscription auto-renews."
 msgstr "Cancel anytime, subscription auto-renews."
 
-#: src/strings.ts:2538
+#: src/strings.ts:2539
 msgid "Cancel anytime."
 msgstr "Cancel anytime."
 
-#: src/strings.ts:517
+#: src/strings.ts:518
 msgid "Cancel download"
 msgstr "Cancel download"
 
-#: src/strings.ts:554
+#: src/strings.ts:555
 msgid "Cancel login"
 msgstr "Cancel login"
 
-#: src/strings.ts:1828
+#: src/strings.ts:1829
 msgid "Cancel subscription"
 msgstr "Cancel subscription"
 
-#: src/strings.ts:518
+#: src/strings.ts:519
 msgid "Cancel upload"
 msgstr "Cancel upload"
 
-#: src/strings.ts:2677
+#: src/strings.ts:2678
 msgid "Cannot create more than 10 api keys at a time. Please revoke some existing keys before creating new ones."
 msgstr "Cannot create more than 10 api keys at a time. Please revoke some existing keys before creating new ones."
 
-#: src/strings.ts:2303
+#: src/strings.ts:2304
 msgid "Cell background color"
 msgstr "Cell background color"
 
-#: src/strings.ts:2305
+#: src/strings.ts:2306
 msgid "Cell border color"
 msgstr "Cell border color"
 
-#: src/strings.ts:2307
 #: src/strings.ts:2308
+#: src/strings.ts:2309
 msgid "Cell border width"
 msgstr "Cell border width"
 
-#: src/strings.ts:2289
+#: src/strings.ts:2290
 msgid "Cell properties"
 msgstr "Cell properties"
 
-#: src/strings.ts:2306
+#: src/strings.ts:2307
 msgid "Cell text color"
 msgstr "Cell text color"
 
@@ -1390,23 +1398,23 @@ msgstr "Cell text color"
 msgid "Change"
 msgstr "Change"
 
-#: src/strings.ts:1061
+#: src/strings.ts:1062
 msgid "Change 2FA fallback method"
 msgstr "Change 2FA fallback method"
 
-#: src/strings.ts:678
+#: src/strings.ts:679
 msgid "Change 2FA method"
 msgstr "Change 2FA method"
 
-#: src/strings.ts:1200
+#: src/strings.ts:1201
 msgid "Change app lock password"
 msgstr "Change app lock password"
 
-#: src/strings.ts:1199
+#: src/strings.ts:1200
 msgid "Change app lock pin"
 msgstr "Change app lock pin"
 
-#: src/strings.ts:1234
+#: src/strings.ts:1235
 msgid "Change backup directory"
 msgstr "Change backup directory"
 
@@ -1414,15 +1422,15 @@ msgstr "Change backup directory"
 msgid "Change email address"
 msgstr "Change email address"
 
-#: src/strings.ts:1127
+#: src/strings.ts:1128
 msgid "Change how the app behaves in different situations"
 msgstr "Change how the app behaves in different situations"
 
-#: src/strings.ts:2354
+#: src/strings.ts:2355
 msgid "Change language"
 msgstr "Change language"
 
-#: src/strings.ts:1255
+#: src/strings.ts:1256
 msgid "Change notification sound"
 msgstr "Change notification sound"
 
@@ -1430,23 +1438,23 @@ msgstr "Change notification sound"
 msgid "Change password"
 msgstr "Change password"
 
-#: src/strings.ts:2587
+#: src/strings.ts:2588
 msgid "Change plan"
 msgstr "Change plan"
 
-#: src/strings.ts:1820
+#: src/strings.ts:1821
 msgid "Change profile picture"
 msgstr "Change profile picture"
 
-#: src/strings.ts:2182
+#: src/strings.ts:2183
 msgid "Change proxy"
 msgstr "Change proxy"
 
-#: src/strings.ts:2203
+#: src/strings.ts:2204
 msgid "Change the payment method you used to purchase this subscription."
 msgstr "Change the payment method you used to purchase this subscription."
 
-#: src/strings.ts:1257
+#: src/strings.ts:1258
 msgid "Change the sound that plays when you receive a notification"
 msgstr "Change the sound that plays when you receive a notification"
 
@@ -1454,55 +1462,55 @@ msgstr "Change the sound that plays when you receive a notification"
 msgid "Change vault password"
 msgstr "Change vault password"
 
-#: src/strings.ts:1055
+#: src/strings.ts:1056
 msgid "Change your account password"
 msgstr "Change your account password"
 
-#: src/strings.ts:1057
+#: src/strings.ts:1058
 msgid "Change your primary two-factor authentication method"
 msgstr "Change your primary two-factor authentication method"
 
-#: src/strings.ts:1091
+#: src/strings.ts:1092
 msgid "Changes from other devices won't be updated in the editor in real-time."
 msgstr "Changes from other devices won't be updated in the editor in real-time."
 
-#: src/strings.ts:2697
+#: src/strings.ts:2698
 msgid "Changing Inbox PGP keys will delete all your unsynced inbox items."
 msgstr "Changing Inbox PGP keys will delete all your unsynced inbox items."
 
-#: src/strings.ts:734
+#: src/strings.ts:735
 msgid "Changing password is an irreversible process. You will be logged out from all your devices. Please make sure you do not close the app while your password is changing and have good internet connection."
 msgstr "Changing password is an irreversible process. You will be logged out from all your devices. Please make sure you do not close the app while your password is changing and have good internet connection."
 
-#: src/strings.ts:2492
+#: src/strings.ts:2493
 msgid "Characters"
 msgstr "Characters"
 
-#: src/strings.ts:1298
+#: src/strings.ts:1299
 msgid "Check for new version of Notesnook"
 msgstr "Check for new version of Notesnook"
 
-#: src/strings.ts:1301
+#: src/strings.ts:1302
 msgid "Check for new version of the app available on app launch"
 msgstr "Check for new version of the app available on app launch"
 
-#: src/strings.ts:1297
+#: src/strings.ts:1298
 msgid "Check for updates"
 msgstr "Check for updates"
 
-#: src/strings.ts:1299
+#: src/strings.ts:1300
 msgid "Check for updates automatically"
 msgstr "Check for updates automatically"
 
-#: src/strings.ts:2155
+#: src/strings.ts:2156
 msgid "Check roadmap"
 msgstr "Check roadmap"
 
-#: src/strings.ts:684
+#: src/strings.ts:685
 msgid "Check your spam folder if you haven't received an email yet."
 msgstr "Check your spam folder if you haven't received an email yet."
 
-#: src/strings.ts:2403
+#: src/strings.ts:2404
 msgid "Checking all attachments"
 msgstr "Checking all attachments"
 
@@ -1510,51 +1518,51 @@ msgstr "Checking all attachments"
 msgid "Checking for new version"
 msgstr "Checking for new version"
 
-#: src/strings.ts:1707
+#: src/strings.ts:1708
 msgid "Checking for updates"
 msgstr "Checking for updates"
 
-#: src/strings.ts:2402
+#: src/strings.ts:2403
 msgid "Checking note attachments"
 msgstr "Checking note attachments"
 
-#: src/strings.ts:2277
+#: src/strings.ts:2278
 msgid "Checklist"
 msgstr "Checklist"
 
-#: src/strings.ts:2331
+#: src/strings.ts:2332
 msgid "Choose a block to insert"
 msgstr "Choose a block to insert"
 
-#: src/strings.ts:1799
+#: src/strings.ts:1800
 msgid "Choose a recovery method"
 msgstr "Choose a recovery method"
 
-#: src/strings.ts:2104
+#: src/strings.ts:2105
 msgid "Choose backup format"
 msgstr "Choose backup format"
 
-#: src/strings.ts:2367
+#: src/strings.ts:2368
 msgid "Choose custom color"
 msgstr "Choose custom color"
 
-#: src/strings.ts:1120
+#: src/strings.ts:1121
 msgid "Choose from pre-built themes or create your own"
 msgstr "Choose from pre-built themes or create your own"
 
-#: src/strings.ts:1135
+#: src/strings.ts:1136
 msgid "Choose how dates are displayed in the app"
 msgstr "Choose how dates are displayed in the app"
 
-#: src/strings.ts:2622
+#: src/strings.ts:2623
 msgid "Choose how day is displayed in the app"
 msgstr "Choose how day is displayed in the app"
 
-#: src/strings.ts:1160
+#: src/strings.ts:1161
 msgid "Choose how the new note titles are formatted"
 msgstr "Choose how the new note titles are formatted"
 
-#: src/strings.ts:1137
+#: src/strings.ts:1138
 msgid "Choose how time is displayed in the app"
 msgstr "Choose how time is displayed in the app"
 
@@ -1562,67 +1570,67 @@ msgstr "Choose how time is displayed in the app"
 msgid "Choose how you want to secure your notes locally."
 msgstr "Choose how you want to secure your notes locally."
 
-#: src/strings.ts:2627
+#: src/strings.ts:2628
 msgid "Choose what day to display as the first day of the week"
 msgstr "Choose what day to display as the first day of the week"
 
-#: src/strings.ts:1230
+#: src/strings.ts:1231
 msgid "Choose where to save your backups"
 msgstr "Choose where to save your backups"
 
-#: src/strings.ts:2064
+#: src/strings.ts:2065
 msgid "Choose your style"
 msgstr "Choose your style"
 
-#: src/strings.ts:1619
+#: src/strings.ts:1620
 msgid "cleaningUp"
 msgstr "cleaningUp"
 
-#: src/strings.ts:1016
+#: src/strings.ts:1017
 msgid "Clear"
 msgstr "Clear"
 
-#: src/strings.ts:1872
+#: src/strings.ts:1873
 msgid "Clear all cached attachments. Current cache size: {cacheSize}"
 msgstr "Clear all cached attachments. Current cache size: {cacheSize}"
 
-#: src/strings.ts:2271
+#: src/strings.ts:2272
 msgid "Clear all formatting"
 msgstr "Clear all formatting"
 
-#: src/strings.ts:1873
+#: src/strings.ts:1874
 msgid "Clear attachments cache?"
 msgstr "Clear attachments cache?"
 
-#: src/strings.ts:1870
+#: src/strings.ts:1871
 msgid "Clear cache"
 msgstr "Clear cache"
 
-#: src/strings.ts:2365
+#: src/strings.ts:2366
 msgid "Clear completed tasks"
 msgstr "Clear completed tasks"
 
-#: src/strings.ts:1807
+#: src/strings.ts:1808
 msgid "Clear data & reset account"
 msgstr "Clear data & reset account"
 
-#: src/strings.ts:1141
+#: src/strings.ts:1142
 msgid "Clear default notebook"
 msgstr "Clear default notebook"
 
-#: src/strings.ts:1015
+#: src/strings.ts:1016
 msgid "Clear logs"
 msgstr "Clear logs"
 
-#: src/strings.ts:2198
+#: src/strings.ts:2199
 msgid "clear sessions"
 msgstr "clear sessions"
 
-#: src/strings.ts:1324
+#: src/strings.ts:1325
 msgid "Clear trash"
 msgstr "Clear trash"
 
-#: src/strings.ts:1138
+#: src/strings.ts:1139
 msgid "Clear trash interval"
 msgstr "Clear trash interval"
 
@@ -1630,7 +1638,7 @@ msgstr "Clear trash interval"
 msgid "Clear vault"
 msgstr "Clear vault"
 
-#: src/strings.ts:1875
+#: src/strings.ts:1876
 msgid ""
 "Clearing attachments cache will perform the following actions:\n"
 "\n"
@@ -1656,7 +1664,7 @@ msgstr ""
 "\n"
 "**Only use this for troubleshooting purposes. If you are having persistent issues, it is recommended that you reach out to us via support@streetwriters.co so we can help you resolve it permanently.**"
 
-#: src/strings.ts:2609
+#: src/strings.ts:2610
 msgid "Click here to directly claim the promotion."
 msgstr "Click here to directly claim the promotion."
 
@@ -1664,71 +1672,71 @@ msgstr "Click here to directly claim the promotion."
 msgid "Click to deselect"
 msgstr "Click to deselect"
 
-#: src/strings.ts:1869
+#: src/strings.ts:1870
 msgid "Click to preview"
 msgstr "Click to preview"
 
-#: src/strings.ts:1774
+#: src/strings.ts:1775
 msgid "Click to remove"
 msgstr "Click to remove"
 
-#: src/strings.ts:2394
+#: src/strings.ts:2395
 msgid "Click to reset {title}"
 msgstr "Click to reset {title}"
 
-#: src/strings.ts:2617
+#: src/strings.ts:2618
 msgid "Click to save"
 msgstr "Click to save"
 
-#: src/strings.ts:2613
+#: src/strings.ts:2614
 msgid "Click to update"
 msgstr "Click to update"
 
-#: src/strings.ts:1383
+#: src/strings.ts:1384
 msgid "Close"
 msgstr "Close"
 
-#: src/strings.ts:2021
+#: src/strings.ts:2022
 msgid "Close all"
 msgstr "Close all"
 
-#: src/strings.ts:2452
+#: src/strings.ts:2453
 msgid "Close all tabs"
 msgstr "Close all tabs"
 
-#: src/strings.ts:2451
+#: src/strings.ts:2452
 msgid "Close current tab"
 msgstr "Close current tab"
 
-#: src/strings.ts:2018
+#: src/strings.ts:2019
 msgid "Close others"
 msgstr "Close others"
 
-#: src/strings.ts:2122
+#: src/strings.ts:2123
 msgid "Close to system tray"
 msgstr "Close to system tray"
 
-#: src/strings.ts:2020
+#: src/strings.ts:2021
 msgid "Close to the left"
 msgstr "Close to the left"
 
-#: src/strings.ts:2019
+#: src/strings.ts:2020
 msgid "Close to the right"
 msgstr "Close to the right"
 
-#: src/strings.ts:2530
+#: src/strings.ts:2531
 msgid "cloud storage space for storing images and files."
 msgstr "cloud storage space for storing images and files."
 
-#: src/strings.ts:2269
+#: src/strings.ts:2270
 msgid "Code"
 msgstr "Code"
 
-#: src/strings.ts:2333
+#: src/strings.ts:2334
 msgid "Code block"
 msgstr "Code block"
 
-#: src/strings.ts:2270
+#: src/strings.ts:2271
 msgid "Code remove"
 msgstr "Code remove"
 
@@ -1741,19 +1749,19 @@ msgid "color"
 msgstr "color"
 
 #: src/strings.ts:299
-#: src/strings.ts:1846
+#: src/strings.ts:1847
 msgid "Color"
 msgstr "Color"
 
-#: src/strings.ts:787
+#: src/strings.ts:788
 msgid "Color #{color} already exists"
 msgstr "Color #{color} already exists"
 
-#: src/strings.ts:2097
+#: src/strings.ts:2098
 msgid "Color scheme"
 msgstr "Color scheme"
 
-#: src/strings.ts:1491
+#: src/strings.ts:1492
 msgid "Color title"
 msgstr "Color title"
 
@@ -1765,19 +1773,19 @@ msgstr "colors"
 msgid "Colors"
 msgstr "Colors"
 
-#: src/strings.ts:2287
+#: src/strings.ts:2288
 msgid "Column properties"
 msgstr "Column properties"
 
-#: src/strings.ts:2443
+#: src/strings.ts:2444
 msgid "Command palette"
 msgstr "Command palette"
 
-#: src/strings.ts:1273
+#: src/strings.ts:1274
 msgid "Community"
 msgstr "Community"
 
-#: src/strings.ts:2550
+#: src/strings.ts:2551
 msgid "Compare plans"
 msgstr "Compare plans"
 
@@ -1789,7 +1797,7 @@ msgstr "Completed"
 msgid "Compress"
 msgstr "Compress"
 
-#: src/strings.ts:1131
+#: src/strings.ts:1132
 msgid "Compress images before uploading"
 msgstr "Compress images before uploading"
 
@@ -1797,96 +1805,96 @@ msgstr "Compress images before uploading"
 msgid "Compressed images are uploaded in Full HD resolution and usually are good enough for most use cases."
 msgstr "Compressed images are uploaded in Full HD resolution and usually are good enough for most use cases."
 
-#: src/strings.ts:2253
+#: src/strings.ts:2254
 msgid "Configure"
 msgstr "Configure"
 
-#: src/strings.ts:2408
+#: src/strings.ts:2409
 msgid "Configure server URLs for Notesnook"
 msgstr "Configure server URLs for Notesnook"
 
-#: src/strings.ts:682
+#: src/strings.ts:683
 msgid "Confirm email"
 msgstr "Confirm email"
 
-#: src/strings.ts:903
+#: src/strings.ts:904
 msgid "Confirm email to publish note"
 msgstr "Confirm email to publish note"
 
-#: src/strings.ts:1490
+#: src/strings.ts:1491
 msgid "Confirm new password"
 msgstr "Confirm new password"
 
-#: src/strings.ts:1485
+#: src/strings.ts:1486
 msgid "Confirm password"
 msgstr "Confirm password"
 
-#: src/strings.ts:1489
+#: src/strings.ts:1490
 msgid "Confirm pin"
 msgstr "Confirm pin"
 
-#: src/strings.ts:2641
+#: src/strings.ts:2642
 msgid "Confirmation email sent"
 msgstr "Confirmation email sent"
 
-#: src/strings.ts:2082
+#: src/strings.ts:2083
 msgid "Congratulations!"
 msgstr "Congratulations!"
 
-#: src/strings.ts:1638
+#: src/strings.ts:1639
 msgid "Connected to all servers sucessfully."
 msgstr "Connected to all servers sucessfully."
 
-#: src/strings.ts:1673
+#: src/strings.ts:1674
 msgid "Contact support"
 msgstr "Contact support"
 
-#: src/strings.ts:1264
+#: src/strings.ts:1265
 msgid "Contact us directly via support@streetwriters.co for any help or support"
 msgstr "Contact us directly via support@streetwriters.co for any help or support"
 
-#: src/strings.ts:543
+#: src/strings.ts:544
 msgid "Continue"
 msgstr "Continue"
 
-#: src/strings.ts:1166
+#: src/strings.ts:1167
 msgid "Contribute towards a better Notesnook. All tracking information is anonymous."
 msgstr "Contribute towards a better Notesnook. All tracking information is anonymous."
 
-#: src/strings.ts:1250
+#: src/strings.ts:1251
 msgid "Controls whether this device should receive reminder notifications."
 msgstr "Controls whether this device should receive reminder notifications."
 
-#: src/strings.ts:1992
+#: src/strings.ts:1993
 msgid "Copied"
 msgstr "Copied"
 
-#: src/strings.ts:675
+#: src/strings.ts:676
 msgid "Copy"
 msgstr "Copy"
 
 #. placeholder {0}: format ? " " + format : ""
-#: src/strings.ts:2038
+#: src/strings.ts:2039
 msgid "Copy as{0}"
 msgstr "Copy as{0}"
 
-#: src/strings.ts:679
+#: src/strings.ts:680
 msgid "Copy codes"
 msgstr "Copy codes"
 
-#: src/strings.ts:912
+#: src/strings.ts:913
 msgid "Copy ID"
 msgstr "Copy ID"
 
-#: src/strings.ts:2249
+#: src/strings.ts:2250
 msgid "Copy image"
 msgstr "Copy image"
 
-#: src/strings.ts:910
+#: src/strings.ts:911
 msgid "Copy link"
 msgstr "Copy link"
 
-#: src/strings.ts:2248
+#: src/strings.ts:2249
 msgid "Copy link text"
 msgstr "Copy link text"
 
@@ -1894,39 +1902,39 @@ msgstr "Copy link text"
 msgid "Copy note"
 msgstr "Copy note"
 
-#: src/strings.ts:591
+#: src/strings.ts:592
 msgid "Copy to clipboard"
 msgstr "Copy to clipboard"
 
-#: src/strings.ts:1621
+#: src/strings.ts:1622
 msgid "Copying backup files to cache"
 msgstr "Copying backup files to cache"
 
-#: src/strings.ts:1170
+#: src/strings.ts:1171
 msgid "CORS bypass"
 msgstr "CORS bypass"
 
-#: src/strings.ts:1988
+#: src/strings.ts:1989
 msgid "Could not activate trial. Please try again later."
 msgstr "Could not activate trial. Please try again later."
 
-#: src/strings.ts:2006
+#: src/strings.ts:2007
 msgid "Could not clear trash."
 msgstr "Could not clear trash."
 
-#: src/strings.ts:1641
+#: src/strings.ts:1642
 msgid "Could not connect to {server}."
 msgstr "Could not connect to {server}."
 
-#: src/strings.ts:1953
+#: src/strings.ts:1954
 msgid "Could not convert note to {format}."
 msgstr "Could not convert note to {format}."
 
-#: src/strings.ts:769
+#: src/strings.ts:770
 msgid "Could not create backup"
 msgstr "Could not create backup"
 
-#: src/strings.ts:559
+#: src/strings.ts:560
 msgid "Could not unlock"
 msgstr "Could not unlock"
 
@@ -1934,55 +1942,55 @@ msgstr "Could not unlock"
 msgid "Create"
 msgstr "Create"
 
-#: src/strings.ts:730
+#: src/strings.ts:731
 msgid "Create a group"
 msgstr "Create a group"
 
-#: src/strings.ts:940
+#: src/strings.ts:941
 msgid "Create a new note"
 msgstr "Create a new note"
 
-#: src/strings.ts:953
+#: src/strings.ts:954
 msgid "Create a note first"
 msgstr "Create a note first"
 
-#: src/strings.ts:670
+#: src/strings.ts:671
 msgid "Create a shortcut"
 msgstr "Create a shortcut"
 
-#: src/strings.ts:573
+#: src/strings.ts:574
 msgid "Create a tag to group related notes together."
 msgstr "Create a tag to group related notes together."
 
-#: src/strings.ts:1851
+#: src/strings.ts:1852
 msgid "Create account"
 msgstr "Create account"
 
-#: src/strings.ts:2656
+#: src/strings.ts:2657
 msgid "Create API Key"
 msgstr "Create API Key"
 
-#: src/strings.ts:2673
+#: src/strings.ts:2674
 msgid "Create Key"
 msgstr "Create Key"
 
-#: src/strings.ts:581
+#: src/strings.ts:582
 msgid "Create link"
 msgstr "Create link"
 
-#: src/strings.ts:1475
+#: src/strings.ts:1476
 msgid "Create shortcut of this notebook in side menu"
 msgstr "Create shortcut of this notebook in side menu"
 
-#: src/strings.ts:1389
+#: src/strings.ts:1390
 msgid "Create unlimited notebooks with Notesnook Pro"
 msgstr "Create unlimited notebooks with Notesnook Pro"
 
-#: src/strings.ts:1388
+#: src/strings.ts:1389
 msgid "Create unlimited tags with Notesnook Pro"
 msgstr "Create unlimited tags with Notesnook Pro"
 
-#: src/strings.ts:1390
+#: src/strings.ts:1391
 msgid "Create unlimited vaults with Notesnook Pro"
 msgstr "Create unlimited vaults with Notesnook Pro"
 
@@ -1990,218 +1998,218 @@ msgstr "Create unlimited vaults with Notesnook Pro"
 msgid "Create vault"
 msgstr "Create vault"
 
-#: src/strings.ts:522
+#: src/strings.ts:523
 msgid "Create your account"
 msgstr "Create your account"
 
-#: src/strings.ts:2672
+#: src/strings.ts:2673
 msgid "Create your first api key to get started."
 msgstr "Create your first api key to get started."
 
-#: src/strings.ts:2231
+#: src/strings.ts:2232
 msgid "Created at"
 msgstr "Created at"
 
-#: src/strings.ts:2692
+#: src/strings.ts:2693
 msgid "Created on"
 msgstr "Created on"
 
 #. placeholder {0}: type === "full" ? " full" : ""
-#: src/strings.ts:1346
+#: src/strings.ts:1347
 msgid "Creating a{0} backup"
 msgstr "Creating a{0} backup"
 
-#: src/strings.ts:2664
+#: src/strings.ts:2665
 msgid "Creating..."
 msgstr "Creating..."
 
-#: src/strings.ts:2051
+#: src/strings.ts:2052
 msgid "Credentials"
 msgstr "Credentials"
 
-#: src/strings.ts:2067
+#: src/strings.ts:2068
 msgid "Cross platform & 100% encrypted"
 msgstr "Cross platform & 100% encrypted"
 
-#: src/strings.ts:741
+#: src/strings.ts:742
 msgid "Curate the toolbar that fits your needs and matches your personality."
 msgstr "Curate the toolbar that fits your needs and matches your personality."
 
-#: src/strings.ts:1838
+#: src/strings.ts:1839
 msgid "Current note"
 msgstr "Current note"
 
-#: src/strings.ts:1487
+#: src/strings.ts:1488
 msgid "Current password"
 msgstr "Current password"
 
-#: src/strings.ts:1231
+#: src/strings.ts:1232
 msgid "Current path: {path}"
 msgstr "Current path: {path}"
 
-#: src/strings.ts:1486
+#: src/strings.ts:1487
 msgid "Current pin"
 msgstr "Current pin"
 
-#: src/strings.ts:1775
+#: src/strings.ts:1776
 msgid "CURRENT PLAN"
 msgstr "CURRENT PLAN"
 
-#: src/strings.ts:2012
+#: src/strings.ts:2013
 msgid "Custom"
 msgstr "Custom"
 
-#: src/strings.ts:2133
+#: src/strings.ts:2134
 msgid "Custom dictionary words"
 msgstr "Custom dictionary words"
 
-#: src/strings.ts:1115
+#: src/strings.ts:1116
 msgid "Customization"
 msgstr "Customization"
 
-#: src/strings.ts:1118
+#: src/strings.ts:1119
 msgid "Customize the appearance of the app with custom themes"
 msgstr "Customize the appearance of the app with custom themes"
 
-#: src/strings.ts:1145
+#: src/strings.ts:1146
 msgid "Customize the note editor"
 msgstr "Customize the note editor"
 
-#: src/strings.ts:1147
+#: src/strings.ts:1148
 msgid "Customize the toolbar in the note editor"
 msgstr "Customize the toolbar in the note editor"
 
-#: src/strings.ts:1146
+#: src/strings.ts:1147
 msgid "Customize toolbar"
 msgstr "Customize toolbar"
 
-#: src/strings.ts:2247
+#: src/strings.ts:2248
 msgid "Cut"
 msgstr "Cut"
 
 #: src/strings.ts:167
-#: src/strings.ts:1570
+#: src/strings.ts:1571
 msgid "Daily"
 msgstr "Daily"
 
-#: src/strings.ts:724
+#: src/strings.ts:725
 msgid "Dark"
 msgstr "Dark"
 
-#: src/strings.ts:1124
+#: src/strings.ts:1125
 msgid "Dark mode"
 msgstr "Dark mode"
 
-#: src/strings.ts:2098
+#: src/strings.ts:2099
 msgid "Dark or light, we won't judge."
 msgstr "Dark or light, we won't judge."
 
-#: src/strings.ts:1549
+#: src/strings.ts:1550
 msgid "Database setup failed, could not get database key"
 msgstr "Database setup failed, could not get database key"
 
-#: src/strings.ts:1841
+#: src/strings.ts:1842
 msgid "Date"
 msgstr "Date"
 
-#: src/strings.ts:2107
+#: src/strings.ts:2108
 msgid "Date & time"
 msgstr "Date & time"
 
-#: src/strings.ts:653
+#: src/strings.ts:654
 msgid "Date created"
 msgstr "Date created"
 
-#: src/strings.ts:656
+#: src/strings.ts:657
 msgid "Date deleted"
 msgstr "Date deleted"
 
-#: src/strings.ts:652
+#: src/strings.ts:653
 msgid "Date edited"
 msgstr "Date edited"
 
-#: src/strings.ts:1134
+#: src/strings.ts:1135
 msgid "Date format"
 msgstr "Date format"
 
-#: src/strings.ts:651
+#: src/strings.ts:652
 msgid "Date modified"
 msgstr "Date modified"
 
-#: src/strings.ts:2044
+#: src/strings.ts:2045
 msgid "Date uploaded"
 msgstr "Date uploaded"
 
-#: src/strings.ts:1843
+#: src/strings.ts:1844
 msgid "Day"
 msgstr "Day"
 
-#: src/strings.ts:2621
+#: src/strings.ts:2622
 msgid "Day format"
 msgstr "Day format"
 
-#: src/strings.ts:2040
+#: src/strings.ts:2041
 msgid "Deactivate"
 msgstr "Deactivate"
 
-#: src/strings.ts:1013
+#: src/strings.ts:1014
 msgid "Debug log copied!"
 msgstr "Debug log copied!"
 
-#: src/strings.ts:1271
+#: src/strings.ts:1272
 msgid "Debug logs"
 msgstr "Debug logs"
 
-#: src/strings.ts:1014
+#: src/strings.ts:1015
 msgid "Debug logs downloaded"
 msgstr "Debug logs downloaded"
 
-#: src/strings.ts:1268
+#: src/strings.ts:1269
 msgid "Debugging"
 msgstr "Debugging"
 
-#: src/strings.ts:2396
+#: src/strings.ts:2397
 msgid "Decrease {title}"
 msgstr "Decrease {title}"
 
-#: src/strings.ts:660
-#: src/strings.ts:2010
+#: src/strings.ts:661
+#: src/strings.ts:2011
 msgid "Default"
 msgstr "Default"
 
-#: src/strings.ts:1157
+#: src/strings.ts:1158
 msgid "Default font family"
 msgstr "Default font family"
 
-#: src/strings.ts:1158
+#: src/strings.ts:1159
 msgid "Default font family in editor"
 msgstr "Default font family in editor"
 
-#: src/strings.ts:1155
+#: src/strings.ts:1156
 msgid "Default font size"
 msgstr "Default font size"
 
-#: src/strings.ts:1156
+#: src/strings.ts:1157
 msgid "Default font size in editor"
 msgstr "Default font size in editor"
 
-#: src/strings.ts:1143
+#: src/strings.ts:1144
 msgid "Default notebook cleared"
 msgstr "Default notebook cleared"
 
-#: src/strings.ts:1129
+#: src/strings.ts:1130
 msgid "Default screen to open on app launch"
 msgstr "Default screen to open on app launch"
 
-#: src/strings.ts:2483
+#: src/strings.ts:2484
 msgid "Default sidebar tab"
 msgstr "Default sidebar tab"
 
-#: src/strings.ts:1251
+#: src/strings.ts:1252
 msgid "Default snooze time"
 msgstr "Default snooze time"
 
-#: src/strings.ts:1303
+#: src/strings.ts:1304
 msgid "Default sound"
 msgstr "Default sound"
 
@@ -2209,43 +2217,43 @@ msgstr "Default sound"
 msgid "Delete"
 msgstr "Delete"
 
-#: src/strings.ts:1078
+#: src/strings.ts:1079
 msgid "Delete account"
 msgstr "Delete account"
 
-#: src/strings.ts:1321
+#: src/strings.ts:1322
 msgid "Delete collapsed section"
 msgstr "Delete collapsed section"
 
-#: src/strings.ts:2294
+#: src/strings.ts:2295
 msgid "Delete column"
 msgstr "Delete column"
 
-#: src/strings.ts:2638
+#: src/strings.ts:2639
 msgid "Delete data"
 msgstr "Delete data"
 
-#: src/strings.ts:1316
+#: src/strings.ts:1317
 msgid "Delete group"
 msgstr "Delete group"
 
-#: src/strings.ts:2368
+#: src/strings.ts:2369
 msgid "Delete mode"
 msgstr "Delete mode"
 
-#: src/strings.ts:562
+#: src/strings.ts:563
 msgid "Delete notes in this vault"
 msgstr "Delete notes in this vault"
 
-#: src/strings.ts:569
+#: src/strings.ts:570
 msgid "Delete permanently"
 msgstr "Delete permanently"
 
-#: src/strings.ts:2301
+#: src/strings.ts:2302
 msgid "Delete row"
 msgstr "Delete row"
 
-#: src/strings.ts:2302
+#: src/strings.ts:2303
 msgid "Delete table"
 msgstr "Delete table"
 
@@ -2253,7 +2261,7 @@ msgstr "Delete table"
 msgid "Delete vault"
 msgstr "Delete vault"
 
-#: src/strings.ts:1178
+#: src/strings.ts:1179
 msgid "Delete vault (and optionally remove all notes)."
 msgstr "Delete vault (and optionally remove all notes)."
 
@@ -2261,47 +2269,47 @@ msgstr "Delete vault (and optionally remove all notes)."
 msgid "Deleted on {date}"
 msgstr "Deleted on {date}"
 
-#: src/strings.ts:1930
+#: src/strings.ts:1931
 msgid "Deleting"
 msgstr "Deleting"
 
-#: src/strings.ts:1840
+#: src/strings.ts:1841
 msgid "Description"
 msgstr "Description"
 
-#: src/strings.ts:2108
+#: src/strings.ts:2109
 msgid "Desktop app"
 msgstr "Desktop app"
 
-#: src/strings.ts:2112
+#: src/strings.ts:2113
 msgid "Desktop integration"
 msgstr "Desktop integration"
 
-#: src/strings.ts:871
+#: src/strings.ts:872
 msgid "Did you save recovery key?"
 msgstr "Did you save recovery key?"
 
-#: src/strings.ts:1378
+#: src/strings.ts:1379
 msgid "Disable"
 msgstr "Disable"
 
-#: src/strings.ts:1086
+#: src/strings.ts:1087
 msgid "Disable auto sync"
 msgstr "Disable auto sync"
 
-#: src/strings.ts:2013
+#: src/strings.ts:2014
 msgid "Disable editor margins"
 msgstr "Disable editor margins"
 
-#: src/strings.ts:2650
+#: src/strings.ts:2651
 msgid "Disable Inbox API"
 msgstr "Disable Inbox API"
 
-#: src/strings.ts:1089
+#: src/strings.ts:1090
 msgid "Disable realtime sync"
 msgstr "Disable realtime sync"
 
-#: src/strings.ts:1092
+#: src/strings.ts:1093
 msgid "Disable sync"
 msgstr "Disable sync"
 
@@ -2309,19 +2317,19 @@ msgstr "Disable sync"
 msgid "Disabled"
 msgstr "Disabled"
 
-#: src/strings.ts:2652
+#: src/strings.ts:2653
 msgid "Disabling will delete all your unsynced inbox items. Additionally, disabling will revoke all existing API keys, they will no longer work. Are you sure?"
 msgstr "Disabling will delete all your unsynced inbox items. Additionally, disabling will revoke all existing API keys, they will no longer work. Are you sure?"
 
-#: src/strings.ts:565
+#: src/strings.ts:566
 msgid "Discard"
 msgstr "Discard"
 
-#: src/strings.ts:1599
+#: src/strings.ts:1600
 msgid "Dismiss"
 msgstr "Dismiss"
 
-#: src/strings.ts:1652
+#: src/strings.ts:1653
 msgid "Dismiss announcement"
 msgstr "Dismiss announcement"
 
@@ -2333,27 +2341,27 @@ msgstr "Disputed"
 msgid "Do you enjoy using Notesnook?"
 msgstr "Do you enjoy using Notesnook?"
 
-#: src/strings.ts:2230
+#: src/strings.ts:2231
 msgid "Do you want to clear the trash?"
 msgstr "Do you want to clear the trash?"
 
-#: src/strings.ts:1265
+#: src/strings.ts:1266
 msgid "Documentation"
 msgstr "Documentation"
 
-#: src/strings.ts:757
+#: src/strings.ts:758
 msgid "Documents"
 msgstr "Documents"
 
-#: src/strings.ts:986
+#: src/strings.ts:987
 msgid "Don't have access to your authenticator app?"
 msgstr "Don't have access to your authenticator app?"
 
-#: src/strings.ts:993
+#: src/strings.ts:994
 msgid "Don't have access to your email address?"
 msgstr "Don't have access to your email address?"
 
-#: src/strings.ts:1002
+#: src/strings.ts:1003
 msgid "Don't have access to your phone number?"
 msgstr "Don't have access to your phone number?"
 
@@ -2361,23 +2369,23 @@ msgstr "Don't have access to your phone number?"
 msgid "Don't have an account?"
 msgstr "Don't have an account?"
 
-#: src/strings.ts:1834
+#: src/strings.ts:1835
 msgid "Don't have backup file?"
 msgstr "Don't have backup file?"
 
-#: src/strings.ts:1833
+#: src/strings.ts:1006
+msgid "Don't have your 2FA backup codes?"
+msgstr "Don't have your 2FA backup codes?"
+
+#: src/strings.ts:1834
 msgid "Don't have your account recovery key?"
 msgstr "Don't have your account recovery key?"
 
-#: src/strings.ts:1005
-msgid "Don't have your recovery codes?"
-msgstr "Don't have your recovery codes?"
-
-#: src/strings.ts:1812
+#: src/strings.ts:1813
 msgid "Don't show again"
 msgstr "Don't show again"
 
-#: src/strings.ts:1813
+#: src/strings.ts:1814
 msgid "Don't show again on this device?"
 msgstr "Don't show again on this device?"
 
@@ -2385,60 +2393,60 @@ msgstr "Don't show again on this device?"
 msgid "Done"
 msgstr "Done"
 
-#: src/strings.ts:1151
+#: src/strings.ts:1152
 msgid "Double spaced lines"
 msgstr "Double spaced lines"
 
-#: src/strings.ts:509
+#: src/strings.ts:510
 msgid "Download"
 msgstr "Download"
 
-#: src/strings.ts:1818
+#: src/strings.ts:1819
 msgid "Download all attachments"
 msgstr "Download all attachments"
 
-#: src/strings.ts:2317
+#: src/strings.ts:2318
 msgid "Download attachment"
 msgstr "Download attachment"
 
-#: src/strings.ts:1862
+#: src/strings.ts:1863
 msgid "Download backup file"
 msgstr "Download backup file"
 
-#: src/strings.ts:516
+#: src/strings.ts:517
 msgid "Download cancelled"
 msgstr "Download cancelled"
 
-#: src/strings.ts:2210
+#: src/strings.ts:2211
 msgid "Download everything including attachments on sync"
 msgstr "Download everything including attachments on sync"
 
-#: src/strings.ts:1292
+#: src/strings.ts:1293
 msgid "Download on desktop"
 msgstr "Download on desktop"
 
-#: src/strings.ts:806
+#: src/strings.ts:807
 msgid "Download started... Please wait"
 msgstr "Download started... Please wait"
 
-#: src/strings.ts:514
+#: src/strings.ts:515
 msgid "Download successful"
 msgstr "Download successful"
 
-#: src/strings.ts:667
+#: src/strings.ts:668
 msgid "Download update"
 msgstr "Download update"
 
-#: src/strings.ts:508
+#: src/strings.ts:509
 msgid "Downloaded"
 msgstr "Downloaded"
 
 #: src/strings.ts:64
-#: src/strings.ts:507
+#: src/strings.ts:508
 msgid "Downloading"
 msgstr "Downloading"
 
-#: src/strings.ts:507
+#: src/strings.ts:508
 msgid "Downloading ({progress})"
 msgstr "Downloading ({progress})"
 
@@ -2446,125 +2454,125 @@ msgstr "Downloading ({progress})"
 msgid "Downloading attachments"
 msgstr "Downloading attachments"
 
-#: src/strings.ts:1706
+#: src/strings.ts:1707
 msgid "Downloading images"
 msgstr "Downloading images"
 
-#: src/strings.ts:1772
+#: src/strings.ts:1773
 msgid "Drag & drop files here, or click to select files"
 msgstr "Drag & drop files here, or click to select files"
 
-#: src/strings.ts:1771
+#: src/strings.ts:1772
 msgid "Drop the files here"
 msgstr "Drop the files here"
 
-#: src/strings.ts:1665
+#: src/strings.ts:1666
 msgid "Drop your files here to attach"
 msgstr "Drop your files here to attach"
 
-#: src/strings.ts:2560
+#: src/strings.ts:2561
 msgid "Due {date}"
 msgstr "Due {date}"
 
-#: src/strings.ts:655
+#: src/strings.ts:656
 msgid "Due date"
 msgstr "Due date"
 
-#: src/strings.ts:2558
+#: src/strings.ts:2559
 msgid "Due today"
 msgstr "Due today"
 
-#: src/strings.ts:926
+#: src/strings.ts:927
 msgid "Duplicate"
 msgstr "Duplicate"
 
-#: src/strings.ts:2658
+#: src/strings.ts:2659
 msgid "e.g., Todo integration"
 msgstr "e.g., Todo integration"
 
-#: src/strings.ts:644
+#: src/strings.ts:645
 msgid "Earliest first"
 msgstr "Earliest first"
 
-#: src/strings.ts:2420
+#: src/strings.ts:2421
 msgid "Easy access"
 msgstr "Easy access"
 
-#: src/strings.ts:1779
+#: src/strings.ts:1780
 msgid "Edit"
 msgstr "Edit"
 
-#: src/strings.ts:2628
+#: src/strings.ts:2629
 msgid "Edit creation date"
 msgstr "Edit creation date"
 
-#: src/strings.ts:527
+#: src/strings.ts:528
 msgid "Edit internal link"
 msgstr "Edit internal link"
 
-#: src/strings.ts:2236
-#: src/strings.ts:2264
+#: src/strings.ts:2237
+#: src/strings.ts:2265
 msgid "Edit link"
 msgstr "Edit link"
 
-#: src/strings.ts:2476
+#: src/strings.ts:2477
 msgid "Edit profile"
 msgstr "Edit profile"
 
-#: src/strings.ts:1309
+#: src/strings.ts:1310
 msgid "Edit profile picture"
 msgstr "Edit profile picture"
 
-#: src/strings.ts:1821
+#: src/strings.ts:1822
 msgid "Edit your full name"
 msgstr "Edit your full name"
 
-#: src/strings.ts:1144
-#: src/strings.ts:1528
+#: src/strings.ts:1145
+#: src/strings.ts:1529
 msgid "Editor"
 msgstr "Editor"
 
-#: src/strings.ts:2584
+#: src/strings.ts:2585
 msgid "Education plan"
 msgstr "Education plan"
 
-#: src/strings.ts:1483
+#: src/strings.ts:1484
 msgid "Email"
 msgstr "Email"
 
-#: src/strings.ts:2433
+#: src/strings.ts:2434
 msgid "Email copied"
 msgstr "Email copied"
 
-#: src/strings.ts:772
+#: src/strings.ts:773
 msgid "Email is required"
 msgstr "Email is required"
 
-#: src/strings.ts:764
+#: src/strings.ts:765
 msgid "Email not confirmed"
 msgstr "Email not confirmed"
 
-#: src/strings.ts:1555
+#: src/strings.ts:1556
 msgid "Email or password incorrect"
 msgstr "Email or password incorrect"
 
-#: src/strings.ts:1262
+#: src/strings.ts:1263
 msgid "Email support"
 msgstr "Email support"
 
-#: src/strings.ts:857
+#: src/strings.ts:858
 msgid "Email updated to {email}"
 msgstr "Email updated to {email}"
 
-#: src/strings.ts:2343
+#: src/strings.ts:2344
 msgid "Embed"
 msgstr "Embed"
 
-#: src/strings.ts:2323
+#: src/strings.ts:2324
 msgid "Embed properties"
 msgstr "Embed properties"
 
-#: src/strings.ts:2319
+#: src/strings.ts:2320
 msgid "Embed settings"
 msgstr "Embed settings"
 
@@ -2572,31 +2580,31 @@ msgstr "Embed settings"
 msgid "Enable"
 msgstr "Enable"
 
-#: src/strings.ts:1133
+#: src/strings.ts:1134
 msgid "Enable (Recommended)"
 msgstr "Enable (Recommended)"
 
-#: src/strings.ts:1187
+#: src/strings.ts:1188
 msgid "Enable app lock"
 msgstr "Enable app lock"
 
-#: src/strings.ts:2014
+#: src/strings.ts:2015
 msgid "Enable editor margins"
 msgstr "Enable editor margins"
 
-#: src/strings.ts:2645
+#: src/strings.ts:2646
 msgid "Enable Inbox API"
 msgstr "Enable Inbox API"
 
-#: src/strings.ts:2467
+#: src/strings.ts:2468
 msgid "Enable ligatures for common symbols like →, ←, etc"
 msgstr "Enable ligatures for common symbols like →, ←, etc"
 
-#: src/strings.ts:2383
+#: src/strings.ts:2384
 msgid "Enable regex"
 msgstr "Enable regex"
 
-#: src/strings.ts:2129
+#: src/strings.ts:2130
 msgid "Enable spell checker"
 msgstr "Enable spell checker"
 
@@ -2604,11 +2612,11 @@ msgstr "Enable spell checker"
 msgid "Enable two-factor authentication to add an extra layer of security to your account."
 msgstr "Enable two-factor authentication to add an extra layer of security to your account."
 
-#: src/strings.ts:2646
+#: src/strings.ts:2647
 msgid "Enable/Disable Inbox API"
 msgstr "Enable/Disable Inbox API"
 
-#: src/strings.ts:1236
+#: src/strings.ts:1237
 msgid "Encrypt your backups for added security"
 msgstr "Encrypt your backups for added security"
 
@@ -2616,47 +2624,51 @@ msgstr "Encrypt your backups for added security"
 msgid "Encrypted and synced"
 msgstr "Encrypted and synced"
 
-#: src/strings.ts:2243
+#: src/strings.ts:2244
 msgid "Encrypted backup"
 msgstr "Encrypted backup"
 
-#: src/strings.ts:1659
+#: src/strings.ts:1660
 msgid "Encrypted, private, secure."
 msgstr "Encrypted, private, secure."
 
-#: src/strings.ts:942
+#: src/strings.ts:943
 msgid "Encrypting attachment"
 msgstr "Encrypting attachment"
 
-#: src/strings.ts:1845
+#: src/strings.ts:1846
 msgid "Encryption key"
 msgstr "Encryption key"
 
-#: src/strings.ts:820
+#: src/strings.ts:821
 msgid "End to end encrypted."
 msgstr "End to end encrypted."
+
+#: src/strings.ts:1007
+msgid "Enter 2FA backup code"
+msgstr "Enter 2FA backup code"
 
 #: src/strings.ts:399
 msgid "Enter 6 digit code"
 msgstr "Enter 6 digit code"
 
-#: src/strings.ts:1081
+#: src/strings.ts:1082
 msgid "Enter account password"
 msgstr "Enter account password"
 
-#: src/strings.ts:1082
+#: src/strings.ts:1083
 msgid "Enter account password to proceed."
 msgstr "Enter account password to proceed."
 
-#: src/strings.ts:1854
+#: src/strings.ts:1855
 msgid "Enter account recovery key"
 msgstr "Enter account recovery key"
 
-#: src/strings.ts:1021
+#: src/strings.ts:1022
 msgid "Enter app lock password"
 msgstr "Enter app lock password"
 
-#: src/strings.ts:1024
+#: src/strings.ts:1025
 msgid "Enter app lock pin"
 msgstr "Enter app lock pin"
 
@@ -2664,41 +2676,41 @@ msgstr "Enter app lock pin"
 msgid "Enter code from authenticator app"
 msgstr "Enter code from authenticator app"
 
-#: src/strings.ts:1513
+#: src/strings.ts:1514
 msgid "Enter email address"
 msgstr "Enter email address"
 
-#: src/strings.ts:2371
+#: src/strings.ts:2372
 msgid "Enter embed source URL"
 msgstr "Enter embed source URL"
 
-#: src/strings.ts:1315
+#: src/strings.ts:1316
 msgid "Enter full name"
 msgstr "Enter full name"
 
-#: src/strings.ts:1703
+#: src/strings.ts:1704
 msgid "Enter fullscreen"
 msgstr "Enter fullscreen"
 
-#: src/strings.ts:1492
+#: src/strings.ts:1493
 msgid "Enter notebook description"
 msgstr "Enter notebook description"
 
-#: src/strings.ts:856
+#: src/strings.ts:857
 msgid "Enter notebook title"
 msgstr "Enter notebook title"
 
-#: src/strings.ts:791
+#: src/strings.ts:792
 msgid "Enter password"
 msgstr "Enter password"
 
-#: src/strings.ts:2090
+#: src/strings.ts:2091
 msgid "Enter pin or password to enable app lock."
 msgstr "Enter pin or password to enable app lock."
 
-#: src/strings.ts:1006
-msgid "Enter recovery code"
-msgstr "Enter recovery code"
+#: src/strings.ts:120
+msgid "Enter the 2FA backup code to continue logging in"
+msgstr "Enter the 2FA backup code to continue logging in"
 
 #: src/strings.ts:119
 msgid "Enter the 6 digit code from your authenticator app to continue logging in"
@@ -2712,43 +2724,39 @@ msgstr "Enter the 6 digit code sent to your email to continue logging in"
 msgid "Enter the 6 digit code sent to your phone number to continue logging in"
 msgstr "Enter the 6 digit code sent to your phone number to continue logging in"
 
-#: src/strings.ts:2435
+#: src/strings.ts:2436
 msgid "Enter the gift code to redeem your subscription."
 msgstr "Enter the gift code to redeem your subscription."
 
-#: src/strings.ts:120
-msgid "Enter the recovery code to continue logging in"
-msgstr "Enter the recovery code to continue logging in"
-
-#: src/strings.ts:2620
+#: src/strings.ts:2621
 msgid "Enter title"
 msgstr "Enter title"
 
-#: src/strings.ts:1495
+#: src/strings.ts:1496
 msgid "Enter verification code sent to your new email"
 msgstr "Enter verification code sent to your new email"
 
-#: src/strings.ts:1494
+#: src/strings.ts:1495
 msgid "Enter your new email"
 msgstr "Enter your new email"
 
-#: src/strings.ts:2091
+#: src/strings.ts:2092
 msgid "Enter your username"
 msgstr "Enter your username"
 
-#: src/strings.ts:2427
+#: src/strings.ts:2428
 msgid "Error"
 msgstr "Error"
 
-#: src/strings.ts:1556
+#: src/strings.ts:1557
 msgid "Error applying promo code"
 msgstr "Error applying promo code"
 
-#: src/strings.ts:747
+#: src/strings.ts:748
 msgid "Error downloading file: {message}"
 msgstr "Error downloading file: {message}"
 
-#: src/strings.ts:1516
+#: src/strings.ts:1517
 msgid "Error getting codes"
 msgstr "Error getting codes"
 
@@ -2756,83 +2764,83 @@ msgstr "Error getting codes"
 msgid "Error loading themes"
 msgstr "Error loading themes"
 
-#: src/strings.ts:1077
+#: src/strings.ts:1078
 msgid "Error logging out"
 msgstr "Error logging out"
 
-#: src/strings.ts:1011
+#: src/strings.ts:1012
 msgid "Error sending 2FA code"
 msgstr "Error sending 2FA code"
 
-#: src/strings.ts:759
+#: src/strings.ts:760
 msgid "Errors"
 msgstr "Errors"
 
-#: src/strings.ts:1698
+#: src/strings.ts:1699
 msgid "Errors in {count} attachments"
 msgstr "Errors in {count} attachments"
 
-#: src/strings.ts:2472
+#: src/strings.ts:2473
 msgid "Essential plan"
 msgstr "Essential plan"
 
-#: src/strings.ts:1630
+#: src/strings.ts:1631
 msgid "Events server"
 msgstr "Events server"
 
-#: src/strings.ts:2413
+#: src/strings.ts:2414
 msgid "Every Notebook can have notes and sub notebooks."
 msgstr "Every Notebook can have notes and sub notebooks."
 
-#: src/strings.ts:2415
+#: src/strings.ts:2416
 msgid "Everything related to my job in one place."
 msgstr "Everything related to my job in one place."
 
-#: src/strings.ts:2424
+#: src/strings.ts:2425
 msgid "Everything related to my school in one place."
 msgstr "Everything related to my school in one place."
 
-#: src/strings.ts:2441
+#: src/strings.ts:2442
 msgid "Execute"
 msgstr "Execute"
 
-#: src/strings.ts:2440
+#: src/strings.ts:2441
 msgid "Execute a command..."
 msgstr "Execute a command..."
 
-#: src/strings.ts:2015
+#: src/strings.ts:2016
 msgid "Exit fullscreen"
 msgstr "Exit fullscreen"
 
-#: src/strings.ts:2375
+#: src/strings.ts:2376
 msgid "Expand"
 msgstr "Expand"
 
-#: src/strings.ts:2468
+#: src/strings.ts:2469
 msgid "Expand sidebar"
 msgstr "Expand sidebar"
 
-#: src/strings.ts:2074
+#: src/strings.ts:2075
 msgid "Experience the next level of private note taking\""
 msgstr "Experience the next level of private note taking\""
 
-#: src/strings.ts:2694
+#: src/strings.ts:2695
 msgid "Expired"
 msgstr "Expired"
 
-#: src/strings.ts:2659
+#: src/strings.ts:2660
 msgid "Expires in"
 msgstr "Expires in"
 
-#: src/strings.ts:2695
+#: src/strings.ts:2696
 msgid "Expires on"
 msgstr "Expires on"
 
-#: src/strings.ts:2634
+#: src/strings.ts:2635
 msgid "Expiry date"
 msgstr "Expiry date"
 
-#: src/strings.ts:2541
+#: src/strings.ts:2542
 msgid "Explore all plans"
 msgstr "Explore all plans"
 
@@ -2840,28 +2848,28 @@ msgstr "Explore all plans"
 msgid "Export"
 msgstr "Export"
 
-#: src/strings.ts:578
+#: src/strings.ts:579
 msgid "Export again"
 msgstr "Export again"
 
-#: src/strings.ts:1239
+#: src/strings.ts:1240
 msgid "Export all notes"
 msgstr "Export all notes"
 
-#: src/strings.ts:1241
+#: src/strings.ts:1242
 msgid "Export all notes as pdf, markdown, html or text in a single zip file"
 msgstr "Export all notes as pdf, markdown, html or text in a single zip file"
 
 #. placeholder {0}: format ? " " + format : ""
-#: src/strings.ts:2037
+#: src/strings.ts:2038
 msgid "Export as{0}"
 msgstr "Export as{0}"
 
-#: src/strings.ts:2635
+#: src/strings.ts:2636
 msgid "Export CSV"
 msgstr "Export CSV"
 
-#: src/strings.ts:1387
+#: src/strings.ts:1388
 msgid "Export notes as PDF, Markdown and HTML with Notesnook Pro"
 msgstr "Export notes as PDF, Markdown and HTML with Notesnook Pro"
 
@@ -2869,108 +2877,108 @@ msgstr "Export notes as PDF, Markdown and HTML with Notesnook Pro"
 msgid "Exporting \"{title}\""
 msgstr "Exporting \"{title}\""
 
-#: src/strings.ts:1620
+#: src/strings.ts:1621
 msgid "Extracting files..."
 msgstr "Extracting files..."
 
-#: src/strings.ts:1809
+#: src/strings.ts:1810
 msgid "EXTREMELY DANGEROUS! This action is irreversible. All your data including notes, notebooks, attachments & settings will be deleted. This is a full account reset. Proceed with caution."
 msgstr "EXTREMELY DANGEROUS! This action is irreversible. All your data including notes, notebooks, attachments & settings will be deleted. This is a full account reset. Proceed with caution."
 
-#: src/strings.ts:1261
+#: src/strings.ts:1262
 msgid "Faced an issue or have a suggestion? Click here to create a bug report"
 msgstr "Faced an issue or have a suggestion? Click here to create a bug report"
 
-#: src/strings.ts:2405
+#: src/strings.ts:2406
 msgid "Failed"
 msgstr "Failed"
 
-#: src/strings.ts:2639
+#: src/strings.ts:2640
 msgid "Failed to attach file"
 msgstr "Failed to attach file"
 
-#: src/strings.ts:1938
+#: src/strings.ts:1939
 msgid "Failed to copy note"
 msgstr "Failed to copy note"
 
-#: src/strings.ts:2684
+#: src/strings.ts:2685
 msgid "Failed to copy to clipboard"
 msgstr "Failed to copy to clipboard"
 
 #. placeholder {0}: message ? `: ${message}` : ""
-#: src/strings.ts:2663
+#: src/strings.ts:2664
 msgid "Failed to create API key{0}"
 msgstr "Failed to create API key{0}"
 
-#: src/strings.ts:1562
+#: src/strings.ts:1563
 msgid "Failed to decrypt backup"
 msgstr "Failed to decrypt backup"
 
-#: src/strings.ts:2004
+#: src/strings.ts:2005
 msgid "Failed to delete"
 msgstr "Failed to delete"
 
-#: src/strings.ts:1083
+#: src/strings.ts:1084
 msgid "Failed to delete account"
 msgstr "Failed to delete account"
 
-#: src/strings.ts:792
+#: src/strings.ts:793
 msgid "Failed to download file"
 msgstr "Failed to download file"
 
-#: src/strings.ts:2000
+#: src/strings.ts:2001
 msgid "Failed to install theme."
 msgstr "Failed to install theme."
 
-#: src/strings.ts:2670
+#: src/strings.ts:2671
 msgid "Failed to load API keys. Please try again."
 msgstr "Failed to load API keys. Please try again."
 
-#: src/strings.ts:950
+#: src/strings.ts:951
 msgid "Failed to open"
 msgstr "Failed to open"
 
-#: src/strings.ts:867
+#: src/strings.ts:868
 msgid "Failed to publish note"
 msgstr "Failed to publish note"
 
-#: src/strings.ts:2005
+#: src/strings.ts:2006
 msgid "Failed to register task"
 msgstr "Failed to register task"
 
-#: src/strings.ts:804
+#: src/strings.ts:805
 msgid "Failed to resolve download url"
 msgstr "Failed to resolve download url"
 
-#: src/strings.ts:2689
+#: src/strings.ts:2690
 msgid "Failed to revoke API key"
 msgstr "Failed to revoke API key"
 
-#: src/strings.ts:773
+#: src/strings.ts:774
 msgid "Failed to send recovery email"
 msgstr "Failed to send recovery email"
 
-#: src/strings.ts:1403
+#: src/strings.ts:1404
 msgid "Failed to send verification email"
 msgstr "Failed to send verification email"
 
-#: src/strings.ts:939
+#: src/strings.ts:940
 msgid "Failed to subscribe"
 msgstr "Failed to subscribe"
 
-#: src/strings.ts:2205
+#: src/strings.ts:2206
 msgid "Failed to take backup"
 msgstr "Failed to take backup"
 
-#: src/strings.ts:2207
+#: src/strings.ts:2208
 msgid "Failed to take backup of your data. Do you want to continue logging out?"
 msgstr "Failed to take backup of your data. Do you want to continue logging out?"
 
-#: src/strings.ts:868
+#: src/strings.ts:869
 msgid "Failed to unpublish note"
 msgstr "Failed to unpublish note"
 
-#: src/strings.ts:798
+#: src/strings.ts:799
 msgid "Failed to zip files"
 msgstr "Failed to zip files"
 
@@ -2978,140 +2986,140 @@ msgstr "Failed to zip files"
 msgid "Fallback method for 2FA enabled"
 msgstr "Fallback method for 2FA enabled"
 
-#: src/strings.ts:2551
+#: src/strings.ts:2552
 msgid "FAQs"
 msgstr "FAQs"
 
-#: src/strings.ts:2034
+#: src/strings.ts:2035
 msgid "Favorite"
 msgstr "Favorite"
 
 #: src/strings.ts:321
-#: src/strings.ts:1523
+#: src/strings.ts:1524
 msgid "Favorites"
 msgstr "Favorites"
 
-#: src/strings.ts:2549
+#: src/strings.ts:2550
 msgid "Featured on"
 msgstr "Featured on"
 
-#: src/strings.ts:2417
+#: src/strings.ts:2418
 msgid "February 2022 Week 2"
 msgstr "February 2022 Week 2"
 
-#: src/strings.ts:2418
+#: src/strings.ts:2419
 msgid "February 2022 Week 3"
 msgstr "February 2022 Week 3"
 
-#: src/strings.ts:732
+#: src/strings.ts:733
 msgid "File check failed: {reason} Try reuploading the file to fix the issue."
 msgstr "File check failed: {reason} Try reuploading the file to fix the issue."
 
-#: src/strings.ts:750
+#: src/strings.ts:751
 msgid "File check passed"
 msgstr "File check passed"
 
-#: src/strings.ts:801
+#: src/strings.ts:802
 msgid "File length is 0. Please upload this file again from the attachment manager."
 msgstr "File length is 0. Please upload this file again from the attachment manager."
 
-#: src/strings.ts:803
+#: src/strings.ts:804
 msgid "File length mismatch. Expected {expectedSize} but got {currentSize} bytes. Please upload this file again from the attachment manager."
 msgstr "File length mismatch. Expected {expectedSize} but got {currentSize} bytes. Please upload this file again from the attachment manager."
 
-#: src/strings.ts:951
+#: src/strings.ts:952
 msgid "File mismatch"
 msgstr "File mismatch"
 
-#: src/strings.ts:947
+#: src/strings.ts:948
 msgid "File size should be less than {sizeInMB}"
 msgstr "File size should be less than {sizeInMB}"
 
-#: src/strings.ts:945
+#: src/strings.ts:946
 msgid "File too big"
 msgstr "File too big"
 
-#: src/strings.ts:1480
+#: src/strings.ts:1481
 msgid "Filter attachments by filename, type or hash"
 msgstr "Filter attachments by filename, type or hash"
 
-#: src/strings.ts:1835
+#: src/strings.ts:1836
 msgid "Filter languages"
 msgstr "Filter languages"
 
-#: src/strings.ts:2606
+#: src/strings.ts:2607
 msgid "Finish your purchase in the browser."
 msgstr "Finish your purchase in the browser."
 
-#: src/strings.ts:1671
+#: src/strings.ts:1672
 msgid "Fix it"
 msgstr "Fix it"
 
-#: src/strings.ts:2017
+#: src/strings.ts:2018
 msgid "Focus mode"
 msgstr "Focus mode"
 
-#: src/strings.ts:2165
+#: src/strings.ts:2166
 msgid "Follow"
 msgstr "Follow"
 
-#: src/strings.ts:1277
+#: src/strings.ts:1278
 msgid "Follow us on Mastodon"
 msgstr "Follow us on Mastodon"
 
-#: src/strings.ts:1279
+#: src/strings.ts:1280
 msgid "Follow us on Mastodon for updates and news about Notesnook"
 msgstr "Follow us on Mastodon for updates and news about Notesnook"
 
-#: src/strings.ts:1280
+#: src/strings.ts:1281
 msgid "Follow us on X"
 msgstr "Follow us on X"
 
-#: src/strings.ts:1281
+#: src/strings.ts:1282
 msgid "Follow us on X for updates and news about Notesnook"
 msgstr "Follow us on X for updates and news about Notesnook"
 
-#: src/strings.ts:2278
+#: src/strings.ts:2279
 msgid "Font family"
 msgstr "Font family"
 
-#: src/strings.ts:2465
+#: src/strings.ts:2466
 msgid "Font ligatures"
 msgstr "Font ligatures"
 
-#: src/strings.ts:2279
+#: src/strings.ts:2280
 msgid "Font size"
 msgstr "Font size"
 
-#: src/strings.ts:2523
+#: src/strings.ts:2524
 msgid "For a monthly subscription, you can get a refund within 7 days of purchase. For a yearly subscription, we offer a full refund within 14 days of purchase. For a 5 year subscription, you can request a refund within 30 days of purchase."
 msgstr "For a monthly subscription, you can get a refund within 7 days of purchase. For a yearly subscription, we offer a full refund within 14 days of purchase. For a 5 year subscription, you can request a refund within 30 days of purchase."
 
-#: src/strings.ts:1688
+#: src/strings.ts:1689
 msgid "For a more integrated user experience, try out Notesnook for {platform}"
 msgstr "For a more integrated user experience, try out Notesnook for {platform}"
 
-#: src/strings.ts:1769
+#: src/strings.ts:1770
 msgid "for help regarding how to use the Notesnook Importer."
 msgstr "for help regarding how to use the Notesnook Importer."
 
-#: src/strings.ts:2532
+#: src/strings.ts:2533
 msgid "for locking your notes as soon as app enters background"
 msgstr "for locking your notes as soon as app enters background"
 
-#: src/strings.ts:2197
+#: src/strings.ts:2198
 msgid "Force logout from all your other logged in devices."
 msgstr "Force logout from all your other logged in devices."
 
-#: src/strings.ts:1098
+#: src/strings.ts:1099
 msgid "Force pull changes"
 msgstr "Force pull changes"
 
-#: src/strings.ts:1107
+#: src/strings.ts:1108
 msgid "Force push changes"
 msgstr "Force push changes"
 
-#: src/strings.ts:2214
+#: src/strings.ts:2215
 msgid ""
 "Force push:\n"
 "Use this if changes made on this device are not appearing on other devices. This will overwrite the data on the server with the data from this device.\n"
@@ -3129,91 +3137,95 @@ msgstr ""
 "\n"
 "**These must only be used for troubleshooting. Using them regularly for sync is not recommended and will lead to unexpected data loss and other issues. If you are having persistent issues with sync, please report them to us at support@streetwriters.co.**"
 
-#: src/strings.ts:553
+#: src/strings.ts:554
 msgid "Forgot password?"
 msgstr "Forgot password?"
 
-#: src/strings.ts:2566
+#: src/strings.ts:2567
 msgid "Free {duration} day trial, cancel any time"
 msgstr "Free {duration} day trial, cancel any time"
 
-#: src/strings.ts:2470
+#: src/strings.ts:2471
 msgid "Free plan"
 msgstr "Free plan"
 
-#: src/strings.ts:627
+#: src/strings.ts:628
 msgid "Fri"
 msgstr "Fri"
 
-#: src/strings.ts:618
+#: src/strings.ts:619
 msgid "Friday"
 msgstr "Friday"
 
-#: src/strings.ts:2373
+#: src/strings.ts:2374
 msgid "From code"
 msgstr "From code"
 
-#: src/strings.ts:2370
+#: src/strings.ts:2371
 msgid "From URL"
 msgstr "From URL"
 
-#: src/strings.ts:2001
+#: src/strings.ts:2002
 msgid "Full name updated"
 msgstr "Full name updated"
 
-#: src/strings.ts:2208
+#: src/strings.ts:2209
 msgid "Full offline mode"
 msgstr "Full offline mode"
 
-#: src/strings.ts:2325
+#: src/strings.ts:2326
 msgid "Full screen"
 msgstr "Full screen"
 
-#: src/strings.ts:2094
+#: src/strings.ts:2095
 msgid "General"
 msgstr "General"
 
-#: src/strings.ts:1270
+#: src/strings.ts:1271
 msgid "Get helpful debug info about the app to help us find bugs."
 msgstr "Get helpful debug info about the app to help us find bugs."
 
-#: src/strings.ts:1294
+#: src/strings.ts:1295
 msgid "Get Notesnook app on your desktop and access all notes"
 msgstr "Get Notesnook app on your desktop and access all notes"
 
-#: src/strings.ts:2159
+#: src/strings.ts:2160
 msgid "Get Notesnook app on your iPhone and access all your notes on the go."
 msgstr "Get Notesnook app on your iPhone and access all your notes on the go."
 
-#: src/strings.ts:2161
+#: src/strings.ts:2162
 msgid "Get Notesnook app on your iPhone or Android device and access all your notes on the go."
 msgstr "Get Notesnook app on your iPhone or Android device and access all your notes on the go."
 
-#: src/strings.ts:1384
+#: src/strings.ts:1385
 msgid "Get Notesnook Pro"
 msgstr "Get Notesnook Pro"
 
-#: src/strings.ts:1369
+#: src/strings.ts:1370
 msgid "Get Notesnook Pro to enable automatic backups"
 msgstr "Get Notesnook Pro to enable automatic backups"
 
-#: src/strings.ts:2409
+#: src/strings.ts:2410
 msgid "Get Priority support"
 msgstr "Get Priority support"
 
-#: src/strings.ts:688
+#: src/strings.ts:689
 msgid "Get Pro"
 msgstr "Get Pro"
 
-#: src/strings.ts:563
+#: src/strings.ts:564
 msgid "Get started"
 msgstr "Get started"
 
-#: src/strings.ts:2529
+#: src/strings.ts:2530
 msgid "Get this and so much more:"
 msgstr "Get this and so much more:"
 
-#: src/strings.ts:1887
+#: src/strings.ts:400
+msgid "Getting 2FA backup codes"
+msgstr "Getting 2FA backup codes"
+
+#: src/strings.ts:1888
 msgid "Getting encryption key..."
 msgstr "Getting encryption key..."
 
@@ -3221,63 +3233,59 @@ msgstr "Getting encryption key..."
 msgid "Getting information"
 msgstr "Getting information"
 
-#: src/strings.ts:400
-msgid "Getting recovery codes"
-msgstr "Getting recovery codes"
-
-#: src/strings.ts:2164
+#: src/strings.ts:2165
 msgid "GNU GENERAL PUBLIC LICENSE Version 3"
 msgstr "GNU GENERAL PUBLIC LICENSE Version 3"
 
-#: src/strings.ts:2607
+#: src/strings.ts:2608
 msgid "Go back"
 msgstr "Go back"
 
-#: src/strings.ts:2448
+#: src/strings.ts:2449
 msgid "Go back in tab"
 msgstr "Go back in tab"
 
-#: src/strings.ts:2227
+#: src/strings.ts:2228
 msgid "Go back to notebooks"
 msgstr "Go back to notebooks"
 
-#: src/strings.ts:2228
+#: src/strings.ts:2229
 msgid "Go back to tags"
 msgstr "Go back to tags"
 
-#: src/strings.ts:2447
+#: src/strings.ts:2448
 msgid "Go forward in tab"
 msgstr "Go forward in tab"
 
-#: src/strings.ts:1815
+#: src/strings.ts:1816
 msgid "Go to"
 msgstr "Go to"
 
-#: src/strings.ts:1816
+#: src/strings.ts:1817
 msgid "Go to #{tag}"
 msgstr "Go to #{tag}"
 
-#: src/strings.ts:1699
+#: src/strings.ts:1700
 msgid "Go to next page"
 msgstr "Go to next page"
 
-#: src/strings.ts:1700
+#: src/strings.ts:1701
 msgid "Go to previous page"
 msgstr "Go to previous page"
 
-#: src/strings.ts:1306
+#: src/strings.ts:1307
 msgid "Go to web app"
 msgstr "Go to web app"
 
-#: src/strings.ts:2540
+#: src/strings.ts:2541
 msgid "Google will remind you 2 days before your trial ends."
 msgstr "Google will remind you 2 days before your trial ends."
 
-#: src/strings.ts:2567
+#: src/strings.ts:2568
 msgid "Google will remind you before your trial ends"
 msgstr "Google will remind you before your trial ends"
 
-#: src/strings.ts:586
+#: src/strings.ts:587
 msgid "Got it"
 msgstr "Got it"
 
@@ -3285,39 +3293,39 @@ msgstr "Got it"
 msgid "GROUP"
 msgstr "GROUP"
 
-#: src/strings.ts:1889
+#: src/strings.ts:1890
 msgid "Group added successfully"
 msgstr "Group added successfully"
 
-#: src/strings.ts:537
+#: src/strings.ts:538
 msgid "Group by"
 msgstr "Group by"
 
-#: src/strings.ts:752
+#: src/strings.ts:753
 msgid "Hash copied"
 msgstr "Hash copied"
 
-#: src/strings.ts:2211
+#: src/strings.ts:2212
 msgid "Having problems with sync?"
 msgstr "Having problems with sync?"
 
-#: src/strings.ts:2555
+#: src/strings.ts:2556
 msgid "hdImages"
 msgstr "hdImages"
 
-#: src/strings.ts:2351
+#: src/strings.ts:2352
 msgid "Heading {level}"
 msgstr "Heading {level}"
 
-#: src/strings.ts:2280
+#: src/strings.ts:2281
 msgid "Headings"
 msgstr "Headings"
 
-#: src/strings.ts:2386
+#: src/strings.ts:2387
 msgid "Height"
 msgstr "Height"
 
-#: src/strings.ts:1258
+#: src/strings.ts:1259
 msgid "Help and support"
 msgstr "Help and support"
 
@@ -3325,57 +3333,61 @@ msgstr "Help and support"
 msgid "Help improve Notesnook by sending completely anonymized"
 msgstr "Help improve Notesnook by sending completely anonymized"
 
-#: src/strings.ts:1377
+#: src/strings.ts:1378
 msgid "Hide"
 msgstr "Hide"
 
-#: src/strings.ts:1184
+#: src/strings.ts:1185
 msgid "Hide app contents when you switch to other apps. This will also disable screenshot taking in the app."
 msgstr "Hide app contents when you switch to other apps. This will also disable screenshot taking in the app."
 
-#: src/strings.ts:2170
+#: src/strings.ts:2171
 msgid "Hide note title"
 msgstr "Hide note title"
 
-#: src/strings.ts:2283
+#: src/strings.ts:2284
 msgid "Highlight"
 msgstr "Highlight"
 
-#: src/strings.ts:909
+#: src/strings.ts:910
 msgid "History"
 msgstr "History"
 
-#: src/strings.ts:1529
+#: src/strings.ts:1530
 msgid "Home"
 msgstr "Home"
 
-#: src/strings.ts:1128
+#: src/strings.ts:1129
 msgid "Homepage"
 msgstr "Homepage"
 
-#: src/strings.ts:1319
+#: src/strings.ts:1320
 msgid "Homepage changed to {name}"
 msgstr "Homepage changed to {name}"
 
-#: src/strings.ts:2332
+#: src/strings.ts:2333
 msgid "Horizontal rule"
 msgstr "Horizontal rule"
 
-#: src/strings.ts:1800
+#: src/strings.ts:1801
 msgid "How do you want to recover your account?"
 msgstr "How do you want to recover your account?"
 
-#: src/strings.ts:1670
+#: src/strings.ts:1671
 msgid "How to fix it?"
 msgstr "How to fix it?"
 
-#: src/strings.ts:880
+#: src/strings.ts:881
 msgid "hr"
 msgstr "hr"
 
-#: src/strings.ts:2500
+#: src/strings.ts:2501
 msgid "I already have an account"
 msgstr "I already have an account"
+
+#: src/strings.ts:126
+msgid "I don't have 2FA backup codes"
+msgstr "I don't have 2FA backup codes"
 
 #: src/strings.ts:125
 msgid "I don't have access to authenticator app"
@@ -3389,31 +3401,27 @@ msgstr "I don't have access to email"
 msgid "I don't have access to my phone"
 msgstr "I don't have access to my phone"
 
-#: src/strings.ts:126
-msgid "I don't have recovery codes"
-msgstr "I don't have recovery codes"
-
 #: src/strings.ts:133
-msgid "I have a recovery code"
-msgstr "I have a recovery code"
+msgid "I have a 2FA backup code"
+msgstr "I have a 2FA backup code"
 
-#: src/strings.ts:1888
+#: src/strings.ts:1889
 msgid "I have saved my key"
 msgstr "I have saved my key"
 
-#: src/strings.ts:2426
+#: src/strings.ts:2427
 msgid "I love cooking and collecting recipes."
 msgstr "I love cooking and collecting recipes."
 
-#: src/strings.ts:2212
+#: src/strings.ts:2213
 msgid "I understand"
 msgstr "I understand"
 
-#: src/strings.ts:551
+#: src/strings.ts:552
 msgid "I understand, change my password"
 msgstr "I understand, change my password"
 
-#: src/strings.ts:913
+#: src/strings.ts:914
 msgid "ID copied"
 msgstr "ID copied"
 
@@ -3425,19 +3433,19 @@ msgstr "If the editor fails to load even after reloading. Try restarting the app
 msgid "If this continues to happen, please reach out to us via"
 msgstr "If this continues to happen, please reach out to us via"
 
-#: src/strings.ts:2115
+#: src/strings.ts:2116
 msgid "If true, Notesnook will automatically start up when you turn on & login to your system."
 msgstr "If true, Notesnook will automatically start up when you turn on & login to your system."
 
-#: src/strings.ts:2118
+#: src/strings.ts:2119
 msgid "If true, Notesnook will start minimized to either the system tray or your system taskbar/dock. This setting only works with Auto start on system startup is enabled."
 msgstr "If true, Notesnook will start minimized to either the system tray or your system taskbar/dock. This setting only works with Auto start on system startup is enabled."
 
-#: src/strings.ts:1726
+#: src/strings.ts:1727
 msgid "If you can't scan the QR code above, enter this text instead (spaces don't matter)"
 msgstr "If you can't scan the QR code above, enter this text instead (spaces don't matter)"
 
-#: src/strings.ts:1396
+#: src/strings.ts:1397
 msgid ""
 "If you didn't get an email from us or the confirmation link isn't\n"
 "            working,"
@@ -3445,11 +3453,11 @@ msgstr ""
 "If you didn't get an email from us or the confirmation link isn't\n"
 "            working,"
 
-#: src/strings.ts:1806
+#: src/strings.ts:1807
 msgid "If you don't have a recovery key, you can recover your data by restoring a Notesnook data backup file (.nnbackup)."
 msgstr "If you don't have a recovery key, you can recover your data by restoring a Notesnook data backup file (.nnbackup)."
 
-#: src/strings.ts:2079
+#: src/strings.ts:2080
 msgid "If you face any issue, you can reach out to us anytime."
 msgstr "If you face any issue, you can reach out to us anytime."
 
@@ -3457,27 +3465,27 @@ msgstr "If you face any issue, you can reach out to us anytime."
 msgid "If you want to ask something in general or need some assistance, we would suggest that you"
 msgstr "If you want to ask something in general or need some assistance, we would suggest that you"
 
-#: src/strings.ts:2337
+#: src/strings.ts:2338
 msgid "Image"
 msgstr "Image"
 
-#: src/strings.ts:1130
+#: src/strings.ts:1131
 msgid "Image Compression"
 msgstr "Image Compression"
 
-#: src/strings.ts:2313
+#: src/strings.ts:2314
 msgid "Image properties"
 msgstr "Image properties"
 
-#: src/strings.ts:2309
+#: src/strings.ts:2310
 msgid "Image settings"
 msgstr "Image settings"
 
-#: src/strings.ts:949
+#: src/strings.ts:950
 msgid "Image size should be less than {sizeInMB}"
 msgstr "Image size should be less than {sizeInMB}"
 
-#: src/strings.ts:755
+#: src/strings.ts:756
 msgid "Images"
 msgstr "Images"
 
@@ -3485,35 +3493,35 @@ msgstr "Images"
 msgid "Images uploaded without compression are slow to load and take more bandwidth. We recommend compressing images unless you need image in original quality."
 msgstr "Images uploaded without compression are slow to load and take more bandwidth. We recommend compressing images unless you need image in original quality."
 
-#: src/strings.ts:1584
+#: src/strings.ts:1585
 msgid "Immediately"
 msgstr "Immediately"
 
-#: src/strings.ts:2142
+#: src/strings.ts:2143
 msgid "Import & export"
 msgstr "Import & export"
 
-#: src/strings.ts:1753
+#: src/strings.ts:1754
 msgid "Import completed"
 msgstr "Import completed"
 
-#: src/strings.ts:2636
+#: src/strings.ts:2637
 msgid "Import CSV"
 msgstr "Import CSV"
 
-#: src/strings.ts:1768
+#: src/strings.ts:1769
 msgid "import guide"
 msgstr "import guide"
 
-#: src/strings.ts:2642
+#: src/strings.ts:2643
 msgid "Inbox API"
 msgstr "Inbox API"
 
-#: src/strings.ts:2647
+#: src/strings.ts:2648
 msgid "Inbox Keys"
 msgstr "Inbox Keys"
 
-#: src/strings.ts:2702
+#: src/strings.ts:2703
 msgid "Inbox keys saved"
 msgstr "Inbox keys saved"
 
@@ -3521,104 +3529,104 @@ msgstr "Inbox keys saved"
 msgid "Incoming"
 msgstr "Incoming"
 
-#: src/strings.ts:1839
+#: src/strings.ts:1840
 msgid "Incoming note"
 msgstr "Incoming note"
 
-#: src/strings.ts:784
+#: src/strings.ts:785
 msgid "Incorrect {type}"
 msgstr "Incorrect {type}"
 
-#: src/strings.ts:2395
+#: src/strings.ts:2396
 msgid "Increase {title}"
 msgstr "Increase {title}"
 
-#: src/strings.ts:2237
+#: src/strings.ts:2238
 msgid "Insert"
 msgstr "Insert"
 
-#: src/strings.ts:2392
+#: src/strings.ts:2393
 msgid "Insert a {rows}x{columns} table"
 msgstr "Insert a {rows}x{columns} table"
 
-#: src/strings.ts:2342
+#: src/strings.ts:2343
 msgid "Insert a table"
 msgstr "Insert a table"
 
-#: src/strings.ts:2344
+#: src/strings.ts:2345
 msgid "Insert an embed"
 msgstr "Insert an embed"
 
-#: src/strings.ts:2338
+#: src/strings.ts:2339
 msgid "Insert an image"
 msgstr "Insert an image"
 
-#: src/strings.ts:2290
+#: src/strings.ts:2291
 msgid "Insert column left"
 msgstr "Insert column left"
 
-#: src/strings.ts:2291
+#: src/strings.ts:2292
 msgid "Insert column right"
 msgstr "Insert column right"
 
-#: src/strings.ts:2235
+#: src/strings.ts:2236
 msgid "Insert link"
 msgstr "Insert link"
 
-#: src/strings.ts:2297
+#: src/strings.ts:2298
 msgid "Insert row above"
 msgstr "Insert row above"
 
-#: src/strings.ts:2298
+#: src/strings.ts:2299
 msgid "Insert row below"
 msgstr "Insert row below"
 
-#: src/strings.ts:1686
+#: src/strings.ts:1687
 msgid "Install Notesnook"
 msgstr "Install Notesnook"
 
-#: src/strings.ts:2150
+#: src/strings.ts:2151
 msgid "Install update"
 msgstr "Install update"
 
-#: src/strings.ts:1721
+#: src/strings.ts:1722
 msgid "installs"
 msgstr "installs"
 
-#: src/strings.ts:748
+#: src/strings.ts:749
 msgid "Invalid {type}"
 msgstr "Invalid {type}"
 
-#: src/strings.ts:1993
+#: src/strings.ts:1994
 msgid "Invalid CORS proxy url"
 msgstr "Invalid CORS proxy url"
 
-#: src/strings.ts:1484
+#: src/strings.ts:1485
 msgid "Invalid email"
 msgstr "Invalid email"
 
-#: src/strings.ts:2682
+#: src/strings.ts:2683
 msgid "Invalid password"
 msgstr "Invalid password"
 
-#: src/strings.ts:2701
+#: src/strings.ts:2702
 msgid "Invalid PGP key pair. Please check your keys and try again."
 msgstr "Invalid PGP key pair. Please check your keys and try again."
 
-#: src/strings.ts:2708
-msgid "Invalid recovery key. Make sure to input your account recovery key, not a 2FA recovery code."
-msgstr "Invalid recovery key. Make sure to input your account recovery key, not a 2FA recovery code."
+#: src/strings.ts:2709
+msgid "Invalid recovery key. Make sure to input your account recovery key, not a 2FA backup code."
+msgstr "Invalid recovery key. Make sure to input your account recovery key, not a 2FA backup code."
 
 #: src/strings.ts:224
 msgid "Issue created"
 msgstr "Issue created"
 
-#: src/strings.ts:992
-#: src/strings.ts:1001
+#: src/strings.ts:993
+#: src/strings.ts:1002
 msgid "It may take a minute to receive your code."
 msgstr "It may take a minute to receive your code."
 
-#: src/strings.ts:1592
+#: src/strings.ts:1593
 msgid "It seems that your changes could not be saved. What to do next:"
 msgstr "It seems that your changes could not be saved. What to do next:"
 
@@ -3626,7 +3634,7 @@ msgstr "It seems that your changes could not be saved. What to do next:"
 msgid "It took us a year to bring Notesnook to life. Share your experience and suggestions to help us improve it."
 msgstr "It took us a year to bring Notesnook to life. Share your experience and suggestions to help us improve it."
 
-#: src/strings.ts:2259
+#: src/strings.ts:2260
 msgid "Italic"
 msgstr "Italic"
 
@@ -3639,7 +3647,7 @@ msgid "Item"
 msgstr "Item"
 
 #: src/strings.ts:311
-#: src/strings.ts:1705
+#: src/strings.ts:1706
 msgid "items"
 msgstr "items"
 
@@ -3647,7 +3655,7 @@ msgstr "items"
 msgid "Items"
 msgstr "Items"
 
-#: src/strings.ts:2162
+#: src/strings.ts:2163
 msgid "Join community"
 msgstr "Join community"
 
@@ -3655,63 +3663,63 @@ msgstr "Join community"
 msgid "join our community on Discord."
 msgstr "join our community on Discord."
 
-#: src/strings.ts:1282
+#: src/strings.ts:1283
 msgid "Join our Discord server"
 msgstr "Join our Discord server"
 
-#: src/strings.ts:1284
+#: src/strings.ts:1285
 msgid "Join our Discord server to chat with other users and the team"
 msgstr "Join our Discord server to chat with other users and the team"
 
-#: src/strings.ts:1274
+#: src/strings.ts:1275
 msgid "Join our Telegram group"
 msgstr "Join our Telegram group"
 
-#: src/strings.ts:1276
+#: src/strings.ts:1277
 msgid "Join our Telegram group to chat with other users and the team"
 msgstr "Join our Telegram group to chat with other users and the team"
 
-#: src/strings.ts:2070
+#: src/strings.ts:2071
 msgid "Join the cause"
 msgstr "Join the cause"
 
-#: src/strings.ts:2028
+#: src/strings.ts:2029
 msgid "Jump to group"
 msgstr "Jump to group"
 
-#: src/strings.ts:567
+#: src/strings.ts:568
 msgid "Keep"
 msgstr "Keep"
 
-#: src/strings.ts:2023
+#: src/strings.ts:2024
 msgid "Keep open"
 msgstr "Keep open"
 
-#: src/strings.ts:1361
+#: src/strings.ts:1362
 msgid "Keep your data safe"
 msgstr "Keep your data safe"
 
-#: src/strings.ts:2657
+#: src/strings.ts:2658
 msgid "Key name"
 msgstr "Key name"
 
-#: src/strings.ts:2130
+#: src/strings.ts:2131
 msgid "Languages"
 msgstr "Languages"
 
-#: src/strings.ts:2232
+#: src/strings.ts:2233
 msgid "Last edited at"
 msgstr "Last edited at"
 
-#: src/strings.ts:2690
+#: src/strings.ts:2691
 msgid "Last used on"
 msgstr "Last used on"
 
-#: src/strings.ts:590
+#: src/strings.ts:591
 msgid "Later"
 msgstr "Later"
 
-#: src/strings.ts:643
+#: src/strings.ts:644
 msgid "Latest first"
 msgstr "Latest first"
 
@@ -3719,11 +3727,11 @@ msgstr "Latest first"
 msgid "Learn how this works."
 msgstr "Learn how this works."
 
-#: src/strings.ts:571
+#: src/strings.ts:572
 msgid "Learn more"
 msgstr "Learn more"
 
-#: src/strings.ts:979
+#: src/strings.ts:980
 msgid "Learn more about Monographs"
 msgstr "Learn more about Monographs"
 
@@ -3731,11 +3739,11 @@ msgstr "Learn more about Monographs"
 msgid "Learn more about Notesnook Monograph"
 msgstr "Learn more about Notesnook Monograph"
 
-#: src/strings.ts:646
+#: src/strings.ts:647
 msgid "Least relevant first"
 msgstr "Least relevant first"
 
-#: src/strings.ts:1564
+#: src/strings.ts:1565
 msgid "Legal"
 msgstr "Legal"
 
@@ -3743,55 +3751,55 @@ msgstr "Legal"
 msgid "Let us know if you have faced any issue/bug while using Notesnook. We will try to fix it as soon as possible."
 msgstr "Let us know if you have faced any issue/bug while using Notesnook. We will try to fix it as soon as possible."
 
-#: src/strings.ts:2163
+#: src/strings.ts:2164
 msgid "License"
 msgstr "License"
 
-#: src/strings.ts:1722
+#: src/strings.ts:1723
 msgid "Licensed under {license}"
 msgstr "Licensed under {license}"
 
-#: src/strings.ts:2328
+#: src/strings.ts:2329
 msgid "Lift list item"
 msgstr "Lift list item"
 
-#: src/strings.ts:725
+#: src/strings.ts:726
 msgid "Light"
 msgstr "Light"
 
-#: src/strings.ts:2358
+#: src/strings.ts:2359
 msgid "Line {line}, Column {column}"
 msgstr "Line {line}, Column {column}"
 
-#: src/strings.ts:2618
+#: src/strings.ts:2619
 msgid "Line height"
 msgstr "Line height"
 
-#: src/strings.ts:1154
+#: src/strings.ts:1155
 msgid "Line spacing changed"
 msgstr "Line spacing changed"
 
-#: src/strings.ts:2263
+#: src/strings.ts:2264
 msgid "Link"
 msgstr "Link"
 
-#: src/strings.ts:911
+#: src/strings.ts:912
 msgid "Link copied"
 msgstr "Link copied"
 
-#: src/strings.ts:931
+#: src/strings.ts:932
 msgid "Link notebooks"
 msgstr "Link notebooks"
 
-#: src/strings.ts:2477
+#: src/strings.ts:2478
 msgid "Link notes"
 msgstr "Link notes"
 
-#: src/strings.ts:2268
+#: src/strings.ts:2269
 msgid "Link settings"
 msgstr "Link settings"
 
-#: src/strings.ts:2388
+#: src/strings.ts:2389
 msgid "Link text"
 msgstr "Link text"
 
@@ -3799,31 +3807,31 @@ msgstr "Link text"
 msgid "LINK TO A SECTION"
 msgstr "LINK TO A SECTION"
 
-#: src/strings.ts:526
+#: src/strings.ts:527
 msgid "Link to note"
 msgstr "Link to note"
 
-#: src/strings.ts:851
+#: src/strings.ts:852
 msgid "Link to notebook"
 msgstr "Link to notebook"
 
-#: src/strings.ts:595
+#: src/strings.ts:596
 msgid "Linked notes"
 msgstr "Linked notes"
 
-#: src/strings.ts:1598
+#: src/strings.ts:1599
 msgid "Linking to a specific block is not available for locked notes."
 msgstr "Linking to a specific block is not available for locked notes."
 
-#: src/strings.ts:504
+#: src/strings.ts:505
 msgid "List of"
 msgstr "List of"
 
-#: src/strings.ts:727
+#: src/strings.ts:728
 msgid "Load from file"
 msgstr "Load from file"
 
-#: src/strings.ts:1697
+#: src/strings.ts:1698
 msgid "Loading"
 msgstr "Loading"
 
@@ -3832,15 +3840,15 @@ msgstr "Loading"
 msgid "Loading {0}, please wait..."
 msgstr "Loading {0}, please wait..."
 
-#: src/strings.ts:2669
+#: src/strings.ts:2670
 msgid "Loading API keys..."
 msgstr "Loading API keys..."
 
-#: src/strings.ts:1666
+#: src/strings.ts:1667
 msgid "Loading editor. Please wait..."
 msgstr "Loading editor. Please wait..."
 
-#: src/strings.ts:1066
+#: src/strings.ts:1067
 msgid "Loading subscription details"
 msgstr "Loading subscription details"
 
@@ -3848,35 +3856,35 @@ msgstr "Loading subscription details"
 msgid "Loading themes..."
 msgstr "Loading themes..."
 
-#: src/strings.ts:1329
+#: src/strings.ts:1330
 msgid "Loading trash"
 msgstr "Loading trash"
 
-#: src/strings.ts:975
+#: src/strings.ts:976
 msgid "Loading your archive"
 msgstr "Loading your archive"
 
-#: src/strings.ts:969
+#: src/strings.ts:970
 msgid "Loading your favorites"
 msgstr "Loading your favorites"
 
-#: src/strings.ts:974
+#: src/strings.ts:975
 msgid "Loading your monographs"
 msgstr "Loading your monographs"
 
-#: src/strings.ts:972
+#: src/strings.ts:973
 msgid "Loading your notebooks"
 msgstr "Loading your notebooks"
 
-#: src/strings.ts:970
+#: src/strings.ts:971
 msgid "Loading your notes"
 msgstr "Loading your notes"
 
-#: src/strings.ts:973
+#: src/strings.ts:974
 msgid "Loading your reminders"
 msgstr "Loading your reminders"
 
-#: src/strings.ts:971
+#: src/strings.ts:972
 msgid "Loading your tags"
 msgstr "Loading your tags"
 
@@ -3888,23 +3896,23 @@ msgstr "Lock"
 msgid "Lock note"
 msgstr "Lock note"
 
-#: src/strings.ts:1186
+#: src/strings.ts:1187
 msgid "Lock the app with a password or pin"
 msgstr "Lock the app with a password or pin"
 
-#: src/strings.ts:2703
+#: src/strings.ts:2704
 msgid "Lock vault after"
 msgstr "Lock vault after"
 
-#: src/strings.ts:901
+#: src/strings.ts:902
 msgid "Locked notes cannot be pinned"
 msgstr "Locked notes cannot be pinned"
 
-#: src/strings.ts:904
+#: src/strings.ts:905
 msgid "Locked notes cannot be published"
 msgstr "Locked notes cannot be published"
 
-#: src/strings.ts:2195
+#: src/strings.ts:2196
 msgid "Log out from all other devices"
 msgstr "Log out from all other devices"
 
@@ -3912,7 +3920,7 @@ msgstr "Log out from all other devices"
 msgid "Logged in as {email}"
 msgstr "Logged in as {email}"
 
-#: src/strings.ts:1076
+#: src/strings.ts:1077
 msgid "Logging out will clear all data stored on THIS DEVICE. Make sure you have synced all your changes before logging out."
 msgstr "Logging out will clear all data stored on THIS DEVICE. Make sure you have synced all your changes before logging out."
 
@@ -3920,7 +3928,7 @@ msgstr "Logging out will clear all data stored on THIS DEVICE. Make sure you hav
 msgid "Logging out. Please wait..."
 msgstr "Logging out. Please wait..."
 
-#: src/strings.ts:1784
+#: src/strings.ts:1785
 msgid "Logging you in"
 msgstr "Logging you in"
 
@@ -3928,131 +3936,131 @@ msgstr "Logging you in"
 msgid "Login"
 msgstr "Login"
 
-#: src/strings.ts:778
+#: src/strings.ts:779
 msgid "Login failed"
 msgstr "Login failed"
 
-#: src/strings.ts:902
+#: src/strings.ts:903
 msgid "Login required"
 msgstr "Login required"
 
-#: src/strings.ts:779
+#: src/strings.ts:780
 msgid "Login successful"
 msgstr "Login successful"
 
-#: src/strings.ts:1364
+#: src/strings.ts:1365
 msgid "Login to encrypt and sync notes"
 msgstr "Login to encrypt and sync notes"
 
-#: src/strings.ts:2611
+#: src/strings.ts:2612
 msgid "Login to upload attachments. [Read more](https://help.notesnook.com/faqs/login-to-upload-attachments)"
 msgstr "Login to upload attachments. [Read more](https://help.notesnook.com/faqs/login-to-upload-attachments)"
 
-#: src/strings.ts:542
+#: src/strings.ts:543
 msgid "Login to your account"
 msgstr "Login to your account"
 
-#: src/strings.ts:776
+#: src/strings.ts:777
 msgid "Logout"
 msgstr "Logout"
 
-#: src/strings.ts:582
+#: src/strings.ts:583
 msgid "Logout and clear data"
 msgstr "Logout and clear data"
 
-#: src/strings.ts:555
+#: src/strings.ts:556
 msgid "Logout from this device"
 msgstr "Logout from this device"
 
-#: src/strings.ts:1414
+#: src/strings.ts:1415
 msgid "Long press on any item in list to enter multi-select mode."
 msgstr "Long press on any item in list to enter multi-select mode."
 
-#: src/strings.ts:2363
+#: src/strings.ts:2364
 msgid "Make task list readonly"
 msgstr "Make task list readonly"
 
-#: src/strings.ts:1040
+#: src/strings.ts:1041
 msgid "Manage account"
 msgstr "Manage account"
 
-#: src/strings.ts:1053
+#: src/strings.ts:1054
 msgid "Manage attachments"
 msgstr "Manage attachments"
 
-#: src/strings.ts:685
+#: src/strings.ts:686
 msgid "Manage subscription on desktop"
 msgstr "Manage subscription on desktop"
 
-#: src/strings.ts:850
+#: src/strings.ts:851
 msgid "Manage tags"
 msgstr "Manage tags"
 
-#: src/strings.ts:1041
+#: src/strings.ts:1042
 msgid "Manage your account related settings here"
 msgstr "Manage your account related settings here"
 
-#: src/strings.ts:1054
+#: src/strings.ts:1055
 msgid "Manage your attachments in one place"
 msgstr "Manage your attachments in one place"
 
-#: src/strings.ts:1213
+#: src/strings.ts:1214
 msgid "Manage your backups and restore data"
 msgstr "Manage your backups and restore data"
 
-#: src/strings.ts:1247
+#: src/strings.ts:1248
 msgid "Manage your reminders"
 msgstr "Manage your reminders"
 
-#: src/strings.ts:1085
+#: src/strings.ts:1086
 msgid "Manage your sync settings here"
 msgstr "Manage your sync settings here"
 
-#: src/strings.ts:1442
+#: src/strings.ts:1443
 msgid "Mark important notes by adding them to favorites."
 msgstr "Mark important notes by adding them to favorites."
 
-#: src/strings.ts:1161
+#: src/strings.ts:1162
 msgid "Markdown shortcuts"
 msgstr "Markdown shortcuts"
 
-#: src/strings.ts:1167
+#: src/strings.ts:1168
 msgid "Marketing emails"
 msgstr "Marketing emails"
 
-#: src/strings.ts:2376
+#: src/strings.ts:2377
 msgid "Match case"
 msgstr "Match case"
 
-#: src/strings.ts:2377
+#: src/strings.ts:2378
 msgid "Match whole word"
 msgstr "Match whole word"
 
-#: src/strings.ts:2285
+#: src/strings.ts:2286
 msgid "Math (inline)"
 msgstr "Math (inline)"
 
-#: src/strings.ts:2335
+#: src/strings.ts:2336
 msgid "Math & formulas"
 msgstr "Math & formulas"
 
-#: src/strings.ts:2042
+#: src/strings.ts:2043
 msgid "Maximize"
 msgstr "Maximize"
 
-#: src/strings.ts:2072
+#: src/strings.ts:2073
 msgid "Meet other privacy-minded people & talk to us directly about your concerns, issues and suggestions."
 msgstr "Meet other privacy-minded people & talk to us directly about your concerns, issues and suggestions."
 
-#: src/strings.ts:2419
+#: src/strings.ts:2420
 msgid "Meetings"
 msgstr "Meetings"
 
-#: src/strings.ts:1781
+#: src/strings.ts:1782
 msgid "Member since {date}"
 msgstr "Member since {date}"
 
-#: src/strings.ts:2296
+#: src/strings.ts:2297
 msgid "Merge cells"
 msgstr "Merge cells"
 
@@ -4066,134 +4074,134 @@ msgstr "Migrating {0} {1}... please wait"
 msgid "Migration failed"
 msgstr "Migration failed"
 
-#: src/strings.ts:879
+#: src/strings.ts:880
 msgid "min"
 msgstr "min"
 
-#: src/strings.ts:2011
+#: src/strings.ts:2012
 msgid "Minimal"
 msgstr "Minimal"
 
-#: src/strings.ts:2041
+#: src/strings.ts:2042
 msgid "Minimize"
 msgstr "Minimize"
 
-#: src/strings.ts:2119
+#: src/strings.ts:2120
 msgid "Minimize to system tray"
 msgstr "Minimize to system tray"
 
-#: src/strings.ts:689
+#: src/strings.ts:690
 msgid "mo"
 msgstr "mo"
 
-#: src/strings.ts:623
+#: src/strings.ts:624
 msgid "Mon"
 msgstr "Mon"
 
-#: src/strings.ts:614
+#: src/strings.ts:615
 msgid "Monday"
 msgstr "Monday"
 
-#: src/strings.ts:1633
+#: src/strings.ts:1634
 msgid "Monograph server"
 msgstr "Monograph server"
 
-#: src/strings.ts:870
+#: src/strings.ts:871
 msgid "Monograph URL copied"
 msgstr "Monograph URL copied"
 
 #: src/strings.ts:322
-#: src/strings.ts:941
-#: src/strings.ts:1531
+#: src/strings.ts:942
+#: src/strings.ts:1532
 msgid "Monographs"
 msgstr "Monographs"
 
-#: src/strings.ts:1424
+#: src/strings.ts:1425
 msgid "Monographs can be encrypted with a secret key and shared with anyone."
 msgstr "Monographs can be encrypted with a secret key and shared with anyone."
 
-#: src/strings.ts:1419
+#: src/strings.ts:1420
 msgid "Monographs enable you to share your notes in a secure and private way."
 msgstr "Monographs enable you to share your notes in a secure and private way."
 
-#: src/strings.ts:1842
+#: src/strings.ts:1843
 msgid "month"
 msgstr "month"
 
-#: src/strings.ts:665
+#: src/strings.ts:666
 msgid "Month"
 msgstr "Month"
 
 #: src/strings.ts:169
-#: src/strings.ts:1572
+#: src/strings.ts:1573
 msgid "Monthly"
 msgstr "Monthly"
 
-#: src/strings.ts:2315
+#: src/strings.ts:2316
 msgid "More"
 msgstr "More"
 
-#: src/strings.ts:645
+#: src/strings.ts:646
 msgid "Most relevant first"
 msgstr "Most relevant first"
 
-#: src/strings.ts:852
+#: src/strings.ts:853
 msgid "Move"
 msgstr "Move"
 
-#: src/strings.ts:2364
+#: src/strings.ts:2365
 msgid "Move all checked tasks to bottom"
 msgstr "Move all checked tasks to bottom"
 
-#: src/strings.ts:2292
+#: src/strings.ts:2293
 msgid "Move column left"
 msgstr "Move column left"
 
-#: src/strings.ts:2293
+#: src/strings.ts:2294
 msgid "Move column right"
 msgstr "Move column right"
 
-#: src/strings.ts:938
+#: src/strings.ts:939
 msgid "Move notebook"
 msgstr "Move notebook"
 
-#: src/strings.ts:898
+#: src/strings.ts:899
 msgid "Move notes"
 msgstr "Move notes"
 
-#: src/strings.ts:2300
+#: src/strings.ts:2301
 msgid "Move row down"
 msgstr "Move row down"
 
-#: src/strings.ts:2299
+#: src/strings.ts:2300
 msgid "Move row up"
 msgstr "Move row up"
 
-#: src/strings.ts:585
+#: src/strings.ts:586
 msgid "Move selected notes"
 msgstr "Move selected notes"
 
-#: src/strings.ts:584
+#: src/strings.ts:585
 msgid "Move to top"
 msgstr "Move to top"
 
-#: src/strings.ts:855
+#: src/strings.ts:856
 msgid "Move to trash"
 msgstr "Move to trash"
 
-#: src/strings.ts:1174
+#: src/strings.ts:1175
 msgid "Multi-layer encryption to most important notes"
 msgstr "Multi-layer encryption to most important notes"
 
-#: src/strings.ts:887
+#: src/strings.ts:888
 msgid "Name"
 msgstr "Name"
 
-#: src/strings.ts:1690
+#: src/strings.ts:1691
 msgid "Native high-performance encryption"
 msgstr "Native high-performance encryption"
 
-#: src/strings.ts:2444
+#: src/strings.ts:2445
 msgid "Navigate"
 msgstr "Navigate"
 
@@ -4201,39 +4209,39 @@ msgstr "Navigate"
 msgid "Never"
 msgstr "Never"
 
-#: src/strings.ts:1344
+#: src/strings.ts:1345
 msgid "Never ask again"
 msgstr "Never ask again"
 
-#: src/strings.ts:2693
+#: src/strings.ts:2694
 msgid "Never expires"
 msgstr "Never expires"
 
-#: src/strings.ts:1039
+#: src/strings.ts:1040
 msgid "Never hesitate to choose privacy"
 msgstr "Never hesitate to choose privacy"
 
-#: src/strings.ts:672
+#: src/strings.ts:673
 msgid "Never show again"
 msgstr "Never show again"
 
-#: src/strings.ts:2691
+#: src/strings.ts:2692
 msgid "Never used"
 msgstr "Never used"
 
-#: src/strings.ts:642
+#: src/strings.ts:643
 msgid "New - old"
 msgstr "New - old"
 
-#: src/strings.ts:528
+#: src/strings.ts:529
 msgid "New color"
 msgstr "New color"
 
-#: src/strings.ts:1848
+#: src/strings.ts:1849
 msgid "New Email"
 msgstr "New Email"
 
-#: src/strings.ts:1153
+#: src/strings.ts:1154
 msgid "New lines will be double spaced (old ones won't be affected)."
 msgstr "New lines will be double spaced (old ones won't be affected)."
 
@@ -4241,63 +4249,63 @@ msgstr "New lines will be double spaced (old ones won't be affected)."
 msgid "New note"
 msgstr "New note"
 
-#: src/strings.ts:525
+#: src/strings.ts:526
 msgid "New notebook"
 msgstr "New notebook"
 
-#: src/strings.ts:1482
+#: src/strings.ts:1483
 msgid "New password"
 msgstr "New password"
 
-#: src/strings.ts:1488
+#: src/strings.ts:1489
 msgid "New pin"
 msgstr "New pin"
 
-#: src/strings.ts:535
+#: src/strings.ts:536
 msgid "New reminder"
 msgstr "New reminder"
 
-#: src/strings.ts:576
+#: src/strings.ts:577
 msgid "New tab"
 msgstr "New tab"
 
-#: src/strings.ts:2450
+#: src/strings.ts:2451
 msgid "New tag"
 msgstr "New tag"
 
-#: src/strings.ts:1370
+#: src/strings.ts:1371
 msgid "New update available"
 msgstr "New update available"
 
-#: src/strings.ts:531
+#: src/strings.ts:532
 msgid "New version"
 msgstr "New version"
 
-#: src/strings.ts:2026
+#: src/strings.ts:2027
 msgid "Newest - oldest"
 msgstr "Newest - oldest"
 
-#: src/strings.ts:1142
+#: src/strings.ts:1143
 msgid "Newly created notes will be uncategorized"
 msgstr "Newly created notes will be uncategorized"
 
-#: src/strings.ts:552
+#: src/strings.ts:553
 msgid "Next"
 msgstr "Next"
 
-#: src/strings.ts:2380
+#: src/strings.ts:2381
 msgid "Next match"
 msgstr "Next match"
 
-#: src/strings.ts:2445
+#: src/strings.ts:2446
 msgid "Next tab"
 msgstr "Next tab"
 
-#: src/strings.ts:547
+#: src/strings.ts:548
 msgid "No"
 msgstr "No"
 
-#: src/strings.ts:859
+#: src/strings.ts:860
 msgid "No application found to open {fileToOpen}"
 msgstr "No application found to open {fileToOpen}"
 
@@ -4313,11 +4321,11 @@ msgstr "No backups found"
 msgid "No blocks linked"
 msgstr "No blocks linked"
 
-#: src/strings.ts:786
+#: src/strings.ts:787
 msgid "No color selected"
 msgstr "No color selected"
 
-#: src/strings.ts:1233
+#: src/strings.ts:1234
 msgid "No directory selected"
 msgstr "No directory selected"
 
@@ -4325,15 +4333,15 @@ msgstr "No directory selected"
 msgid "No downloads in progress."
 msgstr "No downloads in progress."
 
-#: src/strings.ts:1986
+#: src/strings.ts:1987
 msgid "No encryption key found"
 msgstr "No encryption key found"
 
-#: src/strings.ts:1667
+#: src/strings.ts:1668
 msgid "No headings found"
 msgstr "No headings found"
 
-#: src/strings.ts:596
+#: src/strings.ts:597
 msgid "No linked notes"
 msgstr "No linked notes"
 
@@ -4345,7 +4353,7 @@ msgstr "No links found"
 msgid "No note history available for this device."
 msgstr "No note history available for this device."
 
-#: src/strings.ts:2494
+#: src/strings.ts:2495
 msgid "No notebooks selected to move"
 msgstr "No notebooks selected to move"
 
@@ -4353,7 +4361,7 @@ msgstr "No notebooks selected to move"
 msgid "No one can view this {type} except you."
 msgstr "No one can view this {type} except you."
 
-#: src/strings.ts:2614
+#: src/strings.ts:2615
 msgid "No password"
 msgstr "No password"
 
@@ -4361,7 +4369,7 @@ msgstr "No password"
 msgid "No references found of this note"
 msgstr "No references found of this note"
 
-#: src/strings.ts:1518
+#: src/strings.ts:1519
 msgid "No results found"
 msgstr "No results found"
 
@@ -4369,7 +4377,7 @@ msgstr "No results found"
 msgid "No results found for \"{query}\""
 msgstr "No results found for \"{query}\""
 
-#: src/strings.ts:1518
+#: src/strings.ts:1519
 msgid "No results found for {query}"
 msgstr "No results found for {query}"
 
@@ -4381,11 +4389,11 @@ msgstr "No themes found"
 msgid "No updates available"
 msgstr "No updates available"
 
-#: src/strings.ts:661
+#: src/strings.ts:662
 msgid "None"
 msgstr "None"
 
-#: src/strings.ts:2016
+#: src/strings.ts:2017
 msgid "Normal mode"
 msgstr "Normal mode"
 
@@ -4402,11 +4410,11 @@ msgstr "note"
 msgid "Note"
 msgstr "Note"
 
-#: src/strings.ts:815
+#: src/strings.ts:816
 msgid "Note copied to clipboard"
 msgstr "Note copied to clipboard"
 
-#: src/strings.ts:1951
+#: src/strings.ts:1952
 msgid "Note does not exist"
 msgstr "Note does not exist"
 
@@ -4414,19 +4422,19 @@ msgstr "Note does not exist"
 msgid "Note history"
 msgstr "Note history"
 
-#: src/strings.ts:810
+#: src/strings.ts:811
 msgid "Note locked"
 msgstr "Note locked"
 
-#: src/strings.ts:845
+#: src/strings.ts:846
 msgid "Note restored from history"
 msgstr "Note restored from history"
 
-#: src/strings.ts:1587
+#: src/strings.ts:1588
 msgid "Note title"
 msgstr "Note title"
 
-#: src/strings.ts:814
+#: src/strings.ts:815
 msgid "Note unlocked"
 msgstr "Note unlocked"
 
@@ -4434,7 +4442,7 @@ msgstr "Note unlocked"
 msgid "Note version history is local only."
 msgstr "Note version history is local only."
 
-#: src/strings.ts:1226
+#: src/strings.ts:1227
 msgid "NOTE: Creating a backup with attachments can take a while, and also fail completely. The app will try to resume/restart the backup in case of interruptions."
 msgstr "NOTE: Creating a backup with attachments can take a while, and also fail completely. The app will try to resume/restart the backup in case of interruptions."
 
@@ -4443,11 +4451,11 @@ msgid "notebook"
 msgstr "notebook"
 
 #: src/strings.ts:296
-#: src/strings.ts:1522
+#: src/strings.ts:1523
 msgid "Notebook"
 msgstr "Notebook"
 
-#: src/strings.ts:2480
+#: src/strings.ts:2481
 msgid "Notebook added"
 msgstr "Notebook added"
 
@@ -4457,15 +4465,15 @@ msgstr "notebooks"
 
 #: src/strings.ts:258
 #: src/strings.ts:316
-#: src/strings.ts:1521
+#: src/strings.ts:1522
 msgid "Notebooks"
 msgstr "Notebooks"
 
-#: src/strings.ts:1796
+#: src/strings.ts:1797
 msgid "NOTEBOOKS"
 msgstr "NOTEBOOKS"
 
-#: src/strings.ts:2242
+#: src/strings.ts:2243
 msgid "Notebooks are the best way to organize your notes."
 msgstr "Notebooks are the best way to organize your notes."
 
@@ -4474,7 +4482,7 @@ msgid "notes"
 msgstr "notes"
 
 #: src/strings.ts:315
-#: src/strings.ts:1520
+#: src/strings.ts:1521
 msgid "Notes"
 msgstr "Notes"
 
@@ -4482,35 +4490,35 @@ msgstr "Notes"
 msgid "Notes exported as {path} successfully"
 msgstr "Notes exported as {path} successfully"
 
-#: src/strings.ts:1752
+#: src/strings.ts:1753
 msgid "notes imported"
 msgstr "notes imported"
 
-#: src/strings.ts:2544
+#: src/strings.ts:2545
 msgid "Notesnook"
 msgstr "Notesnook"
 
-#: src/strings.ts:2599
+#: src/strings.ts:2600
 msgid "Notesnook Circle"
 msgstr "Notesnook Circle"
 
-#: src/strings.ts:2601
+#: src/strings.ts:2602
 msgid "Notesnook Circle brings together trusted partners who share our commitment to privacy, transparency, and user freedom."
 msgstr "Notesnook Circle brings together trusted partners who share our commitment to privacy, transparency, and user freedom."
 
-#: src/strings.ts:2069
+#: src/strings.ts:2070
 msgid "Notesnook encrypts everything offline before syncing to your other devices. This means that no one can read your notes except you. Not even us."
 msgstr "Notesnook encrypts everything offline before syncing to your other devices. This means that no one can read your notes except you. Not even us."
 
-#: src/strings.ts:2144
+#: src/strings.ts:2145
 msgid "Notesnook Importer"
 msgstr "Notesnook Importer"
 
-#: src/strings.ts:1068
+#: src/strings.ts:1069
 msgid "Notesnook Pro"
 msgstr "Notesnook Pro"
 
-#: src/strings.ts:2176
+#: src/strings.ts:2177
 msgid ""
 "Notesnook uses the following DNS providers:\n"
 "\n"
@@ -4526,31 +4534,31 @@ msgstr ""
 "\n"
 "This can sometimes bypass local ISP blockages on Notesnook traffic. Disable this if you want the app to use system's DNS settings."
 
-#: src/strings.ts:989
+#: src/strings.ts:990
 msgid "Notesnook will send you a 2FA code on your email when prompted"
 msgstr "Notesnook will send you a 2FA code on your email when prompted"
 
-#: src/strings.ts:996
+#: src/strings.ts:997
 msgid "Notesnook will send you an SMS with a 2FA code when prompted"
 msgstr "Notesnook will send you an SMS with a 2FA code when prompted"
 
-#: src/strings.ts:2139
+#: src/strings.ts:2140
 msgid "Notifications"
 msgstr "Notifications"
 
-#: src/strings.ts:1379
+#: src/strings.ts:1380
 msgid "Notifications disabled"
 msgstr "Notifications disabled"
 
-#: src/strings.ts:2276
+#: src/strings.ts:2277
 msgid "Numbered list"
 msgstr "Numbered list"
 
-#: src/strings.ts:1720
+#: src/strings.ts:1721
 msgid "of"
 msgstr "of"
 
-#: src/strings.ts:1604
+#: src/strings.ts:1605
 msgid "Off"
 msgstr "Off"
 
@@ -4558,39 +4566,39 @@ msgstr "Off"
 msgid "Offline"
 msgstr "Offline"
 
-#: src/strings.ts:2674
+#: src/strings.ts:2675
 msgid "OK"
 msgstr "OK"
 
-#: src/strings.ts:2229
+#: src/strings.ts:2230
 msgid "Okay"
 msgstr "Okay"
 
-#: src/strings.ts:641
+#: src/strings.ts:642
 msgid "Old - new"
 msgstr "Old - new"
 
-#: src/strings.ts:1481
+#: src/strings.ts:1482
 msgid "Old password"
 msgstr "Old password"
 
-#: src/strings.ts:1837
+#: src/strings.ts:1838
 msgid "Older version"
 msgstr "Older version"
 
-#: src/strings.ts:2025
+#: src/strings.ts:2026
 msgid "Oldest - newest"
 msgstr "Oldest - newest"
 
-#: src/strings.ts:736
+#: src/strings.ts:737
 msgid "Once your password is changed, please make sure to save the new account recovery key"
 msgstr "Once your password is changed, please make sure to save the new account recovery key"
 
-#: src/strings.ts:2562
+#: src/strings.ts:2563
 msgid "One time purchase, no auto-renewal"
 msgstr "One time purchase, no auto-renewal"
 
-#: src/strings.ts:1773
+#: src/strings.ts:1774
 msgid "Only .zip files are supported."
 msgstr "Only .zip files are supported."
 
@@ -4598,7 +4606,7 @@ msgstr "Only .zip files are supported."
 msgid "Open"
 msgstr "Open"
 
-#: src/strings.ts:577
+#: src/strings.ts:578
 msgid "Open file location"
 msgstr "Open file location"
 
@@ -4606,51 +4614,51 @@ msgstr "Open file location"
 msgid "Open in browser"
 msgstr "Open in browser"
 
-#: src/strings.ts:1308
+#: src/strings.ts:1309
 msgid "Open in browser to manage subscription"
 msgstr "Open in browser to manage subscription"
 
-#: src/strings.ts:2326
+#: src/strings.ts:2327
 msgid "Open in new tab"
 msgstr "Open in new tab"
 
-#: src/strings.ts:579
+#: src/strings.ts:580
 msgid "Open issue"
 msgstr "Open issue"
 
-#: src/strings.ts:2266
+#: src/strings.ts:2267
 msgid "Open link"
 msgstr "Open link"
 
-#: src/strings.ts:1865
+#: src/strings.ts:1866
 msgid "Open note"
 msgstr "Open note"
 
-#: src/strings.ts:1382
+#: src/strings.ts:1383
 msgid "Open settings"
 msgstr "Open settings"
 
-#: src/strings.ts:2327
+#: src/strings.ts:2328
 msgid "Open source"
 msgstr "Open source"
 
-#: src/strings.ts:1290
+#: src/strings.ts:1291
 msgid "Open source libraries used in Notesnook"
 msgstr "Open source libraries used in Notesnook"
 
-#: src/strings.ts:1289
+#: src/strings.ts:1290
 msgid "Open source licenses"
 msgstr "Open source licenses"
 
-#: src/strings.ts:819
+#: src/strings.ts:820
 msgid "Open source."
 msgstr "Open source."
 
-#: src/strings.ts:985
+#: src/strings.ts:986
 msgid "Open the two-factor authentication (TOTP) app to view your authentication code."
 msgstr "Open the two-factor authentication (TOTP) app to view your authentication code."
 
-#: src/strings.ts:1859
+#: src/strings.ts:1860
 msgid "Optional"
 msgstr "Optional"
 
@@ -4658,36 +4666,36 @@ msgstr "Optional"
 msgid "or email us at"
 msgstr "or email us at"
 
-#: src/strings.ts:2024
+#: src/strings.ts:2025
 msgid "Order by"
 msgstr "Order by"
 
-#: src/strings.ts:2222
+#: src/strings.ts:2223
 msgid "Order ID"
 msgstr "Order ID"
 
-#: src/strings.ts:758
-#: src/strings.ts:762
+#: src/strings.ts:759
+#: src/strings.ts:763
 msgid "Orphaned"
 msgstr "Orphaned"
 
-#: src/strings.ts:2147
+#: src/strings.ts:2148
 msgid "Other"
 msgstr "Other"
 
-#: src/strings.ts:2347
+#: src/strings.ts:2348
 msgid "Outline list"
 msgstr "Outline list"
 
-#: src/strings.ts:2350
+#: src/strings.ts:2351
 msgid "Paragraph"
 msgstr "Paragraph"
 
-#: src/strings.ts:2493
+#: src/strings.ts:2494
 msgid "Paragraphs"
 msgstr "Paragraphs"
 
-#: src/strings.ts:2103
+#: src/strings.ts:2104
 msgid "Partial backups contain all your data except attachments. They are created from data already available on your device and do not require an Internet connection."
 msgstr "Partial backups contain all your data except attachments. They are created from data already available on your device and do not require an Internet connection."
 
@@ -4695,31 +4703,31 @@ msgstr "Partial backups contain all your data except attachments. They are creat
 msgid "Partially refunded"
 msgstr "Partially refunded"
 
-#: src/strings.ts:2404
+#: src/strings.ts:2405
 msgid "Passed"
 msgstr "Passed"
 
-#: src/strings.ts:883
+#: src/strings.ts:884
 msgid "Password"
 msgstr "Password"
 
-#: src/strings.ts:771
+#: src/strings.ts:772
 msgid "Password change failed"
 msgstr "Password change failed"
 
-#: src/strings.ts:770
+#: src/strings.ts:771
 msgid "Password changed successfully"
 msgstr "Password changed successfully"
 
-#: src/strings.ts:808
+#: src/strings.ts:809
 msgid "Password does not match"
 msgstr "Password does not match"
 
-#: src/strings.ts:783
+#: src/strings.ts:784
 msgid "Password incorrect"
 msgstr "Password incorrect"
 
-#: src/strings.ts:807
+#: src/strings.ts:808
 msgid "Password not entered"
 msgstr "Password not entered"
 
@@ -4727,181 +4735,181 @@ msgstr "Password not entered"
 msgid "Password protection"
 msgstr "Password protection"
 
-#: src/strings.ts:809
+#: src/strings.ts:810
 msgid "Password updated"
 msgstr "Password updated"
 
-#: src/strings.ts:2083
+#: src/strings.ts:2084
 msgid "Password/pin"
 msgstr "Password/pin"
 
-#: src/strings.ts:2250
+#: src/strings.ts:2251
 msgid "Paste"
 msgstr "Paste"
 
-#: src/strings.ts:2251
+#: src/strings.ts:2252
 msgid "Paste and match style"
 msgstr "Paste and match style"
 
-#: src/strings.ts:2372
+#: src/strings.ts:2373
 msgid "Paste embed code here. Only iframes are supported."
 msgstr "Paste embed code here. Only iframes are supported."
 
-#: src/strings.ts:2387
+#: src/strings.ts:2388
 msgid "Paste image URL here"
 msgstr "Paste image URL here"
 
-#: src/strings.ts:2252
+#: src/strings.ts:2253
 msgid "Paste without formatting"
 msgstr "Paste without formatting"
 
-#: src/strings.ts:2563
+#: src/strings.ts:2564
 msgid "Pay once and use for 5 years"
 msgstr "Pay once and use for 5 years"
 
-#: src/strings.ts:2201
+#: src/strings.ts:2202
 msgid "Payment method"
 msgstr "Payment method"
 
-#: src/strings.ts:788
+#: src/strings.ts:789
 msgid "PDF is password protected"
 msgstr "PDF is password protected"
 
-#: src/strings.ts:1731
+#: src/strings.ts:1732
 msgid "phone number"
 msgstr "phone number"
 
-#: src/strings.ts:1850
+#: src/strings.ts:1851
 msgid "Phone number"
 msgstr "Phone number"
 
-#: src/strings.ts:1009
+#: src/strings.ts:1010
 msgid "Phone number not entered"
 msgstr "Phone number not entered"
 
-#: src/strings.ts:900
+#: src/strings.ts:901
 msgid "Pin"
 msgstr "Pin"
 
-#: src/strings.ts:1692
+#: src/strings.ts:1693
 msgid "Pin notes in notifications drawer"
 msgstr "Pin notes in notifications drawer"
 
-#: src/strings.ts:930
+#: src/strings.ts:931
 msgid "Pin notification"
 msgstr "Pin notification"
 
-#: src/strings.ts:523
+#: src/strings.ts:524
 msgid "Pinned"
 msgstr "Pinned"
 
-#: src/strings.ts:2581
+#: src/strings.ts:2582
 msgid "Plan limits"
 msgstr "Plan limits"
 
-#: src/strings.ts:2544
+#: src/strings.ts:2545
 msgid "Plans"
 msgstr "Plans"
 
-#: src/strings.ts:1366
+#: src/strings.ts:1367
 msgid "Please confirm your email to sync notes"
 msgstr "Please confirm your email to sync notes"
 
-#: src/strings.ts:1004
-msgid "Please confirm your identity by entering a recovery code."
-msgstr "Please confirm your identity by entering a recovery code."
+#: src/strings.ts:1005
+msgid "Please confirm your identity by entering a 2FA backup code."
+msgstr "Please confirm your identity by entering a 2FA backup code."
 
-#: src/strings.ts:983
-#: src/strings.ts:2234
+#: src/strings.ts:984
+#: src/strings.ts:2235
 msgid "Please confirm your identity by entering the authentication code from your authenticator app."
 msgstr "Please confirm your identity by entering the authentication code from your authenticator app."
 
 #. placeholder {0}: phoneNumber ? phoneNumber : "your registered phone number."
-#: src/strings.ts:998
+#: src/strings.ts:999
 msgid "Please confirm your identity by entering the authentication code sent to {0}."
 msgstr "Please confirm your identity by entering the authentication code sent to {0}."
 
-#: src/strings.ts:991
+#: src/strings.ts:992
 msgid "Please confirm your identity by entering the authentication code sent to your email address."
 msgstr "Please confirm your identity by entering the authentication code sent to your email address."
 
-#: src/strings.ts:1911
+#: src/strings.ts:1912
 msgid "Please download a backup of your data as your account will be cleared before recovery."
 msgstr "Please download a backup of your data as your account will be cleared before recovery."
 
-#: src/strings.ts:2009
+#: src/strings.ts:2010
 msgid "Please enable automatic backups to avoid losing important data."
 msgstr "Please enable automatic backups to avoid losing important data."
 
-#: src/strings.ts:2660
+#: src/strings.ts:2661
 msgid "Please enter a key name"
 msgstr "Please enter a key name"
 
-#: src/strings.ts:1514
+#: src/strings.ts:1515
 msgid "Please enter a valid email address"
 msgstr "Please enter a valid email address"
 
-#: src/strings.ts:1956
+#: src/strings.ts:1957
 msgid "Please enter a valid hex color (e.g. #ffffff)"
 msgstr "Please enter a valid hex color (e.g. #ffffff)"
 
-#: src/strings.ts:1515
+#: src/strings.ts:1516
 msgid "Please enter a valid phone number with country code"
 msgstr "Please enter a valid phone number with country code"
 
-#: src/strings.ts:1637
+#: src/strings.ts:1638
 msgid "Please enter a valid URL"
 msgstr "Please enter a valid URL"
 
-#: src/strings.ts:1622
+#: src/strings.ts:1623
 msgid "Please enter password of this backup file"
 msgstr "Please enter password of this backup file"
 
-#: src/strings.ts:2245
+#: src/strings.ts:2246
 msgid "Please enter the password to decrypt and restore this backup."
 msgstr "Please enter the password to decrypt and restore this backup."
 
-#: src/strings.ts:790
+#: src/strings.ts:791
 msgid "Please enter the password to unlock the PDF and view the content."
 msgstr "Please enter the password to unlock the PDF and view the content."
 
-#: src/strings.ts:1867
+#: src/strings.ts:1868
 msgid "Please enter the password to unlock this note"
 msgstr "Please enter the password to unlock this note"
 
-#: src/strings.ts:1864
+#: src/strings.ts:1865
 msgid "Please enter the password to view this version"
 msgstr "Please enter the password to view this version"
 
-#: src/strings.ts:2680
+#: src/strings.ts:2681
 msgid "Please enter your account password to view this API key."
 msgstr "Please enter your account password to view this API key."
 
-#: src/strings.ts:1023
+#: src/strings.ts:1024
 msgid "Please enter your app lock password to continue"
 msgstr "Please enter your app lock password to continue"
 
-#: src/strings.ts:1025
+#: src/strings.ts:1026
 msgid "Please enter your app lock pin to continue"
 msgstr "Please enter your app lock pin to continue"
 
-#: src/strings.ts:1019
+#: src/strings.ts:1020
 msgid "Please enter your password to continue"
 msgstr "Please enter your password to continue"
 
-#: src/strings.ts:1935
+#: src/strings.ts:1936
 msgid "Please enter your vault password to continue"
 msgstr "Please enter your vault password to continue"
 
-#: src/strings.ts:768
+#: src/strings.ts:769
 msgid "Please fill all the fields to continue."
 msgstr "Please fill all the fields to continue."
 
-#: src/strings.ts:1558
+#: src/strings.ts:1559
 msgid "Please grant notifications permission to add new reminders."
 msgstr "Please grant notifications permission to add new reminders."
 
-#: src/strings.ts:873
+#: src/strings.ts:874
 msgid "Please make sure you have saved the recovery key. Tap one more time to confirm."
 msgstr "Please make sure you have saved the recovery key. Tap one more time to confirm."
 
@@ -4909,27 +4917,27 @@ msgstr "Please make sure you have saved the recovery key. Tap one more time to c
 msgid "Please note that we will respond to your issue on the given link. We recommend that you save it."
 msgstr "Please note that we will respond to your issue on the given link. We recommend that you save it."
 
-#: src/strings.ts:1767
+#: src/strings.ts:1768
 msgid "Please refer to the"
 msgstr "Please refer to the"
 
-#: src/strings.ts:1559
+#: src/strings.ts:1560
 msgid "Please select the day to repeat the reminder on"
 msgstr "Please select the day to repeat the reminder on"
 
-#: src/strings.ts:1398
+#: src/strings.ts:1399
 msgid "please send us an email from your registered email address"
 msgstr "please send us an email from your registered email address"
 
-#: src/strings.ts:2393
+#: src/strings.ts:2394
 msgid "Please set a table size"
 msgstr "Please set a table size"
 
-#: src/strings.ts:1560
+#: src/strings.ts:1561
 msgid "Please set title of the reminder"
 msgstr "Please set title of the reminder"
 
-#: src/strings.ts:1989
+#: src/strings.ts:1990
 msgid "Please try again"
 msgstr "Please try again"
 
@@ -4941,16 +4949,16 @@ msgstr "Please verify it's you"
 msgid "Please wait"
 msgstr "Please wait"
 
-#: src/strings.ts:1008
+#: src/strings.ts:1009
 msgid "Please wait before requesting a new code"
 msgstr "Please wait before requesting a new code"
 
-#: src/strings.ts:1401
-#: src/strings.ts:1553
+#: src/strings.ts:1402
+#: src/strings.ts:1554
 msgid "Please wait before requesting another email"
 msgstr "Please wait before requesting another email"
 
-#: src/strings.ts:944
+#: src/strings.ts:945
 msgid "Please wait while we encrypt {name} for upload."
 msgstr "Please wait while we encrypt {name} for upload."
 
@@ -4962,11 +4970,11 @@ msgstr "Please wait while we export your not."
 msgid "Please wait while we export your notes."
 msgstr "Please wait while we export your notes."
 
-#: src/strings.ts:1896
+#: src/strings.ts:1897
 msgid "Please wait while we finalize your account."
 msgstr "Please wait while we finalize your account."
 
-#: src/strings.ts:1067
+#: src/strings.ts:1068
 msgid "Please wait while we load your subscription"
 msgstr "Please wait while we load your subscription"
 
@@ -4974,15 +4982,15 @@ msgstr "Please wait while we load your subscription"
 msgid "Please wait while we log you out."
 msgstr "Please wait while we log you out."
 
-#: src/strings.ts:1917
+#: src/strings.ts:1918
 msgid "Please wait while we reset your account password."
 msgstr "Please wait while we reset your account password."
 
-#: src/strings.ts:1615
+#: src/strings.ts:1616
 msgid "Please wait while we restore your backup..."
 msgstr "Please wait while we restore your backup..."
 
-#: src/strings.ts:1899
+#: src/strings.ts:1900
 msgid "Please wait while we send you recovery instructions"
 msgstr "Please wait while we send you recovery instructions"
 
@@ -4990,24 +4998,24 @@ msgstr "Please wait while we send you recovery instructions"
 msgid "Please wait while we sync all your data."
 msgstr "Please wait while we sync all your data."
 
-#: src/strings.ts:1073
+#: src/strings.ts:1074
 msgid "Please wait while we verify your subscription"
 msgstr "Please wait while we verify your subscription"
 
-#: src/strings.ts:1785
-#: src/strings.ts:1892
+#: src/strings.ts:1786
+#: src/strings.ts:1893
 msgid "Please wait while you are authenticated."
 msgstr "Please wait while you are authenticated."
 
-#: src/strings.ts:1904
+#: src/strings.ts:1905
 msgid "Please wait while your data is downloaded & decrypted."
 msgstr "Please wait while your data is downloaded & decrypted."
 
-#: src/strings.ts:905
+#: src/strings.ts:906
 msgid "Preparing note for share"
 msgstr "Preparing note for share"
 
-#: src/strings.ts:1617
+#: src/strings.ts:1618
 msgid "Preparing to restore backup file..."
 msgstr "Preparing to restore backup file..."
 
@@ -5015,19 +5023,19 @@ msgstr "Preparing to restore backup file..."
 msgid "PRESETS"
 msgstr "PRESETS"
 
-#: src/strings.ts:2121
+#: src/strings.ts:2122
 msgid "Pressing \"—\" will hide the app in your system tray."
 msgstr "Pressing \"—\" will hide the app in your system tray."
 
-#: src/strings.ts:2124
+#: src/strings.ts:2125
 msgid "Pressing \"X\" will hide the app in your system tray."
 msgstr "Pressing \"X\" will hide the app in your system tray."
 
-#: src/strings.ts:2172
+#: src/strings.ts:2173
 msgid "Prevent note title from appearing in tab/window title."
 msgstr "Prevent note title from appearing in tab/window title."
 
-#: src/strings.ts:2314
+#: src/strings.ts:2315
 msgid "Preview attachment"
 msgstr "Preview attachment"
 
@@ -5035,43 +5043,43 @@ msgstr "Preview attachment"
 msgid "Preview not available, content is encrypted."
 msgstr "Preview not available, content is encrypted."
 
-#: src/strings.ts:2381
+#: src/strings.ts:2382
 msgid "Previous match"
 msgstr "Previous match"
 
-#: src/strings.ts:2446
+#: src/strings.ts:2447
 msgid "Previous tab"
 msgstr "Previous tab"
 
-#: src/strings.ts:2036
+#: src/strings.ts:2037
 msgid "Print"
 msgstr "Print"
 
-#: src/strings.ts:2146
+#: src/strings.ts:2147
 msgid "Privacy"
 msgstr "Privacy"
 
-#: src/strings.ts:1163
+#: src/strings.ts:1164
 msgid "Privacy & security"
 msgstr "Privacy & security"
 
-#: src/strings.ts:1657
+#: src/strings.ts:1658
 msgid "Privacy comes first."
 msgstr "Privacy comes first."
 
-#: src/strings.ts:827
+#: src/strings.ts:828
 msgid "Privacy for everyone"
 msgstr "Privacy for everyone"
 
-#: src/strings.ts:1182
+#: src/strings.ts:1183
 msgid "Privacy mode"
 msgstr "Privacy mode"
 
-#: src/strings.ts:2576
+#: src/strings.ts:2577
 msgid "privacy policy"
 msgstr "privacy policy"
 
-#: src/strings.ts:1287
+#: src/strings.ts:1288
 msgid "Privacy policy"
 msgstr "Privacy policy"
 
@@ -5083,47 +5091,47 @@ msgstr "Privacy Policy. "
 msgid "private analytics and bug reports."
 msgstr "private analytics and bug reports."
 
-#: src/strings.ts:2699
+#: src/strings.ts:2700
 msgid "Private Key:"
 msgstr "Private Key:"
 
-#: src/strings.ts:821
+#: src/strings.ts:822
 msgid "Private."
 msgstr "Private."
 
-#: src/strings.ts:829
+#: src/strings.ts:830
 msgid "privileged few"
 msgstr "privileged few"
 
-#: src/strings.ts:1723
+#: src/strings.ts:1724
 msgid "Pro"
 msgstr "Pro"
 
-#: src/strings.ts:2471
+#: src/strings.ts:2472
 msgid "Pro plan"
 msgstr "Pro plan"
 
-#: src/strings.ts:2049
+#: src/strings.ts:2050
 msgid "Processing {collection}..."
 msgstr "Processing {collection}..."
 
-#: src/strings.ts:2048
+#: src/strings.ts:2049
 msgid "Processing..."
 msgstr "Processing..."
 
-#: src/strings.ts:1242
+#: src/strings.ts:1243
 msgid "Productivity"
 msgstr "Productivity"
 
-#: src/strings.ts:2135
+#: src/strings.ts:2136
 msgid "Profile"
 msgstr "Profile"
 
-#: src/strings.ts:1957
+#: src/strings.ts:1958
 msgid "Profile updated"
 msgstr "Profile updated"
 
-#: src/strings.ts:1868
+#: src/strings.ts:1869
 msgid "Properties"
 msgstr "Properties"
 
@@ -5131,11 +5139,11 @@ msgstr "Properties"
 msgid "Protect your notes"
 msgstr "Protect your notes"
 
-#: src/strings.ts:2183
+#: src/strings.ts:2184
 msgid "Proxy"
 msgstr "Proxy"
 
-#: src/strings.ts:2698
+#: src/strings.ts:2699
 msgid "Public Key:"
 msgstr "Public Key:"
 
@@ -5147,7 +5155,7 @@ msgstr "Publish"
 msgid "Publish note"
 msgstr "Publish note"
 
-#: src/strings.ts:2615
+#: src/strings.ts:2616
 msgid "Publish to the web"
 msgstr "Publish to the web"
 
@@ -5155,7 +5163,7 @@ msgstr "Publish to the web"
 msgid "Publish your note to share it with others. You can set a password to protect it."
 msgstr "Publish your note to share it with others. You can set a password to protect it."
 
-#: src/strings.ts:928
+#: src/strings.ts:929
 msgid "Published"
 msgstr "Published"
 
@@ -5171,43 +5179,43 @@ msgstr "Published note can only be viewed by someone with the password."
 msgid "Published note link will be automatically deleted once it is viewed by someone."
 msgstr "Published note link will be automatically deleted once it is viewed by someone."
 
-#: src/strings.ts:2569
+#: src/strings.ts:2570
 msgid "Purchase"
 msgstr "Purchase"
 
-#: src/strings.ts:1373
+#: src/strings.ts:1374
 msgid "Quick note"
 msgstr "Quick note"
 
-#: src/strings.ts:1243
+#: src/strings.ts:1244
 msgid "Quick note notification"
 msgstr "Quick note notification"
 
-#: src/strings.ts:1694
+#: src/strings.ts:1695
 msgid "Quick note widgets"
 msgstr "Quick note widgets"
 
-#: src/strings.ts:2442
+#: src/strings.ts:2443
 msgid "Quick open"
 msgstr "Quick open"
 
-#: src/strings.ts:1245
+#: src/strings.ts:1246
 msgid "Quickly create a note from the notification"
 msgstr "Quickly create a note from the notification"
 
-#: src/strings.ts:2334
+#: src/strings.ts:2335
 msgid "Quote"
 msgstr "Quote"
 
-#: src/strings.ts:1359
+#: src/strings.ts:1360
 msgid "Rate Notesnook on App Store"
 msgstr "Rate Notesnook on App Store"
 
-#: src/strings.ts:1360
+#: src/strings.ts:1361
 msgid "Rate Notesnook on Play Store"
 msgstr "Rate Notesnook on Play Store"
 
-#: src/strings.ts:589
+#: src/strings.ts:590
 msgid "Rate now (It takes only a second)"
 msgstr "Rate now (It takes only a second)"
 
@@ -5215,51 +5223,51 @@ msgstr "Rate now (It takes only a second)"
 msgid "Read full release notes on Github"
 msgstr "Read full release notes on Github"
 
-#: src/strings.ts:914
+#: src/strings.ts:915
 msgid "Read only"
 msgstr "Read only"
 
-#: src/strings.ts:1267
+#: src/strings.ts:1268
 msgid "Read the documentation to learn more about Notesnook"
 msgstr "Read the documentation to learn more about Notesnook"
 
-#: src/strings.ts:1288
+#: src/strings.ts:1289
 msgid "Read the privacy policy"
 msgstr "Read the privacy policy"
 
-#: src/strings.ts:1286
+#: src/strings.ts:1287
 msgid "Read the terms of service"
 msgstr "Read the terms of service"
 
-#: src/strings.ts:1618
+#: src/strings.ts:1619
 msgid "Reading backup file..."
 msgstr "Reading backup file..."
 
-#: src/strings.ts:2546
+#: src/strings.ts:2547
 msgid "Ready to take the next step on your private note taking journey?"
 msgstr "Ready to take the next step on your private note taking journey?"
 
-#: src/strings.ts:2225
+#: src/strings.ts:2226
 msgid "Receipt"
 msgstr "Receipt"
 
-#: src/strings.ts:1613
+#: src/strings.ts:1614
 msgid "RECENT BACKUPS"
 msgstr "RECENT BACKUPS"
 
-#: src/strings.ts:2457
+#: src/strings.ts:2458
 msgid "Recents"
 msgstr "Recents"
 
-#: src/strings.ts:2400
+#: src/strings.ts:2401
 msgid "Recheck all"
 msgstr "Recheck all"
 
-#: src/strings.ts:2003
+#: src/strings.ts:2004
 msgid "Rechecking failed"
 msgstr "Rechecking failed"
 
-#: src/strings.ts:2425
+#: src/strings.ts:2426
 msgid "Recipes"
 msgstr "Recipes"
 
@@ -5267,21 +5275,13 @@ msgstr "Recipes"
 msgid "Recommended"
 msgstr "Recommended"
 
-#: src/strings.ts:2548
+#: src/strings.ts:2549
 msgid "Recommended by Privacy Guides"
 msgstr "Recommended by Privacy Guides"
 
 #: src/strings.ts:435
 msgid "Recover your account"
 msgstr "Recover your account"
-
-#: src/strings.ts:1007
-msgid "Recovery codes copied!"
-msgstr "Recovery codes copied!"
-
-#: src/strings.ts:1012
-msgid "Recovery codes saved!"
-msgstr "Recovery codes saved!"
 
 #: src/strings.ts:94
 msgid "Recovery email has been sent to your email address. Please check your inbox and follow the instructions to recover your account."
@@ -5291,39 +5291,39 @@ msgstr "Recovery email has been sent to your email address. Please check your in
 msgid "Recovery email sent!"
 msgstr "Recovery email sent!"
 
-#: src/strings.ts:876
+#: src/strings.ts:877
 msgid "Recovery key copied"
 msgstr "Recovery key copied"
 
-#: src/strings.ts:874
+#: src/strings.ts:875
 msgid "Recovery key QR code saved"
 msgstr "Recovery key QR code saved"
 
-#: src/strings.ts:875
+#: src/strings.ts:876
 msgid "Recovery key text file saved"
 msgstr "Recovery key text file saved"
 
-#: src/strings.ts:1918
+#: src/strings.ts:1919
 msgid "Recovery successful!"
 msgstr "Recovery successful!"
 
-#: src/strings.ts:2437
+#: src/strings.ts:2438
 msgid "Redeem"
 msgstr "Redeem"
 
-#: src/strings.ts:2598
+#: src/strings.ts:2599
 msgid "Redeem code"
 msgstr "Redeem code"
 
-#: src/strings.ts:2434
+#: src/strings.ts:2435
 msgid "Redeem gift code"
 msgstr "Redeem gift code"
 
-#: src/strings.ts:2436
+#: src/strings.ts:2437
 msgid "Redeeming gift code"
 msgstr "Redeeming gift code"
 
-#: src/strings.ts:521
+#: src/strings.ts:522
 msgid "Redo"
 msgstr "Redo"
 
@@ -5331,15 +5331,15 @@ msgstr "Redo"
 msgid "Referenced in"
 msgstr "Referenced in"
 
-#: src/strings.ts:937
+#: src/strings.ts:938
 msgid "References"
 msgstr "References"
 
-#: src/strings.ts:520
+#: src/strings.ts:521
 msgid "Regenerate"
 msgstr "Regenerate"
 
-#: src/strings.ts:2089
+#: src/strings.ts:2090
 msgid "Register"
 msgstr "Register"
 
@@ -5347,27 +5347,27 @@ msgstr "Register"
 msgid "Release notes"
 msgstr "Release notes"
 
-#: src/strings.ts:2459
+#: src/strings.ts:2460
 msgid "Release track"
 msgstr "Release track"
 
-#: src/strings.ts:657
+#: src/strings.ts:658
 msgid "Relevance"
 msgstr "Relevance"
 
-#: src/strings.ts:1672
+#: src/strings.ts:1673
 msgid "Reload app"
 msgstr "Reload app"
 
-#: src/strings.ts:1830
+#: src/strings.ts:1831
 msgid "Relogin to your account"
 msgstr "Relogin to your account"
 
-#: src/strings.ts:1798
+#: src/strings.ts:1799
 msgid "Remembered your password?"
 msgstr "Remembered your password?"
 
-#: src/strings.ts:927
+#: src/strings.ts:928
 msgid "Remind me"
 msgstr "Remind me"
 
@@ -5375,7 +5375,7 @@ msgstr "Remind me"
 msgid "Remind me in"
 msgstr "Remind me in"
 
-#: src/strings.ts:1508
+#: src/strings.ts:1509
 msgid "Remind me of..."
 msgstr "Remind me of..."
 
@@ -5387,11 +5387,11 @@ msgstr "reminder"
 msgid "Reminder"
 msgstr "Reminder"
 
-#: src/strings.ts:1248
+#: src/strings.ts:1249
 msgid "Reminder notifications"
 msgstr "Reminder notifications"
 
-#: src/strings.ts:1561
+#: src/strings.ts:1562
 msgid "Reminder time cannot be earlier than the current time."
 msgstr "Reminder time cannot be earlier than the current time."
 
@@ -5400,92 +5400,92 @@ msgid "reminders"
 msgstr "reminders"
 
 #: src/strings.ts:318
-#: src/strings.ts:1246
-#: src/strings.ts:1524
+#: src/strings.ts:1247
+#: src/strings.ts:1525
 msgid "Reminders"
 msgstr "Reminders"
 
-#: src/strings.ts:1381
+#: src/strings.ts:1382
 msgid "Reminders cannot be set because notifications have been disabled from app settings. If you want to keep receiving reminder notifications, enable notifications for Notesnook from app settings."
 msgstr "Reminders cannot be set because notifications have been disabled from app settings. If you want to keep receiving reminder notifications, enable notifications for Notesnook from app settings."
 
-#: src/strings.ts:1955
+#: src/strings.ts:1956
 msgid "Reminders will not be active on this device as it does not support notifications."
 msgstr "Reminders will not be active on this device as it does not support notifications."
 
-#: src/strings.ts:782
+#: src/strings.ts:783
 msgid "Remove"
 msgstr "Remove"
 
-#: src/strings.ts:1177
+#: src/strings.ts:1178
 msgid "Remove all notes from the vault."
 msgstr "Remove all notes from the vault."
 
-#: src/strings.ts:1204
+#: src/strings.ts:1205
 msgid "Remove app lock password"
 msgstr "Remove app lock password"
 
-#: src/strings.ts:1208
+#: src/strings.ts:1209
 msgid "Remove app lock password, app lock will be disabled if no other security method is enabled."
 msgstr "Remove app lock password, app lock will be disabled if no other security method is enabled."
 
-#: src/strings.ts:1203
+#: src/strings.ts:1204
 msgid "Remove app lock pin"
 msgstr "Remove app lock pin"
 
-#: src/strings.ts:1206
+#: src/strings.ts:1207
 msgid "Remove app lock pin, app lock will be disabled if no other security method is enabled."
 msgstr "Remove app lock pin, app lock will be disabled if no other security method is enabled."
 
-#: src/strings.ts:896
+#: src/strings.ts:897
 msgid "Remove as default"
 msgstr "Remove as default"
 
-#: src/strings.ts:2318
+#: src/strings.ts:2319
 msgid "Remove attachment"
 msgstr "Remove attachment"
 
-#: src/strings.ts:933
+#: src/strings.ts:934
 msgid "Remove from all"
 msgstr "Remove from all"
 
-#: src/strings.ts:906
+#: src/strings.ts:907
 msgid "Remove from notebook"
 msgstr "Remove from notebook"
 
-#: src/strings.ts:2458
+#: src/strings.ts:2459
 msgid "Remove from recents"
 msgstr "Remove from recents"
 
-#: src/strings.ts:1046
+#: src/strings.ts:1047
 msgid "Remove full name"
 msgstr "Remove full name"
 
-#: src/strings.ts:2265
+#: src/strings.ts:2266
 msgid "Remove link"
 msgstr "Remove link"
 
-#: src/strings.ts:1042
+#: src/strings.ts:1043
 msgid "Remove profile picture"
 msgstr "Remove profile picture"
 
-#: src/strings.ts:1049
+#: src/strings.ts:1050
 msgid "Remove your full name from profile"
 msgstr "Remove your full name from profile"
 
-#: src/strings.ts:1043
+#: src/strings.ts:1044
 msgid "Remove your profile picture"
 msgstr "Remove your profile picture"
 
-#: src/strings.ts:546
+#: src/strings.ts:547
 msgid "Rename"
 msgstr "Rename"
 
-#: src/strings.ts:751
+#: src/strings.ts:752
 msgid "Rename file"
 msgstr "Rename file"
 
-#: src/strings.ts:891
+#: src/strings.ts:892
 msgid "Reorder"
 msgstr "Reorder"
 
@@ -5493,19 +5493,19 @@ msgstr "Reorder"
 msgid "Repeats daily at {date}"
 msgstr "Repeats daily at {date}"
 
-#: src/strings.ts:2378
+#: src/strings.ts:2379
 msgid "Replace"
 msgstr "Replace"
 
-#: src/strings.ts:2379
+#: src/strings.ts:2380
 msgid "Replace all"
 msgstr "Replace all"
 
-#: src/strings.ts:2166
+#: src/strings.ts:2167
 msgid "Report"
 msgstr "Report"
 
-#: src/strings.ts:1259
+#: src/strings.ts:1260
 msgid "Report an issue"
 msgstr "Report an issue"
 
@@ -5518,95 +5518,95 @@ msgid "Resend code in ({seconds})"
 msgstr "Resend code in ({seconds})"
 
 #. placeholder {0}: seconds ? ` in ${seconds}` : ""
-#: src/strings.ts:677
+#: src/strings.ts:678
 msgid "Resend code{0}"
 msgstr "Resend code{0}"
 
-#: src/strings.ts:1404
+#: src/strings.ts:1405
 msgid "Resend email"
 msgstr "Resend email"
 
-#: src/strings.ts:1822
+#: src/strings.ts:1823
 msgid "Reset"
 msgstr "Reset"
 
-#: src/strings.ts:1914
+#: src/strings.ts:1915
 msgid "Reset account password"
 msgstr "Reset account password"
 
-#: src/strings.ts:2485
+#: src/strings.ts:2486
 msgid "Reset homepage"
 msgstr "Reset homepage"
 
-#: src/strings.ts:1823
+#: src/strings.ts:1824
 msgid "Reset selection"
 msgstr "Reset selection"
 
-#: src/strings.ts:1650
+#: src/strings.ts:1651
 msgid "Reset server urls"
 msgstr "Reset server urls"
 
-#: src/strings.ts:2032
+#: src/strings.ts:2033
 msgid "Reset sidebar"
 msgstr "Reset sidebar"
 
-#: src/strings.ts:1149
+#: src/strings.ts:1150
 msgid "Reset the toolbar to default settings"
 msgstr "Reset the toolbar to default settings"
 
-#: src/strings.ts:1148
+#: src/strings.ts:1149
 msgid "Reset toolbar"
 msgstr "Reset toolbar"
 
-#: src/strings.ts:1916
+#: src/strings.ts:1917
 msgid "Resetting account password ({progress})"
 msgstr "Resetting account password ({progress})"
 
-#: src/strings.ts:1991
+#: src/strings.ts:1992
 msgid "Restart now"
 msgstr "Restart now"
 
-#: src/strings.ts:1649
+#: src/strings.ts:1650
 msgid "Restart the app for changes to take effect."
 msgstr "Restart the app for changes to take effect."
 
-#: src/strings.ts:1320
+#: src/strings.ts:1321
 msgid "Restart the app to apply the changes"
 msgstr "Restart the app to apply the changes"
 
-#: src/strings.ts:1595
+#: src/strings.ts:1596
 msgid "Restart the app."
 msgstr "Restart the app."
 
-#: src/strings.ts:568
+#: src/strings.ts:569
 msgid "Restore"
 msgstr "Restore"
 
-#: src/strings.ts:1237
+#: src/strings.ts:1238
 msgid "Restore backup"
 msgstr "Restore backup"
 
-#: src/strings.ts:2407
+#: src/strings.ts:2408
 msgid "Restore backup?"
 msgstr "Restore backup?"
 
-#: src/strings.ts:890
+#: src/strings.ts:891
 msgid "Restore failed"
 msgstr "Restore failed"
 
-#: src/strings.ts:1612
+#: src/strings.ts:1613
 msgid "Restore from files"
 msgstr "Restore from files"
 
-#: src/strings.ts:1662
+#: src/strings.ts:1663
 msgid "Restore this version"
 msgstr "Restore this version"
 
-#: src/strings.ts:1238
+#: src/strings.ts:1239
 msgid "Restore your data from a backup"
 msgstr "Restore your data from a backup"
 
-#: src/strings.ts:849
+#: src/strings.ts:850
 msgid "Restored successfully"
 msgstr "Restored successfully"
 
@@ -5618,27 +5618,27 @@ msgstr "Restoring"
 msgid "Restoring {collection}..."
 msgstr "Restoring {collection}..."
 
-#: src/strings.ts:1614
+#: src/strings.ts:1615
 msgid "Restoring backup..."
 msgstr "Restoring backup..."
 
-#: src/strings.ts:686
+#: src/strings.ts:687
 msgid "Resubscribe from Playstore"
 msgstr "Resubscribe from Playstore"
 
-#: src/strings.ts:687
+#: src/strings.ts:688
 msgid "Resubscribe to Pro"
 msgstr "Resubscribe to Pro"
 
-#: src/strings.ts:2671
+#: src/strings.ts:2672
 msgid "Retry"
 msgstr "Retry"
 
-#: src/strings.ts:513
+#: src/strings.ts:514
 msgid "Reupload"
 msgstr "Reupload"
 
-#: src/strings.ts:2022
+#: src/strings.ts:2023
 msgid "Reveal in list"
 msgstr "Reveal in list"
 
@@ -5646,11 +5646,11 @@ msgstr "Reveal in list"
 msgid "Revoke"
 msgstr "Revoke"
 
-#: src/strings.ts:1181
+#: src/strings.ts:1182
 msgid "Revoke biometric unlocking"
 msgstr "Revoke biometric unlocking"
 
-#: src/strings.ts:2685
+#: src/strings.ts:2686
 msgid "Revoke Inbox API Key - {name}"
 msgstr "Revoke Inbox API Key - {name}"
 
@@ -5658,51 +5658,55 @@ msgstr "Revoke Inbox API Key - {name}"
 msgid "Revoke vault fingerprint unlock"
 msgstr "Revoke vault fingerprint unlock"
 
-#: src/strings.ts:1295
+#: src/strings.ts:1296
 msgid "Roadmap"
 msgstr "Roadmap"
 
-#: src/strings.ts:2050
+#: src/strings.ts:2051
 msgid "Root"
 msgstr "Root"
 
-#: src/strings.ts:2029
+#: src/strings.ts:2030
 msgid "Rotate left"
 msgstr "Rotate left"
 
-#: src/strings.ts:2030
+#: src/strings.ts:2031
 msgid "Rotate right"
 msgstr "Rotate right"
 
-#: src/strings.ts:2288
+#: src/strings.ts:2289
 msgid "Row properties"
 msgstr "Row properties"
 
-#: src/strings.ts:545
+#: src/strings.ts:546
 msgid "Run file check"
 msgstr "Run file check"
 
-#: src/strings.ts:2061
+#: src/strings.ts:2062
 msgid "Safe & encrypted notes"
 msgstr "Safe & encrypted notes"
 
-#: src/strings.ts:628
+#: src/strings.ts:629
 msgid "Sat"
 msgstr "Sat"
 
-#: src/strings.ts:619
+#: src/strings.ts:620
 msgid "Saturday"
 msgstr "Saturday"
 
-#: src/strings.ts:574
+#: src/strings.ts:575
 msgid "Save"
 msgstr "Save"
+
+#: src/strings.ts:497
+msgid "Save 2FA backup codes"
+msgstr "Save 2FA backup codes"
 
 #: src/strings.ts:477
 msgid "Save a backup of your notes"
 msgstr "Save a backup of your notes"
 
-#: src/strings.ts:564
+#: src/strings.ts:565
 msgid "Save a copy"
 msgstr "Save a copy"
 
@@ -5710,35 +5714,35 @@ msgstr "Save a copy"
 msgid "Save account recovery key"
 msgstr "Save account recovery key"
 
-#: src/strings.ts:583
+#: src/strings.ts:584
 msgid "Save and continue"
 msgstr "Save and continue"
 
-#: src/strings.ts:1050
+#: src/strings.ts:1051
 msgid "Save data recovery key"
 msgstr "Save data recovery key"
 
-#: src/strings.ts:955
+#: src/strings.ts:956
 msgid "Save failed. Vault is locked"
 msgstr "Save failed. Vault is locked"
 
-#: src/strings.ts:592
+#: src/strings.ts:593
 msgid "Save QR code to gallery"
 msgstr "Save QR code to gallery"
 
-#: src/strings.ts:497
-msgid "Save recovery codes"
-msgstr "Save recovery codes"
-
-#: src/strings.ts:680
+#: src/strings.ts:681
 msgid "Save to file"
 msgstr "Save to file"
 
-#: src/strings.ts:593
+#: src/strings.ts:594
 msgid "Save to text file"
 msgstr "Save to text file"
 
-#: src/strings.ts:1362
+#: src/strings.ts:499
+msgid "Save your 2FA backup codes in a safe place. You will need them to log into your account in case you lose access to your two-factor authentication methods."
+msgstr "Save your 2FA backup codes in a safe place. You will need them to log into your account in case you lose access to your two-factor authentication methods."
+
+#: src/strings.ts:1363
 msgid "Save your account recovery key"
 msgstr "Save your account recovery key"
 
@@ -5746,68 +5750,64 @@ msgstr "Save your account recovery key"
 msgid "Save your account recovery key in a safe place. You will need it to recover your account in case you forget your password."
 msgstr "Save your account recovery key in a safe place. You will need it to recover your account in case you forget your password."
 
-#: src/strings.ts:1052
+#: src/strings.ts:1053
 msgid "Save your data recovery key in a safe place. You will need it to recover your data in case you forget your password."
 msgstr "Save your data recovery key in a safe place. You will need it to recover your data in case you forget your password."
 
-#: src/strings.ts:499
-msgid "Save your recovery codes in a safe place. You will need them to recover your account in case you lose access to your two-factor authentication methods."
-msgstr "Save your recovery codes in a safe place. You will need them to recover your account in case you lose access to your two-factor authentication methods."
-
-#: src/strings.ts:2397
+#: src/strings.ts:2398
 msgid "Saved"
 msgstr "Saved"
 
-#: src/strings.ts:2398
+#: src/strings.ts:2399
 msgid "Saving"
 msgstr "Saving"
 
-#: src/strings.ts:1590
+#: src/strings.ts:1591
 msgid "Saving this note is taking too long. Copy your changes and restart the app to prevent data loss. If the problem persists, please report it to us at support@streetwriters.co."
 msgstr "Saving this note is taking too long. Copy your changes and restart the app to prevent data loss. If the problem persists, please report it to us at support@streetwriters.co."
 
-#: src/strings.ts:796
+#: src/strings.ts:797
 msgid "Saving zip file ({progress}%). Please wait..."
 msgstr "Saving zip file ({progress}%). Please wait..."
 
-#: src/strings.ts:797
+#: src/strings.ts:798
 msgid "Saving zip file. Please wait..."
 msgstr "Saving zip file. Please wait..."
 
-#: src/strings.ts:1724
+#: src/strings.ts:1725
 msgid "Scan the QR code with your authenticator app"
 msgstr "Scan the QR code with your authenticator app"
 
-#: src/strings.ts:2423
+#: src/strings.ts:2424
 msgid "School work"
 msgstr "School work"
 
-#: src/strings.ts:2496
+#: src/strings.ts:2497
 msgid "Scroll to bottom"
 msgstr "Scroll to bottom"
 
-#: src/strings.ts:2495
+#: src/strings.ts:2496
 msgid "Scroll to top"
 msgstr "Scroll to top"
 
-#: src/strings.ts:1512
-#: src/strings.ts:1530
+#: src/strings.ts:1513
+#: src/strings.ts:1531
 msgid "Search"
 msgstr "Search"
 
-#: src/strings.ts:1507
+#: src/strings.ts:1508
 msgid "Search a note"
 msgstr "Search a note"
 
-#: src/strings.ts:1505
+#: src/strings.ts:1506
 msgid "Search a note to link to"
 msgstr "Search a note to link to"
 
-#: src/strings.ts:2439
+#: src/strings.ts:2440
 msgid "Search for notes, notebooks, and tags..."
 msgstr "Search for notes, notebooks, and tags..."
 
-#: src/strings.ts:1540
+#: src/strings.ts:1541
 msgid "Search in {routeName}"
 msgstr "Search in {routeName}"
 
@@ -5859,75 +5859,75 @@ msgstr "Search in Tags"
 msgid "Search in Trash"
 msgstr "Search in Trash"
 
-#: src/strings.ts:2360
+#: src/strings.ts:2361
 msgid "Search languages"
 msgstr "Search languages"
 
-#: src/strings.ts:1493
+#: src/strings.ts:1494
 msgid "Search notebooks"
 msgstr "Search notebooks"
 
-#: src/strings.ts:1506
+#: src/strings.ts:1507
 msgid "Search or add a tag"
 msgstr "Search or add a tag"
 
-#: src/strings.ts:1836
+#: src/strings.ts:1837
 msgid "Search themes"
 msgstr "Search themes"
 
-#: src/strings.ts:1510
+#: src/strings.ts:1511
 msgid "Searching for {query}..."
 msgstr "Searching for {query}..."
 
-#: src/strings.ts:878
+#: src/strings.ts:879
 msgid "sec"
 msgstr "sec"
 
-#: src/strings.ts:2145
+#: src/strings.ts:2146
 msgid "Security & privacy"
 msgstr "Security & privacy"
 
-#: src/strings.ts:2085
+#: src/strings.ts:2086
 msgid "Security key"
 msgstr "Security key"
 
-#: src/strings.ts:1990
+#: src/strings.ts:1991
 msgid "Security key successfully registered."
 msgstr "Security key successfully registered."
 
-#: src/strings.ts:1296
+#: src/strings.ts:1297
 msgid "See what the future of Notesnook is going to be like."
 msgstr "See what the future of Notesnook is going to be like."
 
-#: src/strings.ts:1336
+#: src/strings.ts:1337
 msgid "Select"
 msgstr "Select"
 
-#: src/strings.ts:1611
+#: src/strings.ts:1612
 msgid "Select a backup file from your device to restore backup"
 msgstr "Select a backup file from your device to restore backup"
 
-#: src/strings.ts:2490
+#: src/strings.ts:2491
 msgid "Select a notebook to move this notebook into, or unselect to move it to the root level."
 msgstr "Select a notebook to move this notebook into, or unselect to move it to the root level."
 
-#: src/strings.ts:2100
+#: src/strings.ts:2101
 msgid "Select a theme"
 msgstr "Select a theme"
 
-#: src/strings.ts:1228
+#: src/strings.ts:1229
 msgid "Select backup directory"
 msgstr "Select backup directory"
 
-#: src/strings.ts:1857
+#: src/strings.ts:1858
 msgid "Select backup file"
 msgstr "Select backup file"
 
-#: src/strings.ts:640
+#: src/strings.ts:641
 msgid "Select backups folder"
 msgstr "Select backups folder"
 
-#: src/strings.ts:630
+#: src/strings.ts:631
 msgid "Select date"
 msgstr "Select date"
 
@@ -5935,15 +5935,15 @@ msgstr "Select date"
 msgid "Select day of the week to repeat the reminder."
 msgstr "Select day of the week to repeat the reminder."
 
-#: src/strings.ts:1765
+#: src/strings.ts:1766
 msgid "Select files to import"
 msgstr "Select files to import"
 
-#: src/strings.ts:1608
+#: src/strings.ts:1609
 msgid "Select folder where Notesnook backup files are stored to view and restore them from the app"
 msgstr "Select folder where Notesnook backup files are stored to view and restore them from the app"
 
-#: src/strings.ts:1609
+#: src/strings.ts:1610
 msgid "Select folder with backup files"
 msgstr "Select folder with backup files"
 
@@ -5951,7 +5951,7 @@ msgstr "Select folder with backup files"
 msgid "Select how you would like to recieve the code"
 msgstr "Select how you would like to recieve the code"
 
-#: src/strings.ts:2355
+#: src/strings.ts:2356
 msgid "Select language"
 msgstr "Select language"
 
@@ -5967,7 +5967,7 @@ msgstr "Select notebooks"
 msgid "Select notebooks you want to add note(s) to."
 msgstr "Select notebooks you want to add note(s) to."
 
-#: src/strings.ts:2478
+#: src/strings.ts:2479
 msgid "Select notes to link to \"{title}\""
 msgstr "Select notes to link to \"{title}\""
 
@@ -5975,11 +5975,11 @@ msgstr "Select notes to link to \"{title}\""
 msgid "Select nth day of the month to repeat the reminder."
 msgstr "Select nth day of the month to repeat the reminder."
 
-#: src/strings.ts:1819
+#: src/strings.ts:1820
 msgid "Select profile picture"
 msgstr "Select profile picture"
 
-#: src/strings.ts:2484
+#: src/strings.ts:2485
 msgid "Select the default sidebar tab"
 msgstr "Select the default sidebar tab"
 
@@ -5987,11 +5987,11 @@ msgstr "Select the default sidebar tab"
 msgid "Select the folder that includes your backup files to list them here."
 msgstr "Select the folder that includes your backup files to list them here."
 
-#: src/strings.ts:2132
+#: src/strings.ts:2133
 msgid "Select the languages the spell checker should check in."
 msgstr "Select the languages the spell checker should check in."
 
-#: src/strings.ts:2460
+#: src/strings.ts:2461
 msgid "Select the release track for Notesnook."
 msgstr "Select the release track for Notesnook."
 
@@ -6003,7 +6003,7 @@ msgstr "SELECTED NOTE"
 msgid "Self destruct"
 msgstr "Self destruct"
 
-#: src/strings.ts:2167
+#: src/strings.ts:2168
 msgid "Send"
 msgstr "Send"
 
@@ -6019,47 +6019,47 @@ msgstr "Send code via email"
 msgid "Send code via SMS"
 msgstr "Send code via SMS"
 
-#: src/strings.ts:1861
+#: src/strings.ts:1862
 msgid "Send recovery email"
 msgstr "Send recovery email"
 
-#: src/strings.ts:1897
+#: src/strings.ts:1898
 msgid "Sending recovery email"
 msgstr "Sending recovery email"
 
-#: src/strings.ts:1648
+#: src/strings.ts:1649
 msgid "Server url changed"
 msgstr "Server url changed"
 
-#: src/strings.ts:1651
+#: src/strings.ts:1652
 msgid "Server urls reset"
 msgstr "Server urls reset"
 
-#: src/strings.ts:1629
+#: src/strings.ts:1630
 msgid "Server used for login/sign up and authentication."
 msgstr "Server used for login/sign up and authentication."
 
-#: src/strings.ts:1634
+#: src/strings.ts:1635
 msgid "Server used to host your published notes."
 msgstr "Server used to host your published notes."
 
-#: src/strings.ts:1632
+#: src/strings.ts:1633
 msgid "Server used to receive important notifications & events."
 msgstr "Server used to receive important notifications & events."
 
-#: src/strings.ts:1627
+#: src/strings.ts:1628
 msgid "Server used to sync your notes & other data between devices."
 msgstr "Server used to sync your notes & other data between devices."
 
-#: src/strings.ts:1640
+#: src/strings.ts:1641
 msgid "Server with host {host} not found."
 msgstr "Server with host {host} not found."
 
-#: src/strings.ts:2140
+#: src/strings.ts:2141
 msgid "Servers"
 msgstr "Servers"
 
-#: src/strings.ts:2141
+#: src/strings.ts:2142
 msgid "Servers configuration"
 msgstr "Servers configuration"
 
@@ -6067,55 +6067,55 @@ msgstr "Servers configuration"
 msgid "Session expired"
 msgstr "Session expired"
 
-#: src/strings.ts:2193
+#: src/strings.ts:2194
 msgid "Sessions"
 msgstr "Sessions"
 
-#: src/strings.ts:978
+#: src/strings.ts:979
 msgid "Set a reminder"
 msgstr "Set a reminder"
 
-#: src/strings.ts:728
+#: src/strings.ts:729
 msgid "Set as dark theme"
 msgstr "Set as dark theme"
 
-#: src/strings.ts:897
+#: src/strings.ts:898
 msgid "Set as default"
 msgstr "Set as default"
 
-#: src/strings.ts:2482
+#: src/strings.ts:2483
 msgid "Set as homepage"
 msgstr "Set as homepage"
 
-#: src/strings.ts:729
+#: src/strings.ts:730
 msgid "Set as light theme"
 msgstr "Set as light theme"
 
-#: src/strings.ts:1335
+#: src/strings.ts:1336
 msgid "Set automatic trash cleanup interval from Settings > Behaviour > Clean trash interval."
 msgstr "Set automatic trash cleanup interval from Settings > Behaviour > Clean trash interval."
 
-#: src/strings.ts:2632
+#: src/strings.ts:2633
 msgid "Set expiry"
 msgstr "Set expiry"
 
-#: src/strings.ts:1312
+#: src/strings.ts:1313
 msgid "Set full name"
 msgstr "Set full name"
 
-#: src/strings.ts:1254
+#: src/strings.ts:1255
 msgid "Set snooze time in minutes"
 msgstr "Set snooze time in minutes"
 
-#: src/strings.ts:1253
+#: src/strings.ts:1254
 msgid "Set the default time to snooze a reminder to when you press the snooze button on a notification."
 msgstr "Set the default time to snooze a reminder to when you press the snooze button on a notification."
 
-#: src/strings.ts:1225
+#: src/strings.ts:1226
 msgid "Set the interval to create a backup (with attachments) automatically."
 msgstr "Set the interval to create a backup (with attachments) automatically."
 
-#: src/strings.ts:1222
+#: src/strings.ts:1223
 msgid "Set the interval to create a partial backup (without attachments) automatically."
 msgstr "Set the interval to create a partial backup (without attachments) automatically."
 
@@ -6124,24 +6124,24 @@ msgid "Set your name"
 msgstr "Set your name"
 
 #: src/strings.ts:387
-#: src/strings.ts:1526
+#: src/strings.ts:1527
 msgid "Settings"
 msgstr "Settings"
 
-#: src/strings.ts:1201
 #: src/strings.ts:1202
+#: src/strings.ts:1203
 msgid "Setup a new password for app lock"
 msgstr "Setup a new password for app lock"
 
-#: src/strings.ts:1198
+#: src/strings.ts:1199
 msgid "Setup a password to lock the app"
 msgstr "Setup a password to lock the app"
 
-#: src/strings.ts:1196
+#: src/strings.ts:1197
 msgid "Setup a pin to lock the app"
 msgstr "Setup a pin to lock the app"
 
-#: src/strings.ts:2185
+#: src/strings.ts:2186
 msgid ""
 "Setup an HTTP/HTTPS/SOCKS proxy.\n"
 "\n"
@@ -6161,27 +6161,27 @@ msgstr ""
 "\n"
 "To remove the proxy, simply erase everything in the input."
 
-#: src/strings.ts:1197
+#: src/strings.ts:1198
 msgid "Setup app lock password"
 msgstr "Setup app lock password"
 
-#: src/strings.ts:1195
+#: src/strings.ts:1196
 msgid "Setup app lock pin"
 msgstr "Setup app lock pin"
 
-#: src/strings.ts:681
+#: src/strings.ts:682
 msgid "Setup secondary 2FA method"
 msgstr "Setup secondary 2FA method"
 
-#: src/strings.ts:980
+#: src/strings.ts:981
 msgid "Setup using an Authenticator app"
 msgstr "Setup using an Authenticator app"
 
-#: src/strings.ts:987
+#: src/strings.ts:988
 msgid "Setup using email"
 msgstr "Setup using email"
 
-#: src/strings.ts:994
+#: src/strings.ts:995
 msgid "Setup using SMS"
 msgstr "Setup using SMS"
 
@@ -6189,11 +6189,11 @@ msgstr "Setup using SMS"
 msgid "Share"
 msgstr "Share"
 
-#: src/strings.ts:1693
+#: src/strings.ts:1694
 msgid "Share & append to notes from anywhere"
 msgstr "Share & append to notes from anywhere"
 
-#: src/strings.ts:1343
+#: src/strings.ts:1344
 msgid "Share backup"
 msgstr "Share backup"
 
@@ -6201,15 +6201,15 @@ msgstr "Share backup"
 msgid "Share note"
 msgstr "Share note"
 
-#: src/strings.ts:1789
+#: src/strings.ts:1790
 msgid "Share Notesnook with friends!"
 msgstr "Share Notesnook with friends!"
 
-#: src/strings.ts:2644
+#: src/strings.ts:2645
 msgid "Share things to Notesbook from anywhere using the Inbox API"
 msgstr "Share things to Notesbook from anywhere using the Inbox API"
 
-#: src/strings.ts:594
+#: src/strings.ts:595
 msgid "Share to cloud"
 msgstr "Share to cloud"
 
@@ -6221,7 +6221,7 @@ msgstr "shortcut"
 msgid "Shortcut"
 msgstr "Shortcut"
 
-#: src/strings.ts:2002
+#: src/strings.ts:2003
 msgid "Shortcut removed"
 msgstr "Shortcut removed"
 
@@ -6237,11 +6237,11 @@ msgstr "Shortcuts"
 msgid "Sign up"
 msgstr "Sign up"
 
-#: src/strings.ts:1032
+#: src/strings.ts:1033
 msgid "Signed up on {date}"
 msgstr "Signed up on {date}"
 
-#: src/strings.ts:777
+#: src/strings.ts:778
 msgid "Signup failed"
 msgstr "Signup failed"
 
@@ -6249,95 +6249,95 @@ msgstr "Signup failed"
 msgid "Silent"
 msgstr "Silent"
 
-#: src/strings.ts:2329
+#: src/strings.ts:2330
 msgid "Sink list item"
 msgstr "Sink list item"
 
-#: src/strings.ts:2043
+#: src/strings.ts:2044
 msgid "Size"
 msgstr "Size"
 
-#: src/strings.ts:550
+#: src/strings.ts:551
 msgid "Skip"
 msgstr "Skip"
 
-#: src/strings.ts:1831
+#: src/strings.ts:1832
 msgid "Skip & go directly to the app"
 msgstr "Skip & go directly to the app"
 
-#: src/strings.ts:673
+#: src/strings.ts:674
 msgid "Skip introduction"
 msgstr "Skip introduction"
 
-#: src/strings.ts:1606
+#: src/strings.ts:1607
 msgid "Some exported notes are locked, Unlock to export them"
 msgstr "Some exported notes are locked, Unlock to export them"
 
-#: src/strings.ts:1478
+#: src/strings.ts:1479
 msgid "Some notes are published"
 msgstr "Some notes are published"
 
-#: src/strings.ts:1668
+#: src/strings.ts:1669
 msgid "Something went wrong"
 msgstr "Something went wrong"
 
-#: src/strings.ts:2027
+#: src/strings.ts:2028
 msgid "Sort"
 msgstr "Sort"
 
-#: src/strings.ts:536
+#: src/strings.ts:537
 msgid "Sort by"
 msgstr "Sort by"
 
-#: src/strings.ts:2151
+#: src/strings.ts:2152
 msgid "Source code"
 msgstr "Source code"
 
-#: src/strings.ts:2356
+#: src/strings.ts:2357
 msgid "Spaces"
 msgstr "Spaces"
 
-#: src/strings.ts:2591
+#: src/strings.ts:2592
 msgid "Special Offer"
 msgstr "Special Offer"
 
-#: src/strings.ts:2128
+#: src/strings.ts:2129
 msgid "Spell check"
 msgstr "Spell check"
 
-#: src/strings.ts:2295
+#: src/strings.ts:2296
 msgid "Split cells"
 msgstr "Split cells"
 
-#: src/strings.ts:2461
+#: src/strings.ts:2462
 msgid "Stable"
 msgstr "Stable"
 
-#: src/strings.ts:1114
+#: src/strings.ts:1115
 msgid "Start"
 msgstr "Start"
 
-#: src/strings.ts:1832
+#: src/strings.ts:1833
 msgid "Start account recovery"
 msgstr "Start account recovery"
 
-#: src/strings.ts:1827
+#: src/strings.ts:1828
 msgid "Start import"
 msgstr "Start import"
 
-#: src/strings.ts:1824
+#: src/strings.ts:1825
 msgid "Start importing now"
 msgstr "Start importing now"
 
-#: src/strings.ts:2116
+#: src/strings.ts:2117
 msgid "Start minimized"
 msgstr "Start minimized"
 
-#: src/strings.ts:1759
+#: src/strings.ts:1760
 msgid "Start over"
 msgstr "Start over"
 
-#: src/strings.ts:952
+#: src/strings.ts:953
 msgid "Start writing to create a new note"
 msgstr "Start writing to create a new note"
 
@@ -6345,103 +6345,103 @@ msgstr "Start writing to create a new note"
 msgid "Start writing to save your note."
 msgstr "Start writing to save your note."
 
-#: src/strings.ts:1603
+#: src/strings.ts:1604
 msgid "Start writing your note..."
 msgstr "Start writing your note..."
 
-#: src/strings.ts:2224
+#: src/strings.ts:2225
 msgid "Status"
 msgstr "Status"
 
-#: src/strings.ts:2474
+#: src/strings.ts:2475
 msgid "Storage"
 msgstr "Storage"
 
-#: src/strings.ts:1550
+#: src/strings.ts:1551
 msgid "Streaming not supported"
 msgstr "Streaming not supported"
 
-#: src/strings.ts:2261
+#: src/strings.ts:2262
 msgid "Strikethrough"
 msgstr "Strikethrough"
 
-#: src/strings.ts:2226
+#: src/strings.ts:2227
 msgid "Subgroup 1"
 msgstr "Subgroup 1"
 
-#: src/strings.ts:1996
+#: src/strings.ts:1997
 msgid "Subgroup added"
 msgstr "Subgroup added"
 
-#: src/strings.ts:580
+#: src/strings.ts:581
 msgid "Submit"
 msgstr "Submit"
 
-#: src/strings.ts:2570
+#: src/strings.ts:2571
 msgid "Subscribe"
 msgstr "Subscribe"
 
-#: src/strings.ts:2571
+#: src/strings.ts:2572
 msgid "Subscribe and start free trial"
 msgstr "Subscribe and start free trial"
 
-#: src/strings.ts:1027
+#: src/strings.ts:1028
 msgid "Subscribe to Pro"
 msgstr "Subscribe to Pro"
 
-#: src/strings.ts:707
+#: src/strings.ts:708
 msgid "Subscribed on Android"
 msgstr "Subscribed on Android"
 
-#: src/strings.ts:700
+#: src/strings.ts:701
 msgid "Subscribed on iOS"
 msgstr "Subscribed on iOS"
 
-#: src/strings.ts:1307
+#: src/strings.ts:1308
 msgid "Subscribed on web"
 msgstr "Subscribed on web"
 
-#: src/strings.ts:714
+#: src/strings.ts:715
 msgid "Subscribed on Web"
 msgstr "Subscribed on Web"
 
-#: src/strings.ts:720
+#: src/strings.ts:721
 msgid "Subscribed using gift card"
 msgstr "Subscribed using gift card"
 
-#: src/strings.ts:2272
+#: src/strings.ts:2273
 msgid "Subscript"
 msgstr "Subscript"
 
-#: src/strings.ts:694
+#: src/strings.ts:695
 msgid "Subscription awarded from Streetwriters"
 msgstr "Subscription awarded from Streetwriters"
 
-#: src/strings.ts:1031
+#: src/strings.ts:1032
 msgid "Subscription details"
 msgstr "Subscription details"
 
-#: src/strings.ts:1065
+#: src/strings.ts:1066
 msgid "Subscription not activated?"
 msgstr "Subscription not activated?"
 
-#: src/strings.ts:622
+#: src/strings.ts:623
 msgid "Sun"
 msgstr "Sun"
 
-#: src/strings.ts:613
+#: src/strings.ts:614
 msgid "Sunday"
 msgstr "Sunday"
 
-#: src/strings.ts:2273
+#: src/strings.ts:2274
 msgid "Superscript"
 msgstr "Superscript"
 
-#: src/strings.ts:1471
+#: src/strings.ts:1472
 msgid "Switch to search/replace mode"
 msgstr "Switch to search/replace mode"
 
-#: src/strings.ts:2137
+#: src/strings.ts:2138
 msgid "Sync"
 msgstr "Sync"
 
@@ -6449,7 +6449,7 @@ msgstr "Sync"
 msgid "Sync failed"
 msgstr "Sync failed"
 
-#: src/strings.ts:1365
+#: src/strings.ts:1366
 msgid "Sync is disabled"
 msgstr "Sync is disabled"
 
@@ -6457,19 +6457,19 @@ msgstr "Sync is disabled"
 msgid "Sync now"
 msgstr "Sync now"
 
-#: src/strings.ts:915
+#: src/strings.ts:916
 msgid "Sync off"
 msgstr "Sync off"
 
-#: src/strings.ts:1625
+#: src/strings.ts:1626
 msgid "Sync server"
 msgstr "Sync server"
 
-#: src/strings.ts:1084
+#: src/strings.ts:1085
 msgid "Sync settings"
 msgstr "Sync settings"
 
-#: src/strings.ts:1097
+#: src/strings.ts:1098
 msgid "Sync your notes in the background even when the app is closed. This is an experimental feature. If you face any issues, please turn it off."
 msgstr "Sync your notes in the background even when the app is closed. This is an experimental feature. If you face any issues, please turn it off."
 
@@ -6485,27 +6485,27 @@ msgstr "Syncing"
 msgid "Syncing your data"
 msgstr "Syncing your data"
 
-#: src/strings.ts:1704
+#: src/strings.ts:1705
 msgid "Syncing your notes"
 msgstr "Syncing your notes"
 
-#: src/strings.ts:2341
+#: src/strings.ts:2342
 msgid "Table"
 msgstr "Table"
 
-#: src/strings.ts:538
+#: src/strings.ts:539
 msgid "Table of contents"
 msgstr "Table of contents"
 
-#: src/strings.ts:2286
+#: src/strings.ts:2287
 msgid "Table settings"
 msgstr "Table settings"
 
-#: src/strings.ts:2535
+#: src/strings.ts:2536
 msgid "tables, outlines, block level note linking"
 msgstr "tables, outlines, block level note linking"
 
-#: src/strings.ts:529
+#: src/strings.ts:530
 msgid "Tabs"
 msgstr "Tabs"
 
@@ -6522,55 +6522,55 @@ msgid "tags"
 msgstr "tags"
 
 #: src/strings.ts:317
-#: src/strings.ts:1527
+#: src/strings.ts:1528
 msgid "Tags"
 msgstr "Tags"
 
-#: src/strings.ts:1545
+#: src/strings.ts:1546
 msgid "Take a backup before logging out"
 msgstr "Take a backup before logging out"
 
-#: src/strings.ts:1217
+#: src/strings.ts:1218
 msgid "Take a full backup of your data with all attachments"
 msgstr "Take a full backup of your data with all attachments"
 
-#: src/strings.ts:1219
+#: src/strings.ts:1220
 msgid "Take a partial backup of your data that does not include attachments"
 msgstr "Take a partial backup of your data that does not include attachments"
 
-#: src/strings.ts:2340
+#: src/strings.ts:2341
 msgid "Take a photo using camera"
 msgstr "Take a photo using camera"
 
-#: src/strings.ts:1375
+#: src/strings.ts:1376
 msgid "Take note"
 msgstr "Take note"
 
-#: src/strings.ts:1658
+#: src/strings.ts:1659
 msgid "Take notes privately."
 msgstr "Take notes privately."
 
-#: src/strings.ts:674
+#: src/strings.ts:675
 msgid "Taking too long? Reload editor"
 msgstr "Taking too long? Reload editor"
 
-#: src/strings.ts:1459
+#: src/strings.ts:1460
 msgid "Tap here to change sorting"
 msgstr "Tap here to change sorting"
 
-#: src/strings.ts:1463
+#: src/strings.ts:1464
 msgid "Tap here to jump to a section"
 msgstr "Tap here to jump to a section"
 
-#: src/strings.ts:1371
+#: src/strings.ts:1372
 msgid "Tap here to update to the latest version"
 msgstr "Tap here to update to the latest version"
 
-#: src/strings.ts:1594
+#: src/strings.ts:1595
 msgid "Tap on \"Dismiss\" and copy the contents of your note so they are not lost."
 msgstr "Tap on \"Dismiss\" and copy the contents of your note so they are not lost."
 
-#: src/strings.ts:1374
+#: src/strings.ts:1375
 msgid "Tap on \"Take note\" to add a note."
 msgstr "Tap on \"Take note\" to add a note."
 
@@ -6586,11 +6586,11 @@ msgstr "Tap to cancel"
 msgid "Tap to deselect"
 msgstr "Tap to deselect"
 
-#: src/strings.ts:668
+#: src/strings.ts:669
 msgid "Tap to stop reordering"
 msgstr "Tap to stop reordering"
 
-#: src/strings.ts:1355
+#: src/strings.ts:1356
 msgid "Tap to try again"
 msgstr "Tap to try again"
 
@@ -6598,19 +6598,19 @@ msgstr "Tap to try again"
 msgid "Tap twice to confirm you have saved the recovery key."
 msgstr "Tap twice to confirm you have saved the recovery key."
 
-#: src/strings.ts:2346
+#: src/strings.ts:2347
 msgid "Task list"
 msgstr "Task list"
 
-#: src/strings.ts:2416
+#: src/strings.ts:2417
 msgid "Tasks"
 msgstr "Tasks"
 
-#: src/strings.ts:1164
+#: src/strings.ts:1165
 msgid "Telemetry"
 msgstr "Telemetry"
 
-#: src/strings.ts:1497
+#: src/strings.ts:1498
 msgid ""
 "Tell us more about the issue you are facing.\n"
 "\n"
@@ -6628,11 +6628,11 @@ msgstr ""
 "- Steps to reproduce the issue\n"
 "- Things you have tried etc."
 
-#: src/strings.ts:1496
+#: src/strings.ts:1497
 msgid "Tell us what happened"
 msgstr "Tell us what happened"
 
-#: src/strings.ts:1285
+#: src/strings.ts:1286
 msgid "Terms of service"
 msgstr "Terms of service"
 
@@ -6640,39 +6640,39 @@ msgstr "Terms of service"
 msgid "Terms of Service "
 msgstr "Terms of Service "
 
-#: src/strings.ts:2578
+#: src/strings.ts:2579
 msgid "terms of use."
 msgstr "terms of use."
 
-#: src/strings.ts:1624
+#: src/strings.ts:1625
 msgid "Test connection"
 msgstr "Test connection"
 
-#: src/strings.ts:1647
+#: src/strings.ts:1648
 msgid "Test connection before changing server urls"
 msgstr "Test connection before changing server urls"
 
-#: src/strings.ts:2284
+#: src/strings.ts:2285
 msgid "Text color"
 msgstr "Text color"
 
-#: src/strings.ts:2282
+#: src/strings.ts:2283
 msgid "Text direction"
 msgstr "Text direction"
 
-#: src/strings.ts:1788
+#: src/strings.ts:1789
 msgid "Thank you for choosing end-to-end encrypted note taking. Now you can sync your notes to unlimited devices."
 msgstr "Thank you for choosing end-to-end encrypted note taking. Now you can sync your notes to unlimited devices."
 
-#: src/strings.ts:2052
+#: src/strings.ts:2053
 msgid "Thank you for reporting!"
 msgstr "Thank you for reporting!"
 
-#: src/strings.ts:2552
+#: src/strings.ts:2553
 msgid "Thank you for subscribing"
 msgstr "Thank you for subscribing"
 
-#: src/strings.ts:2586
+#: src/strings.ts:2587
 msgid "Thank you for the purchase"
 msgstr "Thank you for the purchase"
 
@@ -6680,15 +6680,15 @@ msgstr "Thank you for the purchase"
 msgid "Thank you for updating Notesnook! We will be applying some minor changes for a better note taking experience."
 msgstr "Thank you for updating Notesnook! We will be applying some minor changes for a better note taking experience."
 
-#: src/strings.ts:2077
+#: src/strings.ts:2078
 msgid "Thank you. You are the proof that privacy always comes first."
 msgstr "Thank you. You are the proof that privacy always comes first."
 
-#: src/strings.ts:1645
+#: src/strings.ts:1646
 msgid "The {title} at {url} is not compatible with this client."
 msgstr "The {title} at {url} is not compatible with this client."
 
-#: src/strings.ts:2631
+#: src/strings.ts:2632
 msgid "The incoming note could not be unlocked with the provided password. Enter the correct password for the incoming note"
 msgstr "The incoming note could not be unlocked with the provided password. Enter the correct password for the incoming note"
 
@@ -6696,11 +6696,11 @@ msgstr "The incoming note could not be unlocked with the provided password. Ente
 msgid "The information above will be publically available at"
 msgstr "The information above will be publically available at"
 
-#: src/strings.ts:2605
+#: src/strings.ts:2606
 msgid "The Notesnook Circle is exclusive to subscribers. Please consider subscribing to gain access to Notesnook Circle and enjoy additional benefits."
 msgstr "The Notesnook Circle is exclusive to subscribers. Please consider subscribing to gain access to Notesnook Circle and enjoy additional benefits."
 
-#: src/strings.ts:2084
+#: src/strings.ts:2085
 msgid "The password/pin for unlocking the app."
 msgstr "The password/pin for unlocking the app."
 
@@ -6712,19 +6712,19 @@ msgstr "The reminder will repeat daily at {date}."
 msgid "The reminder will repeat every year on {date}."
 msgstr "The reminder will repeat every year on {date}."
 
-#: src/strings.ts:1714
+#: src/strings.ts:1715
 msgid "The reminder will start on {date} at {time}."
 msgstr "The reminder will start on {date} at {time}."
 
-#: src/strings.ts:2087
+#: src/strings.ts:2088
 msgid "The security key for unlocking the app. This is the most secure method."
 msgstr "The security key for unlocking the app. This is the most secure method."
 
-#: src/strings.ts:1643
+#: src/strings.ts:1644
 msgid "The URL you have given ({url}) does not point to the {server}."
 msgstr "The URL you have given ({url}) does not point to the {server}."
 
-#: src/strings.ts:1119
+#: src/strings.ts:1120
 msgid "Themes"
 msgstr "Themes"
 
@@ -6732,11 +6732,11 @@ msgstr "Themes"
 msgid "There are no blocks in this note."
 msgstr "There are no blocks in this note."
 
-#: src/strings.ts:2239
+#: src/strings.ts:2240
 msgid "These items will be **kept in your Trash for {interval} days** after which they will be permanently deleted."
 msgstr "These items will be **kept in your Trash for {interval} days** after which they will be permanently deleted."
 
-#: src/strings.ts:1922
+#: src/strings.ts:1923
 msgid "This action is IRREVERSIBLE."
 msgstr "This action is IRREVERSIBLE."
 
@@ -6744,60 +6744,60 @@ msgstr "This action is IRREVERSIBLE."
 msgid "This device"
 msgstr "This device"
 
-#: src/strings.ts:1685
+#: src/strings.ts:1686
 msgid "This error can be fixed by rebuilding the search index. This action won't result in any kind of data loss."
 msgstr "This error can be fixed by rebuilding the search index. This action won't result in any kind of data loss."
 
-#: src/strings.ts:1677
+#: src/strings.ts:1678
 msgid "This error can only be fixed by wiping & reseting the database. Beware that this will wipe all your data inside the database with no way to recover it later on. This WILL NOT change/affect/delete/wipe your data on the server but ONLY on this device."
 msgstr "This error can only be fixed by wiping & reseting the database. Beware that this will wipe all your data inside the database with no way to recover it later on. This WILL NOT change/affect/delete/wipe your data on the server but ONLY on this device."
 
-#: src/strings.ts:1681
+#: src/strings.ts:1682
 msgid "This error can only be fixed by wiping & reseting the Key Store and the database. This WILL NOT change/affect/delete/wipe your data on the server but ONLY on this device."
 msgstr "This error can only be fixed by wiping & reseting the Key Store and the database. This WILL NOT change/affect/delete/wipe your data on the server but ONLY on this device."
 
-#: src/strings.ts:1679
+#: src/strings.ts:1680
 msgid "This error means the at rest encryption key could not be decrypted. This can be due to data corruption or implementation change."
 msgstr "This error means the at rest encryption key could not be decrypted. This can be due to data corruption or implementation change."
 
-#: src/strings.ts:1675
+#: src/strings.ts:1676
 msgid "This error usually means the database file is either corrupt or it could not be decrypted."
 msgstr "This error usually means the database file is either corrupt or it could not be decrypted."
 
-#: src/strings.ts:1683
+#: src/strings.ts:1684
 msgid "This error usually means the search index is corrupted."
 msgstr "This error usually means the search index is corrupted."
 
-#: src/strings.ts:2709
+#: src/strings.ts:2710
 msgid "This feature is not available on this plan."
 msgstr "This feature is not available on this plan."
 
-#: src/strings.ts:1936
+#: src/strings.ts:1937
 msgid "This image cannot be previewed"
 msgstr "This image cannot be previewed"
 
-#: src/strings.ts:2572
+#: src/strings.ts:2573
 msgid "This is a one time purchase, no subscription."
 msgstr "This is a one time purchase, no subscription."
 
-#: src/strings.ts:2047
+#: src/strings.ts:2048
 msgid "This may take a while"
 msgstr "This may take a while"
 
-#: src/strings.ts:1103
-#: src/strings.ts:1112
+#: src/strings.ts:1104
+#: src/strings.ts:1113
 msgid "This must only be used for troubleshooting. Using it regularly for sync is not recommended and will lead to unexpected data loss and other issues. If you are having persistent issues with sync, please report them to us at support@streetwriters.co."
 msgstr "This must only be used for troubleshooting. Using it regularly for sync is not recommended and will lead to unexpected data loss and other issues. If you are having persistent issues with sync, please report them to us at support@streetwriters.co."
 
-#: src/strings.ts:2637
+#: src/strings.ts:2638
 msgid "This note is empty"
 msgstr "This note is empty"
 
-#: src/strings.ts:1596
+#: src/strings.ts:1597
 msgid "This note is locked"
 msgstr "This note is locked"
 
-#: src/strings.ts:954
+#: src/strings.ts:955
 msgid "This note is locked. Unlock note to save changes"
 msgstr "This note is locked. Unlock note to save changes"
 
@@ -6813,129 +6813,129 @@ msgstr "This note is not referenced in other notes."
 msgid "This note will be published to a public URL."
 msgstr "This note will be published to a public URL."
 
-#: src/strings.ts:2093
+#: src/strings.ts:2094
 msgid "This username will be used to distinguish between different credentials in your security key. Make sure it is unique."
 msgstr "This username will be used to distinguish between different credentials in your security key. Make sure it is unique."
 
-#: src/strings.ts:1305
+#: src/strings.ts:1306
 msgid "This version of Notesnook app does not support in-app purchases. Kindly login on the Notesnook web app to make the purchase."
 msgstr "This version of Notesnook app does not support in-app purchases. Kindly login on the Notesnook web app to make the purchase."
 
-#: src/strings.ts:626
+#: src/strings.ts:627
 msgid "Thu"
 msgstr "Thu"
 
-#: src/strings.ts:617
+#: src/strings.ts:618
 msgid "Thursday"
 msgstr "Thursday"
 
-#: src/strings.ts:1844
+#: src/strings.ts:1845
 msgid "Time"
 msgstr "Time"
 
-#: src/strings.ts:1136
+#: src/strings.ts:1137
 msgid "Time format"
 msgstr "Time format"
 
-#: src/strings.ts:671
+#: src/strings.ts:672
 msgid "TIP"
 msgstr "TIP"
 
-#: src/strings.ts:649
-#: src/strings.ts:654
+#: src/strings.ts:650
+#: src/strings.ts:655
 msgid "Title"
 msgstr "Title"
 
-#: src/strings.ts:1159
+#: src/strings.ts:1160
 msgid "Title format"
 msgstr "Title format"
 
-#: src/strings.ts:1190
+#: src/strings.ts:1191
 msgid "To use app lock, you must enable biometrics such as Fingerprint lock or Face ID on your phone."
 msgstr "To use app lock, you must enable biometrics such as Fingerprint lock or Face ID on your phone."
 
-#: src/strings.ts:1814
+#: src/strings.ts:1815
 msgid "Toggle dark/light mode"
 msgstr "Toggle dark/light mode"
 
-#: src/strings.ts:2464
+#: src/strings.ts:2465
 msgid "Toggle focus mode"
 msgstr "Toggle focus mode"
 
-#: src/strings.ts:2353
+#: src/strings.ts:2354
 msgid "Toggle indentation mode"
 msgstr "Toggle indentation mode"
 
-#: src/strings.ts:2382
+#: src/strings.ts:2383
 msgid "Toggle replace"
 msgstr "Toggle replace"
 
-#: src/strings.ts:2453
+#: src/strings.ts:2454
 msgid "Toggle theme"
 msgstr "Toggle theme"
 
-#: src/strings.ts:2134
+#: src/strings.ts:2135
 msgid "Toolbar"
 msgstr "Toolbar"
 
-#: src/strings.ts:1150
+#: src/strings.ts:1151
 msgid "Toolbar reset to default preset"
 msgstr "Toolbar reset to default preset"
 
-#: src/strings.ts:1328
-#: src/strings.ts:1525
+#: src/strings.ts:1329
+#: src/strings.ts:1526
 msgid "Trash"
 msgstr "Trash"
 
-#: src/strings.ts:1327
+#: src/strings.ts:1328
 msgid "Trash cleared successfully!"
 msgstr "Trash cleared successfully!"
 
-#: src/strings.ts:1333
+#: src/strings.ts:1334
 msgid "Trash gets automatically cleaned up after {days} days"
 msgstr "Trash gets automatically cleaned up after {days} days"
 
-#: src/strings.ts:1331
+#: src/strings.ts:1332
 msgid "Trash gets automatically cleaned up daily"
 msgstr "Trash gets automatically cleaned up daily"
 
-#: src/strings.ts:2542
+#: src/strings.ts:2543
 msgid "Try {plan} for free"
 msgstr "Try {plan} for free"
 
-#: src/strings.ts:1467
+#: src/strings.ts:1468
 msgid "Try compact mode to fit more items on screen"
 msgstr "Try compact mode to fit more items on screen"
 
-#: src/strings.ts:1826
+#: src/strings.ts:1827
 msgid "Try free for 14 days"
 msgstr "Try free for 14 days"
 
-#: src/strings.ts:2528
+#: src/strings.ts:2529
 msgid "Try it for free"
 msgstr "Try it for free"
 
-#: src/strings.ts:624
+#: src/strings.ts:625
 msgid "Tue"
 msgstr "Tue"
 
-#: src/strings.ts:615
+#: src/strings.ts:616
 msgid "Tuesday"
 msgstr "Tuesday"
 
-#: src/strings.ts:1088
+#: src/strings.ts:1089
 msgid "Turn off automatic syncing. Changes from this client will be synced only when you run sync manually."
 msgstr "Turn off automatic syncing. Changes from this client will be synced only when you run sync manually."
 
-#: src/strings.ts:892
+#: src/strings.ts:893
 msgid "Turn off reminder"
 msgstr "Turn off reminder"
 
-#: src/strings.ts:893
+#: src/strings.ts:894
 msgid "Turn on reminder"
 msgstr "Turn on reminder"
 
-#: src/strings.ts:1094
+#: src/strings.ts:1095
 msgid "Turns off syncing completely on this device. Any changes made will remain local only and new changes from your other devices won't sync to this device."
 msgstr "Turns off syncing completely on this device. Any changes made will remain local only and new changes from your other devices won't sync to this device."
 
@@ -6947,51 +6947,55 @@ msgstr "Two factor authentication"
 msgid "Two-factor authentication"
 msgstr "Two-factor authentication"
 
+#: src/strings.ts:504
+msgid "Two-factor authentication disabled"
+msgstr "Two-factor authentication disabled"
+
 #: src/strings.ts:503
 msgid "Two-factor authentication enabled"
 msgstr "Two-factor authentication enabled"
 
-#: src/strings.ts:1504
+#: src/strings.ts:1505
 msgid "Type # to search for headings"
 msgstr "Type # to search for headings"
 
-#: src/strings.ts:1511
+#: src/strings.ts:1512
 msgid "Type a keyword"
 msgstr "Type a keyword"
 
-#: src/strings.ts:1551
+#: src/strings.ts:1552
 msgid "Unable to resolve download url"
 msgstr "Unable to resolve download url"
 
-#: src/strings.ts:1554
+#: src/strings.ts:1555
 msgid "Unable to send 2FA code"
 msgstr "Unable to send 2FA code"
 
-#: src/strings.ts:2488
+#: src/strings.ts:2489
 msgid "Unarchive"
 msgstr "Unarchive"
 
-#: src/strings.ts:2260
+#: src/strings.ts:2261
 msgid "Underline"
 msgstr "Underline"
 
-#: src/strings.ts:566
+#: src/strings.ts:567
 msgid "Undo"
 msgstr "Undo"
 
-#: src/strings.ts:854
+#: src/strings.ts:855
 msgid "Unfavorite"
 msgstr "Unfavorite"
 
-#: src/strings.ts:2582
+#: src/strings.ts:2583
 msgid "Unlimited"
 msgstr "Unlimited"
 
-#: src/strings.ts:932
+#: src/strings.ts:933
 msgid "Unlink from all"
 msgstr "Unlink from all"
 
-#: src/strings.ts:853
+#: src/strings.ts:854
 msgid "Unlink notebook"
 msgstr "Unlink notebook"
 
@@ -6999,40 +7003,40 @@ msgstr "Unlink notebook"
 msgid "Unlock"
 msgstr "Unlock"
 
-#: src/strings.ts:2629
+#: src/strings.ts:2630
 msgid "Unlock incoming note"
 msgstr "Unlock incoming note"
 
-#: src/strings.ts:1385
+#: src/strings.ts:1386
 msgid "Unlock more colors with Notesnook Pro"
 msgstr "Unlock more colors with Notesnook Pro"
 
 #: src/strings.ts:455
-#: src/strings.ts:558
+#: src/strings.ts:559
 msgid "Unlock note"
 msgstr "Unlock note"
 
-#: src/strings.ts:888
+#: src/strings.ts:889
 msgid "Unlock note to delete it"
 msgstr "Unlock note to delete it"
 
-#: src/strings.ts:2640
+#: src/strings.ts:2641
 msgid "Unlock note to merge conflicts"
 msgstr "Unlock note to merge conflicts"
 
-#: src/strings.ts:1210
+#: src/strings.ts:1211
 msgid "Unlock the app with biometric authentication. This requires biometrics to be enabled on your device."
 msgstr "Unlock the app with biometric authentication. This requires biometrics to be enabled on your device."
 
-#: src/strings.ts:1934
+#: src/strings.ts:1935
 msgid "Unlock vault"
 msgstr "Unlock vault"
 
-#: src/strings.ts:544
+#: src/strings.ts:545
 msgid "Unlock with biometrics"
 msgstr "Unlock with biometrics"
 
-#: src/strings.ts:1829
+#: src/strings.ts:1830
 msgid "Unlock with security key"
 msgstr "Unlock with security key"
 
@@ -7040,44 +7044,44 @@ msgstr "Unlock with security key"
 msgid "Unlock your notes"
 msgstr "Unlock your notes"
 
-#: src/strings.ts:1180
+#: src/strings.ts:1181
 msgid "Unlock your vault with biometric authentication"
 msgstr "Unlock your vault with biometric authentication"
 
-#: src/strings.ts:1712
+#: src/strings.ts:1713
 msgid "Unlocking"
 msgstr "Unlocking"
 
-#: src/strings.ts:899
+#: src/strings.ts:900
 msgid "Unpin"
 msgstr "Unpin"
 
-#: src/strings.ts:929
+#: src/strings.ts:930
 msgid "Unpin notification"
 msgstr "Unpin notification"
 
-#: src/strings.ts:587
+#: src/strings.ts:588
 msgid "Unpublish"
 msgstr "Unpublish"
 
-#: src/strings.ts:1479
+#: src/strings.ts:1480
 msgid "Unpublish notes to delete them"
 msgstr "Unpublish notes to delete them"
 
-#: src/strings.ts:2088
+#: src/strings.ts:2089
 msgid "Unregister"
 msgstr "Unregister"
 
-#: src/strings.ts:2633
+#: src/strings.ts:2634
 msgid "Unset expiry"
 msgstr "Unset expiry"
 
 #: src/strings.ts:210
-#: src/strings.ts:2362
+#: src/strings.ts:2363
 msgid "Untitled"
 msgstr "Untitled"
 
-#: src/strings.ts:588
+#: src/strings.ts:589
 msgid "Update"
 msgstr "Update"
 
@@ -7085,65 +7089,65 @@ msgstr "Update"
 msgid "Update available"
 msgstr "Update available"
 
-#: src/strings.ts:1372
+#: src/strings.ts:1373
 msgid "Update now"
 msgstr "Update now"
 
-#: src/strings.ts:2502
+#: src/strings.ts:2503
 msgid "Upgrade"
 msgstr "Upgrade"
 
-#: src/strings.ts:1920
+#: src/strings.ts:1921
 msgid "Upgrade now"
 msgstr "Upgrade now"
 
-#: src/strings.ts:2501
+#: src/strings.ts:2502
 msgid "Upgrade plan"
 msgstr "Upgrade plan"
 
-#: src/strings.ts:2527
+#: src/strings.ts:2528
 msgid "Upgrade plan to {plan} to use this feature."
 msgstr "Upgrade plan to {plan} to use this feature."
 
-#: src/strings.ts:1941
+#: src/strings.ts:1942
 msgid "Upgrade to Notesnook Pro to add colors."
 msgstr "Upgrade to Notesnook Pro to add colors."
 
-#: src/strings.ts:1942
+#: src/strings.ts:1943
 msgid "Upgrade to Notesnook Pro to create more tags."
 msgstr "Upgrade to Notesnook Pro to create more tags."
 
-#: src/strings.ts:749
+#: src/strings.ts:750
 msgid "Upgrade to Pro"
 msgstr "Upgrade to Pro"
 
-#: src/strings.ts:2597
+#: src/strings.ts:2598
 msgid "Upgrade to redeem"
 msgstr "Upgrade to redeem"
 
-#: src/strings.ts:510
+#: src/strings.ts:511
 msgid "Upload"
 msgstr "Upload"
 
-#: src/strings.ts:2339
+#: src/strings.ts:2340
 msgid "Upload from disk"
 msgstr "Upload from disk"
 
-#: src/strings.ts:511
-#: src/strings.ts:1653
+#: src/strings.ts:512
+#: src/strings.ts:1654
 msgid "Uploaded"
 msgstr "Uploaded"
 
-#: src/strings.ts:799
+#: src/strings.ts:800
 msgid "Uploaded file verification failed."
 msgstr "Uploaded file verification failed."
 
 #: src/strings.ts:65
-#: src/strings.ts:512
+#: src/strings.ts:513
 msgid "Uploading"
 msgstr "Uploading"
 
-#: src/strings.ts:763
+#: src/strings.ts:764
 msgid "Uploads"
 msgstr "Uploads"
 
@@ -7151,11 +7155,11 @@ msgstr "Uploads"
 msgid "Urgent"
 msgstr "Urgent"
 
-#: src/strings.ts:2389
+#: src/strings.ts:2390
 msgid "URL"
 msgstr "URL"
 
-#: src/strings.ts:1791
+#: src/strings.ts:1792
 msgid "Use"
 msgstr "Use"
 
@@ -7163,55 +7167,55 @@ msgstr "Use"
 msgid "Use {keyboardShortcut}+click to select multiple notebooks"
 msgstr "Use {keyboardShortcut}+click to select multiple notebooks"
 
-#: src/strings.ts:1804
+#: src/strings.ts:1805
 msgid "Use a backup file"
 msgstr "Use a backup file"
 
-#: src/strings.ts:1902
+#: src/strings.ts:1903
 msgid "Use a data recovery key to reset your account password."
 msgstr "Use a data recovery key to reset your account password."
 
-#: src/strings.ts:556
+#: src/strings.ts:557
 msgid "Use account password"
 msgstr "Use account password"
 
-#: src/strings.ts:2534
+#: src/strings.ts:2535
 msgid "Use advanced note taking features like"
 msgstr "Use advanced note taking features like"
 
-#: src/strings.ts:981
+#: src/strings.ts:982
 msgid "Use an authenticator app to generate 2FA codes."
 msgstr "Use an authenticator app to generate 2FA codes."
 
-#: src/strings.ts:2174
+#: src/strings.ts:2175
 msgid "Use custom DNS"
 msgstr "Use custom DNS"
 
-#: src/strings.ts:1125
+#: src/strings.ts:1126
 msgid "Use dark mode for the app"
 msgstr "Use dark mode for the app"
 
-#: src/strings.ts:1623
+#: src/strings.ts:1624
 msgid "Use encryption key"
 msgstr "Use encryption key"
 
-#: src/strings.ts:1162
+#: src/strings.ts:1163
 msgid "Use markdown shortcuts in the editor"
 msgstr "Use markdown shortcuts in the editor"
 
-#: src/strings.ts:2127
+#: src/strings.ts:2128
 msgid "Use native OS titlebar instead of replacing it with a custom one. Requires app restart for changes to take effect."
 msgstr "Use native OS titlebar instead of replacing it with a custom one. Requires app restart for changes to take effect."
 
-#: src/strings.ts:2125
+#: src/strings.ts:2126
 msgid "Use native titlebar"
 msgstr "Use native titlebar"
 
-#: src/strings.ts:1801
+#: src/strings.ts:1802
 msgid "Use recovery key"
 msgstr "Use recovery key"
 
-#: src/strings.ts:1121
+#: src/strings.ts:1122
 msgid "Use system theme"
 msgstr "Use system theme"
 
@@ -7237,51 +7241,51 @@ msgstr ""
 "$headline$: Use starting line of the note as title.\n"
 "$day$: Current day (eg. Monday)"
 
-#: src/strings.ts:1101
+#: src/strings.ts:1102
 msgid "Use this if changes from other devices are not appearing on this device. This will overwrite the data on this device with the latest data from the server."
 msgstr "Use this if changes from other devices are not appearing on this device. This will overwrite the data on this device with the latest data from the server."
 
-#: src/strings.ts:1110
+#: src/strings.ts:1111
 msgid "Use this if changes made on this device are not appearing on other devices. This will overwrite the data on the server with the data from this device."
 msgstr "Use this if changes made on this device are not appearing on other devices. This will overwrite the data on the server with the data from this device."
 
-#: src/strings.ts:2475
+#: src/strings.ts:2476
 msgid "used"
 msgstr "used"
 
-#: src/strings.ts:1020
+#: src/strings.ts:1021
 msgid "User verification failed"
 msgstr "User verification failed"
 
-#: src/strings.ts:2256
+#: src/strings.ts:2257
 msgid "Using {instance} (v{version})"
 msgstr "Using {instance} (v{version})"
 
-#: src/strings.ts:2254
+#: src/strings.ts:2255
 msgid "Using official Notesnook instance"
 msgstr "Using official Notesnook instance"
 
-#: src/strings.ts:1711
+#: src/strings.ts:1712
 msgid "v{version} available"
 msgstr "v{version} available"
 
-#: src/strings.ts:2711
+#: src/strings.ts:2712
 msgid "Value must be between {min} and {max}"
 msgstr "Value must be between {min} and {max}"
 
-#: src/strings.ts:1173
+#: src/strings.ts:1174
 msgid "Vault"
 msgstr "Vault"
 
-#: src/strings.ts:1994
+#: src/strings.ts:1995
 msgid "Vault cleared"
 msgstr "Vault cleared"
 
-#: src/strings.ts:813
+#: src/strings.ts:814
 msgid "Vault created"
 msgstr "Vault created"
 
-#: src/strings.ts:1995
+#: src/strings.ts:1996
 msgid "Vault deleted"
 msgstr "Vault deleted"
 
@@ -7289,35 +7293,35 @@ msgstr "Vault deleted"
 msgid "Vault fingerprint unlock"
 msgstr "Vault fingerprint unlock"
 
-#: src/strings.ts:1933
+#: src/strings.ts:1934
 msgid "Vault locked"
 msgstr "Vault locked"
 
-#: src/strings.ts:1932
+#: src/strings.ts:1933
 msgid "Vault unlocked"
 msgstr "Vault unlocked"
 
-#: src/strings.ts:1402
+#: src/strings.ts:1403
 msgid "Verification email sent"
 msgstr "Verification email sent"
 
-#: src/strings.ts:575
+#: src/strings.ts:576
 msgid "Verify"
 msgstr "Verify"
 
-#: src/strings.ts:1071
+#: src/strings.ts:1072
 msgid "Verify subscription"
 msgstr "Verify subscription"
 
-#: src/strings.ts:1074
+#: src/strings.ts:1075
 msgid "Verify your subscription to Notesnook Pro"
 msgstr "Verify your subscription to Notesnook Pro"
 
-#: src/strings.ts:1905
+#: src/strings.ts:1906
 msgid "Verifying 2FA code"
 msgstr "Verifying 2FA code"
 
-#: src/strings.ts:1891
+#: src/strings.ts:1892
 msgid "Verifying your email"
 msgstr "Verifying your email"
 
@@ -7329,43 +7333,43 @@ msgstr "Version"
 msgid "Vibrate"
 msgstr "Vibrate"
 
-#: src/strings.ts:756
+#: src/strings.ts:757
 msgid "Videos"
 msgstr "Videos"
 
-#: src/strings.ts:570
+#: src/strings.ts:1063
+msgid "View 2FA backup codes"
+msgstr "View 2FA backup codes"
+
+#: src/strings.ts:571
 msgid "View all linked notebooks"
 msgstr "View all linked notebooks"
 
-#: src/strings.ts:2649
+#: src/strings.ts:2650
 msgid "View and edit your inbox public/private key pair"
 msgstr "View and edit your inbox public/private key pair"
 
-#: src/strings.ts:2655
+#: src/strings.ts:2656
 msgid "View and manage inbox API keys"
 msgstr "View and manage inbox API keys"
 
-#: src/strings.ts:1272
+#: src/strings.ts:1273
 msgid "View and share debug logs"
 msgstr "View and share debug logs"
 
-#: src/strings.ts:1749
+#: src/strings.ts:1750
 msgid "View receipt"
 msgstr "View receipt"
 
-#: src/strings.ts:1062
-msgid "View recovery codes"
-msgstr "View recovery codes"
-
-#: src/strings.ts:2154
+#: src/strings.ts:2155
 msgid "View source code"
 msgstr "View source code"
 
-#: src/strings.ts:1064
-msgid "View your recovery codes to recover your account in case you lose access to your two-factor authentication methods."
-msgstr "View your recovery codes to recover your account in case you lose access to your two-factor authentication methods."
+#: src/strings.ts:1065
+msgid "View your 2FA backup codes to log into your account in case you lose access to your two-factor authentication methods."
+msgstr "View your 2FA backup codes to log into your account in case you lose access to your two-factor authentication methods."
 
-#: src/strings.ts:2612
+#: src/strings.ts:2613
 msgid "Views"
 msgstr "Views"
 
@@ -7373,15 +7377,15 @@ msgstr "Views"
 msgid "Visit homepage"
 msgstr "Visit homepage"
 
-#: src/strings.ts:1352
+#: src/strings.ts:1353
 msgid "Wait 30 seconds to try again"
 msgstr "Wait 30 seconds to try again"
 
-#: src/strings.ts:1654
+#: src/strings.ts:1655
 msgid "Waiting for upload"
 msgstr "Waiting for upload"
 
-#: src/strings.ts:1913
+#: src/strings.ts:1914
 msgid "We are creating a backup of your data. Please wait..."
 msgstr "We are creating a backup of your data. Please wait..."
 
@@ -7389,137 +7393,137 @@ msgstr "We are creating a backup of your data. Please wait..."
 msgid "We are sorry, it seems that the app crashed due to an error. You can submit a bug report below so we can fix this asap."
 msgstr "We are sorry, it seems that the app crashed due to an error. You can submit a bug report below so we can fix this asap."
 
-#: src/strings.ts:1392
+#: src/strings.ts:1393
 msgid "We have sent you an email confirmation link. Please check your email inbox. If you cannot find the email, check your spam folder."
 msgstr "We have sent you an email confirmation link. Please check your email inbox. If you cannot find the email, check your spam folder."
 
-#: src/strings.ts:2513
+#: src/strings.ts:2514
 msgid "We require credit card details to fight abuse and to make it seamless for you to upgrade. Your credit card is NOT charged until your free trial ends and your subscription starts. You will be notified via email of the upcoming charge before your trial ends."
 msgstr "We require credit card details to fight abuse and to make it seamless for you to upgrade. Your credit card is NOT charged until your free trial ends and your subscription starts. You will be notified via email of the upcoming charge before your trial ends."
 
-#: src/strings.ts:2169
+#: src/strings.ts:2170
 msgid "We send you occasional promotional offers & product updates on your email (once every month)."
 msgstr "We send you occasional promotional offers & product updates on your email (once every month)."
 
-#: src/strings.ts:1169
+#: src/strings.ts:1170
 msgid "We will send you occasional promotional offers & product updates on your email (sent once every month)."
 msgstr "We will send you occasional promotional offers & product updates on your email (sent once every month)."
 
-#: src/strings.ts:1356
+#: src/strings.ts:1357
 msgid "We would love to know what you think!"
 msgstr "We would love to know what you think!"
 
-#: src/strings.ts:2554
+#: src/strings.ts:2555
 msgid "We’re setting up your plan right now. We’ll notify you as soon as everything is ready."
 msgstr "We’re setting up your plan right now. We’ll notify you as soon as everything is ready."
 
-#: src/strings.ts:2324
+#: src/strings.ts:2325
 msgid "Web clip settings"
 msgstr "Web clip settings"
 
-#: src/strings.ts:2031
+#: src/strings.ts:2032
 msgid "Website"
 msgstr "Website"
 
-#: src/strings.ts:625
+#: src/strings.ts:626
 msgid "Wed"
 msgstr "Wed"
 
-#: src/strings.ts:616
+#: src/strings.ts:617
 msgid "Wednesday"
 msgstr "Wednesday"
 
-#: src/strings.ts:664
+#: src/strings.ts:665
 msgid "Week"
 msgstr "Week"
 
-#: src/strings.ts:2625
+#: src/strings.ts:2626
 msgid "Week format"
 msgstr "Week format"
 
 #: src/strings.ts:168
-#: src/strings.ts:1571
+#: src/strings.ts:1572
 msgid "Weekly"
 msgstr "Weekly"
 
-#: src/strings.ts:780
+#: src/strings.ts:781
 msgid "Welcome back, {email}"
 msgstr "Welcome back, {email}"
 
-#: src/strings.ts:1890
+#: src/strings.ts:1891
 msgid "Welcome back!"
 msgstr "Welcome back!"
 
-#: src/strings.ts:2585
+#: src/strings.ts:2586
 msgid "Welcome to Notesnook {plan}"
 msgstr "Welcome to Notesnook {plan}"
 
-#: src/strings.ts:2075
+#: src/strings.ts:2076
 msgid "Welcome to Notesnook Pro"
 msgstr "Welcome to Notesnook Pro"
 
-#: src/strings.ts:1394
+#: src/strings.ts:1395
 msgid "What do I do if I am not getting the email?"
 msgstr "What do I do if I am not getting the email?"
 
-#: src/strings.ts:2505
+#: src/strings.ts:2506
 msgid "What happens to my data if I switch plans?"
 msgstr "What happens to my data if I switch plans?"
 
-#: src/strings.ts:2521
+#: src/strings.ts:2522
 msgid "What is your refund policy?"
 msgstr "What is your refund policy?"
 
-#: src/strings.ts:1669
+#: src/strings.ts:1670
 msgid "What went wrong?"
 msgstr "What went wrong?"
 
-#: src/strings.ts:2511
+#: src/strings.ts:2512
 msgid "Why do you need my credit card details for a free trial?"
 msgstr "Why do you need my credit card details for a free trial?"
 
-#: src/strings.ts:2385
+#: src/strings.ts:2386
 msgid "Width"
 msgstr "Width"
 
-#: src/strings.ts:2491
+#: src/strings.ts:2492
 msgid "Words"
 msgstr "Words"
 
-#: src/strings.ts:2414
+#: src/strings.ts:2415
 msgid "Work & Office"
 msgstr "Work & Office"
 
-#: src/strings.ts:823
+#: src/strings.ts:824
 msgid "Write notes with freedom, no spying, no tracking."
 msgstr "Write notes with freedom, no spying, no tracking."
 
-#: src/strings.ts:1376
+#: src/strings.ts:1377
 msgid "Write something..."
 msgstr "Write something..."
 
-#: src/strings.ts:1656
+#: src/strings.ts:1657
 msgid "Write with freedom."
 msgstr "Write with freedom."
 
-#: src/strings.ts:2063
+#: src/strings.ts:2064
 msgid "Write with freedom. Never compromise on privacy again."
 msgstr "Write with freedom. Never compromise on privacy again."
 
-#: src/strings.ts:663
+#: src/strings.ts:664
 msgid "Year"
 msgstr "Year"
 
 #: src/strings.ts:170
-#: src/strings.ts:1573
+#: src/strings.ts:1574
 msgid "Yearly"
 msgstr "Yearly"
 
-#: src/strings.ts:548
+#: src/strings.ts:549
 msgid "Yes"
 msgstr "Yes"
 
-#: src/strings.ts:2518
+#: src/strings.ts:2519
 msgid "Yes, you can cancel your trial anytime. No questions asked."
 msgstr "Yes, you can cancel your trial anytime. No questions asked."
 
@@ -7527,27 +7531,27 @@ msgstr "Yes, you can cancel your trial anytime. No questions asked."
 msgid "You also agree to recieve marketing emails from us which you can opt-out of from app settings."
 msgstr "You also agree to recieve marketing emails from us which you can opt-out of from app settings."
 
-#: src/strings.ts:2590
+#: src/strings.ts:2591
 msgid "You are already subscribed to this plan."
 msgstr "You are already subscribed to this plan."
 
-#: src/strings.ts:2241
+#: src/strings.ts:2242
 msgid "You are editing \"{notebookTitle}\"."
 msgstr "You are editing \"{notebookTitle}\"."
 
-#: src/strings.ts:2045
+#: src/strings.ts:2046
 msgid "You are editing #{tag}"
 msgstr "You are editing #{tag}"
 
-#: src/strings.ts:1783
+#: src/strings.ts:1784
 msgid "You are logging into the beta version of Notesnook. Switching between beta &amp; stable versions can cause weird issues including data loss. It is recommended that you do not use both simultaneously."
 msgstr "You are logging into the beta version of Notesnook. Switching between beta &amp; stable versions can cause weird issues including data loss. It is recommended that you do not use both simultaneously."
 
-#: src/strings.ts:1363
+#: src/strings.ts:1364
 msgid "You are not logged in"
 msgstr "You are not logged in"
 
-#: src/strings.ts:886
+#: src/strings.ts:887
 msgid "You are renaming color {color}"
 msgstr "You are renaming color {color}"
 
@@ -7555,39 +7559,39 @@ msgstr "You are renaming color {color}"
 msgid "You can also link a note to multiple Notebooks. Tap and hold any notebook to enable multi-select."
 msgstr "You can also link a note to multiple Notebooks. Tap and hold any notebook to enable multi-select."
 
-#: src/strings.ts:2066
+#: src/strings.ts:2067
 msgid "You can change the theme at any time from Settings or the side menu."
 msgstr "You can change the theme at any time from Settings or the side menu."
 
-#: src/strings.ts:2593
+#: src/strings.ts:2594
 msgid "You can change your subscription plan from the web app"
 msgstr "You can change your subscription plan from the web app"
 
-#: src/strings.ts:2422
+#: src/strings.ts:2423
 msgid "You can create shortcuts of frequently accessed notebooks in the side menu"
 msgstr "You can create shortcuts of frequently accessed notebooks in the side menu"
 
-#: src/strings.ts:2081
+#: src/strings.ts:2082
 msgid "You can import your notes from most other note taking apps."
 msgstr "You can import your notes from most other note taking apps."
 
-#: src/strings.ts:1438
+#: src/strings.ts:1439
 msgid "You can multi-select notes and move them to a notebook at once"
 msgstr "You can multi-select notes and move them to a notebook at once"
 
-#: src/strings.ts:1429
+#: src/strings.ts:1430
 msgid "You can pin frequently used Notebooks to the Side Menu to quickly access them."
 msgstr "You can pin frequently used Notebooks to the Side Menu to quickly access them."
 
-#: src/strings.ts:1172
+#: src/strings.ts:1173
 msgid "You can set a custom proxy URL to increase your privacy."
 msgstr "You can set a custom proxy URL to increase your privacy."
 
-#: src/strings.ts:1410
+#: src/strings.ts:1411
 msgid "You can swipe left anywhere in the app to start a new note."
 msgstr "You can swipe left anywhere in the app to start a new note."
 
-#: src/strings.ts:2055
+#: src/strings.ts:2056
 msgid ""
 "You can track your bug report at [{url}]({url}).\n"
 "\n"
@@ -7605,91 +7609,91 @@ msgstr ""
 msgid "You can track your issue at "
 msgstr "You can track your issue at "
 
-#: src/strings.ts:1030
+#: src/strings.ts:1031
 msgid "You can use all premium features for free for the next 14 days"
 msgstr "You can use all premium features for free for the next 14 days"
 
-#: src/strings.ts:1060
+#: src/strings.ts:1061
 msgid "You can use fallback 2FA method incase you are unable to login via primary method"
 msgstr "You can use fallback 2FA method incase you are unable to login via primary method"
 
-#: src/strings.ts:1452
+#: src/strings.ts:1453
 msgid "You can view & restore older versions of any note by going to its properties -> History."
 msgstr "You can view & restore older versions of any note by going to its properties -> History."
 
-#: src/strings.ts:1751
+#: src/strings.ts:1752
 msgid "You have {count} custom dictionary words."
 msgstr "You have {count} custom dictionary words."
 
-#: src/strings.ts:2200
+#: src/strings.ts:2201
 msgid "You have been logged out from all other devices."
 msgstr "You have been logged out from all other devices."
 
-#: src/strings.ts:2194
+#: src/strings.ts:2195
 msgid "You have been logged out."
 msgstr "You have been logged out."
 
-#: src/strings.ts:2589
+#: src/strings.ts:2590
 msgid "You have made a one time purchase. To change your plan please contact support."
 msgstr "You have made a one time purchase. To change your plan please contact support."
 
-#: src/strings.ts:966
+#: src/strings.ts:967
 msgid "You have not added any notebooks yet"
 msgstr "You have not added any notebooks yet"
 
-#: src/strings.ts:965
+#: src/strings.ts:966
 msgid "You have not added any tags yet"
 msgstr "You have not added any tags yet"
 
-#: src/strings.ts:964
+#: src/strings.ts:965
 msgid "You have not created any notes yet"
 msgstr "You have not created any notes yet"
 
-#: src/strings.ts:963
+#: src/strings.ts:964
 msgid "You have not favorited any notes yet"
 msgstr "You have not favorited any notes yet"
 
-#: src/strings.ts:968
+#: src/strings.ts:969
 msgid "You have not published any monographs yet"
 msgstr "You have not published any monographs yet"
 
-#: src/strings.ts:967
+#: src/strings.ts:968
 msgid "You have not set any reminders yet"
 msgstr "You have not set any reminders yet"
 
-#: src/strings.ts:1547
+#: src/strings.ts:1548
 msgid "You have unsynced notes. Take a backup or sync your notes to avoid losing your critical data."
 msgstr "You have unsynced notes. Take a backup or sync your notes to avoid losing your critical data."
 
-#: src/strings.ts:1636
+#: src/strings.ts:1637
 msgid "You must log out in order to change/reset server URLs."
 msgstr "You must log out in order to change/reset server URLs."
 
-#: src/strings.ts:836
+#: src/strings.ts:837
 msgid "You simply cannot get any better of a note taking app than @notesnook. The UI is clean and slick, it is feature rich, encrypted, reasonably priced (esp. for students & educators) & open source"
 msgstr "You simply cannot get any better of a note taking app than @notesnook. The UI is clean and slick, it is feature rich, encrypted, reasonably priced (esp. for students & educators) & open source"
 
-#: src/strings.ts:1070
+#: src/strings.ts:1071
 msgid "You subscribed to Notesnook Pro on {date}. Verify this subscription?"
 msgstr "You subscribed to Notesnook Pro on {date}. Verify this subscription?"
 
-#: src/strings.ts:709
+#: src/strings.ts:710
 msgid "You subscribed to Notesnook Pro on Android Phone/Tablet using Google In App Purchase."
 msgstr "You subscribed to Notesnook Pro on Android Phone/Tablet using Google In App Purchase."
 
-#: src/strings.ts:702
+#: src/strings.ts:703
 msgid "You subscribed to Notesnook Pro on iOS using Apple In App Purchase. You can cancel anytime with your iTunes Account settings."
 msgstr "You subscribed to Notesnook Pro on iOS using Apple In App Purchase. You can cancel anytime with your iTunes Account settings."
 
-#: src/strings.ts:715
+#: src/strings.ts:716
 msgid "You subscribed to Notesnook Pro on the Web/Desktop App."
 msgstr "You subscribed to Notesnook Pro on the Web/Desktop App."
 
-#: src/strings.ts:721
+#: src/strings.ts:722
 msgid "You subscribed to Notesnook Pro using a gift card."
 msgstr "You subscribed to Notesnook Pro using a gift card."
 
-#: src/strings.ts:696
+#: src/strings.ts:697
 msgid "You were awarded a subscription to Notesnook Pro by Streetwriters."
 msgstr "You were awarded a subscription to Notesnook Pro by Streetwriters."
 
@@ -7697,7 +7701,7 @@ msgstr "You were awarded a subscription to Notesnook Pro by Streetwriters."
 msgid "You will be logged out from all your devices"
 msgstr "You will be logged out from all your devices"
 
-#: src/strings.ts:1853
+#: src/strings.ts:1854
 msgid "You will receive instructions on how to recover your account on this email"
 msgstr "You will receive instructions on how to recover your account on this email"
 
@@ -7705,144 +7709,144 @@ msgstr "You will receive instructions on how to recover your account on this ema
 msgid "Your account email will be changed without affecting your subscription or any other settings."
 msgstr "Your account email will be changed without affecting your subscription or any other settings."
 
-#: src/strings.ts:1919
+#: src/strings.ts:1920
 msgid "Your account has been recovered."
 msgstr "Your account has been recovered."
 
 #: src/strings.ts:502
-#: src/strings.ts:1730
+#: src/strings.ts:1731
 msgid "Your account is now 100% secure against unauthorized logins."
 msgstr "Your account is now 100% secure against unauthorized logins."
 
-#: src/strings.ts:1858
+#: src/strings.ts:1859
 msgid "Your account password must be strong & unique."
 msgstr "Your account password must be strong & unique."
 
-#: src/strings.ts:1036
+#: src/strings.ts:1037
 msgid "Your account will be downgraded in {days} days"
 msgstr "Your account will be downgraded in {days} days"
 
-#: src/strings.ts:1080
+#: src/strings.ts:1081
 msgid "Your account will be permanently deleted along with all your data, login credentials, and subscription information. This action is IRREVERSIBLE. Make sure you have saved a backup of your notes before proceeding."
 msgstr "Your account will be permanently deleted along with all your data, login credentials, and subscription information. This action is IRREVERSIBLE. Make sure you have saved a backup of your notes before proceeding."
 
-#: src/strings.ts:962
+#: src/strings.ts:963
 msgid "Your archive"
 msgstr "Your archive"
 
-#: src/strings.ts:2487
+#: src/strings.ts:2488
 msgid "Your archive is empty"
 msgstr "Your archive is empty"
 
-#: src/strings.ts:1931
+#: src/strings.ts:1932
 msgid "Your backup is ready to download"
 msgstr "Your backup is ready to download"
 
-#: src/strings.ts:1588
+#: src/strings.ts:1589
 msgid "Your changes could not be saved"
 msgstr "Your changes could not be saved"
 
-#: src/strings.ts:1778
+#: src/strings.ts:1779
 msgid "Your changes have been saved and will be reflected after the app has refreshed."
 msgstr "Your changes have been saved and will be reflected after the app has refreshed."
 
-#: src/strings.ts:2101
+#: src/strings.ts:2102
 msgid "Your current 2FA method is {method}"
 msgstr "Your current 2FA method is {method}"
 
-#: src/strings.ts:2596
+#: src/strings.ts:2597
 msgid "Your current subscription does not allow changing plans"
 msgstr "Your current subscription does not allow changing plans"
 
-#: src/strings.ts:1803
+#: src/strings.ts:1804
 msgid "Your data recovery key is basically a hashed version of your password (plus some random salt). It can be used to decrypt your data for re-encryption."
 msgstr "Your data recovery key is basically a hashed version of your password (plus some random salt). It can be used to decrypt your data for re-encryption."
 
-#: src/strings.ts:1856
+#: src/strings.ts:1857
 msgid "Your data recovery key will be used to decrypt your data"
 msgstr "Your data recovery key will be used to decrypt your data"
 
-#: src/strings.ts:2507
+#: src/strings.ts:2508
 msgid "Your data remains 100% accessible regardless of what plan you are on. That includes your notes, notebooks, attachments, and anything else you might have created."
 msgstr "Your data remains 100% accessible regardless of what plan you are on. That includes your notes, notebooks, attachments, and anything else you might have created."
 
-#: src/strings.ts:1786
+#: src/strings.ts:1787
 msgid "Your email has been confirmed."
 msgstr "Your email has been confirmed."
 
-#: src/strings.ts:2498
+#: src/strings.ts:2499
 msgid "Your email has been confirmed. You can now securely sync your encrypted notes across all devices."
 msgstr "Your email has been confirmed. You can now securely sync your encrypted notes across all devices."
 
-#: src/strings.ts:766
+#: src/strings.ts:767
 msgid "Your email is not confirmed. Please confirm your email address to change account password."
 msgstr "Your email is not confirmed. Please confirm your email address to change account password."
 
-#: src/strings.ts:956
+#: src/strings.ts:957
 msgid "Your favorites"
 msgstr "Your favorites"
 
-#: src/strings.ts:1033
+#: src/strings.ts:1034
 msgid "Your free trial ends on {date}"
 msgstr "Your free trial ends on {date}"
 
-#: src/strings.ts:1406
+#: src/strings.ts:1407
 msgid "Your free trial has expired"
 msgstr "Your free trial has expired"
 
-#: src/strings.ts:1028
+#: src/strings.ts:1029
 msgid "Your free trial has started"
 msgstr "Your free trial has started"
 
-#: src/strings.ts:1405
+#: src/strings.ts:1406
 msgid "Your free trial is ending soon"
 msgstr "Your free trial is ending soon"
 
-#: src/strings.ts:2624
+#: src/strings.ts:2625
 msgid "Your free trial is on-going. Your subscription will start on {trialExpiryDate}"
 msgstr "Your free trial is on-going. Your subscription will start on {trialExpiryDate}"
 
-#: src/strings.ts:1780
+#: src/strings.ts:1781
 msgid "Your full name"
 msgstr "Your full name"
 
-#: src/strings.ts:961
+#: src/strings.ts:962
 msgid "Your monographs"
 msgstr "Your monographs"
 
-#: src/strings.ts:1314
+#: src/strings.ts:1315
 msgid "Your name is stored 100% end-to-end encrypted and only visible to you."
 msgstr "Your name is stored 100% end-to-end encrypted and only visible to you."
 
-#: src/strings.ts:561
+#: src/strings.ts:562
 msgid "Your note will be unencrypted and removed from the vault."
 msgstr "Your note will be unencrypted and removed from the vault."
 
-#: src/strings.ts:959
+#: src/strings.ts:960
 msgid "Your notebooks"
 msgstr "Your notebooks"
 
-#: src/strings.ts:957
+#: src/strings.ts:958
 msgid "Your notes"
 msgstr "Your notes"
 
-#: src/strings.ts:1894
+#: src/strings.ts:1895
 msgid "Your password is always hashed before leaving this device."
 msgstr "Your password is always hashed before leaving this device."
 
-#: src/strings.ts:832
+#: src/strings.ts:833
 msgid "Your privacy matters to us, no matter who you are. In a world where everyone is trying to spy on you, Notesnook encrypts all your data before it leaves your device. With Notesnook no one can ever sell your data again."
 msgstr "Your privacy matters to us, no matter who you are. In a world where everyone is trying to spy on you, Notesnook encrypts all your data before it leaves your device. With Notesnook no one can ever sell your data again."
 
-#: src/strings.ts:1311
+#: src/strings.ts:1312
 msgid "Your profile pictrure is stored 100% end-to-end encrypted and only visible to you."
 msgstr "Your profile pictrure is stored 100% end-to-end encrypted and only visible to you."
 
-#: src/strings.ts:1999
+#: src/strings.ts:2000
 msgid "Your refund has been issued. Please wait 24 hours before reaching out to us in case you do not receive your funds."
 msgstr "Your refund has been issued. Please wait 24 hours before reaching out to us in case you do not receive your funds."
 
-#: src/strings.ts:960
+#: src/strings.ts:961
 msgid "Your reminders"
 msgstr "Your reminders"
 
@@ -7850,54 +7854,54 @@ msgstr "Your reminders"
 msgid "Your session has expired. Please enter password for {obfuscatedEmail} to continue."
 msgstr "Your session has expired. Please enter password for {obfuscatedEmail} to continue."
 
-#: src/strings.ts:1037
+#: src/strings.ts:1038
 msgid "Your subscription ends on {date}"
 msgstr "Your subscription ends on {date}"
 
-#: src/strings.ts:1997
+#: src/strings.ts:1998
 msgid "Your subscription has been canceled."
 msgstr "Your subscription has been canceled."
 
-#: src/strings.ts:1034
+#: src/strings.ts:1035
 msgid "Your subscription has ended"
 msgstr "Your subscription has ended"
 
-#: src/strings.ts:1038
+#: src/strings.ts:1039
 msgid "Your subscription renews on {date}"
 msgstr "Your subscription renews on {date}"
 
-#: src/strings.ts:958
+#: src/strings.ts:959
 msgid "Your tags"
 msgstr "Your tags"
 
-#: src/strings.ts:690
+#: src/strings.ts:691
 msgid "yr"
 msgstr "yr"
 
-#: src/strings.ts:648
+#: src/strings.ts:649
 msgid "Z to A"
 msgstr "Z to A"
 
-#: src/strings.ts:793
+#: src/strings.ts:794
 msgid "Zipping"
 msgstr "Zipping"
 
-#: src/strings.ts:2463
+#: src/strings.ts:2464
 msgid "Zoom"
 msgstr "Zoom"
 
-#: src/strings.ts:2095
+#: src/strings.ts:2096
 msgid "Zoom factor"
 msgstr "Zoom factor"
 
-#: src/strings.ts:1702
+#: src/strings.ts:1703
 msgid "Zoom in"
 msgstr "Zoom in"
 
-#: src/strings.ts:2096
+#: src/strings.ts:2097
 msgid "Zoom in or out the app content."
 msgstr "Zoom in or out the app content."
 
-#: src/strings.ts:1701
+#: src/strings.ts:1702
 msgid "Zoom out"
 msgstr "Zoom out"

--- a/packages/intl/locale/pseudo-LOCALE.po
+++ b/packages/intl/locale/pseudo-LOCALE.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2025-09-22 09:18+0500\n"
+"POT-Creation-Date: 2026-04-24 10:46+0500\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -19,7 +19,7 @@ msgstr ""
 
 #: src/strings.ts:148
 msgid " Unlock with password once to enable biometric access."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1944
 msgid " Upgrade to Notesnook Pro to add more notebooks."
@@ -66,7 +66,7 @@ msgstr ""
 #. placeholder {0}: version ? `v${version} ` : "New version"
 #: src/strings.ts:534
 msgid "{0} Highlights 🎉"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1756
 msgid "{count, plural, one {# error occured} other {# errors occured}}"
@@ -82,7 +82,7 @@ msgstr ""
 
 #: src/strings.ts:60
 msgid "{count, plural, one {# note} other {# notes}}"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1581
 msgid "{count, plural, one {1 hour} other {# hours}}"
@@ -334,7 +334,7 @@ msgstr ""
 
 #: generated/actions.ts:118
 msgid "{count, plural, one {Note unpublished} other {# notes unpublished}}"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:923
 msgid "{count, plural, one {Note will be automatically deleted from all other devices & any future changes won't get synced. Are you sure you want to continue?} other {# notes will be automatically deleted from all other devices & any future changes won't get synced. Are you sure you want to continue?}}"
@@ -388,7 +388,7 @@ msgstr ""
 
 #: generated/do-actions.ts:88
 msgid "{count, plural, one {Pin notebook} other {Pin # notebooks}}"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:918
 msgid "{count, plural, one {Prevent note from syncing} other {Prevent # notes from syncing}}"
@@ -493,7 +493,7 @@ msgstr ""
 
 #: src/strings.ts:2500
 msgid "{count} characters"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1567
 msgid "{days, plural, one {1 day} other {# days}}"
@@ -537,7 +537,7 @@ msgstr ""
 
 #: src/strings.ts:599
 msgid "{mode, select, repeat {Repeat} once {Once} permanent {Permanent} other {Unknown mode}}"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1979
 msgid "{n} {added, plural, one {added to 1 notebook} other {added to # notebooks}} and {removed, plural, one {removed from 1 notebook} other {removed from # notebooks}}."
@@ -557,7 +557,7 @@ msgstr ""
 
 #: src/strings.ts:471
 msgid "{notes, plural, one {Export note} other {Export # notes}}"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1709
 msgid "{percentage}% updating..."
@@ -569,7 +569,7 @@ msgstr ""
 
 #: src/strings.ts:744
 msgid "{platform, select, android {{name} saved to selected path} other {{name} saved to File Manager/Notesnook/downloads}}"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1340
 msgid "{platform, select, android {Backup file saved in \"Notesnook backups\" folder on your phone.} other {Backup file is saved in File Manager/Notesnook folder}}"
@@ -593,7 +593,7 @@ msgstr ""
 
 #: src/strings.ts:786
 msgid "{type} does not match"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1602
 msgid "{words, plural, one {# word} other {# words}}"
@@ -605,11 +605,11 @@ msgstr ""
 
 #: src/strings.ts:1793
 msgid "#notesnook"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2666
 msgid "1 day"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2668
 msgid "1 month"
@@ -649,7 +649,7 @@ msgstr ""
 
 #: src/strings.ts:2584
 msgid "5 year plan (One time purchase)"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1848
 msgid "6 digit code"
@@ -669,7 +669,7 @@ msgstr ""
 
 #: src/strings.ts:663
 msgid "Abc"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1292
 msgid "About"
@@ -693,7 +693,7 @@ msgstr ""
 
 #: src/strings.ts:2457
 msgid "Actions for tag: {title}"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2040
 msgid "Activate"
@@ -705,7 +705,7 @@ msgstr ""
 
 #: src/strings.ts:531
 msgid "Add"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1059
 msgid "Add 2FA fallback method"
@@ -721,7 +721,7 @@ msgstr ""
 
 #: src/strings.ts:558
 msgid "Add color"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2654
 msgid "Add key"
@@ -749,7 +749,7 @@ msgstr ""
 
 #: src/strings.ts:573
 msgid "Add tag"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:936
 msgid "Add tags"
@@ -769,7 +769,7 @@ msgstr ""
 
 #: src/strings.ts:2480
 msgid "Add to notebook"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:977
 msgid "Add your first note"
@@ -781,7 +781,7 @@ msgstr ""
 
 #: src/strings.ts:2620
 msgid "Adjust the line height of the editor"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2174
 msgid "Advanced"
@@ -821,7 +821,7 @@ msgstr ""
 
 #: src/strings.ts:755
 msgid "All files"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1177
 msgid "All locked notes will be re-encrypted with the new password."
@@ -829,7 +829,7 @@ msgstr ""
 
 #: src/strings.ts:740
 msgid "All logs are local only and are not sent to any server. You can share the logs from here with us if you face an issue to help us find the root cause."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1640
 msgid "All server urls are required."
@@ -845,7 +845,7 @@ msgstr ""
 
 #: src/strings.ts:430
 msgid "All tools are grouped"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1324
 msgid "All tools in the collapsed section will be removed"
@@ -861,7 +861,7 @@ msgstr ""
 
 #: src/strings.ts:108
 msgid "Already have an account?"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2224
 msgid "Amount"
@@ -877,7 +877,7 @@ msgstr ""
 
 #: src/strings.ts:103
 msgid "and "
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1794
 msgid "and get a chance to win free promo codes."
@@ -885,7 +885,7 @@ msgstr ""
 
 #: src/strings.ts:2537
 msgid "and much more."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1400
 msgid "and we will manually confirm your account."
@@ -893,7 +893,7 @@ msgstr ""
 
 #: src/strings.ts:2595
 msgid "ANNOUNCEMENT"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2684
 msgid "API key copied to clipboard"
@@ -917,7 +917,7 @@ msgstr ""
 
 #: src/strings.ts:252
 msgid "App data has been cleared. Kindly relaunch the app to login again."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1186
 #: src/strings.ts:1696
@@ -955,7 +955,7 @@ msgstr ""
 
 #: src/strings.ts:457
 msgid "Apply changes"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2047
 msgid "Applying changes"
@@ -964,7 +964,7 @@ msgstr ""
 #: src/strings.ts:1533
 #: src/strings.ts:2487
 msgid "Archive"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1448
 msgid "Are you scrolling a lot to find a specific note? Pin it to the top from Note properties."
@@ -984,7 +984,7 @@ msgstr ""
 
 #: src/strings.ts:776
 msgid "Are you sure you want to logout from this device? Any unsynced changes will be lost."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1049
 msgid "Are you sure you want to remove your name?"
@@ -992,11 +992,11 @@ msgstr ""
 
 #: src/strings.ts:1046
 msgid "Are you sure you want to remove your profile picture?"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2688
 msgid "Are you sure you want to revoke the key \"{name}\"? All inbox actions using this key will stop working immediately."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1326
 msgid "Are you sure?"
@@ -1037,7 +1037,7 @@ msgstr ""
 
 #: src/strings.ts:2450
 msgid "Attachment manager"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1938
 msgid "Attachment preview failed"
@@ -1058,7 +1058,7 @@ msgstr ""
 #: src/strings.ts:320
 #: src/strings.ts:908
 msgid "Attachments"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1887
 msgid "Attachments cache cleared!"
@@ -1070,15 +1070,15 @@ msgstr ""
 
 #: src/strings.ts:761
 msgid "Audios"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1629
 msgid "Auth server"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2682
 msgid "Authenticate"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2679
 msgid "Authenticate to view API key"
@@ -1163,7 +1163,7 @@ msgstr ""
 
 #: src/strings.ts:2158
 msgid "Available on iOS & Android"
-msgstr "<<<<<<< HEAD<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2707
 msgid "Back"
@@ -1171,7 +1171,7 @@ msgstr ""
 
 #: src/strings.ts:2305
 msgid "Background color"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1096
 msgid "Background sync (experimental)"
@@ -1207,7 +1207,7 @@ msgstr ""
 
 #: src/strings.ts:883
 msgid "Backup is encrypted"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1617
 msgid "Backup is encrypted, decrypting..."
@@ -1223,7 +1223,7 @@ msgstr ""
 
 #: src/strings.ts:890
 msgid "Backup restored"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1922
 msgid "Backup saved at {path}"
@@ -1243,7 +1243,7 @@ msgstr ""
 
 #: src/strings.ts:542
 msgid "Basic"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1796
 msgid "Because where's the fun in nookin' alone?"
@@ -1279,7 +1279,7 @@ msgstr ""
 
 #: src/strings.ts:2558
 msgid "billed monthly at {price}"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2205
 msgid "Billing history"
@@ -1295,7 +1295,7 @@ msgstr ""
 
 #: src/strings.ts:812
 msgid "Biometric unlocking enabled"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1352
 msgid "Biometrics authentication failed. Please try again."
@@ -1311,7 +1311,7 @@ msgstr ""
 
 #: src/strings.ts:2412
 msgid "Boost your productivity with Notebooks and organize your notes."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1812
 msgid "Browse"
@@ -1359,7 +1359,7 @@ msgstr ""
 
 #: src/strings.ts:555
 msgid "Cancel login"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1829
 msgid "Cancel subscription"
@@ -1367,7 +1367,7 @@ msgstr ""
 
 #: src/strings.ts:519
 msgid "Cancel upload"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2678
 msgid "Cannot create more than 10 api keys at a time. Please revoke some existing keys before creating new ones."
@@ -1396,7 +1396,7 @@ msgstr ""
 
 #: src/strings.ts:153
 msgid "Change"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1062
 msgid "Change 2FA fallback method"
@@ -1404,7 +1404,7 @@ msgstr ""
 
 #: src/strings.ts:679
 msgid "Change 2FA method"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1201
 msgid "Change app lock password"
@@ -1420,7 +1420,7 @@ msgstr ""
 
 #: src/strings.ts:465
 msgid "Change email address"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1128
 msgid "Change how the app behaves in different situations"
@@ -1428,7 +1428,7 @@ msgstr ""
 
 #: src/strings.ts:2355
 msgid "Change language"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1256
 msgid "Change notification sound"
@@ -1440,7 +1440,7 @@ msgstr ""
 
 #: src/strings.ts:2588
 msgid "Change plan"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1821
 msgid "Change profile picture"
@@ -1460,7 +1460,7 @@ msgstr ""
 
 #: src/strings.ts:451
 msgid "Change vault password"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1056
 msgid "Change your account password"
@@ -1472,7 +1472,7 @@ msgstr ""
 
 #: src/strings.ts:1092
 msgid "Changes from other devices won't be updated in the editor in real-time."
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2698
 msgid "Changing Inbox PGP keys will delete all your unsynced inbox items."
@@ -1484,7 +1484,7 @@ msgstr ""
 
 #: src/strings.ts:2493
 msgid "Characters"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1299
 msgid "Check for new version of Notesnook"
@@ -1516,7 +1516,7 @@ msgstr ""
 
 #: src/strings.ts:378
 msgid "Checking for new version"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1708
 msgid "Checking for updates"
@@ -1532,7 +1532,7 @@ msgstr ""
 
 #: src/strings.ts:2332
 msgid "Choose a block to insert"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1800
 msgid "Choose a recovery method"
@@ -1544,7 +1544,7 @@ msgstr ""
 
 #: src/strings.ts:2368
 msgid "Choose custom color"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1121
 msgid "Choose from pre-built themes or create your own"
@@ -1556,7 +1556,7 @@ msgstr ""
 
 #: src/strings.ts:2623
 msgid "Choose how day is displayed in the app"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1161
 msgid "Choose how the new note titles are formatted"
@@ -1572,7 +1572,7 @@ msgstr ""
 
 #: src/strings.ts:2628
 msgid "Choose what day to display as the first day of the week"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1231
 msgid "Choose where to save your backups"
@@ -1596,7 +1596,7 @@ msgstr ""
 
 #: src/strings.ts:2272
 msgid "Clear all formatting"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1874
 msgid "Clear attachments cache?"
@@ -1608,7 +1608,7 @@ msgstr ""
 
 #: src/strings.ts:2366
 msgid "Clear completed tasks"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1808
 msgid "Clear data & reset account"
@@ -1636,7 +1636,7 @@ msgstr ""
 
 #: src/strings.ts:150
 msgid "Clear vault"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1876
 msgid ""
@@ -1651,7 +1651,7 @@ msgid ""
 "---\n"
 "\n"
 "**Only use this for troubleshooting purposes. If you are having persistent issues, it is recommended that you reach out to us via support@streetwriters.co so we can help you resolve it permanently.**"
-msgstr "<<<<<<< Updated upstream======="
+msgstr ""
 
 #: src/strings.ts:2610
 msgid "Click here to directly claim the promotion."
@@ -1659,7 +1659,7 @@ msgstr ""
 
 #: src/strings.ts:239
 msgid "Click to deselect"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1870
 msgid "Click to preview"
@@ -1679,7 +1679,7 @@ msgstr ""
 
 #: src/strings.ts:2614
 msgid "Click to update"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1384
 msgid "Close"
@@ -1695,7 +1695,7 @@ msgstr ""
 
 #: src/strings.ts:2452
 msgid "Close current tab"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2019
 msgid "Close others"
@@ -1744,7 +1744,7 @@ msgstr ""
 
 #: src/strings.ts:788
 msgid "Color #{color} already exists"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2098
 msgid "Color scheme"
@@ -1768,7 +1768,7 @@ msgstr ""
 
 #: src/strings.ts:2444
 msgid "Command palette"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1274
 msgid "Community"
@@ -1784,7 +1784,7 @@ msgstr ""
 
 #: src/strings.ts:139
 msgid "Compress"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1132
 msgid "Compress images before uploading"
@@ -1808,7 +1808,7 @@ msgstr ""
 
 #: src/strings.ts:904
 msgid "Confirm email to publish note"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1491
 msgid "Confirm new password"
@@ -1824,7 +1824,7 @@ msgstr ""
 
 #: src/strings.ts:2642
 msgid "Confirmation email sent"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2083
 msgid "Congratulations!"
@@ -1844,7 +1844,7 @@ msgstr ""
 
 #: src/strings.ts:544
 msgid "Continue"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1167
 msgid "Contribute towards a better Notesnook. All tracking information is anonymous."
@@ -1869,11 +1869,11 @@ msgstr ""
 
 #: src/strings.ts:680
 msgid "Copy codes"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:913
 msgid "Copy ID"
-msgstr "=======>>>>>>> Stashed changes"
+msgstr ""
 
 #: src/strings.ts:2250
 msgid "Copy image"
@@ -1893,7 +1893,7 @@ msgstr ""
 
 #: src/strings.ts:592
 msgid "Copy to clipboard"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1622
 msgid "Copying backup files to cache"
@@ -1933,7 +1933,7 @@ msgstr ""
 
 #: src/strings.ts:731
 msgid "Create a group"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:941
 msgid "Create a new note"
@@ -1949,11 +1949,11 @@ msgstr ""
 
 #: src/strings.ts:574
 msgid "Create a tag to group related notes together."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1852
 msgid "Create account"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2657
 msgid "Create API Key"
@@ -1965,7 +1965,7 @@ msgstr ""
 
 #: src/strings.ts:582
 msgid "Create link"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1476
 msgid "Create shortcut of this notebook in side menu"
@@ -1989,7 +1989,7 @@ msgstr ""
 
 #: src/strings.ts:523
 msgid "Create your account"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2673
 msgid "Create your first api key to get started."
@@ -1997,7 +1997,7 @@ msgstr ""
 
 #: src/strings.ts:2232
 msgid "Created at"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2693
 msgid "Created on"
@@ -2006,11 +2006,11 @@ msgstr ""
 #. placeholder {0}: type === "full" ? " full" : ""
 #: src/strings.ts:1347
 msgid "Creating a{0} backup"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2665
 msgid "Creating..."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2052
 msgid "Credentials"
@@ -2022,7 +2022,7 @@ msgstr ""
 
 #: src/strings.ts:742
 msgid "Curate the toolbar that fits your needs and matches your personality."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1839
 msgid "Current note"
@@ -2083,7 +2083,7 @@ msgstr ""
 
 #: src/strings.ts:725
 msgid "Dark"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1125
 msgid "Dark mode"
@@ -2115,7 +2115,7 @@ msgstr ""
 
 #: src/strings.ts:653
 msgid "Date edited"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1135
 msgid "Date format"
@@ -2123,7 +2123,7 @@ msgstr ""
 
 #: src/strings.ts:652
 msgid "Date modified"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2045
 msgid "Date uploaded"
@@ -2135,7 +2135,7 @@ msgstr ""
 
 #: src/strings.ts:2622
 msgid "Day format"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2041
 msgid "Deactivate"
@@ -2159,7 +2159,7 @@ msgstr ""
 
 #: src/strings.ts:2397
 msgid "Decrease {title}"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:661
 #: src/strings.ts:2011
@@ -2192,7 +2192,7 @@ msgstr ""
 
 #: src/strings.ts:2484
 msgid "Default sidebar tab"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1252
 msgid "Default snooze time"
@@ -2204,7 +2204,7 @@ msgstr ""
 
 #: src/strings.ts:154
 msgid "Delete"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1079
 msgid "Delete account"
@@ -2220,7 +2220,7 @@ msgstr ""
 
 #: src/strings.ts:2639
 msgid "Delete data"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1317
 msgid "Delete group"
@@ -2248,7 +2248,7 @@ msgstr ""
 
 #: src/strings.ts:149
 msgid "Delete vault"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1179
 msgid "Delete vault (and optionally remove all notes)."
@@ -2256,7 +2256,7 @@ msgstr ""
 
 #: src/strings.ts:164
 msgid "Deleted on {date}"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1931
 msgid "Deleting"
@@ -2276,7 +2276,7 @@ msgstr ""
 
 #: src/strings.ts:872
 msgid "Did you save recovery key?"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1379
 msgid "Disable"
@@ -2288,11 +2288,11 @@ msgstr ""
 
 #: src/strings.ts:2014
 msgid "Disable editor margins"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2651
 msgid "Disable Inbox API"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1090
 msgid "Disable realtime sync"
@@ -2304,7 +2304,7 @@ msgstr ""
 
 #: src/strings.ts:165
 msgid "Disabled"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2653
 msgid "Disabling will delete all your unsynced inbox items. Additionally, disabling will revoke all existing API keys, they will no longer work. Are you sure?"
@@ -2312,7 +2312,7 @@ msgstr ""
 
 #: src/strings.ts:566
 msgid "Discard"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1600
 msgid "Dismiss"
@@ -2328,7 +2328,7 @@ msgstr ""
 
 #: src/strings.ts:273
 msgid "Do you enjoy using Notesnook?"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2231
 msgid "Do you want to clear the trash?"
@@ -2340,7 +2340,7 @@ msgstr ""
 
 #: src/strings.ts:758
 msgid "Documents"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:987
 msgid "Don't have access to your authenticator app?"
@@ -2356,7 +2356,7 @@ msgstr ""
 
 #: src/strings.ts:95
 msgid "Don't have an account?"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1835
 msgid "Don't have backup file?"
@@ -2380,7 +2380,7 @@ msgstr ""
 
 #: src/strings.ts:55
 msgid "Done"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1152
 msgid "Double spaced lines"
@@ -2388,7 +2388,7 @@ msgstr ""
 
 #: src/strings.ts:510
 msgid "Download"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1819
 msgid "Download all attachments"
@@ -2396,7 +2396,7 @@ msgstr ""
 
 #: src/strings.ts:2318
 msgid "Download attachment"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1863
 msgid "Download backup file"
@@ -2404,7 +2404,7 @@ msgstr ""
 
 #: src/strings.ts:517
 msgid "Download cancelled"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2211
 msgid "Download everything including attachments on sync"
@@ -2441,7 +2441,7 @@ msgstr ""
 
 #: src/strings.ts:261
 msgid "Downloading attachments"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1707
 msgid "Downloading images"
@@ -2469,11 +2469,11 @@ msgstr ""
 
 #: src/strings.ts:2559
 msgid "Due today"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:927
 msgid "Duplicate"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2659
 msgid "e.g., Todo integration"
@@ -2485,7 +2485,7 @@ msgstr ""
 
 #: src/strings.ts:2421
 msgid "Easy access"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1780
 msgid "Edit"
@@ -2506,7 +2506,7 @@ msgstr ""
 
 #: src/strings.ts:2477
 msgid "Edit profile"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1310
 msgid "Edit profile picture"
@@ -2523,7 +2523,7 @@ msgstr ""
 
 #: src/strings.ts:2585
 msgid "Education plan"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1484
 msgid "Email"
@@ -2539,7 +2539,7 @@ msgstr ""
 
 #: src/strings.ts:765
 msgid "Email not confirmed"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1556
 msgid "Email or password incorrect"
@@ -2567,7 +2567,7 @@ msgstr ""
 
 #: src/strings.ts:151
 msgid "Enable"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1134
 msgid "Enable (Recommended)"
@@ -2579,7 +2579,7 @@ msgstr ""
 
 #: src/strings.ts:2015
 msgid "Enable editor margins"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2646
 msgid "Enable Inbox API"
@@ -2591,19 +2591,23 @@ msgstr ""
 
 #: src/strings.ts:2384
 msgid "Enable regex"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2130
 msgid "Enable spell checker"
 msgstr ""
 
+#: src/strings.ts:2715
+msgid "Enable two factor authentication"
+msgstr ""
+
 #: src/strings.ts:496
 msgid "Enable two-factor authentication to add an extra layer of security to your account."
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2647
 msgid "Enable/Disable Inbox API"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1237
 msgid "Encrypt your backups for added security"
@@ -2615,7 +2619,7 @@ msgstr ""
 
 #: src/strings.ts:2244
 msgid "Encrypted backup"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1660
 msgid "Encrypted, private, secure."
@@ -2639,7 +2643,7 @@ msgstr ""
 
 #: src/strings.ts:399
 msgid "Enter 6 digit code"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1082
 msgid "Enter account password"
@@ -2663,7 +2667,7 @@ msgstr ""
 
 #: src/strings.ts:132
 msgid "Enter code from authenticator app"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1514
 msgid "Enter email address"
@@ -2671,7 +2675,7 @@ msgstr ""
 
 #: src/strings.ts:2372
 msgid "Enter embed source URL"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1316
 msgid "Enter full name"
@@ -2691,7 +2695,7 @@ msgstr ""
 
 #: src/strings.ts:792
 msgid "Enter password"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2091
 msgid "Enter pin or password to enable app lock."
@@ -2715,11 +2719,11 @@ msgstr ""
 
 #: src/strings.ts:2436
 msgid "Enter the gift code to redeem your subscription."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2621
 msgid "Enter title"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1496
 msgid "Enter verification code sent to your new email"
@@ -2735,7 +2739,7 @@ msgstr ""
 
 #: src/strings.ts:2428
 msgid "Error"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1557
 msgid "Error applying promo code"
@@ -2743,7 +2747,7 @@ msgstr ""
 
 #: src/strings.ts:748
 msgid "Error downloading file: {message}"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1517
 msgid "Error getting codes"
@@ -2751,7 +2755,7 @@ msgstr ""
 
 #: src/strings.ts:413
 msgid "Error loading themes"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1078
 msgid "Error logging out"
@@ -2763,7 +2767,7 @@ msgstr ""
 
 #: src/strings.ts:760
 msgid "Errors"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1699
 msgid "Errors in {count} attachments"
@@ -2771,7 +2775,7 @@ msgstr ""
 
 #: src/strings.ts:2473
 msgid "Essential plan"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1631
 msgid "Events server"
@@ -2795,7 +2799,7 @@ msgstr ""
 
 #: src/strings.ts:2441
 msgid "Execute a command..."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2016
 msgid "Exit fullscreen"
@@ -2807,15 +2811,15 @@ msgstr ""
 
 #: src/strings.ts:2469
 msgid "Expand sidebar"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2075
 msgid "Experience the next level of private note taking\""
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2695
 msgid "Expired"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2660
 msgid "Expires in"
@@ -2823,7 +2827,7 @@ msgstr ""
 
 #: src/strings.ts:2696
 msgid "Expires on"
-msgstr "=======>>>>>>> Stashed changes"
+msgstr ""
 
 #: src/strings.ts:2635
 msgid "Expiry date"
@@ -2839,7 +2843,7 @@ msgstr ""
 
 #: src/strings.ts:579
 msgid "Export again"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1240
 msgid "Export all notes"
@@ -2856,7 +2860,7 @@ msgstr ""
 
 #: src/strings.ts:2636
 msgid "Export CSV"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1388
 msgid "Export notes as PDF, Markdown and HTML with Notesnook Pro"
@@ -2864,7 +2868,7 @@ msgstr ""
 
 #: src/strings.ts:215
 msgid "Exporting \"{title}\""
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1621
 msgid "Extracting files..."
@@ -2884,15 +2888,15 @@ msgstr ""
 
 #: src/strings.ts:2640
 msgid "Failed to attach file"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1939
 msgid "Failed to copy note"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2685
 msgid "Failed to copy to clipboard"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #. placeholder {0}: message ? `: ${message}` : ""
 #: src/strings.ts:2664
@@ -2913,15 +2917,15 @@ msgstr ""
 
 #: src/strings.ts:793
 msgid "Failed to download file"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2001
 msgid "Failed to install theme."
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2671
 msgid "Failed to load API keys. Please try again."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:951
 msgid "Failed to open"
@@ -2929,7 +2933,7 @@ msgstr ""
 
 #: src/strings.ts:868
 msgid "Failed to publish note"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2006
 msgid "Failed to register task"
@@ -2937,7 +2941,7 @@ msgstr ""
 
 #: src/strings.ts:805
 msgid "Failed to resolve download url"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2690
 msgid "Failed to revoke API key"
@@ -2945,7 +2949,7 @@ msgstr ""
 
 #: src/strings.ts:774
 msgid "Failed to send recovery email"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1404
 msgid "Failed to send verification email"
@@ -2977,7 +2981,7 @@ msgstr ""
 
 #: src/strings.ts:2552
 msgid "FAQs"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2035
 msgid "Favorite"
@@ -3014,7 +3018,7 @@ msgstr ""
 
 #: src/strings.ts:804
 msgid "File length mismatch. Expected {expectedSize} but got {currentSize} bytes. Please upload this file again from the attachment manager."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:952
 msgid "File mismatch"
@@ -3038,7 +3042,7 @@ msgstr ""
 
 #: src/strings.ts:2607
 msgid "Finish your purchase in the browser."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1672
 msgid "Fix it"
@@ -3082,7 +3086,7 @@ msgstr ""
 
 #: src/strings.ts:2524
 msgid "For a monthly subscription, you can get a refund within 7 days of purchase. For a yearly subscription, we offer a full refund within 14 days of purchase. For a 5 year subscription, you can request a refund within 30 days of purchase."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1689
 msgid "For a more integrated user experience, try out Notesnook for {platform}"
@@ -3094,7 +3098,7 @@ msgstr ""
 
 #: src/strings.ts:2533
 msgid "for locking your notes as soon as app enters background"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2198
 msgid "Force logout from all your other logged in devices."
@@ -3145,7 +3149,7 @@ msgstr ""
 
 #: src/strings.ts:2371
 msgid "From URL"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2002
 msgid "Full name updated"
@@ -3157,7 +3161,7 @@ msgstr ""
 
 #: src/strings.ts:2326
 msgid "Full screen"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2095
 msgid "General"
@@ -3201,7 +3205,7 @@ msgstr ""
 
 #: src/strings.ts:2530
 msgid "Get this and so much more:"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:400
 msgid "Getting 2FA backup codes"
@@ -3213,7 +3217,7 @@ msgstr ""
 
 #: src/strings.ts:398
 msgid "Getting information"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2165
 msgid "GNU GENERAL PUBLIC LICENSE Version 3"
@@ -3225,7 +3229,7 @@ msgstr ""
 
 #: src/strings.ts:2449
 msgid "Go back in tab"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2228
 msgid "Go back to notebooks"
@@ -3237,7 +3241,7 @@ msgstr ""
 
 #: src/strings.ts:2448
 msgid "Go forward in tab"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1816
 msgid "Go to"
@@ -3273,7 +3277,7 @@ msgstr ""
 
 #: src/strings.ts:429
 msgid "GROUP"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1890
 msgid "Group added successfully"
@@ -3285,7 +3289,7 @@ msgstr ""
 
 #: src/strings.ts:753
 msgid "Hash copied"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2212
 msgid "Having problems with sync?"
@@ -3305,7 +3309,7 @@ msgstr ""
 
 #: src/strings.ts:2387
 msgid "Height"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1259
 msgid "Help and support"
@@ -3313,7 +3317,7 @@ msgstr ""
 
 #: src/strings.ts:161
 msgid "Help improve Notesnook by sending completely anonymized"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1378
 msgid "Hide"
@@ -3333,7 +3337,7 @@ msgstr ""
 
 #: src/strings.ts:910
 msgid "History"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1530
 msgid "Home"
@@ -3349,7 +3353,7 @@ msgstr ""
 
 #: src/strings.ts:2333
 msgid "Horizontal rule"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1801
 msgid "How do you want to recover your account?"
@@ -3385,7 +3389,7 @@ msgstr ""
 
 #: src/strings.ts:133
 msgid "I have a 2FA backup code"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1889
 msgid "I have saved my key"
@@ -3393,7 +3397,7 @@ msgstr ""
 
 #: src/strings.ts:2427
 msgid "I love cooking and collecting recipes."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2213
 msgid "I understand"
@@ -3413,7 +3417,7 @@ msgstr ""
 
 #: src/strings.ts:254
 msgid "If this continues to happen, please reach out to us via"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2116
 msgid "If true, Notesnook will automatically start up when you turn on & login to your system."
@@ -3431,7 +3435,7 @@ msgstr ""
 msgid ""
 "If you didn't get an email from us or the confirmation link isn't\n"
 "            working,"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1807
 msgid "If you don't have a recovery key, you can recover your data by restoring a Notesnook data backup file (.nnbackup)."
@@ -3447,7 +3451,7 @@ msgstr ""
 
 #: src/strings.ts:2338
 msgid "Image"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1131
 msgid "Image Compression"
@@ -3459,7 +3463,7 @@ msgstr ""
 
 #: src/strings.ts:2310
 msgid "Image settings"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:950
 msgid "Image size should be less than {sizeInMB}"
@@ -3471,7 +3475,7 @@ msgstr ""
 
 #: src/strings.ts:142
 msgid "Images uploaded without compression are slow to load and take more bandwidth. We recommend compressing images unless you need image in original quality."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1585
 msgid "Immediately"
@@ -3487,11 +3491,11 @@ msgstr ""
 
 #: src/strings.ts:2637
 msgid "Import CSV"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1769
 msgid "import guide"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2643
 msgid "Inbox API"
@@ -3507,7 +3511,7 @@ msgstr ""
 
 #: src/strings.ts:174
 msgid "Incoming"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1840
 msgid "Incoming note"
@@ -3559,7 +3563,7 @@ msgstr ""
 
 #: src/strings.ts:2299
 msgid "Insert row below"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1687
 msgid "Install Notesnook"
@@ -3575,7 +3579,7 @@ msgstr ""
 
 #: src/strings.ts:749
 msgid "Invalid {type}"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1994
 msgid "Invalid CORS proxy url"
@@ -3583,11 +3587,11 @@ msgstr ""
 
 #: src/strings.ts:1485
 msgid "Invalid email"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2683
 msgid "Invalid password"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2702
 msgid "Invalid PGP key pair. Please check your keys and try again."
@@ -3599,7 +3603,7 @@ msgstr ""
 
 #: src/strings.ts:224
 msgid "Issue created"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:993
 #: src/strings.ts:1002
@@ -3633,7 +3637,7 @@ msgstr ""
 
 #: src/strings.ts:323
 msgid "Items"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2163
 msgid "Join community"
@@ -3641,7 +3645,7 @@ msgstr ""
 
 #: src/strings.ts:234
 msgid "join our community on Discord."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1283
 msgid "Join our Discord server"
@@ -3669,7 +3673,7 @@ msgstr ""
 
 #: src/strings.ts:568
 msgid "Keep"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2024
 msgid "Keep open"
@@ -3677,11 +3681,11 @@ msgstr ""
 
 #: src/strings.ts:1362
 msgid "Keep your data safe"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2658
 msgid "Key name"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2131
 msgid "Languages"
@@ -3689,7 +3693,7 @@ msgstr ""
 
 #: src/strings.ts:2233
 msgid "Last edited at"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2691
 msgid "Last used on"
@@ -3709,7 +3713,7 @@ msgstr ""
 
 #: src/strings.ts:572
 msgid "Learn more"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:980
 msgid "Learn more about Monographs"
@@ -3721,7 +3725,7 @@ msgstr ""
 
 #: src/strings.ts:647
 msgid "Least relevant first"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1565
 msgid "Legal"
@@ -3729,7 +3733,7 @@ msgstr ""
 
 #: src/strings.ts:476
 msgid "Let us know if you have faced any issue/bug while using Notesnook. We will try to fix it as soon as possible."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2164
 msgid "License"
@@ -3753,7 +3757,7 @@ msgstr ""
 
 #: src/strings.ts:2619
 msgid "Line height"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1155
 msgid "Line spacing changed"
@@ -3765,7 +3769,7 @@ msgstr ""
 
 #: src/strings.ts:912
 msgid "Link copied"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:932
 msgid "Link notebooks"
@@ -3797,7 +3801,7 @@ msgstr ""
 
 #: src/strings.ts:596
 msgid "Linked notes"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1599
 msgid "Linking to a specific block is not available for locked notes."
@@ -3809,7 +3813,7 @@ msgstr ""
 
 #: src/strings.ts:728
 msgid "Load from file"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1698
 msgid "Loading"
@@ -3818,11 +3822,11 @@ msgstr ""
 #. placeholder {0}: progress ? `(${progress})` : ""
 #: src/strings.ts:146
 msgid "Loading {0}, please wait..."
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2670
 msgid "Loading API keys..."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1667
 msgid "Loading editor. Please wait..."
@@ -3834,7 +3838,7 @@ msgstr ""
 
 #: src/strings.ts:414
 msgid "Loading themes..."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1330
 msgid "Loading trash"
@@ -3874,7 +3878,7 @@ msgstr ""
 
 #: src/strings.ts:456
 msgid "Lock note"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1187
 msgid "Lock the app with a password or pin"
@@ -3890,7 +3894,7 @@ msgstr ""
 
 #: src/strings.ts:905
 msgid "Locked notes cannot be published"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2196
 msgid "Log out from all other devices"
@@ -3898,7 +3902,7 @@ msgstr ""
 
 #: src/strings.ts:389
 msgid "Logged in as {email}"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1077
 msgid "Logging out will clear all data stored on THIS DEVICE. Make sure you have synced all your changes before logging out."
@@ -3906,7 +3910,7 @@ msgstr ""
 
 #: src/strings.ts:403
 msgid "Logging out. Please wait..."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1785
 msgid "Logging you in"
@@ -3926,7 +3930,7 @@ msgstr ""
 
 #: src/strings.ts:780
 msgid "Login successful"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1365
 msgid "Login to encrypt and sync notes"
@@ -3950,7 +3954,7 @@ msgstr ""
 
 #: src/strings.ts:556
 msgid "Logout from this device"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1415
 msgid "Long press on any item in list to enter multi-select mode."
@@ -3958,7 +3962,7 @@ msgstr ""
 
 #: src/strings.ts:2364
 msgid "Make task list readonly"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1041
 msgid "Manage account"
@@ -3974,7 +3978,7 @@ msgstr ""
 
 #: src/strings.ts:851
 msgid "Manage tags"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1042
 msgid "Manage your account related settings here"
@@ -4022,7 +4026,7 @@ msgstr ""
 
 #: src/strings.ts:2336
 msgid "Math & formulas"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2043
 msgid "Maximize"
@@ -4034,7 +4038,7 @@ msgstr ""
 
 #: src/strings.ts:2420
 msgid "Meetings"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1782
 msgid "Member since {date}"
@@ -4056,7 +4060,7 @@ msgstr ""
 
 #: src/strings.ts:880
 msgid "min"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2012
 msgid "Minimal"
@@ -4080,7 +4084,7 @@ msgstr ""
 
 #: src/strings.ts:615
 msgid "Monday"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1634
 msgid "Monograph server"
@@ -4139,7 +4143,7 @@ msgstr ""
 
 #: src/strings.ts:2294
 msgid "Move column right"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:939
 msgid "Move notebook"
@@ -4167,7 +4171,7 @@ msgstr ""
 
 #: src/strings.ts:856
 msgid "Move to trash"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1175
 msgid "Multi-layer encryption to most important notes"
@@ -4175,7 +4179,7 @@ msgstr ""
 
 #: src/strings.ts:888
 msgid "Name"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1691
 msgid "Native high-performance encryption"
@@ -4187,15 +4191,15 @@ msgstr ""
 
 #: src/strings.ts:390
 msgid "Never"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1345
 msgid "Never ask again"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2694
 msgid "Never expires"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1040
 msgid "Never hesitate to choose privacy"
@@ -4203,7 +4207,7 @@ msgstr ""
 
 #: src/strings.ts:673
 msgid "Never show again"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2692
 msgid "Never used"
@@ -4215,7 +4219,7 @@ msgstr ""
 
 #: src/strings.ts:529
 msgid "New color"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1849
 msgid "New Email"
@@ -4231,7 +4235,7 @@ msgstr ""
 
 #: src/strings.ts:526
 msgid "New notebook"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1483
 msgid "New password"
@@ -4251,7 +4255,7 @@ msgstr ""
 
 #: src/strings.ts:2451
 msgid "New tag"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1371
 msgid "New update available"
@@ -4259,7 +4263,7 @@ msgstr ""
 
 #: src/strings.ts:532
 msgid "New version"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2027
 msgid "Newest - oldest"
@@ -4303,7 +4307,7 @@ msgstr ""
 
 #: src/strings.ts:787
 msgid "No color selected"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1234
 msgid "No directory selected"
@@ -4311,7 +4315,7 @@ msgstr ""
 
 #: src/strings.ts:89
 msgid "No downloads in progress."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1987
 msgid "No encryption key found"
@@ -4347,7 +4351,7 @@ msgstr ""
 
 #: src/strings.ts:279
 msgid "No references found of this note"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1519
 msgid "No results found"
@@ -4355,7 +4359,7 @@ msgstr ""
 
 #: src/strings.ts:406
 msgid "No results found for \"{query}\""
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1519
 msgid "No results found for {query}"
@@ -4371,7 +4375,7 @@ msgstr ""
 
 #: src/strings.ts:662
 msgid "None"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2017
 msgid "Normal mode"
@@ -4392,7 +4396,7 @@ msgstr ""
 
 #: src/strings.ts:816
 msgid "Note copied to clipboard"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1952
 msgid "Note does not exist"
@@ -4408,7 +4412,7 @@ msgstr ""
 
 #: src/strings.ts:846
 msgid "Note restored from history"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1588
 msgid "Note title"
@@ -4420,7 +4424,7 @@ msgstr ""
 
 #: src/strings.ts:178
 msgid "Note version history is local only."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1227
 msgid "NOTE: Creating a backup with attachments can take a while, and also fail completely. The app will try to resume/restart the backup in case of interruptions."
@@ -4468,7 +4472,7 @@ msgstr ""
 
 #: src/strings.ts:223
 msgid "Notes exported as {path} successfully"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1753
 msgid "notes imported"
@@ -4484,7 +4488,7 @@ msgstr ""
 
 #: src/strings.ts:2602
 msgid "Notesnook Circle brings together trusted partners who share our commitment to privacy, transparency, and user freedom."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2070
 msgid "Notesnook encrypts everything offline before syncing to your other devices. This means that no one can read your notes except you. Not even us."
@@ -4506,7 +4510,7 @@ msgid ""
 "2. Quad9\n"
 "\n"
 "This can sometimes bypass local ISP blockages on Notesnook traffic. Disable this if you want the app to use system's DNS settings."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:990
 msgid "Notesnook will send you a 2FA code on your email when prompted"
@@ -4526,7 +4530,7 @@ msgstr ""
 
 #: src/strings.ts:2277
 msgid "Numbered list"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1721
 msgid "of"
@@ -4538,11 +4542,11 @@ msgstr ""
 
 #: src/strings.ts:395
 msgid "Offline"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2675
 msgid "OK"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2230
 msgid "Okay"
@@ -4550,7 +4554,7 @@ msgstr ""
 
 #: src/strings.ts:642
 msgid "Old - new"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1482
 msgid "Old password"
@@ -4570,7 +4574,7 @@ msgstr ""
 
 #: src/strings.ts:2563
 msgid "One time purchase, no auto-renewal"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1774
 msgid "Only .zip files are supported."
@@ -4586,7 +4590,7 @@ msgstr ""
 
 #: src/strings.ts:265
 msgid "Open in browser"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1309
 msgid "Open in browser to manage subscription"
@@ -4602,7 +4606,7 @@ msgstr ""
 
 #: src/strings.ts:2267
 msgid "Open link"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1866
 msgid "Open note"
@@ -4614,7 +4618,7 @@ msgstr ""
 
 #: src/strings.ts:2328
 msgid "Open source"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1291
 msgid "Open source libraries used in Notesnook"
@@ -4626,7 +4630,7 @@ msgstr ""
 
 #: src/strings.ts:820
 msgid "Open source."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:986
 msgid "Open the two-factor authentication (TOTP) app to view your authentication code."
@@ -4638,7 +4642,7 @@ msgstr ""
 
 #: src/strings.ts:255
 msgid "or email us at"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2025
 msgid "Order by"
@@ -4651,7 +4655,7 @@ msgstr ""
 #: src/strings.ts:759
 #: src/strings.ts:763
 msgid "Orphaned"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2148
 msgid "Other"
@@ -4667,7 +4671,7 @@ msgstr ""
 
 #: src/strings.ts:2494
 msgid "Paragraphs"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2104
 msgid "Partial backups contain all your data except attachments. They are created from data already available on your device and do not require an Internet connection."
@@ -4711,7 +4715,7 @@ msgstr ""
 
 #: src/strings.ts:810
 msgid "Password updated"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2084
 msgid "Password/pin"
@@ -4739,7 +4743,7 @@ msgstr ""
 
 #: src/strings.ts:2564
 msgid "Pay once and use for 5 years"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2202
 msgid "Payment method"
@@ -4747,7 +4751,7 @@ msgstr ""
 
 #: src/strings.ts:789
 msgid "PDF is password protected"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1732
 msgid "phone number"
@@ -4763,7 +4767,7 @@ msgstr ""
 
 #: src/strings.ts:901
 msgid "Pin"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1693
 msgid "Pin notes in notifications drawer"
@@ -4783,7 +4787,7 @@ msgstr ""
 
 #: src/strings.ts:2545
 msgid "Plans"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1367
 msgid "Please confirm your email to sync notes"
@@ -4813,11 +4817,11 @@ msgstr ""
 
 #: src/strings.ts:2010
 msgid "Please enable automatic backups to avoid losing important data."
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2661
 msgid "Please enter a key name"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1515
 msgid "Please enter a valid email address"
@@ -4845,7 +4849,7 @@ msgstr ""
 
 #: src/strings.ts:791
 msgid "Please enter the password to unlock the PDF and view the content."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1868
 msgid "Please enter the password to unlock this note"
@@ -4853,7 +4857,7 @@ msgstr ""
 
 #: src/strings.ts:1865
 msgid "Please enter the password to view this version"
-msgstr "<<<<<<< HEAD<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2681
 msgid "Please enter your account password to view this API key."
@@ -4877,7 +4881,7 @@ msgstr ""
 
 #: src/strings.ts:769
 msgid "Please fill all the fields to continue."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1559
 msgid "Please grant notifications permission to add new reminders."
@@ -4889,7 +4893,7 @@ msgstr ""
 
 #: src/strings.ts:228
 msgid "Please note that we will respond to your issue on the given link. We recommend that you save it."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1768
 msgid "Please refer to the"
@@ -4905,7 +4909,7 @@ msgstr ""
 
 #: src/strings.ts:2394
 msgid "Please set a table size"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1561
 msgid "Please set title of the reminder"
@@ -4921,7 +4925,7 @@ msgstr ""
 
 #: src/strings.ts:262
 msgid "Please wait"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1009
 msgid "Please wait before requesting a new code"
@@ -4942,7 +4946,7 @@ msgstr ""
 
 #: src/strings.ts:214
 msgid "Please wait while we export your notes."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1897
 msgid "Please wait while we finalize your account."
@@ -4954,7 +4958,7 @@ msgstr ""
 
 #: src/strings.ts:404
 msgid "Please wait while we log you out."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1918
 msgid "Please wait while we reset your account password."
@@ -4970,7 +4974,7 @@ msgstr ""
 
 #: src/strings.ts:260
 msgid "Please wait while we sync all your data."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1074
 msgid "Please wait while we verify your subscription"
@@ -4987,7 +4991,7 @@ msgstr ""
 
 #: src/strings.ts:906
 msgid "Preparing note for share"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1618
 msgid "Preparing to restore backup file..."
@@ -4995,7 +4999,7 @@ msgstr ""
 
 #: src/strings.ts:428
 msgid "PRESETS"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2122
 msgid "Pressing \"—\" will hide the app in your system tray."
@@ -5023,7 +5027,7 @@ msgstr ""
 
 #: src/strings.ts:2447
 msgid "Previous tab"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2037
 msgid "Print"
@@ -5043,7 +5047,7 @@ msgstr ""
 
 #: src/strings.ts:828
 msgid "Privacy for everyone"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1183
 msgid "Privacy mode"
@@ -5051,7 +5055,7 @@ msgstr ""
 
 #: src/strings.ts:2577
 msgid "privacy policy"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1288
 msgid "Privacy policy"
@@ -5063,7 +5067,7 @@ msgstr ""
 
 #: src/strings.ts:162
 msgid "private analytics and bug reports."
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2700
 msgid "Private Key:"
@@ -5075,7 +5079,7 @@ msgstr ""
 
 #: src/strings.ts:830
 msgid "privileged few"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1724
 msgid "Pro"
@@ -5083,7 +5087,7 @@ msgstr ""
 
 #: src/strings.ts:2472
 msgid "Pro plan"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2050
 msgid "Processing {collection}..."
@@ -5111,11 +5115,11 @@ msgstr ""
 
 #: src/strings.ts:401
 msgid "Protect your notes"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2184
 msgid "Proxy"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2699
 msgid "Public Key:"
@@ -5135,7 +5139,7 @@ msgstr ""
 
 #: src/strings.ts:489
 msgid "Publish your note to share it with others. You can set a password to protect it."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:929
 msgid "Published"
@@ -5155,7 +5159,7 @@ msgstr ""
 
 #: src/strings.ts:2570
 msgid "Purchase"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1374
 msgid "Quick note"
@@ -5171,7 +5175,7 @@ msgstr ""
 
 #: src/strings.ts:2443
 msgid "Quick open"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1246
 msgid "Quickly create a note from the notification"
@@ -5179,7 +5183,7 @@ msgstr ""
 
 #: src/strings.ts:2335
 msgid "Quote"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1360
 msgid "Rate Notesnook on App Store"
@@ -5195,7 +5199,7 @@ msgstr ""
 
 #: src/strings.ts:386
 msgid "Read full release notes on Github"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:915
 msgid "Read only"
@@ -5219,7 +5223,7 @@ msgstr ""
 
 #: src/strings.ts:2547
 msgid "Ready to take the next step on your private note taking journey?"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2226
 msgid "Receipt"
@@ -5235,7 +5239,7 @@ msgstr ""
 
 #: src/strings.ts:2401
 msgid "Recheck all"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2004
 msgid "Rechecking failed"
@@ -5255,7 +5259,7 @@ msgstr ""
 
 #: src/strings.ts:435
 msgid "Recover your account"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:94
 msgid "Recovery email has been sent to your email address. Please check your inbox and follow the instructions to recover your account."
@@ -5275,7 +5279,7 @@ msgstr ""
 
 #: src/strings.ts:876
 msgid "Recovery key text file saved"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1919
 msgid "Recovery successful!"
@@ -5303,7 +5307,7 @@ msgstr ""
 
 #: src/strings.ts:372
 msgid "Referenced in"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:938
 msgid "References"
@@ -5311,7 +5315,7 @@ msgstr ""
 
 #: src/strings.ts:521
 msgid "Regenerate"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2090
 msgid "Register"
@@ -5327,7 +5331,7 @@ msgstr ""
 
 #: src/strings.ts:658
 msgid "Relevance"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1673
 msgid "Reload app"
@@ -5347,7 +5351,7 @@ msgstr ""
 
 #: src/strings.ts:371
 msgid "Remind me in"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1509
 msgid "Remind me of..."
@@ -5359,7 +5363,7 @@ msgstr ""
 
 #: src/strings.ts:298
 msgid "Reminder"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1249
 msgid "Reminder notifications"
@@ -5389,7 +5393,7 @@ msgstr ""
 
 #: src/strings.ts:783
 msgid "Remove"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1178
 msgid "Remove all notes from the vault."
@@ -5417,7 +5421,7 @@ msgstr ""
 
 #: src/strings.ts:2319
 msgid "Remove attachment"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:934
 msgid "Remove from all"
@@ -5429,7 +5433,7 @@ msgstr ""
 
 #: src/strings.ts:2459
 msgid "Remove from recents"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1047
 msgid "Remove full name"
@@ -5437,7 +5441,7 @@ msgstr ""
 
 #: src/strings.ts:2266
 msgid "Remove link"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1043
 msgid "Remove profile picture"
@@ -5473,7 +5477,7 @@ msgstr ""
 
 #: src/strings.ts:2380
 msgid "Replace all"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2167
 msgid "Report"
@@ -5494,7 +5498,7 @@ msgstr ""
 #. placeholder {0}: seconds ? ` in ${seconds}` : ""
 #: src/strings.ts:678
 msgid "Resend code{0}"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1405
 msgid "Resend email"
@@ -5510,7 +5514,7 @@ msgstr ""
 
 #: src/strings.ts:2486
 msgid "Reset homepage"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1824
 msgid "Reset selection"
@@ -5554,7 +5558,7 @@ msgstr ""
 
 #: src/strings.ts:569
 msgid "Restore"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1238
 msgid "Restore backup"
@@ -5566,7 +5570,7 @@ msgstr ""
 
 #: src/strings.ts:891
 msgid "Restore failed"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1613
 msgid "Restore from files"
@@ -5590,7 +5594,7 @@ msgstr ""
 
 #: src/strings.ts:377
 msgid "Restoring {collection}..."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1615
 msgid "Restoring backup..."
@@ -5602,7 +5606,7 @@ msgstr ""
 
 #: src/strings.ts:688
 msgid "Resubscribe to Pro"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2672
 msgid "Retry"
@@ -5610,7 +5614,7 @@ msgstr ""
 
 #: src/strings.ts:514
 msgid "Reupload"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2023
 msgid "Reveal in list"
@@ -5618,11 +5622,11 @@ msgstr ""
 
 #: src/strings.ts:152
 msgid "Revoke"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1182
 msgid "Revoke biometric unlocking"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2686
 msgid "Revoke Inbox API Key - {name}"
@@ -5630,7 +5634,7 @@ msgstr ""
 
 #: src/strings.ts:450
 msgid "Revoke vault fingerprint unlock"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1296
 msgid "Roadmap"
@@ -5654,7 +5658,7 @@ msgstr ""
 
 #: src/strings.ts:546
 msgid "Run file check"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2062
 msgid "Safe & encrypted notes"
@@ -5690,7 +5694,7 @@ msgstr ""
 
 #: src/strings.ts:584
 msgid "Save and continue"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1051
 msgid "Save data recovery key"
@@ -5710,7 +5714,7 @@ msgstr ""
 
 #: src/strings.ts:594
 msgid "Save to text file"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:499
 msgid "Save your 2FA backup codes in a safe place. You will need them to log into your account in case you lose access to your two-factor authentication methods."
@@ -5722,11 +5726,11 @@ msgstr ""
 
 #: src/strings.ts:492
 msgid "Save your account recovery key in a safe place. You will need it to recover your account in case you forget your password."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1053
 msgid "Save your data recovery key in a safe place. You will need it to recover your data in case you forget your password."
-msgstr ">>>>>>> Stashed changes"
+msgstr ""
 
 #: src/strings.ts:2398
 msgid "Saved"
@@ -5734,7 +5738,7 @@ msgstr ""
 
 #: src/strings.ts:2399
 msgid "Saving"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1591
 msgid "Saving this note is taking too long. Copy your changes and restart the app to prevent data loss. If the problem persists, please report it to us at support@streetwriters.co."
@@ -5746,7 +5750,7 @@ msgstr ""
 
 #: src/strings.ts:798
 msgid "Saving zip file. Please wait..."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1725
 msgid "Scan the QR code with your authenticator app"
@@ -5762,7 +5766,7 @@ msgstr ""
 
 #: src/strings.ts:2496
 msgid "Scroll to top"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1513
 #: src/strings.ts:1531
@@ -5779,7 +5783,7 @@ msgstr ""
 
 #: src/strings.ts:2440
 msgid "Search for notes, notebooks, and tags..."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1541
 msgid "Search in {routeName}"
@@ -5835,7 +5839,7 @@ msgstr ""
 
 #: src/strings.ts:2361
 msgid "Search languages"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1494
 msgid "Search notebooks"
@@ -5855,7 +5859,7 @@ msgstr ""
 
 #: src/strings.ts:879
 msgid "sec"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2146
 msgid "Security & privacy"
@@ -5883,7 +5887,7 @@ msgstr ""
 
 #: src/strings.ts:2491
 msgid "Select a notebook to move this notebook into, or unselect to move it to the root level."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2101
 msgid "Select a theme"
@@ -5907,7 +5911,7 @@ msgstr ""
 
 #: src/strings.ts:338
 msgid "Select day of the week to repeat the reminder."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1766
 msgid "Select files to import"
@@ -5947,7 +5951,7 @@ msgstr ""
 
 #: src/strings.ts:342
 msgid "Select nth day of the month to repeat the reminder."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1820
 msgid "Select profile picture"
@@ -5959,7 +5963,7 @@ msgstr ""
 
 #: src/strings.ts:374
 msgid "Select the folder that includes your backup files to list them here."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2133
 msgid "Select the languages the spell checker should check in."
@@ -5975,7 +5979,7 @@ msgstr ""
 
 #: src/strings.ts:269
 msgid "Self destruct"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2168
 msgid "Send"
@@ -5991,7 +5995,7 @@ msgstr ""
 
 #: src/strings.ts:130
 msgid "Send code via SMS"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1862
 msgid "Send recovery email"
@@ -6039,7 +6043,7 @@ msgstr ""
 
 #: src/strings.ts:97
 msgid "Session expired"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2194
 msgid "Sessions"
@@ -6063,7 +6067,7 @@ msgstr ""
 
 #: src/strings.ts:730
 msgid "Set as light theme"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1336
 msgid "Set automatic trash cleanup interval from Settings > Behaviour > Clean trash interval."
@@ -6071,7 +6075,7 @@ msgstr ""
 
 #: src/strings.ts:2633
 msgid "Set expiry"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1313
 msgid "Set full name"
@@ -6125,7 +6129,7 @@ msgid ""
 "http://username:password@foobar:80\n"
 "\n"
 "To remove the proxy, simply erase everything in the input."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1198
 msgid "Setup app lock password"
@@ -6137,7 +6141,7 @@ msgstr ""
 
 #: src/strings.ts:682
 msgid "Setup secondary 2FA method"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:981
 msgid "Setup using an Authenticator app"
@@ -6153,7 +6157,7 @@ msgstr ""
 
 #: src/strings.ts:155
 msgid "Share"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1694
 msgid "Share & append to notes from anywhere"
@@ -6165,11 +6169,11 @@ msgstr ""
 
 #: src/strings.ts:453
 msgid "Share note"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1790
 msgid "Share Notesnook with friends!"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2645
 msgid "Share things to Notesbook from anywhere using the Inbox API"
@@ -6185,7 +6189,7 @@ msgstr ""
 
 #: src/strings.ts:302
 msgid "Shortcut"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2003
 msgid "Shortcut removed"
@@ -6201,7 +6205,7 @@ msgstr ""
 
 #: src/strings.ts:96
 msgid "Sign up"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1033
 msgid "Signed up on {date}"
@@ -6217,7 +6221,7 @@ msgstr ""
 
 #: src/strings.ts:2330
 msgid "Sink list item"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2044
 msgid "Size"
@@ -6225,7 +6229,7 @@ msgstr ""
 
 #: src/strings.ts:551
 msgid "Skip"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1832
 msgid "Skip & go directly to the app"
@@ -6233,7 +6237,7 @@ msgstr ""
 
 #: src/strings.ts:674
 msgid "Skip introduction"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1607
 msgid "Some exported notes are locked, Unlock to export them"
@@ -6253,7 +6257,7 @@ msgstr ""
 
 #: src/strings.ts:537
 msgid "Sort by"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2152
 msgid "Source code"
@@ -6265,7 +6269,7 @@ msgstr ""
 
 #: src/strings.ts:2592
 msgid "Special Offer"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2129
 msgid "Spell check"
@@ -6277,7 +6281,7 @@ msgstr ""
 
 #: src/strings.ts:2462
 msgid "Stable"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1115
 msgid "Start"
@@ -6309,7 +6313,7 @@ msgstr ""
 
 #: src/strings.ts:199
 msgid "Start writing to save your note."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1604
 msgid "Start writing your note..."
@@ -6321,7 +6325,7 @@ msgstr ""
 
 #: src/strings.ts:2475
 msgid "Storage"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1551
 msgid "Streaming not supported"
@@ -6329,7 +6333,7 @@ msgstr ""
 
 #: src/strings.ts:2262
 msgid "Strikethrough"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2227
 msgid "Subgroup 1"
@@ -6349,7 +6353,7 @@ msgstr ""
 
 #: src/strings.ts:2572
 msgid "Subscribe and start free trial"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1028
 msgid "Subscribe to Pro"
@@ -6361,7 +6365,7 @@ msgstr ""
 
 #: src/strings.ts:701
 msgid "Subscribed on iOS"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1308
 msgid "Subscribed on web"
@@ -6381,7 +6385,7 @@ msgstr ""
 
 #: src/strings.ts:695
 msgid "Subscription awarded from Streetwriters"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1032
 msgid "Subscription details"
@@ -6401,7 +6405,7 @@ msgstr ""
 
 #: src/strings.ts:2274
 msgid "Superscript"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1472
 msgid "Switch to search/replace mode"
@@ -6413,7 +6417,7 @@ msgstr ""
 
 #: src/strings.ts:393
 msgid "Sync failed"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1366
 msgid "Sync is disabled"
@@ -6421,7 +6425,7 @@ msgstr ""
 
 #: src/strings.ts:392
 msgid "Sync now"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:916
 msgid "Sync off"
@@ -6449,7 +6453,7 @@ msgstr ""
 
 #: src/strings.ts:259
 msgid "Syncing your data"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1705
 msgid "Syncing your notes"
@@ -6506,7 +6510,7 @@ msgstr ""
 
 #: src/strings.ts:2341
 msgid "Take a photo using camera"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1376
 msgid "Take note"
@@ -6518,7 +6522,7 @@ msgstr ""
 
 #: src/strings.ts:675
 msgid "Taking too long? Reload editor"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1460
 msgid "Tap here to change sorting"
@@ -6554,7 +6558,7 @@ msgstr ""
 
 #: src/strings.ts:669
 msgid "Tap to stop reordering"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1356
 msgid "Tap to try again"
@@ -6570,7 +6574,7 @@ msgstr ""
 
 #: src/strings.ts:2417
 msgid "Tasks"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1165
 msgid "Telemetry"
@@ -6585,7 +6589,7 @@ msgid ""
 "- What did you expect to happen?\n"
 "- Steps to reproduce the issue\n"
 "- Things you have tried etc."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1497
 msgid "Tell us what happened"
@@ -6601,7 +6605,7 @@ msgstr ""
 
 #: src/strings.ts:2579
 msgid "terms of use."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1625
 msgid "Test connection"
@@ -6617,7 +6621,7 @@ msgstr ""
 
 #: src/strings.ts:2283
 msgid "Text direction"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1789
 msgid "Thank you for choosing end-to-end encrypted note taking. Now you can sync your notes to unlimited devices."
@@ -6637,7 +6641,7 @@ msgstr ""
 
 #: src/strings.ts:479
 msgid "Thank you for updating Notesnook! We will be applying some minor changes for a better note taking experience."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2078
 msgid "Thank you. You are the proof that privacy always comes first."
@@ -6657,7 +6661,7 @@ msgstr ""
 
 #: src/strings.ts:2606
 msgid "The Notesnook Circle is exclusive to subscribers. Please consider subscribing to gain access to Notesnook Circle and enjoy additional benefits."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2085
 msgid "The password/pin for unlocking the app."
@@ -6669,7 +6673,7 @@ msgstr ""
 
 #: src/strings.ts:340
 msgid "The reminder will repeat every year on {date}."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1715
 msgid "The reminder will start on {date} at {time}."
@@ -6693,7 +6697,7 @@ msgstr ""
 
 #: src/strings.ts:2240
 msgid "These items will be **kept in your Trash for {interval} days** after which they will be permanently deleted."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1923
 msgid "This action is IRREVERSIBLE."
@@ -6701,7 +6705,7 @@ msgstr ""
 
 #: src/strings.ts:173
 msgid "This device"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1686
 msgid "This error can be fixed by rebuilding the search index. This action won't result in any kind of data loss."
@@ -6725,7 +6729,7 @@ msgstr ""
 
 #: src/strings.ts:1684
 msgid "This error usually means the search index is corrupted."
-msgstr "<<<<<<< HEAD<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2710
 msgid "This feature is not available on this plan."
@@ -6737,7 +6741,7 @@ msgstr ""
 
 #: src/strings.ts:2573
 msgid "This is a one time purchase, no subscription."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2048
 msgid "This may take a while"
@@ -6750,7 +6754,7 @@ msgstr ""
 
 #: src/strings.ts:2638
 msgid "This note is empty"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1597
 msgid "This note is locked"
@@ -6770,7 +6774,7 @@ msgstr ""
 
 #: src/strings.ts:264
 msgid "This note will be published to a public URL."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2094
 msgid "This username will be used to distinguish between different credentials in your security key. Make sure it is unique."
@@ -6780,13 +6784,17 @@ msgstr ""
 msgid "This version of Notesnook app does not support in-app purchases. Kindly login on the Notesnook web app to make the purchase."
 msgstr ""
 
+#: src/strings.ts:2714
+msgid "This will reset your current two-factor authentication setup. Do you want to proceed?"
+msgstr ""
+
 #: src/strings.ts:627
 msgid "Thu"
 msgstr ""
 
 #: src/strings.ts:618
 msgid "Thursday"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1845
 msgid "Time"
@@ -6803,7 +6811,7 @@ msgstr ""
 #: src/strings.ts:650
 #: src/strings.ts:655
 msgid "Title"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1160
 msgid "Title format"
@@ -6831,7 +6839,7 @@ msgstr ""
 
 #: src/strings.ts:2454
 msgid "Toggle theme"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2135
 msgid "Toolbar"
@@ -6860,7 +6868,7 @@ msgstr ""
 
 #: src/strings.ts:2543
 msgid "Try {plan} for free"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1468
 msgid "Try compact mode to fit more items on screen"
@@ -6880,7 +6888,7 @@ msgstr ""
 
 #: src/strings.ts:616
 msgid "Tuesday"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1089
 msgid "Turn off automatic syncing. Changes from this client will be synced only when you run sync manually."
@@ -6892,7 +6900,7 @@ msgstr ""
 
 #: src/strings.ts:894
 msgid "Turn on reminder"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1095
 msgid "Turns off syncing completely on this device. Any changes made will remain local only and new changes from your other devices won't sync to this device."
@@ -6912,7 +6920,7 @@ msgstr ""
 
 #: src/strings.ts:503
 msgid "Two-factor authentication enabled"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1505
 msgid "Type # to search for headings"
@@ -6948,7 +6956,7 @@ msgstr ""
 
 #: src/strings.ts:2583
 msgid "Unlimited"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:933
 msgid "Unlink from all"
@@ -6964,7 +6972,7 @@ msgstr ""
 
 #: src/strings.ts:2630
 msgid "Unlock incoming note"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1386
 msgid "Unlock more colors with Notesnook Pro"
@@ -6977,11 +6985,11 @@ msgstr ""
 
 #: src/strings.ts:889
 msgid "Unlock note to delete it"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2641
 msgid "Unlock note to merge conflicts"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1211
 msgid "Unlock the app with biometric authentication. This requires biometrics to be enabled on your device."
@@ -6993,7 +7001,7 @@ msgstr ""
 
 #: src/strings.ts:545
 msgid "Unlock with biometrics"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1830
 msgid "Unlock with security key"
@@ -7001,7 +7009,7 @@ msgstr ""
 
 #: src/strings.ts:57
 msgid "Unlock your notes"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1181
 msgid "Unlock your vault with biometric authentication"
@@ -7013,7 +7021,7 @@ msgstr ""
 
 #: src/strings.ts:900
 msgid "Unpin"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:930
 msgid "Unpin notification"
@@ -7021,7 +7029,7 @@ msgstr ""
 
 #: src/strings.ts:588
 msgid "Unpublish"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1480
 msgid "Unpublish notes to delete them"
@@ -7046,7 +7054,7 @@ msgstr ""
 
 #: src/strings.ts:380
 msgid "Update available"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1373
 msgid "Update now"
@@ -7054,7 +7062,7 @@ msgstr ""
 
 #: src/strings.ts:2503
 msgid "Upgrade"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1921
 msgid "Upgrade now"
@@ -7066,7 +7074,7 @@ msgstr ""
 
 #: src/strings.ts:2528
 msgid "Upgrade plan to {plan} to use this feature."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1942
 msgid "Upgrade to Notesnook Pro to add colors."
@@ -7090,7 +7098,7 @@ msgstr ""
 
 #: src/strings.ts:2340
 msgid "Upload from disk"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:512
 #: src/strings.ts:1654
@@ -7116,7 +7124,7 @@ msgstr ""
 
 #: src/strings.ts:2390
 msgid "URL"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1792
 msgid "Use"
@@ -7124,7 +7132,7 @@ msgstr ""
 
 #: src/strings.ts:462
 msgid "Use {keyboardShortcut}+click to select multiple notebooks"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1805
 msgid "Use a backup file"
@@ -7140,7 +7148,7 @@ msgstr ""
 
 #: src/strings.ts:2535
 msgid "Use advanced note taking features like"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:982
 msgid "Use an authenticator app to generate 2FA codes."
@@ -7189,7 +7197,7 @@ msgid ""
 "$count$: Number of notes + 1.\n"
 "$headline$: Use starting line of the note as title.\n"
 "$day$: Current day (eg. Monday)"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1102
 msgid "Use this if changes from other devices are not appearing on this device. This will overwrite the data on this device with the latest data from the server."
@@ -7201,7 +7209,7 @@ msgstr ""
 
 #: src/strings.ts:2476
 msgid "used"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1021
 msgid "User verification failed"
@@ -7213,11 +7221,11 @@ msgstr ""
 
 #: src/strings.ts:2255
 msgid "Using official Notesnook instance"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1712
 msgid "v{version} available"
-msgstr "<<<<<<< HEAD<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2712
 msgid "Value must be between {min} and {max}"
@@ -7233,7 +7241,7 @@ msgstr ""
 
 #: src/strings.ts:814
 msgid "Vault created"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1996
 msgid "Vault deleted"
@@ -7241,7 +7249,7 @@ msgstr ""
 
 #: src/strings.ts:449
 msgid "Vault fingerprint unlock"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1934
 msgid "Vault locked"
@@ -7257,7 +7265,7 @@ msgstr ""
 
 #: src/strings.ts:576
 msgid "Verify"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1072
 msgid "Verify subscription"
@@ -7293,11 +7301,11 @@ msgstr ""
 
 #: src/strings.ts:571
 msgid "View all linked notebooks"
-msgstr "<<<<<<< HEAD"
+msgstr ""
 
 #: src/strings.ts:2650
 msgid "View and edit your inbox public/private key pair"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2656
 msgid "View and manage inbox API keys"
@@ -7325,7 +7333,7 @@ msgstr ""
 
 #: src/strings.ts:416
 msgid "Visit homepage"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1353
 msgid "Wait 30 seconds to try again"
@@ -7341,7 +7349,7 @@ msgstr ""
 
 #: src/strings.ts:474
 msgid "We are sorry, it seems that the app crashed due to an error. You can submit a bug report below so we can fix this asap."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1393
 msgid "We have sent you an email confirmation link. Please check your email inbox. If you cannot find the email, check your spam folder."
@@ -7349,7 +7357,7 @@ msgstr ""
 
 #: src/strings.ts:2514
 msgid "We require credit card details to fight abuse and to make it seamless for you to upgrade. Your credit card is NOT charged until your free trial ends and your subscription starts. You will be notified via email of the upcoming charge before your trial ends."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2170
 msgid "We send you occasional promotional offers & product updates on your email (once every month)."
@@ -7369,7 +7377,7 @@ msgstr ""
 
 #: src/strings.ts:2325
 msgid "Web clip settings"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2032
 msgid "Website"
@@ -7398,7 +7406,7 @@ msgstr ""
 
 #: src/strings.ts:781
 msgid "Welcome back, {email}"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1891
 msgid "Welcome back!"
@@ -7406,7 +7414,7 @@ msgstr ""
 
 #: src/strings.ts:2586
 msgid "Welcome to Notesnook {plan}"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2076
 msgid "Welcome to Notesnook Pro"
@@ -7422,7 +7430,7 @@ msgstr ""
 
 #: src/strings.ts:2522
 msgid "What is your refund policy?"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1670
 msgid "What went wrong?"
@@ -7446,7 +7454,7 @@ msgstr ""
 
 #: src/strings.ts:824
 msgid "Write notes with freedom, no spying, no tracking."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1377
 msgid "Write something..."
@@ -7487,7 +7495,7 @@ msgstr ""
 
 #: src/strings.ts:2242
 msgid "You are editing \"{notebookTitle}\"."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2046
 msgid "You are editing #{tag}"
@@ -7507,7 +7515,7 @@ msgstr ""
 
 #: src/strings.ts:464
 msgid "You can also link a note to multiple Notebooks. Tap and hold any notebook to enable multi-select."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2067
 msgid "You can change the theme at any time from Settings or the side menu."
@@ -7519,7 +7527,7 @@ msgstr ""
 
 #: src/strings.ts:2423
 msgid "You can create shortcuts of frequently accessed notebooks in the side menu"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2082
 msgid "You can import your notes from most other note taking apps."
@@ -7552,7 +7560,7 @@ msgstr ""
 
 #: src/strings.ts:226
 msgid "You can track your issue at "
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1031
 msgid "You can use all premium features for free for the next 14 days"
@@ -7580,7 +7588,7 @@ msgstr ""
 
 #: src/strings.ts:2590
 msgid "You have made a one time purchase. To change your plan please contact support."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:967
 msgid "You have not added any notebooks yet"
@@ -7616,7 +7624,7 @@ msgstr ""
 
 #: src/strings.ts:837
 msgid "You simply cannot get any better of a note taking app than @notesnook. The UI is clean and slick, it is feature rich, encrypted, reasonably priced (esp. for students & educators) & open source"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1071
 msgid "You subscribed to Notesnook Pro on {date}. Verify this subscription?"
@@ -7644,7 +7652,7 @@ msgstr ""
 
 #: src/strings.ts:468
 msgid "You will be logged out from all your devices"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1854
 msgid "You will receive instructions on how to recover your account on this email"
@@ -7652,7 +7660,7 @@ msgstr ""
 
 #: src/strings.ts:467
 msgid "Your account email will be changed without affecting your subscription or any other settings."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1920
 msgid "Your account has been recovered."
@@ -7681,7 +7689,7 @@ msgstr ""
 
 #: src/strings.ts:2488
 msgid "Your archive is empty"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1932
 msgid "Your backup is ready to download"
@@ -7701,7 +7709,7 @@ msgstr ""
 
 #: src/strings.ts:2597
 msgid "Your current subscription does not allow changing plans"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1804
 msgid "Your data recovery key is basically a hashed version of your password (plus some random salt). It can be used to decrypt your data for re-encryption."
@@ -7713,7 +7721,7 @@ msgstr ""
 
 #: src/strings.ts:2508
 msgid "Your data remains 100% accessible regardless of what plan you are on. That includes your notes, notebooks, attachments, and anything else you might have created."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1787
 msgid "Your email has been confirmed."
@@ -7725,7 +7733,7 @@ msgstr ""
 
 #: src/strings.ts:767
 msgid "Your email is not confirmed. Please confirm your email address to change account password."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:957
 msgid "Your favorites"
@@ -7749,7 +7757,7 @@ msgstr ""
 
 #: src/strings.ts:2625
 msgid "Your free trial is on-going. Your subscription will start on {trialExpiryDate}"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1781
 msgid "Your full name"
@@ -7765,7 +7773,7 @@ msgstr ""
 
 #: src/strings.ts:562
 msgid "Your note will be unencrypted and removed from the vault."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:960
 msgid "Your notebooks"
@@ -7781,7 +7789,7 @@ msgstr ""
 
 #: src/strings.ts:833
 msgid "Your privacy matters to us, no matter who you are. In a world where everyone is trying to spy on you, Notesnook encrypts all your data before it leaves your device. With Notesnook no one can ever sell your data again."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1312
 msgid "Your profile pictrure is stored 100% end-to-end encrypted and only visible to you."
@@ -7797,7 +7805,7 @@ msgstr ""
 
 #: src/strings.ts:99
 msgid "Your session has expired. Please enter password for {obfuscatedEmail} to continue."
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:1038
 msgid "Your subscription ends on {date}"
@@ -7833,7 +7841,7 @@ msgstr ""
 
 #: src/strings.ts:2464
 msgid "Zoom"
-msgstr "<<<<<<< Updated upstream"
+msgstr ""
 
 #: src/strings.ts:2096
 msgid "Zoom factor"

--- a/packages/intl/locale/pseudo-LOCALE.po
+++ b/packages/intl/locale/pseudo-LOCALE.po
@@ -13,35 +13,35 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/strings.ts:2412
+#: src/strings.ts:2413
 msgid " \"Notebook > Notes\""
 msgstr ""
 
 #: src/strings.ts:148
 msgid " Unlock with password once to enable biometric access."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1943
+#: src/strings.ts:1944
 msgid " Upgrade to Notesnook Pro to add more notebooks."
 msgstr ""
 
-#: src/strings.ts:1946
+#: src/strings.ts:1947
 msgid " Upgrade to Notesnook Pro to customize the toolbar."
 msgstr ""
 
-#: src/strings.ts:1945
+#: src/strings.ts:1946
 msgid " Upgrade to Notesnook Pro to use custom toolbar presets."
 msgstr ""
 
-#: src/strings.ts:1944
+#: src/strings.ts:1945
 msgid " Upgrade to Notesnook Pro to use the notes vault."
 msgstr ""
 
-#: src/strings.ts:1947
+#: src/strings.ts:1948
 msgid " Upgrade to Notesnook Pro to use this feature."
 msgstr ""
 
-#: src/strings.ts:828
+#: src/strings.ts:829
 msgid "— not just the"
 msgstr ""
 
@@ -59,36 +59,36 @@ msgid "{0}"
 msgstr ""
 
 #. placeholder {0}: name || "File"
-#: src/strings.ts:515
+#: src/strings.ts:516
 msgid "{0} downloaded"
 msgstr ""
 
 #. placeholder {0}: version ? `v${version} ` : "New version"
-#: src/strings.ts:533
+#: src/strings.ts:534
 msgid "{0} Highlights 🎉"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1755
+#: src/strings.ts:1756
 msgid "{count, plural, one {# error occured} other {# errors occured}}"
 msgstr ""
 
-#: src/strings.ts:1761
+#: src/strings.ts:1762
 msgid "{count, plural, one {# file ready for import} other {# files ready for import}}"
 msgstr ""
 
-#: src/strings.ts:1716
+#: src/strings.ts:1717
 msgid "{count, plural, one {# file} other {# files}}"
 msgstr ""
 
 #: src/strings.ts:60
 msgid "{count, plural, one {# note} other {# notes}}"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1580
+#: src/strings.ts:1581
 msgid "{count, plural, one {1 hour} other {# hours}}"
 msgstr ""
 
-#: src/strings.ts:1575
+#: src/strings.ts:1576
 msgid "{count, plural, one {1 minute} other {# minutes}}"
 msgstr ""
 
@@ -129,7 +129,7 @@ msgstr ""
 msgid "{count, plural, one {Are you sure you want to download all attachments of this note?} other {Are you sure you want to download all attachments?}}"
 msgstr ""
 
-#: src/strings.ts:863
+#: src/strings.ts:864
 msgid "{count, plural, one {Are you sure you want to move this notebook to {selectedNotebookTitle}?} other {Are you sure you want to move these # notebooks {selectedNotebookTitle}?}}"
 msgstr ""
 
@@ -288,11 +288,11 @@ msgstr ""
 msgid "{count, plural, one {Item unpublished} other {# items unpublished}}"
 msgstr ""
 
-#: src/strings.ts:2429
+#: src/strings.ts:2430
 msgid "{count, plural, one {Move all notes in this notebook to trash} other {Move all notes in these notebooks to trash}}"
 msgstr ""
 
-#: src/strings.ts:861
+#: src/strings.ts:862
 msgid "{count, plural, one {Move notebook} other {Move # notebooks}}"
 msgstr ""
 
@@ -334,9 +334,9 @@ msgstr ""
 
 #: generated/actions.ts:118
 msgid "{count, plural, one {Note unpublished} other {# notes unpublished}}"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:922
+#: src/strings.ts:923
 msgid "{count, plural, one {Note will be automatically deleted from all other devices & any future changes won't get synced. Are you sure you want to continue?} other {# notes will be automatically deleted from all other devices & any future changes won't get synced. Are you sure you want to continue?}}"
 msgstr ""
 
@@ -388,9 +388,9 @@ msgstr ""
 
 #: generated/do-actions.ts:88
 msgid "{count, plural, one {Pin notebook} other {Pin # notebooks}}"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:917
+#: src/strings.ts:918
 msgid "{count, plural, one {Prevent note from syncing} other {Prevent # notes from syncing}}"
 msgstr ""
 
@@ -491,15 +491,15 @@ msgstr ""
 msgid "{count, plural, one {Unpublish note} other {Unpublish # notes}}"
 msgstr ""
 
-#: src/strings.ts:2499
+#: src/strings.ts:2500
 msgid "{count} characters"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1566
+#: src/strings.ts:1567
 msgid "{days, plural, one {1 day} other {# days}}"
 msgstr ""
 
-#: src/strings.ts:2559
+#: src/strings.ts:2560
 msgid "{days} days free"
 msgstr ""
 
@@ -531,51 +531,51 @@ msgstr ""
 msgid "{mode, select, create {Create app lock {keyboardType}} change {Change app lock {keyboardType}} remove {Remove app lock {keyboardType}} other {}}"
 msgstr ""
 
-#: src/strings.ts:605
+#: src/strings.ts:606
 msgid "{mode, select, day {Daily} week {Weekly} month {Monthly} year {Yearly} other {Unknown mode}}"
 msgstr ""
 
-#: src/strings.ts:598
+#: src/strings.ts:599
 msgid "{mode, select, repeat {Repeat} once {Once} permanent {Permanent} other {Unknown mode}}"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1978
+#: src/strings.ts:1979
 msgid "{n} {added, plural, one {added to 1 notebook} other {added to # notebooks}} and {removed, plural, one {removed from 1 notebook} other {removed from # notebooks}}."
 msgstr ""
 
-#: src/strings.ts:1973
+#: src/strings.ts:1974
 msgid "{n} {added, plural, one {added to 1 notebook} other {added to # notebooks}}."
 msgstr ""
 
-#: src/strings.ts:1968
+#: src/strings.ts:1969
 msgid "{n} {removed, plural, one {removed from 1 notebook} other {removed from # notebooks}}."
 msgstr ""
 
-#: src/strings.ts:1963
+#: src/strings.ts:1964
 msgid "{notes, plural, one {1 note} other {# notes}}"
 msgstr ""
 
 #: src/strings.ts:471
 msgid "{notes, plural, one {Export note} other {Export # notes}}"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1708
+#: src/strings.ts:1709
 msgid "{percentage}% updating..."
 msgstr ""
 
-#: src/strings.ts:2543
+#: src/strings.ts:2544
 msgid "{plan} plan"
 msgstr ""
 
-#: src/strings.ts:743
+#: src/strings.ts:744
 msgid "{platform, select, android {{name} saved to selected path} other {{name} saved to File Manager/Notesnook/downloads}}"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1339
+#: src/strings.ts:1340
 msgid "{platform, select, android {Backup file saved in \"Notesnook backups\" folder on your phone.} other {Backup file is saved in File Manager/Notesnook folder}}"
 msgstr ""
 
-#: src/strings.ts:2359
+#: src/strings.ts:2360
 msgid "{selected} selected"
 msgstr ""
 
@@ -591,67 +591,75 @@ msgstr ""
 msgid "{type, select, upload {Uploading} download {Downloading} sync {Syncing} other {Loading}}"
 msgstr ""
 
-#: src/strings.ts:785
+#: src/strings.ts:786
 msgid "{type} does not match"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1601
+#: src/strings.ts:1602
 msgid "{words, plural, one {# word} other {# words}}"
 msgstr ""
 
-#: src/strings.ts:1664
+#: src/strings.ts:1665
 msgid "{words, plural, other {# selected}}"
 msgstr ""
 
-#: src/strings.ts:1792
+#: src/strings.ts:1793
 msgid "#notesnook"
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2665
+#: src/strings.ts:2666
 msgid "1 day"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2667
+#: src/strings.ts:2668
 msgid "1 month"
 msgstr ""
 
-#: src/strings.ts:2666
+#: src/strings.ts:2667
 msgid "1 week"
 msgstr ""
 
-#: src/strings.ts:2668
+#: src/strings.ts:2669
 msgid "1 year"
 msgstr ""
 
-#: src/strings.ts:1585
+#: src/strings.ts:1586
 msgid "12-hour"
 msgstr ""
 
-#: src/strings.ts:1586
+#: src/strings.ts:1587
 msgid "24-hour"
 msgstr ""
 
-#: src/strings.ts:1906
+#: src/strings.ts:1008
+msgid "2FA backup codes copied!"
+msgstr ""
+
+#: src/strings.ts:1013
+msgid "2FA backup codes saved!"
+msgstr ""
+
+#: src/strings.ts:1907
 msgid "2FA code is required()"
 msgstr ""
 
-#: src/strings.ts:1010
+#: src/strings.ts:1011
 msgid "2FA code sent via {method}"
 msgstr ""
 
-#: src/strings.ts:2583
+#: src/strings.ts:2584
 msgid "5 year plan (One time purchase)"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1847
+#: src/strings.ts:1848
 msgid "6 digit code"
 msgstr ""
 
-#: src/strings.ts:1433
+#: src/strings.ts:1434
 msgid "A notebook can have unlimited topics with unlimited notes."
 msgstr ""
 
-#: src/strings.ts:647
+#: src/strings.ts:648
 msgid "A to Z"
 msgstr ""
 
@@ -659,71 +667,71 @@ msgstr ""
 msgid "A vault stores your notes in an encrypted storage."
 msgstr ""
 
-#: src/strings.ts:662
+#: src/strings.ts:663
 msgid "Abc"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1291
+#: src/strings.ts:1292
 msgid "About"
 msgstr ""
 
-#: src/strings.ts:1026
+#: src/strings.ts:1027
 msgid "Account"
 msgstr ""
 
-#: src/strings.ts:1849
+#: src/strings.ts:1850
 msgid "Account password"
 msgstr ""
 
-#: src/strings.ts:2454
+#: src/strings.ts:2455
 msgid "Actions for note: {title}"
 msgstr ""
 
-#: src/strings.ts:2455
+#: src/strings.ts:2456
 msgid "Actions for notebook: {title}"
 msgstr ""
 
-#: src/strings.ts:2456
+#: src/strings.ts:2457
 msgid "Actions for tag: {title}"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2039
+#: src/strings.ts:2040
 msgid "Activate"
 msgstr ""
 
-#: src/strings.ts:1825
+#: src/strings.ts:1826
 msgid "Activating trial"
 msgstr ""
 
-#: src/strings.ts:530
+#: src/strings.ts:531
 msgid "Add"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1058
+#: src/strings.ts:1059
 msgid "Add 2FA fallback method"
 msgstr ""
 
-#: src/strings.ts:1509
+#: src/strings.ts:1510
 msgid "Add a short note"
 msgstr ""
 
-#: src/strings.ts:1602
+#: src/strings.ts:1603
 msgid "Add a tag"
 msgstr ""
 
-#: src/strings.ts:557
+#: src/strings.ts:558
 msgid "Add color"
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2653
+#: src/strings.ts:2654
 msgid "Add key"
 msgstr ""
 
-#: src/strings.ts:895
+#: src/strings.ts:896
 msgid "Add notebook"
 msgstr ""
 
-#: src/strings.ts:2481
+#: src/strings.ts:2482
 msgid "Add notes"
 msgstr ""
 
@@ -731,71 +739,71 @@ msgstr ""
 msgid "Add notes to {title}"
 msgstr ""
 
-#: src/strings.ts:894
+#: src/strings.ts:895
 msgid "Add shortcut"
 msgstr ""
 
-#: src/strings.ts:737
+#: src/strings.ts:738
 msgid "Add shortcuts for notebooks and tags here."
 msgstr ""
 
-#: src/strings.ts:572
+#: src/strings.ts:573
 msgid "Add tag"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:935
+#: src/strings.ts:936
 msgid "Add tags"
 msgstr ""
 
-#: src/strings.ts:936
+#: src/strings.ts:937
 msgid "Add tags to multiple notes at once"
 msgstr ""
 
-#: src/strings.ts:2246
+#: src/strings.ts:2247
 msgid "Add to dictionary"
 msgstr ""
 
-#: src/strings.ts:2616
+#: src/strings.ts:2617
 msgid "Add to home"
 msgstr ""
 
-#: src/strings.ts:2479
+#: src/strings.ts:2480
 msgid "Add to notebook"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:976
+#: src/strings.ts:977
 msgid "Add your first note"
 msgstr ""
 
-#: src/strings.ts:977
+#: src/strings.ts:978
 msgid "Add your first notebook"
 msgstr ""
 
-#: src/strings.ts:2619
+#: src/strings.ts:2620
 msgid "Adjust the line height of the editor"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2173
+#: src/strings.ts:2174
 msgid "Advanced"
 msgstr ""
 
-#: src/strings.ts:1728
+#: src/strings.ts:1729
 msgid "After scanning the QR code image, the app will display a code that you can enter below."
 msgstr ""
 
-#: src/strings.ts:2311
+#: src/strings.ts:2312
 msgid "Align left"
 msgstr ""
 
-#: src/strings.ts:2312
+#: src/strings.ts:2313
 msgid "Align right"
 msgstr ""
 
-#: src/strings.ts:2281
+#: src/strings.ts:2282
 msgid "Alignment"
 msgstr ""
 
-#: src/strings.ts:726
+#: src/strings.ts:727
 msgid "All"
 msgstr ""
 
@@ -803,59 +811,59 @@ msgstr ""
 msgid "All attachments are end-to-end encrypted."
 msgstr ""
 
-#: src/strings.ts:2406
+#: src/strings.ts:2407
 msgid "All cached attachments have been cleared."
 msgstr ""
 
-#: src/strings.ts:767
+#: src/strings.ts:768
 msgid "All fields are required"
 msgstr ""
 
-#: src/strings.ts:754
+#: src/strings.ts:755
 msgid "All files"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1176
+#: src/strings.ts:1177
 msgid "All locked notes will be re-encrypted with the new password."
 msgstr ""
 
-#: src/strings.ts:739
+#: src/strings.ts:740
 msgid "All logs are local only and are not sent to any server. You can share the logs from here with us if you face an issue to help us find the root cause."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1639
+#: src/strings.ts:1640
 msgid "All server urls are required."
 msgstr ""
 
-#: src/strings.ts:1908
+#: src/strings.ts:1909
 msgid "All the data in your account will be overwritten with the data in the backup file. There is no way to reverse this action."
 msgstr ""
 
-#: src/strings.ts:2153
+#: src/strings.ts:2154
 msgid "All the source code for Notesnook is available & open for everyone on GitHub."
 msgstr ""
 
 #: src/strings.ts:430
 msgid "All tools are grouped"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1323
+#: src/strings.ts:1324
 msgid "All tools in the collapsed section will be removed"
 msgstr ""
 
-#: src/strings.ts:1318
+#: src/strings.ts:1319
 msgid "All tools in this group will be removed from the toolbar."
 msgstr ""
 
-#: src/strings.ts:1348
+#: src/strings.ts:1349
 msgid "All your backups are stored in 'Phone Storage/Notesnook/backups/' folder"
 msgstr ""
 
 #: src/strings.ts:108
 msgid "Already have an account?"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2223
+#: src/strings.ts:2224
 msgid "Amount"
 msgstr ""
 
@@ -863,146 +871,146 @@ msgstr ""
 msgid "An error occurred while migrating your data. You can logout of your account and try to relogin. However this is not recommended as it may result in some data loss if your data was not synced."
 msgstr ""
 
-#: src/strings.ts:2577
+#: src/strings.ts:2578
 msgid "and"
 msgstr ""
 
 #: src/strings.ts:103
 msgid "and "
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1793
+#: src/strings.ts:1794
 msgid "and get a chance to win free promo codes."
 msgstr ""
 
-#: src/strings.ts:2536
+#: src/strings.ts:2537
 msgid "and much more."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1399
+#: src/strings.ts:1400
 msgid "and we will manually confirm your account."
 msgstr ""
 
-#: src/strings.ts:2594
+#: src/strings.ts:2595
 msgid "ANNOUNCEMENT"
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2683
+#: src/strings.ts:2684
 msgid "API key copied to clipboard"
 msgstr ""
 
-#: src/strings.ts:2661
+#: src/strings.ts:2662
 msgid "API key created successfully"
 msgstr ""
 
-#: src/strings.ts:2688
+#: src/strings.ts:2689
 msgid "API key revoked"
 msgstr ""
 
-#: src/strings.ts:2654
+#: src/strings.ts:2655
 msgid "API Keys"
 msgstr ""
 
-#: src/strings.ts:2675
+#: src/strings.ts:2676
 msgid "API Keys Limit Reached"
 msgstr ""
 
 #: src/strings.ts:252
 msgid "App data has been cleared. Kindly relaunch the app to login again."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1185
-#: src/strings.ts:1695
+#: src/strings.ts:1186
+#: src/strings.ts:1696
 msgid "App lock"
 msgstr ""
 
-#: src/strings.ts:781
-#: src/strings.ts:1211
+#: src/strings.ts:782
+#: src/strings.ts:1212
 msgid "App lock disabled"
 msgstr ""
 
-#: src/strings.ts:1191
+#: src/strings.ts:1192
 msgid "App lock timeout"
 msgstr ""
 
-#: src/strings.ts:1302
+#: src/strings.ts:1303
 msgid "App version"
 msgstr ""
 
-#: src/strings.ts:1776
+#: src/strings.ts:1777
 msgid "App will reload in {sec} seconds"
 msgstr ""
 
-#: src/strings.ts:1116
+#: src/strings.ts:1117
 msgid "Appearance"
 msgstr ""
 
-#: src/strings.ts:539
+#: src/strings.ts:540
 msgid "Applied as dark theme"
 msgstr ""
 
-#: src/strings.ts:540
+#: src/strings.ts:541
 msgid "Applied as light theme"
 msgstr ""
 
 #: src/strings.ts:457
 msgid "Apply changes"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2046
+#: src/strings.ts:2047
 msgid "Applying changes"
 msgstr ""
 
-#: src/strings.ts:1532
-#: src/strings.ts:2486
+#: src/strings.ts:1533
+#: src/strings.ts:2487
 msgid "Archive"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1447
+#: src/strings.ts:1448
 msgid "Are you scrolling a lot to find a specific note? Pin it to the top from Note properties."
 msgstr ""
 
-#: src/strings.ts:1018
+#: src/strings.ts:1019
 msgid "Are you sure you want to clear all logs from {key}?"
 msgstr ""
 
-#: src/strings.ts:1326
+#: src/strings.ts:1327
 msgid "Are you sure you want to clear trash?"
 msgstr ""
 
-#: src/strings.ts:1544
+#: src/strings.ts:1545
 msgid "Are you sure you want to logout and clear all data stored on THIS DEVICE?"
 msgstr ""
 
-#: src/strings.ts:775
+#: src/strings.ts:776
 msgid "Are you sure you want to logout from this device? Any unsynced changes will be lost."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1048
+#: src/strings.ts:1049
 msgid "Are you sure you want to remove your name?"
 msgstr ""
 
-#: src/strings.ts:1045
+#: src/strings.ts:1046
 msgid "Are you sure you want to remove your profile picture?"
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2687
+#: src/strings.ts:2688
 msgid "Are you sure you want to revoke the key \"{name}\"? All inbox actions using this key will stop working immediately."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1325
+#: src/strings.ts:1326
 msgid "Are you sure?"
 msgstr ""
 
-#: src/strings.ts:1132
+#: src/strings.ts:1133
 msgid "Ask every time"
 msgstr ""
 
-#: src/strings.ts:2035
+#: src/strings.ts:2036
 msgid "Assign color"
 msgstr ""
 
-#: src/strings.ts:934
+#: src/strings.ts:935
 msgid "Assign to..."
 msgstr ""
 
@@ -1010,11 +1018,11 @@ msgstr ""
 msgid "Atleast 8 characters required"
 msgstr ""
 
-#: src/strings.ts:2348
+#: src/strings.ts:2349
 msgid "Attach image from URL"
 msgstr ""
 
-#: src/strings.ts:908
+#: src/strings.ts:909
 msgid "Attached files"
 msgstr ""
 
@@ -1023,23 +1031,23 @@ msgid "attachment"
 msgstr ""
 
 #: src/strings.ts:300
-#: src/strings.ts:2345
+#: src/strings.ts:2346
 msgid "Attachment"
 msgstr ""
 
-#: src/strings.ts:2449
+#: src/strings.ts:2450
 msgid "Attachment manager"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1937
+#: src/strings.ts:1938
 msgid "Attachment preview failed"
 msgstr ""
 
-#: src/strings.ts:2399
+#: src/strings.ts:2400
 msgid "Attachment recheck cancelled"
 msgstr ""
 
-#: src/strings.ts:2316
+#: src/strings.ts:2317
 msgid "Attachment settings"
 msgstr ""
 
@@ -1048,184 +1056,184 @@ msgid "attachments"
 msgstr ""
 
 #: src/strings.ts:320
-#: src/strings.ts:907
+#: src/strings.ts:908
 msgid "Attachments"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1886
+#: src/strings.ts:1887
 msgid "Attachments cache cleared!"
 msgstr ""
 
-#: src/strings.ts:2401
+#: src/strings.ts:2402
 msgid "Attachments recheck complete"
 msgstr ""
 
-#: src/strings.ts:760
+#: src/strings.ts:761
 msgid "Audios"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1628
+#: src/strings.ts:1629
 msgid "Auth server"
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2681
+#: src/strings.ts:2682
 msgid "Authenticate"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2678
+#: src/strings.ts:2679
 msgid "Authenticate to view API key"
 msgstr ""
 
-#: src/strings.ts:1797
+#: src/strings.ts:1798
 msgid "Authenticated as {email}"
 msgstr ""
 
-#: src/strings.ts:1900
+#: src/strings.ts:1901
 msgid "Authenticating user"
 msgstr ""
 
-#: src/strings.ts:2136
+#: src/strings.ts:2137
 msgid "Authentication"
 msgstr ""
 
-#: src/strings.ts:1732
+#: src/strings.ts:1733
 msgid "authentication app"
 msgstr ""
 
-#: src/strings.ts:1353
+#: src/strings.ts:1354
 msgid "Authentication cancelled by user"
 msgstr ""
 
-#: src/strings.ts:1354
+#: src/strings.ts:1355
 msgid "Authentication failed"
 msgstr ""
 
-#: src/strings.ts:2099
+#: src/strings.ts:2100
 msgid "Auto"
 msgstr ""
 
-#: src/strings.ts:1663
+#: src/strings.ts:1664
 msgid "Auto save: off"
 msgstr ""
 
-#: src/strings.ts:2113
+#: src/strings.ts:2114
 msgid "Auto start on system startup"
 msgstr ""
 
-#: src/strings.ts:1220
-#: src/strings.ts:1691
+#: src/strings.ts:1221
+#: src/strings.ts:1692
 msgid "Automatic backups"
 msgstr ""
 
-#: src/strings.ts:1367
+#: src/strings.ts:1368
 msgid "Automatic backups are off"
 msgstr ""
 
-#: src/strings.ts:2007
+#: src/strings.ts:2008
 msgid "Automatic backups disabled"
 msgstr ""
 
-#: src/strings.ts:1223
+#: src/strings.ts:1224
 msgid "Automatic backups with attachments"
 msgstr ""
 
-#: src/strings.ts:2109
+#: src/strings.ts:2110
 msgid "Automatic updates"
 msgstr ""
 
-#: src/strings.ts:1140
+#: src/strings.ts:1141
 msgid "Automatically clear trash after a certain period of time"
 msgstr ""
 
-#: src/strings.ts:2111
+#: src/strings.ts:2112
 msgid "Automatically download & install updates in the background without prompting first."
 msgstr ""
 
-#: src/strings.ts:1193
+#: src/strings.ts:1194
 msgid "Automatically lock the app after a certain period"
 msgstr ""
 
-#: src/strings.ts:1123
+#: src/strings.ts:1124
 msgid "Automatically switch between light and dark themes based on your system settings"
 msgstr ""
 
-#: src/strings.ts:2156
+#: src/strings.ts:2157
 msgid "Available on iOS"
 msgstr ""
 
-#: src/strings.ts:2157
+#: src/strings.ts:2158
 msgid "Available on iOS & Android"
-msgstr "<<<<<<< HEAD"
+msgstr "<<<<<<< HEAD<<<<<<< Updated upstream"
 
-#: src/strings.ts:2706
+#: src/strings.ts:2707
 msgid "Back"
 msgstr ""
 
-#: src/strings.ts:2304
+#: src/strings.ts:2305
 msgid "Background color"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1095
+#: src/strings.ts:1096
 msgid "Background sync (experimental)"
 msgstr ""
 
-#: src/strings.ts:2105
+#: src/strings.ts:2106
 msgid "Backup"
 msgstr ""
 
-#: src/strings.ts:2143
+#: src/strings.ts:2144
 msgid "Backup & export"
 msgstr ""
 
-#: src/strings.ts:1212
+#: src/strings.ts:1213
 msgid "Backup & restore"
 msgstr ""
 
-#: src/strings.ts:1337
+#: src/strings.ts:1338
 msgid "Backup complete"
 msgstr ""
 
-#: src/strings.ts:1563
+#: src/strings.ts:1564
 msgid "Backup directory not selected"
 msgstr ""
 
-#: src/strings.ts:1235
+#: src/strings.ts:1236
 msgid "Backup encryption"
 msgstr ""
 
-#: src/strings.ts:1860
+#: src/strings.ts:1861
 msgid "Backup files have .nnbackup extension"
 msgstr ""
 
-#: src/strings.ts:882
+#: src/strings.ts:883
 msgid "Backup is encrypted"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1616
+#: src/strings.ts:1617
 msgid "Backup is encrypted, decrypting..."
 msgstr ""
 
-#: src/strings.ts:1214
+#: src/strings.ts:1215
 msgid "Backup now"
 msgstr ""
 
-#: src/strings.ts:1215
+#: src/strings.ts:1216
 msgid "Backup now with attachments"
 msgstr ""
 
-#: src/strings.ts:889
+#: src/strings.ts:890
 msgid "Backup restored"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1921
+#: src/strings.ts:1922
 msgid "Backup saved at {path}"
 msgstr ""
 
-#: src/strings.ts:1349
+#: src/strings.ts:1350
 msgid "Backup successful"
 msgstr ""
 
-#: src/strings.ts:2106
+#: src/strings.ts:2107
 msgid "Backup with attachments"
 msgstr ""
 
@@ -1233,83 +1241,83 @@ msgstr ""
 msgid "Backups"
 msgstr ""
 
-#: src/strings.ts:541
+#: src/strings.ts:542
 msgid "Basic"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1795
+#: src/strings.ts:1796
 msgid "Because where's the fun in nookin' alone?"
 msgstr ""
 
-#: src/strings.ts:1126
+#: src/strings.ts:1127
 msgid "Behavior"
 msgstr ""
 
-#: src/strings.ts:2138
+#: src/strings.ts:2139
 msgid "Behaviour"
 msgstr ""
 
-#: src/strings.ts:2473
+#: src/strings.ts:2474
 msgid "Believer plan"
 msgstr ""
 
-#: src/strings.ts:2580
+#: src/strings.ts:2581
 msgid "Best value"
 msgstr ""
 
-#: src/strings.ts:2462
+#: src/strings.ts:2463
 msgid "Beta"
 msgstr ""
 
-#: src/strings.ts:2262
+#: src/strings.ts:2263
 msgid "Bi-directional note link"
 msgstr ""
 
-#: src/strings.ts:2556
+#: src/strings.ts:2557
 msgid "billed annually at {price}"
 msgstr ""
 
-#: src/strings.ts:2557
+#: src/strings.ts:2558
 msgid "billed monthly at {price}"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2204
+#: src/strings.ts:2205
 msgid "Billing history"
 msgstr ""
 
-#: src/strings.ts:1179
+#: src/strings.ts:1180
 msgid "Biometric unlocking"
 msgstr ""
 
-#: src/strings.ts:812
+#: src/strings.ts:813
 msgid "Biometric unlocking disabled"
 msgstr ""
 
-#: src/strings.ts:811
+#: src/strings.ts:812
 msgid "Biometric unlocking enabled"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1351
+#: src/strings.ts:1352
 msgid "Biometrics authentication failed. Please try again."
 msgstr ""
 
-#: src/strings.ts:1188
+#: src/strings.ts:1189
 msgid "Biometrics not enrolled"
 msgstr ""
 
-#: src/strings.ts:2258
+#: src/strings.ts:2259
 msgid "Bold"
 msgstr ""
 
-#: src/strings.ts:2411
+#: src/strings.ts:2412
 msgid "Boost your productivity with Notebooks and organize your notes."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1811
+#: src/strings.ts:1812
 msgid "Browse"
 msgstr ""
 
-#: src/strings.ts:2275
+#: src/strings.ts:2276
 msgid "Bullet list"
 msgstr ""
 
@@ -1317,7 +1325,7 @@ msgstr ""
 msgid "By"
 msgstr ""
 
-#: src/strings.ts:2575
+#: src/strings.ts:2576
 msgid "By joining you agree to our"
 msgstr ""
 
@@ -1325,104 +1333,104 @@ msgstr ""
 msgid "By signing up, you agree to our "
 msgstr ""
 
-#: src/strings.ts:2336
+#: src/strings.ts:2337
 msgid "Callout"
 msgstr ""
 
-#: src/strings.ts:2516
+#: src/strings.ts:2517
 msgid "Can I cancel my free trial anytime?"
 msgstr ""
 
-#: src/strings.ts:549
+#: src/strings.ts:550
 msgid "Cancel"
 msgstr ""
 
-#: src/strings.ts:2573
+#: src/strings.ts:2574
 msgid "Cancel anytime, subscription auto-renews."
 msgstr ""
 
-#: src/strings.ts:2538
+#: src/strings.ts:2539
 msgid "Cancel anytime."
 msgstr ""
 
-#: src/strings.ts:517
+#: src/strings.ts:518
 msgid "Cancel download"
 msgstr ""
 
-#: src/strings.ts:554
+#: src/strings.ts:555
 msgid "Cancel login"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1828
+#: src/strings.ts:1829
 msgid "Cancel subscription"
 msgstr ""
 
-#: src/strings.ts:518
+#: src/strings.ts:519
 msgid "Cancel upload"
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2677
+#: src/strings.ts:2678
 msgid "Cannot create more than 10 api keys at a time. Please revoke some existing keys before creating new ones."
 msgstr ""
 
-#: src/strings.ts:2303
+#: src/strings.ts:2304
 msgid "Cell background color"
 msgstr ""
 
-#: src/strings.ts:2305
+#: src/strings.ts:2306
 msgid "Cell border color"
 msgstr ""
 
-#: src/strings.ts:2307
 #: src/strings.ts:2308
+#: src/strings.ts:2309
 msgid "Cell border width"
 msgstr ""
 
-#: src/strings.ts:2289
+#: src/strings.ts:2290
 msgid "Cell properties"
 msgstr ""
 
-#: src/strings.ts:2306
+#: src/strings.ts:2307
 msgid "Cell text color"
 msgstr ""
 
 #: src/strings.ts:153
 msgid "Change"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1061
+#: src/strings.ts:1062
 msgid "Change 2FA fallback method"
 msgstr ""
 
-#: src/strings.ts:678
+#: src/strings.ts:679
 msgid "Change 2FA method"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1200
+#: src/strings.ts:1201
 msgid "Change app lock password"
 msgstr ""
 
-#: src/strings.ts:1199
+#: src/strings.ts:1200
 msgid "Change app lock pin"
 msgstr ""
 
-#: src/strings.ts:1234
+#: src/strings.ts:1235
 msgid "Change backup directory"
 msgstr ""
 
 #: src/strings.ts:465
 msgid "Change email address"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1127
+#: src/strings.ts:1128
 msgid "Change how the app behaves in different situations"
 msgstr ""
 
-#: src/strings.ts:2354
+#: src/strings.ts:2355
 msgid "Change language"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1255
+#: src/strings.ts:1256
 msgid "Change notification sound"
 msgstr ""
 
@@ -1430,131 +1438,131 @@ msgstr ""
 msgid "Change password"
 msgstr ""
 
-#: src/strings.ts:2587
+#: src/strings.ts:2588
 msgid "Change plan"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1820
+#: src/strings.ts:1821
 msgid "Change profile picture"
 msgstr ""
 
-#: src/strings.ts:2182
+#: src/strings.ts:2183
 msgid "Change proxy"
 msgstr ""
 
-#: src/strings.ts:2203
+#: src/strings.ts:2204
 msgid "Change the payment method you used to purchase this subscription."
 msgstr ""
 
-#: src/strings.ts:1257
+#: src/strings.ts:1258
 msgid "Change the sound that plays when you receive a notification"
 msgstr ""
 
 #: src/strings.ts:451
 msgid "Change vault password"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1055
+#: src/strings.ts:1056
 msgid "Change your account password"
 msgstr ""
 
-#: src/strings.ts:1057
+#: src/strings.ts:1058
 msgid "Change your primary two-factor authentication method"
 msgstr ""
 
-#: src/strings.ts:1091
+#: src/strings.ts:1092
 msgid "Changes from other devices won't be updated in the editor in real-time."
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2697
+#: src/strings.ts:2698
 msgid "Changing Inbox PGP keys will delete all your unsynced inbox items."
 msgstr ""
 
-#: src/strings.ts:734
+#: src/strings.ts:735
 msgid "Changing password is an irreversible process. You will be logged out from all your devices. Please make sure you do not close the app while your password is changing and have good internet connection."
 msgstr ""
 
-#: src/strings.ts:2492
+#: src/strings.ts:2493
 msgid "Characters"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1298
+#: src/strings.ts:1299
 msgid "Check for new version of Notesnook"
 msgstr ""
 
-#: src/strings.ts:1301
+#: src/strings.ts:1302
 msgid "Check for new version of the app available on app launch"
 msgstr ""
 
-#: src/strings.ts:1297
+#: src/strings.ts:1298
 msgid "Check for updates"
 msgstr ""
 
-#: src/strings.ts:1299
+#: src/strings.ts:1300
 msgid "Check for updates automatically"
 msgstr ""
 
-#: src/strings.ts:2155
+#: src/strings.ts:2156
 msgid "Check roadmap"
 msgstr ""
 
-#: src/strings.ts:684
+#: src/strings.ts:685
 msgid "Check your spam folder if you haven't received an email yet."
 msgstr ""
 
-#: src/strings.ts:2403
+#: src/strings.ts:2404
 msgid "Checking all attachments"
 msgstr ""
 
 #: src/strings.ts:378
 msgid "Checking for new version"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1707
+#: src/strings.ts:1708
 msgid "Checking for updates"
 msgstr ""
 
-#: src/strings.ts:2402
+#: src/strings.ts:2403
 msgid "Checking note attachments"
 msgstr ""
 
-#: src/strings.ts:2277
+#: src/strings.ts:2278
 msgid "Checklist"
 msgstr ""
 
-#: src/strings.ts:2331
+#: src/strings.ts:2332
 msgid "Choose a block to insert"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1799
+#: src/strings.ts:1800
 msgid "Choose a recovery method"
 msgstr ""
 
-#: src/strings.ts:2104
+#: src/strings.ts:2105
 msgid "Choose backup format"
 msgstr ""
 
-#: src/strings.ts:2367
+#: src/strings.ts:2368
 msgid "Choose custom color"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1120
+#: src/strings.ts:1121
 msgid "Choose from pre-built themes or create your own"
 msgstr ""
 
-#: src/strings.ts:1135
+#: src/strings.ts:1136
 msgid "Choose how dates are displayed in the app"
 msgstr ""
 
-#: src/strings.ts:2622
+#: src/strings.ts:2623
 msgid "Choose how day is displayed in the app"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1160
+#: src/strings.ts:1161
 msgid "Choose how the new note titles are formatted"
 msgstr ""
 
-#: src/strings.ts:1137
+#: src/strings.ts:1138
 msgid "Choose how time is displayed in the app"
 msgstr ""
 
@@ -1562,75 +1570,75 @@ msgstr ""
 msgid "Choose how you want to secure your notes locally."
 msgstr ""
 
-#: src/strings.ts:2627
+#: src/strings.ts:2628
 msgid "Choose what day to display as the first day of the week"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1230
+#: src/strings.ts:1231
 msgid "Choose where to save your backups"
 msgstr ""
 
-#: src/strings.ts:2064
+#: src/strings.ts:2065
 msgid "Choose your style"
 msgstr ""
 
-#: src/strings.ts:1619
+#: src/strings.ts:1620
 msgid "cleaningUp"
 msgstr ""
 
-#: src/strings.ts:1016
+#: src/strings.ts:1017
 msgid "Clear"
 msgstr ""
 
-#: src/strings.ts:1872
+#: src/strings.ts:1873
 msgid "Clear all cached attachments. Current cache size: {cacheSize}"
 msgstr ""
 
-#: src/strings.ts:2271
+#: src/strings.ts:2272
 msgid "Clear all formatting"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1873
+#: src/strings.ts:1874
 msgid "Clear attachments cache?"
 msgstr ""
 
-#: src/strings.ts:1870
+#: src/strings.ts:1871
 msgid "Clear cache"
 msgstr ""
 
-#: src/strings.ts:2365
+#: src/strings.ts:2366
 msgid "Clear completed tasks"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1807
+#: src/strings.ts:1808
 msgid "Clear data & reset account"
 msgstr ""
 
-#: src/strings.ts:1141
+#: src/strings.ts:1142
 msgid "Clear default notebook"
 msgstr ""
 
-#: src/strings.ts:1015
+#: src/strings.ts:1016
 msgid "Clear logs"
 msgstr ""
 
-#: src/strings.ts:2198
+#: src/strings.ts:2199
 msgid "clear sessions"
 msgstr ""
 
-#: src/strings.ts:1324
+#: src/strings.ts:1325
 msgid "Clear trash"
 msgstr ""
 
-#: src/strings.ts:1138
+#: src/strings.ts:1139
 msgid "Clear trash interval"
 msgstr ""
 
 #: src/strings.ts:150
 msgid "Clear vault"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1875
+#: src/strings.ts:1876
 msgid ""
 "Clearing attachments cache will perform the following actions:\n"
 "\n"
@@ -1643,81 +1651,81 @@ msgid ""
 "---\n"
 "\n"
 "**Only use this for troubleshooting purposes. If you are having persistent issues, it is recommended that you reach out to us via support@streetwriters.co so we can help you resolve it permanently.**"
-msgstr ""
+msgstr "<<<<<<< Updated upstream======="
 
-#: src/strings.ts:2609
+#: src/strings.ts:2610
 msgid "Click here to directly claim the promotion."
 msgstr ""
 
 #: src/strings.ts:239
 msgid "Click to deselect"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1869
+#: src/strings.ts:1870
 msgid "Click to preview"
 msgstr ""
 
-#: src/strings.ts:1774
+#: src/strings.ts:1775
 msgid "Click to remove"
 msgstr ""
 
-#: src/strings.ts:2394
+#: src/strings.ts:2395
 msgid "Click to reset {title}"
 msgstr ""
 
-#: src/strings.ts:2617
+#: src/strings.ts:2618
 msgid "Click to save"
 msgstr ""
 
-#: src/strings.ts:2613
+#: src/strings.ts:2614
 msgid "Click to update"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1383
+#: src/strings.ts:1384
 msgid "Close"
 msgstr ""
 
-#: src/strings.ts:2021
+#: src/strings.ts:2022
 msgid "Close all"
 msgstr ""
 
-#: src/strings.ts:2452
+#: src/strings.ts:2453
 msgid "Close all tabs"
 msgstr ""
 
-#: src/strings.ts:2451
+#: src/strings.ts:2452
 msgid "Close current tab"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2018
+#: src/strings.ts:2019
 msgid "Close others"
 msgstr ""
 
-#: src/strings.ts:2122
+#: src/strings.ts:2123
 msgid "Close to system tray"
 msgstr ""
 
-#: src/strings.ts:2020
+#: src/strings.ts:2021
 msgid "Close to the left"
 msgstr ""
 
-#: src/strings.ts:2019
+#: src/strings.ts:2020
 msgid "Close to the right"
 msgstr ""
 
-#: src/strings.ts:2530
+#: src/strings.ts:2531
 msgid "cloud storage space for storing images and files."
 msgstr ""
 
-#: src/strings.ts:2269
+#: src/strings.ts:2270
 msgid "Code"
 msgstr ""
 
-#: src/strings.ts:2333
+#: src/strings.ts:2334
 msgid "Code block"
 msgstr ""
 
-#: src/strings.ts:2270
+#: src/strings.ts:2271
 msgid "Code remove"
 msgstr ""
 
@@ -1730,19 +1738,19 @@ msgid "color"
 msgstr ""
 
 #: src/strings.ts:299
-#: src/strings.ts:1846
+#: src/strings.ts:1847
 msgid "Color"
 msgstr ""
 
-#: src/strings.ts:787
+#: src/strings.ts:788
 msgid "Color #{color} already exists"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2097
+#: src/strings.ts:2098
 msgid "Color scheme"
 msgstr ""
 
-#: src/strings.ts:1491
+#: src/strings.ts:1492
 msgid "Color title"
 msgstr ""
 
@@ -1754,19 +1762,19 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
-#: src/strings.ts:2287
+#: src/strings.ts:2288
 msgid "Column properties"
 msgstr ""
 
-#: src/strings.ts:2443
+#: src/strings.ts:2444
 msgid "Command palette"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1273
+#: src/strings.ts:1274
 msgid "Community"
 msgstr ""
 
-#: src/strings.ts:2550
+#: src/strings.ts:2551
 msgid "Compare plans"
 msgstr ""
 
@@ -1776,9 +1784,9 @@ msgstr ""
 
 #: src/strings.ts:139
 msgid "Compress"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1131
+#: src/strings.ts:1132
 msgid "Compress images before uploading"
 msgstr ""
 
@@ -1786,96 +1794,96 @@ msgstr ""
 msgid "Compressed images are uploaded in Full HD resolution and usually are good enough for most use cases."
 msgstr ""
 
-#: src/strings.ts:2253
+#: src/strings.ts:2254
 msgid "Configure"
 msgstr ""
 
-#: src/strings.ts:2408
+#: src/strings.ts:2409
 msgid "Configure server URLs for Notesnook"
 msgstr ""
 
-#: src/strings.ts:682
+#: src/strings.ts:683
 msgid "Confirm email"
 msgstr ""
 
-#: src/strings.ts:903
+#: src/strings.ts:904
 msgid "Confirm email to publish note"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1490
+#: src/strings.ts:1491
 msgid "Confirm new password"
 msgstr ""
 
-#: src/strings.ts:1485
+#: src/strings.ts:1486
 msgid "Confirm password"
 msgstr ""
 
-#: src/strings.ts:1489
+#: src/strings.ts:1490
 msgid "Confirm pin"
 msgstr ""
 
-#: src/strings.ts:2641
+#: src/strings.ts:2642
 msgid "Confirmation email sent"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2082
+#: src/strings.ts:2083
 msgid "Congratulations!"
 msgstr ""
 
-#: src/strings.ts:1638
+#: src/strings.ts:1639
 msgid "Connected to all servers sucessfully."
 msgstr ""
 
-#: src/strings.ts:1673
+#: src/strings.ts:1674
 msgid "Contact support"
 msgstr ""
 
-#: src/strings.ts:1264
+#: src/strings.ts:1265
 msgid "Contact us directly via support@streetwriters.co for any help or support"
 msgstr ""
 
-#: src/strings.ts:543
+#: src/strings.ts:544
 msgid "Continue"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1166
+#: src/strings.ts:1167
 msgid "Contribute towards a better Notesnook. All tracking information is anonymous."
 msgstr ""
 
-#: src/strings.ts:1250
+#: src/strings.ts:1251
 msgid "Controls whether this device should receive reminder notifications."
 msgstr ""
 
-#: src/strings.ts:1992
+#: src/strings.ts:1993
 msgid "Copied"
 msgstr ""
 
-#: src/strings.ts:675
+#: src/strings.ts:676
 msgid "Copy"
 msgstr ""
 
 #. placeholder {0}: format ? " " + format : ""
-#: src/strings.ts:2038
+#: src/strings.ts:2039
 msgid "Copy as{0}"
 msgstr ""
 
-#: src/strings.ts:679
+#: src/strings.ts:680
 msgid "Copy codes"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:912
+#: src/strings.ts:913
 msgid "Copy ID"
-msgstr ""
+msgstr "=======>>>>>>> Stashed changes"
 
-#: src/strings.ts:2249
+#: src/strings.ts:2250
 msgid "Copy image"
 msgstr ""
 
-#: src/strings.ts:910
+#: src/strings.ts:911
 msgid "Copy link"
 msgstr ""
 
-#: src/strings.ts:2248
+#: src/strings.ts:2249
 msgid "Copy link text"
 msgstr ""
 
@@ -1883,39 +1891,39 @@ msgstr ""
 msgid "Copy note"
 msgstr ""
 
-#: src/strings.ts:591
+#: src/strings.ts:592
 msgid "Copy to clipboard"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1621
+#: src/strings.ts:1622
 msgid "Copying backup files to cache"
 msgstr ""
 
-#: src/strings.ts:1170
+#: src/strings.ts:1171
 msgid "CORS bypass"
 msgstr ""
 
-#: src/strings.ts:1988
+#: src/strings.ts:1989
 msgid "Could not activate trial. Please try again later."
 msgstr ""
 
-#: src/strings.ts:2006
+#: src/strings.ts:2007
 msgid "Could not clear trash."
 msgstr ""
 
-#: src/strings.ts:1641
+#: src/strings.ts:1642
 msgid "Could not connect to {server}."
 msgstr ""
 
-#: src/strings.ts:1953
+#: src/strings.ts:1954
 msgid "Could not convert note to {format}."
 msgstr ""
 
-#: src/strings.ts:769
+#: src/strings.ts:770
 msgid "Could not create backup"
 msgstr ""
 
-#: src/strings.ts:559
+#: src/strings.ts:560
 msgid "Could not unlock"
 msgstr ""
 
@@ -1923,55 +1931,55 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: src/strings.ts:730
+#: src/strings.ts:731
 msgid "Create a group"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:940
+#: src/strings.ts:941
 msgid "Create a new note"
 msgstr ""
 
-#: src/strings.ts:953
+#: src/strings.ts:954
 msgid "Create a note first"
 msgstr ""
 
-#: src/strings.ts:670
+#: src/strings.ts:671
 msgid "Create a shortcut"
 msgstr ""
 
-#: src/strings.ts:573
+#: src/strings.ts:574
 msgid "Create a tag to group related notes together."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1851
+#: src/strings.ts:1852
 msgid "Create account"
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2656
+#: src/strings.ts:2657
 msgid "Create API Key"
 msgstr ""
 
-#: src/strings.ts:2673
+#: src/strings.ts:2674
 msgid "Create Key"
 msgstr ""
 
-#: src/strings.ts:581
+#: src/strings.ts:582
 msgid "Create link"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1475
+#: src/strings.ts:1476
 msgid "Create shortcut of this notebook in side menu"
 msgstr ""
 
-#: src/strings.ts:1389
+#: src/strings.ts:1390
 msgid "Create unlimited notebooks with Notesnook Pro"
 msgstr ""
 
-#: src/strings.ts:1388
+#: src/strings.ts:1389
 msgid "Create unlimited tags with Notesnook Pro"
 msgstr ""
 
-#: src/strings.ts:1390
+#: src/strings.ts:1391
 msgid "Create unlimited vaults with Notesnook Pro"
 msgstr ""
 
@@ -1979,318 +1987,318 @@ msgstr ""
 msgid "Create vault"
 msgstr ""
 
-#: src/strings.ts:522
+#: src/strings.ts:523
 msgid "Create your account"
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2672
+#: src/strings.ts:2673
 msgid "Create your first api key to get started."
 msgstr ""
 
-#: src/strings.ts:2231
+#: src/strings.ts:2232
 msgid "Created at"
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2692
+#: src/strings.ts:2693
 msgid "Created on"
 msgstr ""
 
 #. placeholder {0}: type === "full" ? " full" : ""
-#: src/strings.ts:1346
+#: src/strings.ts:1347
 msgid "Creating a{0} backup"
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2664
+#: src/strings.ts:2665
 msgid "Creating..."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2051
+#: src/strings.ts:2052
 msgid "Credentials"
 msgstr ""
 
-#: src/strings.ts:2067
+#: src/strings.ts:2068
 msgid "Cross platform & 100% encrypted"
 msgstr ""
 
-#: src/strings.ts:741
+#: src/strings.ts:742
 msgid "Curate the toolbar that fits your needs and matches your personality."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1838
+#: src/strings.ts:1839
 msgid "Current note"
 msgstr ""
 
-#: src/strings.ts:1487
+#: src/strings.ts:1488
 msgid "Current password"
 msgstr ""
 
-#: src/strings.ts:1231
+#: src/strings.ts:1232
 msgid "Current path: {path}"
 msgstr ""
 
-#: src/strings.ts:1486
+#: src/strings.ts:1487
 msgid "Current pin"
 msgstr ""
 
-#: src/strings.ts:1775
+#: src/strings.ts:1776
 msgid "CURRENT PLAN"
 msgstr ""
 
-#: src/strings.ts:2012
+#: src/strings.ts:2013
 msgid "Custom"
 msgstr ""
 
-#: src/strings.ts:2133
+#: src/strings.ts:2134
 msgid "Custom dictionary words"
 msgstr ""
 
-#: src/strings.ts:1115
+#: src/strings.ts:1116
 msgid "Customization"
 msgstr ""
 
-#: src/strings.ts:1118
+#: src/strings.ts:1119
 msgid "Customize the appearance of the app with custom themes"
 msgstr ""
 
-#: src/strings.ts:1145
+#: src/strings.ts:1146
 msgid "Customize the note editor"
 msgstr ""
 
-#: src/strings.ts:1147
+#: src/strings.ts:1148
 msgid "Customize the toolbar in the note editor"
 msgstr ""
 
-#: src/strings.ts:1146
+#: src/strings.ts:1147
 msgid "Customize toolbar"
 msgstr ""
 
-#: src/strings.ts:2247
+#: src/strings.ts:2248
 msgid "Cut"
 msgstr ""
 
 #: src/strings.ts:167
-#: src/strings.ts:1570
+#: src/strings.ts:1571
 msgid "Daily"
 msgstr ""
 
-#: src/strings.ts:724
+#: src/strings.ts:725
 msgid "Dark"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1124
+#: src/strings.ts:1125
 msgid "Dark mode"
 msgstr ""
 
-#: src/strings.ts:2098
+#: src/strings.ts:2099
 msgid "Dark or light, we won't judge."
 msgstr ""
 
-#: src/strings.ts:1549
+#: src/strings.ts:1550
 msgid "Database setup failed, could not get database key"
 msgstr ""
 
-#: src/strings.ts:1841
+#: src/strings.ts:1842
 msgid "Date"
 msgstr ""
 
-#: src/strings.ts:2107
+#: src/strings.ts:2108
 msgid "Date & time"
 msgstr ""
 
-#: src/strings.ts:653
+#: src/strings.ts:654
 msgid "Date created"
 msgstr ""
 
-#: src/strings.ts:656
+#: src/strings.ts:657
 msgid "Date deleted"
 msgstr ""
 
-#: src/strings.ts:652
+#: src/strings.ts:653
 msgid "Date edited"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1134
+#: src/strings.ts:1135
 msgid "Date format"
 msgstr ""
 
-#: src/strings.ts:651
+#: src/strings.ts:652
 msgid "Date modified"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2044
+#: src/strings.ts:2045
 msgid "Date uploaded"
 msgstr ""
 
-#: src/strings.ts:1843
+#: src/strings.ts:1844
 msgid "Day"
 msgstr ""
 
-#: src/strings.ts:2621
+#: src/strings.ts:2622
 msgid "Day format"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2040
+#: src/strings.ts:2041
 msgid "Deactivate"
 msgstr ""
 
-#: src/strings.ts:1013
+#: src/strings.ts:1014
 msgid "Debug log copied!"
 msgstr ""
 
-#: src/strings.ts:1271
+#: src/strings.ts:1272
 msgid "Debug logs"
 msgstr ""
 
-#: src/strings.ts:1014
+#: src/strings.ts:1015
 msgid "Debug logs downloaded"
 msgstr ""
 
-#: src/strings.ts:1268
+#: src/strings.ts:1269
 msgid "Debugging"
 msgstr ""
 
-#: src/strings.ts:2396
+#: src/strings.ts:2397
 msgid "Decrease {title}"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:660
-#: src/strings.ts:2010
+#: src/strings.ts:661
+#: src/strings.ts:2011
 msgid "Default"
 msgstr ""
 
-#: src/strings.ts:1157
+#: src/strings.ts:1158
 msgid "Default font family"
 msgstr ""
 
-#: src/strings.ts:1158
+#: src/strings.ts:1159
 msgid "Default font family in editor"
 msgstr ""
 
-#: src/strings.ts:1155
+#: src/strings.ts:1156
 msgid "Default font size"
 msgstr ""
 
-#: src/strings.ts:1156
+#: src/strings.ts:1157
 msgid "Default font size in editor"
 msgstr ""
 
-#: src/strings.ts:1143
+#: src/strings.ts:1144
 msgid "Default notebook cleared"
 msgstr ""
 
-#: src/strings.ts:1129
+#: src/strings.ts:1130
 msgid "Default screen to open on app launch"
 msgstr ""
 
-#: src/strings.ts:2483
+#: src/strings.ts:2484
 msgid "Default sidebar tab"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1251
+#: src/strings.ts:1252
 msgid "Default snooze time"
 msgstr ""
 
-#: src/strings.ts:1303
+#: src/strings.ts:1304
 msgid "Default sound"
 msgstr ""
 
 #: src/strings.ts:154
 msgid "Delete"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1078
+#: src/strings.ts:1079
 msgid "Delete account"
 msgstr ""
 
-#: src/strings.ts:1321
+#: src/strings.ts:1322
 msgid "Delete collapsed section"
 msgstr ""
 
-#: src/strings.ts:2294
+#: src/strings.ts:2295
 msgid "Delete column"
 msgstr ""
 
-#: src/strings.ts:2638
+#: src/strings.ts:2639
 msgid "Delete data"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1316
+#: src/strings.ts:1317
 msgid "Delete group"
 msgstr ""
 
-#: src/strings.ts:2368
+#: src/strings.ts:2369
 msgid "Delete mode"
 msgstr ""
 
-#: src/strings.ts:562
+#: src/strings.ts:563
 msgid "Delete notes in this vault"
 msgstr ""
 
-#: src/strings.ts:569
+#: src/strings.ts:570
 msgid "Delete permanently"
 msgstr ""
 
-#: src/strings.ts:2301
+#: src/strings.ts:2302
 msgid "Delete row"
 msgstr ""
 
-#: src/strings.ts:2302
+#: src/strings.ts:2303
 msgid "Delete table"
 msgstr ""
 
 #: src/strings.ts:149
 msgid "Delete vault"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1178
+#: src/strings.ts:1179
 msgid "Delete vault (and optionally remove all notes)."
 msgstr ""
 
 #: src/strings.ts:164
 msgid "Deleted on {date}"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1930
+#: src/strings.ts:1931
 msgid "Deleting"
 msgstr ""
 
-#: src/strings.ts:1840
+#: src/strings.ts:1841
 msgid "Description"
 msgstr ""
 
-#: src/strings.ts:2108
+#: src/strings.ts:2109
 msgid "Desktop app"
 msgstr ""
 
-#: src/strings.ts:2112
+#: src/strings.ts:2113
 msgid "Desktop integration"
 msgstr ""
 
-#: src/strings.ts:871
+#: src/strings.ts:872
 msgid "Did you save recovery key?"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1378
+#: src/strings.ts:1379
 msgid "Disable"
 msgstr ""
 
-#: src/strings.ts:1086
+#: src/strings.ts:1087
 msgid "Disable auto sync"
 msgstr ""
 
-#: src/strings.ts:2013
+#: src/strings.ts:2014
 msgid "Disable editor margins"
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2650
+#: src/strings.ts:2651
 msgid "Disable Inbox API"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1089
+#: src/strings.ts:1090
 msgid "Disable realtime sync"
 msgstr ""
 
-#: src/strings.ts:1092
+#: src/strings.ts:1093
 msgid "Disable sync"
 msgstr ""
 
@@ -2298,19 +2306,19 @@ msgstr ""
 msgid "Disabled"
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2652
+#: src/strings.ts:2653
 msgid "Disabling will delete all your unsynced inbox items. Additionally, disabling will revoke all existing API keys, they will no longer work. Are you sure?"
 msgstr ""
 
-#: src/strings.ts:565
+#: src/strings.ts:566
 msgid "Discard"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1599
+#: src/strings.ts:1600
 msgid "Dismiss"
 msgstr ""
 
-#: src/strings.ts:1652
+#: src/strings.ts:1653
 msgid "Dismiss announcement"
 msgstr ""
 
@@ -2320,272 +2328,272 @@ msgstr ""
 
 #: src/strings.ts:273
 msgid "Do you enjoy using Notesnook?"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2230
+#: src/strings.ts:2231
 msgid "Do you want to clear the trash?"
 msgstr ""
 
-#: src/strings.ts:1265
+#: src/strings.ts:1266
 msgid "Documentation"
 msgstr ""
 
-#: src/strings.ts:757
+#: src/strings.ts:758
 msgid "Documents"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:986
+#: src/strings.ts:987
 msgid "Don't have access to your authenticator app?"
 msgstr ""
 
-#: src/strings.ts:993
+#: src/strings.ts:994
 msgid "Don't have access to your email address?"
 msgstr ""
 
-#: src/strings.ts:1002
+#: src/strings.ts:1003
 msgid "Don't have access to your phone number?"
 msgstr ""
 
 #: src/strings.ts:95
 msgid "Don't have an account?"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1834
+#: src/strings.ts:1835
 msgid "Don't have backup file?"
 msgstr ""
 
-#: src/strings.ts:1833
+#: src/strings.ts:1006
+msgid "Don't have your 2FA backup codes?"
+msgstr ""
+
+#: src/strings.ts:1834
 msgid "Don't have your account recovery key?"
 msgstr ""
 
-#: src/strings.ts:1005
-msgid "Don't have your recovery codes?"
-msgstr ""
-
-#: src/strings.ts:1812
+#: src/strings.ts:1813
 msgid "Don't show again"
 msgstr ""
 
-#: src/strings.ts:1813
+#: src/strings.ts:1814
 msgid "Don't show again on this device?"
 msgstr ""
 
 #: src/strings.ts:55
 msgid "Done"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1151
+#: src/strings.ts:1152
 msgid "Double spaced lines"
 msgstr ""
 
-#: src/strings.ts:509
+#: src/strings.ts:510
 msgid "Download"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1818
+#: src/strings.ts:1819
 msgid "Download all attachments"
 msgstr ""
 
-#: src/strings.ts:2317
+#: src/strings.ts:2318
 msgid "Download attachment"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1862
+#: src/strings.ts:1863
 msgid "Download backup file"
 msgstr ""
 
-#: src/strings.ts:516
+#: src/strings.ts:517
 msgid "Download cancelled"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2210
+#: src/strings.ts:2211
 msgid "Download everything including attachments on sync"
 msgstr ""
 
-#: src/strings.ts:1292
+#: src/strings.ts:1293
 msgid "Download on desktop"
 msgstr ""
 
-#: src/strings.ts:806
+#: src/strings.ts:807
 msgid "Download started... Please wait"
 msgstr ""
 
-#: src/strings.ts:514
+#: src/strings.ts:515
 msgid "Download successful"
 msgstr ""
 
-#: src/strings.ts:667
+#: src/strings.ts:668
 msgid "Download update"
 msgstr ""
 
-#: src/strings.ts:508
+#: src/strings.ts:509
 msgid "Downloaded"
 msgstr ""
 
 #: src/strings.ts:64
-#: src/strings.ts:507
+#: src/strings.ts:508
 msgid "Downloading"
 msgstr ""
 
-#: src/strings.ts:507
+#: src/strings.ts:508
 msgid "Downloading ({progress})"
 msgstr ""
 
 #: src/strings.ts:261
 msgid "Downloading attachments"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1706
+#: src/strings.ts:1707
 msgid "Downloading images"
 msgstr ""
 
-#: src/strings.ts:1772
+#: src/strings.ts:1773
 msgid "Drag & drop files here, or click to select files"
 msgstr ""
 
-#: src/strings.ts:1771
+#: src/strings.ts:1772
 msgid "Drop the files here"
 msgstr ""
 
-#: src/strings.ts:1665
+#: src/strings.ts:1666
 msgid "Drop your files here to attach"
 msgstr ""
 
-#: src/strings.ts:2560
+#: src/strings.ts:2561
 msgid "Due {date}"
 msgstr ""
 
-#: src/strings.ts:655
+#: src/strings.ts:656
 msgid "Due date"
 msgstr ""
 
-#: src/strings.ts:2558
+#: src/strings.ts:2559
 msgid "Due today"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:926
+#: src/strings.ts:927
 msgid "Duplicate"
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2658
+#: src/strings.ts:2659
 msgid "e.g., Todo integration"
 msgstr ""
 
-#: src/strings.ts:644
+#: src/strings.ts:645
 msgid "Earliest first"
 msgstr ""
 
-#: src/strings.ts:2420
+#: src/strings.ts:2421
 msgid "Easy access"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1779
+#: src/strings.ts:1780
 msgid "Edit"
 msgstr ""
 
-#: src/strings.ts:2628
+#: src/strings.ts:2629
 msgid "Edit creation date"
 msgstr ""
 
-#: src/strings.ts:527
+#: src/strings.ts:528
 msgid "Edit internal link"
 msgstr ""
 
-#: src/strings.ts:2236
-#: src/strings.ts:2264
+#: src/strings.ts:2237
+#: src/strings.ts:2265
 msgid "Edit link"
 msgstr ""
 
-#: src/strings.ts:2476
+#: src/strings.ts:2477
 msgid "Edit profile"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1309
+#: src/strings.ts:1310
 msgid "Edit profile picture"
 msgstr ""
 
-#: src/strings.ts:1821
+#: src/strings.ts:1822
 msgid "Edit your full name"
 msgstr ""
 
-#: src/strings.ts:1144
-#: src/strings.ts:1528
+#: src/strings.ts:1145
+#: src/strings.ts:1529
 msgid "Editor"
 msgstr ""
 
-#: src/strings.ts:2584
+#: src/strings.ts:2585
 msgid "Education plan"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1483
+#: src/strings.ts:1484
 msgid "Email"
 msgstr ""
 
-#: src/strings.ts:2433
+#: src/strings.ts:2434
 msgid "Email copied"
 msgstr ""
 
-#: src/strings.ts:772
+#: src/strings.ts:773
 msgid "Email is required"
 msgstr ""
 
-#: src/strings.ts:764
+#: src/strings.ts:765
 msgid "Email not confirmed"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1555
+#: src/strings.ts:1556
 msgid "Email or password incorrect"
 msgstr ""
 
-#: src/strings.ts:1262
+#: src/strings.ts:1263
 msgid "Email support"
 msgstr ""
 
-#: src/strings.ts:857
+#: src/strings.ts:858
 msgid "Email updated to {email}"
 msgstr ""
 
-#: src/strings.ts:2343
+#: src/strings.ts:2344
 msgid "Embed"
 msgstr ""
 
-#: src/strings.ts:2323
+#: src/strings.ts:2324
 msgid "Embed properties"
 msgstr ""
 
-#: src/strings.ts:2319
+#: src/strings.ts:2320
 msgid "Embed settings"
 msgstr ""
 
 #: src/strings.ts:151
 msgid "Enable"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1133
+#: src/strings.ts:1134
 msgid "Enable (Recommended)"
 msgstr ""
 
-#: src/strings.ts:1187
+#: src/strings.ts:1188
 msgid "Enable app lock"
 msgstr ""
 
-#: src/strings.ts:2014
+#: src/strings.ts:2015
 msgid "Enable editor margins"
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2645
+#: src/strings.ts:2646
 msgid "Enable Inbox API"
 msgstr ""
 
-#: src/strings.ts:2467
+#: src/strings.ts:2468
 msgid "Enable ligatures for common symbols like →, ←, etc"
 msgstr ""
 
-#: src/strings.ts:2383
+#: src/strings.ts:2384
 msgid "Enable regex"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2129
+#: src/strings.ts:2130
 msgid "Enable spell checker"
 msgstr ""
 
@@ -2593,11 +2601,11 @@ msgstr ""
 msgid "Enable two-factor authentication to add an extra layer of security to your account."
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2646
+#: src/strings.ts:2647
 msgid "Enable/Disable Inbox API"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1236
+#: src/strings.ts:1237
 msgid "Encrypt your backups for added security"
 msgstr ""
 
@@ -2605,88 +2613,92 @@ msgstr ""
 msgid "Encrypted and synced"
 msgstr ""
 
-#: src/strings.ts:2243
+#: src/strings.ts:2244
 msgid "Encrypted backup"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1659
+#: src/strings.ts:1660
 msgid "Encrypted, private, secure."
 msgstr ""
 
-#: src/strings.ts:942
+#: src/strings.ts:943
 msgid "Encrypting attachment"
 msgstr ""
 
-#: src/strings.ts:1845
+#: src/strings.ts:1846
 msgid "Encryption key"
 msgstr ""
 
-#: src/strings.ts:820
+#: src/strings.ts:821
 msgid "End to end encrypted."
+msgstr ""
+
+#: src/strings.ts:1007
+msgid "Enter 2FA backup code"
 msgstr ""
 
 #: src/strings.ts:399
 msgid "Enter 6 digit code"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1081
+#: src/strings.ts:1082
 msgid "Enter account password"
 msgstr ""
 
-#: src/strings.ts:1082
+#: src/strings.ts:1083
 msgid "Enter account password to proceed."
 msgstr ""
 
-#: src/strings.ts:1854
+#: src/strings.ts:1855
 msgid "Enter account recovery key"
 msgstr ""
 
-#: src/strings.ts:1021
+#: src/strings.ts:1022
 msgid "Enter app lock password"
 msgstr ""
 
-#: src/strings.ts:1024
+#: src/strings.ts:1025
 msgid "Enter app lock pin"
 msgstr ""
 
 #: src/strings.ts:132
 msgid "Enter code from authenticator app"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1513
+#: src/strings.ts:1514
 msgid "Enter email address"
 msgstr ""
 
-#: src/strings.ts:2371
+#: src/strings.ts:2372
 msgid "Enter embed source URL"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1315
+#: src/strings.ts:1316
 msgid "Enter full name"
 msgstr ""
 
-#: src/strings.ts:1703
+#: src/strings.ts:1704
 msgid "Enter fullscreen"
 msgstr ""
 
-#: src/strings.ts:1492
+#: src/strings.ts:1493
 msgid "Enter notebook description"
 msgstr ""
 
-#: src/strings.ts:856
+#: src/strings.ts:857
 msgid "Enter notebook title"
 msgstr ""
 
-#: src/strings.ts:791
+#: src/strings.ts:792
 msgid "Enter password"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2090
+#: src/strings.ts:2091
 msgid "Enter pin or password to enable app lock."
 msgstr ""
 
-#: src/strings.ts:1006
-msgid "Enter recovery code"
+#: src/strings.ts:120
+msgid "Enter the 2FA backup code to continue logging in"
 msgstr ""
 
 #: src/strings.ts:119
@@ -2701,127 +2713,123 @@ msgstr ""
 msgid "Enter the 6 digit code sent to your phone number to continue logging in"
 msgstr ""
 
-#: src/strings.ts:2435
+#: src/strings.ts:2436
 msgid "Enter the gift code to redeem your subscription."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:120
-msgid "Enter the recovery code to continue logging in"
-msgstr ""
-
-#: src/strings.ts:2620
+#: src/strings.ts:2621
 msgid "Enter title"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1495
+#: src/strings.ts:1496
 msgid "Enter verification code sent to your new email"
 msgstr ""
 
-#: src/strings.ts:1494
+#: src/strings.ts:1495
 msgid "Enter your new email"
 msgstr ""
 
-#: src/strings.ts:2091
+#: src/strings.ts:2092
 msgid "Enter your username"
 msgstr ""
 
-#: src/strings.ts:2427
+#: src/strings.ts:2428
 msgid "Error"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1556
+#: src/strings.ts:1557
 msgid "Error applying promo code"
 msgstr ""
 
-#: src/strings.ts:747
+#: src/strings.ts:748
 msgid "Error downloading file: {message}"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1516
+#: src/strings.ts:1517
 msgid "Error getting codes"
 msgstr ""
 
 #: src/strings.ts:413
 msgid "Error loading themes"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1077
+#: src/strings.ts:1078
 msgid "Error logging out"
 msgstr ""
 
-#: src/strings.ts:1011
+#: src/strings.ts:1012
 msgid "Error sending 2FA code"
 msgstr ""
 
-#: src/strings.ts:759
+#: src/strings.ts:760
 msgid "Errors"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1698
+#: src/strings.ts:1699
 msgid "Errors in {count} attachments"
 msgstr ""
 
-#: src/strings.ts:2472
+#: src/strings.ts:2473
 msgid "Essential plan"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1630
+#: src/strings.ts:1631
 msgid "Events server"
 msgstr ""
 
-#: src/strings.ts:2413
+#: src/strings.ts:2414
 msgid "Every Notebook can have notes and sub notebooks."
 msgstr ""
 
-#: src/strings.ts:2415
+#: src/strings.ts:2416
 msgid "Everything related to my job in one place."
 msgstr ""
 
-#: src/strings.ts:2424
+#: src/strings.ts:2425
 msgid "Everything related to my school in one place."
 msgstr ""
 
-#: src/strings.ts:2441
+#: src/strings.ts:2442
 msgid "Execute"
 msgstr ""
 
-#: src/strings.ts:2440
+#: src/strings.ts:2441
 msgid "Execute a command..."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2015
+#: src/strings.ts:2016
 msgid "Exit fullscreen"
 msgstr ""
 
-#: src/strings.ts:2375
+#: src/strings.ts:2376
 msgid "Expand"
 msgstr ""
 
-#: src/strings.ts:2468
+#: src/strings.ts:2469
 msgid "Expand sidebar"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2074
+#: src/strings.ts:2075
 msgid "Experience the next level of private note taking\""
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2694
+#: src/strings.ts:2695
 msgid "Expired"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2659
+#: src/strings.ts:2660
 msgid "Expires in"
 msgstr ""
 
-#: src/strings.ts:2695
+#: src/strings.ts:2696
 msgid "Expires on"
-msgstr ""
+msgstr "=======>>>>>>> Stashed changes"
 
-#: src/strings.ts:2634
+#: src/strings.ts:2635
 msgid "Expiry date"
 msgstr ""
 
-#: src/strings.ts:2541
+#: src/strings.ts:2542
 msgid "Explore all plans"
 msgstr ""
 
@@ -2829,137 +2837,137 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: src/strings.ts:578
+#: src/strings.ts:579
 msgid "Export again"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1239
+#: src/strings.ts:1240
 msgid "Export all notes"
 msgstr ""
 
-#: src/strings.ts:1241
+#: src/strings.ts:1242
 msgid "Export all notes as pdf, markdown, html or text in a single zip file"
 msgstr ""
 
 #. placeholder {0}: format ? " " + format : ""
-#: src/strings.ts:2037
+#: src/strings.ts:2038
 msgid "Export as{0}"
 msgstr ""
 
-#: src/strings.ts:2635
+#: src/strings.ts:2636
 msgid "Export CSV"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1387
+#: src/strings.ts:1388
 msgid "Export notes as PDF, Markdown and HTML with Notesnook Pro"
 msgstr ""
 
 #: src/strings.ts:215
 msgid "Exporting \"{title}\""
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1620
+#: src/strings.ts:1621
 msgid "Extracting files..."
 msgstr ""
 
-#: src/strings.ts:1809
+#: src/strings.ts:1810
 msgid "EXTREMELY DANGEROUS! This action is irreversible. All your data including notes, notebooks, attachments & settings will be deleted. This is a full account reset. Proceed with caution."
 msgstr ""
 
-#: src/strings.ts:1261
+#: src/strings.ts:1262
 msgid "Faced an issue or have a suggestion? Click here to create a bug report"
 msgstr ""
 
-#: src/strings.ts:2405
+#: src/strings.ts:2406
 msgid "Failed"
 msgstr ""
 
-#: src/strings.ts:2639
+#: src/strings.ts:2640
 msgid "Failed to attach file"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1938
+#: src/strings.ts:1939
 msgid "Failed to copy note"
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2684
+#: src/strings.ts:2685
 msgid "Failed to copy to clipboard"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
 #. placeholder {0}: message ? `: ${message}` : ""
-#: src/strings.ts:2663
+#: src/strings.ts:2664
 msgid "Failed to create API key{0}"
 msgstr ""
 
-#: src/strings.ts:1562
+#: src/strings.ts:1563
 msgid "Failed to decrypt backup"
 msgstr ""
 
-#: src/strings.ts:2004
+#: src/strings.ts:2005
 msgid "Failed to delete"
 msgstr ""
 
-#: src/strings.ts:1083
+#: src/strings.ts:1084
 msgid "Failed to delete account"
 msgstr ""
 
-#: src/strings.ts:792
+#: src/strings.ts:793
 msgid "Failed to download file"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2000
+#: src/strings.ts:2001
 msgid "Failed to install theme."
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2670
+#: src/strings.ts:2671
 msgid "Failed to load API keys. Please try again."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:950
+#: src/strings.ts:951
 msgid "Failed to open"
 msgstr ""
 
-#: src/strings.ts:867
+#: src/strings.ts:868
 msgid "Failed to publish note"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2005
+#: src/strings.ts:2006
 msgid "Failed to register task"
 msgstr ""
 
-#: src/strings.ts:804
+#: src/strings.ts:805
 msgid "Failed to resolve download url"
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2689
+#: src/strings.ts:2690
 msgid "Failed to revoke API key"
 msgstr ""
 
-#: src/strings.ts:773
+#: src/strings.ts:774
 msgid "Failed to send recovery email"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1403
+#: src/strings.ts:1404
 msgid "Failed to send verification email"
 msgstr ""
 
-#: src/strings.ts:939
+#: src/strings.ts:940
 msgid "Failed to subscribe"
 msgstr ""
 
-#: src/strings.ts:2205
+#: src/strings.ts:2206
 msgid "Failed to take backup"
 msgstr ""
 
-#: src/strings.ts:2207
+#: src/strings.ts:2208
 msgid "Failed to take backup of your data. Do you want to continue logging out?"
 msgstr ""
 
-#: src/strings.ts:868
+#: src/strings.ts:869
 msgid "Failed to unpublish note"
 msgstr ""
 
-#: src/strings.ts:798
+#: src/strings.ts:799
 msgid "Failed to zip files"
 msgstr ""
 
@@ -2967,140 +2975,140 @@ msgstr ""
 msgid "Fallback method for 2FA enabled"
 msgstr ""
 
-#: src/strings.ts:2551
+#: src/strings.ts:2552
 msgid "FAQs"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2034
+#: src/strings.ts:2035
 msgid "Favorite"
 msgstr ""
 
 #: src/strings.ts:321
-#: src/strings.ts:1523
+#: src/strings.ts:1524
 msgid "Favorites"
 msgstr ""
 
-#: src/strings.ts:2549
+#: src/strings.ts:2550
 msgid "Featured on"
 msgstr ""
 
-#: src/strings.ts:2417
+#: src/strings.ts:2418
 msgid "February 2022 Week 2"
 msgstr ""
 
-#: src/strings.ts:2418
+#: src/strings.ts:2419
 msgid "February 2022 Week 3"
 msgstr ""
 
-#: src/strings.ts:732
+#: src/strings.ts:733
 msgid "File check failed: {reason} Try reuploading the file to fix the issue."
 msgstr ""
 
-#: src/strings.ts:750
+#: src/strings.ts:751
 msgid "File check passed"
 msgstr ""
 
-#: src/strings.ts:801
+#: src/strings.ts:802
 msgid "File length is 0. Please upload this file again from the attachment manager."
 msgstr ""
 
-#: src/strings.ts:803
+#: src/strings.ts:804
 msgid "File length mismatch. Expected {expectedSize} but got {currentSize} bytes. Please upload this file again from the attachment manager."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:951
+#: src/strings.ts:952
 msgid "File mismatch"
 msgstr ""
 
-#: src/strings.ts:947
+#: src/strings.ts:948
 msgid "File size should be less than {sizeInMB}"
 msgstr ""
 
-#: src/strings.ts:945
+#: src/strings.ts:946
 msgid "File too big"
 msgstr ""
 
-#: src/strings.ts:1480
+#: src/strings.ts:1481
 msgid "Filter attachments by filename, type or hash"
 msgstr ""
 
-#: src/strings.ts:1835
+#: src/strings.ts:1836
 msgid "Filter languages"
 msgstr ""
 
-#: src/strings.ts:2606
+#: src/strings.ts:2607
 msgid "Finish your purchase in the browser."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1671
+#: src/strings.ts:1672
 msgid "Fix it"
 msgstr ""
 
-#: src/strings.ts:2017
+#: src/strings.ts:2018
 msgid "Focus mode"
 msgstr ""
 
-#: src/strings.ts:2165
+#: src/strings.ts:2166
 msgid "Follow"
 msgstr ""
 
-#: src/strings.ts:1277
+#: src/strings.ts:1278
 msgid "Follow us on Mastodon"
 msgstr ""
 
-#: src/strings.ts:1279
+#: src/strings.ts:1280
 msgid "Follow us on Mastodon for updates and news about Notesnook"
 msgstr ""
 
-#: src/strings.ts:1280
+#: src/strings.ts:1281
 msgid "Follow us on X"
 msgstr ""
 
-#: src/strings.ts:1281
+#: src/strings.ts:1282
 msgid "Follow us on X for updates and news about Notesnook"
 msgstr ""
 
-#: src/strings.ts:2278
+#: src/strings.ts:2279
 msgid "Font family"
 msgstr ""
 
-#: src/strings.ts:2465
+#: src/strings.ts:2466
 msgid "Font ligatures"
 msgstr ""
 
-#: src/strings.ts:2279
+#: src/strings.ts:2280
 msgid "Font size"
 msgstr ""
 
-#: src/strings.ts:2523
+#: src/strings.ts:2524
 msgid "For a monthly subscription, you can get a refund within 7 days of purchase. For a yearly subscription, we offer a full refund within 14 days of purchase. For a 5 year subscription, you can request a refund within 30 days of purchase."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1688
+#: src/strings.ts:1689
 msgid "For a more integrated user experience, try out Notesnook for {platform}"
 msgstr ""
 
-#: src/strings.ts:1769
+#: src/strings.ts:1770
 msgid "for help regarding how to use the Notesnook Importer."
 msgstr ""
 
-#: src/strings.ts:2532
+#: src/strings.ts:2533
 msgid "for locking your notes as soon as app enters background"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2197
+#: src/strings.ts:2198
 msgid "Force logout from all your other logged in devices."
 msgstr ""
 
-#: src/strings.ts:1098
+#: src/strings.ts:1099
 msgid "Force pull changes"
 msgstr ""
 
-#: src/strings.ts:1107
+#: src/strings.ts:1108
 msgid "Force push changes"
 msgstr ""
 
-#: src/strings.ts:2214
+#: src/strings.ts:2215
 msgid ""
 "Force push:\n"
 "Use this if changes made on this device are not appearing on other devices. This will overwrite the data on the server with the data from this device.\n"
@@ -3111,252 +3119,256 @@ msgid ""
 "**These must only be used for troubleshooting. Using them regularly for sync is not recommended and will lead to unexpected data loss and other issues. If you are having persistent issues with sync, please report them to us at support@streetwriters.co.**"
 msgstr ""
 
-#: src/strings.ts:553
+#: src/strings.ts:554
 msgid "Forgot password?"
 msgstr ""
 
-#: src/strings.ts:2566
+#: src/strings.ts:2567
 msgid "Free {duration} day trial, cancel any time"
 msgstr ""
 
-#: src/strings.ts:2470
+#: src/strings.ts:2471
 msgid "Free plan"
 msgstr ""
 
-#: src/strings.ts:627
+#: src/strings.ts:628
 msgid "Fri"
 msgstr ""
 
-#: src/strings.ts:618
+#: src/strings.ts:619
 msgid "Friday"
 msgstr ""
 
-#: src/strings.ts:2373
+#: src/strings.ts:2374
 msgid "From code"
 msgstr ""
 
-#: src/strings.ts:2370
+#: src/strings.ts:2371
 msgid "From URL"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2001
+#: src/strings.ts:2002
 msgid "Full name updated"
 msgstr ""
 
-#: src/strings.ts:2208
+#: src/strings.ts:2209
 msgid "Full offline mode"
 msgstr ""
 
-#: src/strings.ts:2325
+#: src/strings.ts:2326
 msgid "Full screen"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2094
+#: src/strings.ts:2095
 msgid "General"
 msgstr ""
 
-#: src/strings.ts:1270
+#: src/strings.ts:1271
 msgid "Get helpful debug info about the app to help us find bugs."
 msgstr ""
 
-#: src/strings.ts:1294
+#: src/strings.ts:1295
 msgid "Get Notesnook app on your desktop and access all notes"
 msgstr ""
 
-#: src/strings.ts:2159
+#: src/strings.ts:2160
 msgid "Get Notesnook app on your iPhone and access all your notes on the go."
 msgstr ""
 
-#: src/strings.ts:2161
+#: src/strings.ts:2162
 msgid "Get Notesnook app on your iPhone or Android device and access all your notes on the go."
 msgstr ""
 
-#: src/strings.ts:1384
+#: src/strings.ts:1385
 msgid "Get Notesnook Pro"
 msgstr ""
 
-#: src/strings.ts:1369
+#: src/strings.ts:1370
 msgid "Get Notesnook Pro to enable automatic backups"
 msgstr ""
 
-#: src/strings.ts:2409
+#: src/strings.ts:2410
 msgid "Get Priority support"
 msgstr ""
 
-#: src/strings.ts:688
+#: src/strings.ts:689
 msgid "Get Pro"
 msgstr ""
 
-#: src/strings.ts:563
+#: src/strings.ts:564
 msgid "Get started"
 msgstr ""
 
-#: src/strings.ts:2529
+#: src/strings.ts:2530
 msgid "Get this and so much more:"
+msgstr "<<<<<<< Updated upstream"
+
+#: src/strings.ts:400
+msgid "Getting 2FA backup codes"
 msgstr ""
 
-#: src/strings.ts:1887
+#: src/strings.ts:1888
 msgid "Getting encryption key..."
 msgstr ""
 
 #: src/strings.ts:398
 msgid "Getting information"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:400
-msgid "Getting recovery codes"
-msgstr ""
-
-#: src/strings.ts:2164
+#: src/strings.ts:2165
 msgid "GNU GENERAL PUBLIC LICENSE Version 3"
 msgstr ""
 
-#: src/strings.ts:2607
+#: src/strings.ts:2608
 msgid "Go back"
 msgstr ""
 
-#: src/strings.ts:2448
+#: src/strings.ts:2449
 msgid "Go back in tab"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2227
+#: src/strings.ts:2228
 msgid "Go back to notebooks"
 msgstr ""
 
-#: src/strings.ts:2228
+#: src/strings.ts:2229
 msgid "Go back to tags"
 msgstr ""
 
-#: src/strings.ts:2447
+#: src/strings.ts:2448
 msgid "Go forward in tab"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1815
+#: src/strings.ts:1816
 msgid "Go to"
 msgstr ""
 
-#: src/strings.ts:1816
+#: src/strings.ts:1817
 msgid "Go to #{tag}"
 msgstr ""
 
-#: src/strings.ts:1699
+#: src/strings.ts:1700
 msgid "Go to next page"
 msgstr ""
 
-#: src/strings.ts:1700
+#: src/strings.ts:1701
 msgid "Go to previous page"
 msgstr ""
 
-#: src/strings.ts:1306
+#: src/strings.ts:1307
 msgid "Go to web app"
 msgstr ""
 
-#: src/strings.ts:2540
+#: src/strings.ts:2541
 msgid "Google will remind you 2 days before your trial ends."
 msgstr ""
 
-#: src/strings.ts:2567
+#: src/strings.ts:2568
 msgid "Google will remind you before your trial ends"
 msgstr ""
 
-#: src/strings.ts:586
+#: src/strings.ts:587
 msgid "Got it"
 msgstr ""
 
 #: src/strings.ts:429
 msgid "GROUP"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1889
+#: src/strings.ts:1890
 msgid "Group added successfully"
 msgstr ""
 
-#: src/strings.ts:537
+#: src/strings.ts:538
 msgid "Group by"
 msgstr ""
 
-#: src/strings.ts:752
+#: src/strings.ts:753
 msgid "Hash copied"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2211
+#: src/strings.ts:2212
 msgid "Having problems with sync?"
 msgstr ""
 
-#: src/strings.ts:2555
+#: src/strings.ts:2556
 msgid "hdImages"
 msgstr ""
 
-#: src/strings.ts:2351
+#: src/strings.ts:2352
 msgid "Heading {level}"
 msgstr ""
 
-#: src/strings.ts:2280
+#: src/strings.ts:2281
 msgid "Headings"
 msgstr ""
 
-#: src/strings.ts:2386
+#: src/strings.ts:2387
 msgid "Height"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1258
+#: src/strings.ts:1259
 msgid "Help and support"
 msgstr ""
 
 #: src/strings.ts:161
 msgid "Help improve Notesnook by sending completely anonymized"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1377
+#: src/strings.ts:1378
 msgid "Hide"
 msgstr ""
 
-#: src/strings.ts:1184
+#: src/strings.ts:1185
 msgid "Hide app contents when you switch to other apps. This will also disable screenshot taking in the app."
 msgstr ""
 
-#: src/strings.ts:2170
+#: src/strings.ts:2171
 msgid "Hide note title"
 msgstr ""
 
-#: src/strings.ts:2283
+#: src/strings.ts:2284
 msgid "Highlight"
 msgstr ""
 
-#: src/strings.ts:909
+#: src/strings.ts:910
 msgid "History"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1529
+#: src/strings.ts:1530
 msgid "Home"
 msgstr ""
 
-#: src/strings.ts:1128
+#: src/strings.ts:1129
 msgid "Homepage"
 msgstr ""
 
-#: src/strings.ts:1319
+#: src/strings.ts:1320
 msgid "Homepage changed to {name}"
 msgstr ""
 
-#: src/strings.ts:2332
+#: src/strings.ts:2333
 msgid "Horizontal rule"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1800
+#: src/strings.ts:1801
 msgid "How do you want to recover your account?"
 msgstr ""
 
-#: src/strings.ts:1670
+#: src/strings.ts:1671
 msgid "How to fix it?"
 msgstr ""
 
-#: src/strings.ts:880
+#: src/strings.ts:881
 msgid "hr"
 msgstr ""
 
-#: src/strings.ts:2500
+#: src/strings.ts:2501
 msgid "I already have an account"
+msgstr ""
+
+#: src/strings.ts:126
+msgid "I don't have 2FA backup codes"
 msgstr ""
 
 #: src/strings.ts:125
@@ -3371,31 +3383,27 @@ msgstr ""
 msgid "I don't have access to my phone"
 msgstr ""
 
-#: src/strings.ts:126
-msgid "I don't have recovery codes"
-msgstr ""
-
 #: src/strings.ts:133
-msgid "I have a recovery code"
-msgstr ""
+msgid "I have a 2FA backup code"
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1888
+#: src/strings.ts:1889
 msgid "I have saved my key"
 msgstr ""
 
-#: src/strings.ts:2426
+#: src/strings.ts:2427
 msgid "I love cooking and collecting recipes."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2212
+#: src/strings.ts:2213
 msgid "I understand"
 msgstr ""
 
-#: src/strings.ts:551
+#: src/strings.ts:552
 msgid "I understand, change my password"
 msgstr ""
 
-#: src/strings.ts:913
+#: src/strings.ts:914
 msgid "ID copied"
 msgstr ""
 
@@ -3405,31 +3413,31 @@ msgstr ""
 
 #: src/strings.ts:254
 msgid "If this continues to happen, please reach out to us via"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2115
+#: src/strings.ts:2116
 msgid "If true, Notesnook will automatically start up when you turn on & login to your system."
 msgstr ""
 
-#: src/strings.ts:2118
+#: src/strings.ts:2119
 msgid "If true, Notesnook will start minimized to either the system tray or your system taskbar/dock. This setting only works with Auto start on system startup is enabled."
 msgstr ""
 
-#: src/strings.ts:1726
+#: src/strings.ts:1727
 msgid "If you can't scan the QR code above, enter this text instead (spaces don't matter)"
 msgstr ""
 
-#: src/strings.ts:1396
+#: src/strings.ts:1397
 msgid ""
 "If you didn't get an email from us or the confirmation link isn't\n"
 "            working,"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1806
+#: src/strings.ts:1807
 msgid "If you don't have a recovery key, you can recover your data by restoring a Notesnook data backup file (.nnbackup)."
 msgstr ""
 
-#: src/strings.ts:2079
+#: src/strings.ts:2080
 msgid "If you face any issue, you can reach out to us anytime."
 msgstr ""
 
@@ -3437,168 +3445,168 @@ msgstr ""
 msgid "If you want to ask something in general or need some assistance, we would suggest that you"
 msgstr ""
 
-#: src/strings.ts:2337
+#: src/strings.ts:2338
 msgid "Image"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1130
+#: src/strings.ts:1131
 msgid "Image Compression"
 msgstr ""
 
-#: src/strings.ts:2313
+#: src/strings.ts:2314
 msgid "Image properties"
 msgstr ""
 
-#: src/strings.ts:2309
+#: src/strings.ts:2310
 msgid "Image settings"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:949
+#: src/strings.ts:950
 msgid "Image size should be less than {sizeInMB}"
 msgstr ""
 
-#: src/strings.ts:755
+#: src/strings.ts:756
 msgid "Images"
 msgstr ""
 
 #: src/strings.ts:142
 msgid "Images uploaded without compression are slow to load and take more bandwidth. We recommend compressing images unless you need image in original quality."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1584
+#: src/strings.ts:1585
 msgid "Immediately"
 msgstr ""
 
-#: src/strings.ts:2142
+#: src/strings.ts:2143
 msgid "Import & export"
 msgstr ""
 
-#: src/strings.ts:1753
+#: src/strings.ts:1754
 msgid "Import completed"
 msgstr ""
 
-#: src/strings.ts:2636
+#: src/strings.ts:2637
 msgid "Import CSV"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1768
+#: src/strings.ts:1769
 msgid "import guide"
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2642
+#: src/strings.ts:2643
 msgid "Inbox API"
 msgstr ""
 
-#: src/strings.ts:2647
+#: src/strings.ts:2648
 msgid "Inbox Keys"
 msgstr ""
 
-#: src/strings.ts:2702
+#: src/strings.ts:2703
 msgid "Inbox keys saved"
 msgstr ""
 
 #: src/strings.ts:174
 msgid "Incoming"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1839
+#: src/strings.ts:1840
 msgid "Incoming note"
 msgstr ""
 
-#: src/strings.ts:784
+#: src/strings.ts:785
 msgid "Incorrect {type}"
 msgstr ""
 
-#: src/strings.ts:2395
+#: src/strings.ts:2396
 msgid "Increase {title}"
 msgstr ""
 
-#: src/strings.ts:2237
+#: src/strings.ts:2238
 msgid "Insert"
 msgstr ""
 
-#: src/strings.ts:2392
+#: src/strings.ts:2393
 msgid "Insert a {rows}x{columns} table"
 msgstr ""
 
-#: src/strings.ts:2342
+#: src/strings.ts:2343
 msgid "Insert a table"
 msgstr ""
 
-#: src/strings.ts:2344
+#: src/strings.ts:2345
 msgid "Insert an embed"
 msgstr ""
 
-#: src/strings.ts:2338
+#: src/strings.ts:2339
 msgid "Insert an image"
 msgstr ""
 
-#: src/strings.ts:2290
+#: src/strings.ts:2291
 msgid "Insert column left"
 msgstr ""
 
-#: src/strings.ts:2291
+#: src/strings.ts:2292
 msgid "Insert column right"
 msgstr ""
 
-#: src/strings.ts:2235
+#: src/strings.ts:2236
 msgid "Insert link"
 msgstr ""
 
-#: src/strings.ts:2297
+#: src/strings.ts:2298
 msgid "Insert row above"
 msgstr ""
 
-#: src/strings.ts:2298
+#: src/strings.ts:2299
 msgid "Insert row below"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1686
+#: src/strings.ts:1687
 msgid "Install Notesnook"
 msgstr ""
 
-#: src/strings.ts:2150
+#: src/strings.ts:2151
 msgid "Install update"
 msgstr ""
 
-#: src/strings.ts:1721
+#: src/strings.ts:1722
 msgid "installs"
 msgstr ""
 
-#: src/strings.ts:748
+#: src/strings.ts:749
 msgid "Invalid {type}"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1993
+#: src/strings.ts:1994
 msgid "Invalid CORS proxy url"
 msgstr ""
 
-#: src/strings.ts:1484
+#: src/strings.ts:1485
 msgid "Invalid email"
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2682
+#: src/strings.ts:2683
 msgid "Invalid password"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2701
+#: src/strings.ts:2702
 msgid "Invalid PGP key pair. Please check your keys and try again."
 msgstr ""
 
-#: src/strings.ts:2708
-msgid "Invalid recovery key. Make sure to input your account recovery key, not a 2FA recovery code."
+#: src/strings.ts:2709
+msgid "Invalid recovery key. Make sure to input your account recovery key, not a 2FA backup code."
 msgstr ""
 
 #: src/strings.ts:224
 msgid "Issue created"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:992
-#: src/strings.ts:1001
+#: src/strings.ts:993
+#: src/strings.ts:1002
 msgid "It may take a minute to receive your code."
 msgstr ""
 
-#: src/strings.ts:1592
+#: src/strings.ts:1593
 msgid "It seems that your changes could not be saved. What to do next:"
 msgstr ""
 
@@ -3606,7 +3614,7 @@ msgstr ""
 msgid "It took us a year to bring Notesnook to life. Share your experience and suggestions to help us improve it."
 msgstr ""
 
-#: src/strings.ts:2259
+#: src/strings.ts:2260
 msgid "Italic"
 msgstr ""
 
@@ -3619,79 +3627,79 @@ msgid "Item"
 msgstr ""
 
 #: src/strings.ts:311
-#: src/strings.ts:1705
+#: src/strings.ts:1706
 msgid "items"
 msgstr ""
 
 #: src/strings.ts:323
 msgid "Items"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2162
+#: src/strings.ts:2163
 msgid "Join community"
 msgstr ""
 
 #: src/strings.ts:234
 msgid "join our community on Discord."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1282
+#: src/strings.ts:1283
 msgid "Join our Discord server"
 msgstr ""
 
-#: src/strings.ts:1284
+#: src/strings.ts:1285
 msgid "Join our Discord server to chat with other users and the team"
 msgstr ""
 
-#: src/strings.ts:1274
+#: src/strings.ts:1275
 msgid "Join our Telegram group"
 msgstr ""
 
-#: src/strings.ts:1276
+#: src/strings.ts:1277
 msgid "Join our Telegram group to chat with other users and the team"
 msgstr ""
 
-#: src/strings.ts:2070
+#: src/strings.ts:2071
 msgid "Join the cause"
 msgstr ""
 
-#: src/strings.ts:2028
+#: src/strings.ts:2029
 msgid "Jump to group"
 msgstr ""
 
-#: src/strings.ts:567
+#: src/strings.ts:568
 msgid "Keep"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2023
+#: src/strings.ts:2024
 msgid "Keep open"
 msgstr ""
 
-#: src/strings.ts:1361
+#: src/strings.ts:1362
 msgid "Keep your data safe"
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2657
+#: src/strings.ts:2658
 msgid "Key name"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2130
+#: src/strings.ts:2131
 msgid "Languages"
 msgstr ""
 
-#: src/strings.ts:2232
+#: src/strings.ts:2233
 msgid "Last edited at"
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2690
+#: src/strings.ts:2691
 msgid "Last used on"
 msgstr ""
 
-#: src/strings.ts:590
+#: src/strings.ts:591
 msgid "Later"
 msgstr ""
 
-#: src/strings.ts:643
+#: src/strings.ts:644
 msgid "Latest first"
 msgstr ""
 
@@ -3699,11 +3707,11 @@ msgstr ""
 msgid "Learn how this works."
 msgstr ""
 
-#: src/strings.ts:571
+#: src/strings.ts:572
 msgid "Learn more"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:979
+#: src/strings.ts:980
 msgid "Learn more about Monographs"
 msgstr ""
 
@@ -3711,67 +3719,67 @@ msgstr ""
 msgid "Learn more about Notesnook Monograph"
 msgstr ""
 
-#: src/strings.ts:646
+#: src/strings.ts:647
 msgid "Least relevant first"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1564
+#: src/strings.ts:1565
 msgid "Legal"
 msgstr ""
 
 #: src/strings.ts:476
 msgid "Let us know if you have faced any issue/bug while using Notesnook. We will try to fix it as soon as possible."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2163
+#: src/strings.ts:2164
 msgid "License"
 msgstr ""
 
-#: src/strings.ts:1722
+#: src/strings.ts:1723
 msgid "Licensed under {license}"
 msgstr ""
 
-#: src/strings.ts:2328
+#: src/strings.ts:2329
 msgid "Lift list item"
 msgstr ""
 
-#: src/strings.ts:725
+#: src/strings.ts:726
 msgid "Light"
 msgstr ""
 
-#: src/strings.ts:2358
+#: src/strings.ts:2359
 msgid "Line {line}, Column {column}"
 msgstr ""
 
-#: src/strings.ts:2618
+#: src/strings.ts:2619
 msgid "Line height"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1154
+#: src/strings.ts:1155
 msgid "Line spacing changed"
 msgstr ""
 
-#: src/strings.ts:2263
+#: src/strings.ts:2264
 msgid "Link"
 msgstr ""
 
-#: src/strings.ts:911
+#: src/strings.ts:912
 msgid "Link copied"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:931
+#: src/strings.ts:932
 msgid "Link notebooks"
 msgstr ""
 
-#: src/strings.ts:2477
+#: src/strings.ts:2478
 msgid "Link notes"
 msgstr ""
 
-#: src/strings.ts:2268
+#: src/strings.ts:2269
 msgid "Link settings"
 msgstr ""
 
-#: src/strings.ts:2388
+#: src/strings.ts:2389
 msgid "Link text"
 msgstr ""
 
@@ -3779,31 +3787,31 @@ msgstr ""
 msgid "LINK TO A SECTION"
 msgstr ""
 
-#: src/strings.ts:526
+#: src/strings.ts:527
 msgid "Link to note"
 msgstr ""
 
-#: src/strings.ts:851
+#: src/strings.ts:852
 msgid "Link to notebook"
 msgstr ""
 
-#: src/strings.ts:595
+#: src/strings.ts:596
 msgid "Linked notes"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1598
+#: src/strings.ts:1599
 msgid "Linking to a specific block is not available for locked notes."
 msgstr ""
 
-#: src/strings.ts:504
+#: src/strings.ts:505
 msgid "List of"
 msgstr ""
 
-#: src/strings.ts:727
+#: src/strings.ts:728
 msgid "Load from file"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1697
+#: src/strings.ts:1698
 msgid "Loading"
 msgstr ""
 
@@ -3812,51 +3820,51 @@ msgstr ""
 msgid "Loading {0}, please wait..."
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2669
+#: src/strings.ts:2670
 msgid "Loading API keys..."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1666
+#: src/strings.ts:1667
 msgid "Loading editor. Please wait..."
 msgstr ""
 
-#: src/strings.ts:1066
+#: src/strings.ts:1067
 msgid "Loading subscription details"
 msgstr ""
 
 #: src/strings.ts:414
 msgid "Loading themes..."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1329
+#: src/strings.ts:1330
 msgid "Loading trash"
 msgstr ""
 
-#: src/strings.ts:975
+#: src/strings.ts:976
 msgid "Loading your archive"
 msgstr ""
 
-#: src/strings.ts:969
+#: src/strings.ts:970
 msgid "Loading your favorites"
 msgstr ""
 
-#: src/strings.ts:974
+#: src/strings.ts:975
 msgid "Loading your monographs"
 msgstr ""
 
-#: src/strings.ts:972
+#: src/strings.ts:973
 msgid "Loading your notebooks"
 msgstr ""
 
-#: src/strings.ts:970
+#: src/strings.ts:971
 msgid "Loading your notes"
 msgstr ""
 
-#: src/strings.ts:973
+#: src/strings.ts:974
 msgid "Loading your reminders"
 msgstr ""
 
-#: src/strings.ts:971
+#: src/strings.ts:972
 msgid "Loading your tags"
 msgstr ""
 
@@ -3866,41 +3874,41 @@ msgstr ""
 
 #: src/strings.ts:456
 msgid "Lock note"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1186
+#: src/strings.ts:1187
 msgid "Lock the app with a password or pin"
 msgstr ""
 
-#: src/strings.ts:2703
+#: src/strings.ts:2704
 msgid "Lock vault after"
 msgstr ""
 
-#: src/strings.ts:901
+#: src/strings.ts:902
 msgid "Locked notes cannot be pinned"
 msgstr ""
 
-#: src/strings.ts:904
+#: src/strings.ts:905
 msgid "Locked notes cannot be published"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2195
+#: src/strings.ts:2196
 msgid "Log out from all other devices"
 msgstr ""
 
 #: src/strings.ts:389
 msgid "Logged in as {email}"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1076
+#: src/strings.ts:1077
 msgid "Logging out will clear all data stored on THIS DEVICE. Make sure you have synced all your changes before logging out."
 msgstr ""
 
 #: src/strings.ts:403
 msgid "Logging out. Please wait..."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1784
+#: src/strings.ts:1785
 msgid "Logging you in"
 msgstr ""
 
@@ -3908,131 +3916,131 @@ msgstr ""
 msgid "Login"
 msgstr ""
 
-#: src/strings.ts:778
+#: src/strings.ts:779
 msgid "Login failed"
 msgstr ""
 
-#: src/strings.ts:902
+#: src/strings.ts:903
 msgid "Login required"
 msgstr ""
 
-#: src/strings.ts:779
+#: src/strings.ts:780
 msgid "Login successful"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1364
+#: src/strings.ts:1365
 msgid "Login to encrypt and sync notes"
 msgstr ""
 
-#: src/strings.ts:2611
+#: src/strings.ts:2612
 msgid "Login to upload attachments. [Read more](https://help.notesnook.com/faqs/login-to-upload-attachments)"
 msgstr ""
 
-#: src/strings.ts:542
+#: src/strings.ts:543
 msgid "Login to your account"
 msgstr ""
 
-#: src/strings.ts:776
+#: src/strings.ts:777
 msgid "Logout"
 msgstr ""
 
-#: src/strings.ts:582
+#: src/strings.ts:583
 msgid "Logout and clear data"
 msgstr ""
 
-#: src/strings.ts:555
+#: src/strings.ts:556
 msgid "Logout from this device"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1414
+#: src/strings.ts:1415
 msgid "Long press on any item in list to enter multi-select mode."
 msgstr ""
 
-#: src/strings.ts:2363
+#: src/strings.ts:2364
 msgid "Make task list readonly"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1040
+#: src/strings.ts:1041
 msgid "Manage account"
 msgstr ""
 
-#: src/strings.ts:1053
+#: src/strings.ts:1054
 msgid "Manage attachments"
 msgstr ""
 
-#: src/strings.ts:685
+#: src/strings.ts:686
 msgid "Manage subscription on desktop"
 msgstr ""
 
-#: src/strings.ts:850
+#: src/strings.ts:851
 msgid "Manage tags"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1041
+#: src/strings.ts:1042
 msgid "Manage your account related settings here"
 msgstr ""
 
-#: src/strings.ts:1054
+#: src/strings.ts:1055
 msgid "Manage your attachments in one place"
 msgstr ""
 
-#: src/strings.ts:1213
+#: src/strings.ts:1214
 msgid "Manage your backups and restore data"
 msgstr ""
 
-#: src/strings.ts:1247
+#: src/strings.ts:1248
 msgid "Manage your reminders"
 msgstr ""
 
-#: src/strings.ts:1085
+#: src/strings.ts:1086
 msgid "Manage your sync settings here"
 msgstr ""
 
-#: src/strings.ts:1442
+#: src/strings.ts:1443
 msgid "Mark important notes by adding them to favorites."
 msgstr ""
 
-#: src/strings.ts:1161
+#: src/strings.ts:1162
 msgid "Markdown shortcuts"
 msgstr ""
 
-#: src/strings.ts:1167
+#: src/strings.ts:1168
 msgid "Marketing emails"
 msgstr ""
 
-#: src/strings.ts:2376
+#: src/strings.ts:2377
 msgid "Match case"
 msgstr ""
 
-#: src/strings.ts:2377
+#: src/strings.ts:2378
 msgid "Match whole word"
 msgstr ""
 
-#: src/strings.ts:2285
+#: src/strings.ts:2286
 msgid "Math (inline)"
 msgstr ""
 
-#: src/strings.ts:2335
+#: src/strings.ts:2336
 msgid "Math & formulas"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2042
+#: src/strings.ts:2043
 msgid "Maximize"
 msgstr ""
 
-#: src/strings.ts:2072
+#: src/strings.ts:2073
 msgid "Meet other privacy-minded people & talk to us directly about your concerns, issues and suggestions."
 msgstr ""
 
-#: src/strings.ts:2419
+#: src/strings.ts:2420
 msgid "Meetings"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1781
+#: src/strings.ts:1782
 msgid "Member since {date}"
 msgstr ""
 
-#: src/strings.ts:2296
+#: src/strings.ts:2297
 msgid "Merge cells"
 msgstr ""
 
@@ -4046,174 +4054,174 @@ msgstr ""
 msgid "Migration failed"
 msgstr ""
 
-#: src/strings.ts:879
+#: src/strings.ts:880
 msgid "min"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2011
+#: src/strings.ts:2012
 msgid "Minimal"
 msgstr ""
 
-#: src/strings.ts:2041
+#: src/strings.ts:2042
 msgid "Minimize"
 msgstr ""
 
-#: src/strings.ts:2119
+#: src/strings.ts:2120
 msgid "Minimize to system tray"
 msgstr ""
 
-#: src/strings.ts:689
+#: src/strings.ts:690
 msgid "mo"
 msgstr ""
 
-#: src/strings.ts:623
+#: src/strings.ts:624
 msgid "Mon"
 msgstr ""
 
-#: src/strings.ts:614
+#: src/strings.ts:615
 msgid "Monday"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1633
+#: src/strings.ts:1634
 msgid "Monograph server"
 msgstr ""
 
-#: src/strings.ts:870
+#: src/strings.ts:871
 msgid "Monograph URL copied"
 msgstr ""
 
 #: src/strings.ts:322
-#: src/strings.ts:941
-#: src/strings.ts:1531
+#: src/strings.ts:942
+#: src/strings.ts:1532
 msgid "Monographs"
 msgstr ""
 
-#: src/strings.ts:1424
+#: src/strings.ts:1425
 msgid "Monographs can be encrypted with a secret key and shared with anyone."
 msgstr ""
 
-#: src/strings.ts:1419
+#: src/strings.ts:1420
 msgid "Monographs enable you to share your notes in a secure and private way."
 msgstr ""
 
-#: src/strings.ts:1842
+#: src/strings.ts:1843
 msgid "month"
 msgstr ""
 
-#: src/strings.ts:665
+#: src/strings.ts:666
 msgid "Month"
 msgstr ""
 
 #: src/strings.ts:169
-#: src/strings.ts:1572
+#: src/strings.ts:1573
 msgid "Monthly"
 msgstr ""
 
-#: src/strings.ts:2315
+#: src/strings.ts:2316
 msgid "More"
 msgstr ""
 
-#: src/strings.ts:645
+#: src/strings.ts:646
 msgid "Most relevant first"
 msgstr ""
 
-#: src/strings.ts:852
+#: src/strings.ts:853
 msgid "Move"
 msgstr ""
 
-#: src/strings.ts:2364
+#: src/strings.ts:2365
 msgid "Move all checked tasks to bottom"
 msgstr ""
 
-#: src/strings.ts:2292
+#: src/strings.ts:2293
 msgid "Move column left"
 msgstr ""
 
-#: src/strings.ts:2293
+#: src/strings.ts:2294
 msgid "Move column right"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:938
+#: src/strings.ts:939
 msgid "Move notebook"
 msgstr ""
 
-#: src/strings.ts:898
+#: src/strings.ts:899
 msgid "Move notes"
 msgstr ""
 
-#: src/strings.ts:2300
+#: src/strings.ts:2301
 msgid "Move row down"
 msgstr ""
 
-#: src/strings.ts:2299
+#: src/strings.ts:2300
 msgid "Move row up"
 msgstr ""
 
-#: src/strings.ts:585
+#: src/strings.ts:586
 msgid "Move selected notes"
 msgstr ""
 
-#: src/strings.ts:584
+#: src/strings.ts:585
 msgid "Move to top"
 msgstr ""
 
-#: src/strings.ts:855
+#: src/strings.ts:856
 msgid "Move to trash"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1174
+#: src/strings.ts:1175
 msgid "Multi-layer encryption to most important notes"
 msgstr ""
 
-#: src/strings.ts:887
+#: src/strings.ts:888
 msgid "Name"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1690
+#: src/strings.ts:1691
 msgid "Native high-performance encryption"
 msgstr ""
 
-#: src/strings.ts:2444
+#: src/strings.ts:2445
 msgid "Navigate"
 msgstr ""
 
 #: src/strings.ts:390
 msgid "Never"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1344
+#: src/strings.ts:1345
 msgid "Never ask again"
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2693
+#: src/strings.ts:2694
 msgid "Never expires"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1039
+#: src/strings.ts:1040
 msgid "Never hesitate to choose privacy"
 msgstr ""
 
-#: src/strings.ts:672
+#: src/strings.ts:673
 msgid "Never show again"
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2691
+#: src/strings.ts:2692
 msgid "Never used"
 msgstr ""
 
-#: src/strings.ts:642
+#: src/strings.ts:643
 msgid "New - old"
 msgstr ""
 
-#: src/strings.ts:528
+#: src/strings.ts:529
 msgid "New color"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1848
+#: src/strings.ts:1849
 msgid "New Email"
 msgstr ""
 
-#: src/strings.ts:1153
+#: src/strings.ts:1154
 msgid "New lines will be double spaced (old ones won't be affected)."
 msgstr ""
 
@@ -4221,63 +4229,63 @@ msgstr ""
 msgid "New note"
 msgstr ""
 
-#: src/strings.ts:525
+#: src/strings.ts:526
 msgid "New notebook"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1482
+#: src/strings.ts:1483
 msgid "New password"
 msgstr ""
 
-#: src/strings.ts:1488
+#: src/strings.ts:1489
 msgid "New pin"
 msgstr ""
 
-#: src/strings.ts:535
+#: src/strings.ts:536
 msgid "New reminder"
 msgstr ""
 
-#: src/strings.ts:576
+#: src/strings.ts:577
 msgid "New tab"
 msgstr ""
 
-#: src/strings.ts:2450
+#: src/strings.ts:2451
 msgid "New tag"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1370
+#: src/strings.ts:1371
 msgid "New update available"
 msgstr ""
 
-#: src/strings.ts:531
+#: src/strings.ts:532
 msgid "New version"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2026
+#: src/strings.ts:2027
 msgid "Newest - oldest"
 msgstr ""
 
-#: src/strings.ts:1142
+#: src/strings.ts:1143
 msgid "Newly created notes will be uncategorized"
 msgstr ""
 
-#: src/strings.ts:552
+#: src/strings.ts:553
 msgid "Next"
 msgstr ""
 
-#: src/strings.ts:2380
+#: src/strings.ts:2381
 msgid "Next match"
 msgstr ""
 
-#: src/strings.ts:2445
+#: src/strings.ts:2446
 msgid "Next tab"
 msgstr ""
 
-#: src/strings.ts:547
+#: src/strings.ts:548
 msgid "No"
 msgstr ""
 
-#: src/strings.ts:859
+#: src/strings.ts:860
 msgid "No application found to open {fileToOpen}"
 msgstr ""
 
@@ -4293,27 +4301,27 @@ msgstr ""
 msgid "No blocks linked"
 msgstr ""
 
-#: src/strings.ts:786
+#: src/strings.ts:787
 msgid "No color selected"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1233
+#: src/strings.ts:1234
 msgid "No directory selected"
 msgstr ""
 
 #: src/strings.ts:89
 msgid "No downloads in progress."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1986
+#: src/strings.ts:1987
 msgid "No encryption key found"
 msgstr ""
 
-#: src/strings.ts:1667
+#: src/strings.ts:1668
 msgid "No headings found"
 msgstr ""
 
-#: src/strings.ts:596
+#: src/strings.ts:597
 msgid "No linked notes"
 msgstr ""
 
@@ -4325,7 +4333,7 @@ msgstr ""
 msgid "No note history available for this device."
 msgstr ""
 
-#: src/strings.ts:2494
+#: src/strings.ts:2495
 msgid "No notebooks selected to move"
 msgstr ""
 
@@ -4333,23 +4341,23 @@ msgstr ""
 msgid "No one can view this {type} except you."
 msgstr ""
 
-#: src/strings.ts:2614
+#: src/strings.ts:2615
 msgid "No password"
 msgstr ""
 
 #: src/strings.ts:279
 msgid "No references found of this note"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1518
+#: src/strings.ts:1519
 msgid "No results found"
 msgstr ""
 
 #: src/strings.ts:406
 msgid "No results found for \"{query}\""
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1518
+#: src/strings.ts:1519
 msgid "No results found for {query}"
 msgstr ""
 
@@ -4361,11 +4369,11 @@ msgstr ""
 msgid "No updates available"
 msgstr ""
 
-#: src/strings.ts:661
+#: src/strings.ts:662
 msgid "None"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2016
+#: src/strings.ts:2017
 msgid "Normal mode"
 msgstr ""
 
@@ -4382,11 +4390,11 @@ msgstr ""
 msgid "Note"
 msgstr ""
 
-#: src/strings.ts:815
+#: src/strings.ts:816
 msgid "Note copied to clipboard"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1951
+#: src/strings.ts:1952
 msgid "Note does not exist"
 msgstr ""
 
@@ -4394,27 +4402,27 @@ msgstr ""
 msgid "Note history"
 msgstr ""
 
-#: src/strings.ts:810
+#: src/strings.ts:811
 msgid "Note locked"
 msgstr ""
 
-#: src/strings.ts:845
+#: src/strings.ts:846
 msgid "Note restored from history"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1587
+#: src/strings.ts:1588
 msgid "Note title"
 msgstr ""
 
-#: src/strings.ts:814
+#: src/strings.ts:815
 msgid "Note unlocked"
 msgstr ""
 
 #: src/strings.ts:178
 msgid "Note version history is local only."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1226
+#: src/strings.ts:1227
 msgid "NOTE: Creating a backup with attachments can take a while, and also fail completely. The app will try to resume/restart the backup in case of interruptions."
 msgstr ""
 
@@ -4423,11 +4431,11 @@ msgid "notebook"
 msgstr ""
 
 #: src/strings.ts:296
-#: src/strings.ts:1522
+#: src/strings.ts:1523
 msgid "Notebook"
 msgstr ""
 
-#: src/strings.ts:2480
+#: src/strings.ts:2481
 msgid "Notebook added"
 msgstr ""
 
@@ -4437,15 +4445,15 @@ msgstr ""
 
 #: src/strings.ts:258
 #: src/strings.ts:316
-#: src/strings.ts:1521
+#: src/strings.ts:1522
 msgid "Notebooks"
 msgstr ""
 
-#: src/strings.ts:1796
+#: src/strings.ts:1797
 msgid "NOTEBOOKS"
 msgstr ""
 
-#: src/strings.ts:2242
+#: src/strings.ts:2243
 msgid "Notebooks are the best way to organize your notes."
 msgstr ""
 
@@ -4454,43 +4462,43 @@ msgid "notes"
 msgstr ""
 
 #: src/strings.ts:315
-#: src/strings.ts:1520
+#: src/strings.ts:1521
 msgid "Notes"
 msgstr ""
 
 #: src/strings.ts:223
 msgid "Notes exported as {path} successfully"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1752
+#: src/strings.ts:1753
 msgid "notes imported"
 msgstr ""
 
-#: src/strings.ts:2544
+#: src/strings.ts:2545
 msgid "Notesnook"
 msgstr ""
 
-#: src/strings.ts:2599
+#: src/strings.ts:2600
 msgid "Notesnook Circle"
 msgstr ""
 
-#: src/strings.ts:2601
+#: src/strings.ts:2602
 msgid "Notesnook Circle brings together trusted partners who share our commitment to privacy, transparency, and user freedom."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2069
+#: src/strings.ts:2070
 msgid "Notesnook encrypts everything offline before syncing to your other devices. This means that no one can read your notes except you. Not even us."
 msgstr ""
 
-#: src/strings.ts:2144
+#: src/strings.ts:2145
 msgid "Notesnook Importer"
 msgstr ""
 
-#: src/strings.ts:1068
+#: src/strings.ts:1069
 msgid "Notesnook Pro"
 msgstr ""
 
-#: src/strings.ts:2176
+#: src/strings.ts:2177
 msgid ""
 "Notesnook uses the following DNS providers:\n"
 "\n"
@@ -4498,33 +4506,33 @@ msgid ""
 "2. Quad9\n"
 "\n"
 "This can sometimes bypass local ISP blockages on Notesnook traffic. Disable this if you want the app to use system's DNS settings."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:989
+#: src/strings.ts:990
 msgid "Notesnook will send you a 2FA code on your email when prompted"
 msgstr ""
 
-#: src/strings.ts:996
+#: src/strings.ts:997
 msgid "Notesnook will send you an SMS with a 2FA code when prompted"
 msgstr ""
 
-#: src/strings.ts:2139
+#: src/strings.ts:2140
 msgid "Notifications"
 msgstr ""
 
-#: src/strings.ts:1379
+#: src/strings.ts:1380
 msgid "Notifications disabled"
 msgstr ""
 
-#: src/strings.ts:2276
+#: src/strings.ts:2277
 msgid "Numbered list"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1720
+#: src/strings.ts:1721
 msgid "of"
 msgstr ""
 
-#: src/strings.ts:1604
+#: src/strings.ts:1605
 msgid "Off"
 msgstr ""
 
@@ -4532,39 +4540,39 @@ msgstr ""
 msgid "Offline"
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2674
+#: src/strings.ts:2675
 msgid "OK"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2229
+#: src/strings.ts:2230
 msgid "Okay"
 msgstr ""
 
-#: src/strings.ts:641
+#: src/strings.ts:642
 msgid "Old - new"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1481
+#: src/strings.ts:1482
 msgid "Old password"
 msgstr ""
 
-#: src/strings.ts:1837
+#: src/strings.ts:1838
 msgid "Older version"
 msgstr ""
 
-#: src/strings.ts:2025
+#: src/strings.ts:2026
 msgid "Oldest - newest"
 msgstr ""
 
-#: src/strings.ts:736
+#: src/strings.ts:737
 msgid "Once your password is changed, please make sure to save the new account recovery key"
 msgstr ""
 
-#: src/strings.ts:2562
+#: src/strings.ts:2563
 msgid "One time purchase, no auto-renewal"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1773
+#: src/strings.ts:1774
 msgid "Only .zip files are supported."
 msgstr ""
 
@@ -4572,96 +4580,96 @@ msgstr ""
 msgid "Open"
 msgstr ""
 
-#: src/strings.ts:577
+#: src/strings.ts:578
 msgid "Open file location"
 msgstr ""
 
 #: src/strings.ts:265
 msgid "Open in browser"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1308
+#: src/strings.ts:1309
 msgid "Open in browser to manage subscription"
 msgstr ""
 
-#: src/strings.ts:2326
+#: src/strings.ts:2327
 msgid "Open in new tab"
 msgstr ""
 
-#: src/strings.ts:579
+#: src/strings.ts:580
 msgid "Open issue"
 msgstr ""
 
-#: src/strings.ts:2266
+#: src/strings.ts:2267
 msgid "Open link"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1865
+#: src/strings.ts:1866
 msgid "Open note"
 msgstr ""
 
-#: src/strings.ts:1382
+#: src/strings.ts:1383
 msgid "Open settings"
 msgstr ""
 
-#: src/strings.ts:2327
+#: src/strings.ts:2328
 msgid "Open source"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1290
+#: src/strings.ts:1291
 msgid "Open source libraries used in Notesnook"
 msgstr ""
 
-#: src/strings.ts:1289
+#: src/strings.ts:1290
 msgid "Open source licenses"
 msgstr ""
 
-#: src/strings.ts:819
+#: src/strings.ts:820
 msgid "Open source."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:985
+#: src/strings.ts:986
 msgid "Open the two-factor authentication (TOTP) app to view your authentication code."
 msgstr ""
 
-#: src/strings.ts:1859
+#: src/strings.ts:1860
 msgid "Optional"
 msgstr ""
 
 #: src/strings.ts:255
 msgid "or email us at"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2024
+#: src/strings.ts:2025
 msgid "Order by"
 msgstr ""
 
-#: src/strings.ts:2222
+#: src/strings.ts:2223
 msgid "Order ID"
 msgstr ""
 
-#: src/strings.ts:758
-#: src/strings.ts:762
+#: src/strings.ts:759
+#: src/strings.ts:763
 msgid "Orphaned"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2147
+#: src/strings.ts:2148
 msgid "Other"
 msgstr ""
 
-#: src/strings.ts:2347
+#: src/strings.ts:2348
 msgid "Outline list"
 msgstr ""
 
-#: src/strings.ts:2350
+#: src/strings.ts:2351
 msgid "Paragraph"
 msgstr ""
 
-#: src/strings.ts:2493
+#: src/strings.ts:2494
 msgid "Paragraphs"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2103
+#: src/strings.ts:2104
 msgid "Partial backups contain all your data except attachments. They are created from data already available on your device and do not require an Internet connection."
 msgstr ""
 
@@ -4669,31 +4677,31 @@ msgstr ""
 msgid "Partially refunded"
 msgstr ""
 
-#: src/strings.ts:2404
+#: src/strings.ts:2405
 msgid "Passed"
 msgstr ""
 
-#: src/strings.ts:883
+#: src/strings.ts:884
 msgid "Password"
 msgstr ""
 
-#: src/strings.ts:771
+#: src/strings.ts:772
 msgid "Password change failed"
 msgstr ""
 
-#: src/strings.ts:770
+#: src/strings.ts:771
 msgid "Password changed successfully"
 msgstr ""
 
-#: src/strings.ts:808
+#: src/strings.ts:809
 msgid "Password does not match"
 msgstr ""
 
-#: src/strings.ts:783
+#: src/strings.ts:784
 msgid "Password incorrect"
 msgstr ""
 
-#: src/strings.ts:807
+#: src/strings.ts:808
 msgid "Password not entered"
 msgstr ""
 
@@ -4701,209 +4709,209 @@ msgstr ""
 msgid "Password protection"
 msgstr ""
 
-#: src/strings.ts:809
+#: src/strings.ts:810
 msgid "Password updated"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2083
+#: src/strings.ts:2084
 msgid "Password/pin"
 msgstr ""
 
-#: src/strings.ts:2250
+#: src/strings.ts:2251
 msgid "Paste"
 msgstr ""
 
-#: src/strings.ts:2251
+#: src/strings.ts:2252
 msgid "Paste and match style"
 msgstr ""
 
-#: src/strings.ts:2372
+#: src/strings.ts:2373
 msgid "Paste embed code here. Only iframes are supported."
 msgstr ""
 
-#: src/strings.ts:2387
+#: src/strings.ts:2388
 msgid "Paste image URL here"
 msgstr ""
 
-#: src/strings.ts:2252
+#: src/strings.ts:2253
 msgid "Paste without formatting"
 msgstr ""
 
-#: src/strings.ts:2563
+#: src/strings.ts:2564
 msgid "Pay once and use for 5 years"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2201
+#: src/strings.ts:2202
 msgid "Payment method"
 msgstr ""
 
-#: src/strings.ts:788
+#: src/strings.ts:789
 msgid "PDF is password protected"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1731
+#: src/strings.ts:1732
 msgid "phone number"
 msgstr ""
 
-#: src/strings.ts:1850
+#: src/strings.ts:1851
 msgid "Phone number"
 msgstr ""
 
-#: src/strings.ts:1009
+#: src/strings.ts:1010
 msgid "Phone number not entered"
 msgstr ""
 
-#: src/strings.ts:900
+#: src/strings.ts:901
 msgid "Pin"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1692
+#: src/strings.ts:1693
 msgid "Pin notes in notifications drawer"
 msgstr ""
 
-#: src/strings.ts:930
+#: src/strings.ts:931
 msgid "Pin notification"
 msgstr ""
 
-#: src/strings.ts:523
+#: src/strings.ts:524
 msgid "Pinned"
 msgstr ""
 
-#: src/strings.ts:2581
+#: src/strings.ts:2582
 msgid "Plan limits"
 msgstr ""
 
-#: src/strings.ts:2544
+#: src/strings.ts:2545
 msgid "Plans"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1366
+#: src/strings.ts:1367
 msgid "Please confirm your email to sync notes"
 msgstr ""
 
-#: src/strings.ts:1004
-msgid "Please confirm your identity by entering a recovery code."
+#: src/strings.ts:1005
+msgid "Please confirm your identity by entering a 2FA backup code."
 msgstr ""
 
-#: src/strings.ts:983
-#: src/strings.ts:2234
+#: src/strings.ts:984
+#: src/strings.ts:2235
 msgid "Please confirm your identity by entering the authentication code from your authenticator app."
 msgstr ""
 
 #. placeholder {0}: phoneNumber ? phoneNumber : "your registered phone number."
-#: src/strings.ts:998
+#: src/strings.ts:999
 msgid "Please confirm your identity by entering the authentication code sent to {0}."
 msgstr ""
 
-#: src/strings.ts:991
+#: src/strings.ts:992
 msgid "Please confirm your identity by entering the authentication code sent to your email address."
 msgstr ""
 
-#: src/strings.ts:1911
+#: src/strings.ts:1912
 msgid "Please download a backup of your data as your account will be cleared before recovery."
 msgstr ""
 
-#: src/strings.ts:2009
+#: src/strings.ts:2010
 msgid "Please enable automatic backups to avoid losing important data."
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2660
+#: src/strings.ts:2661
 msgid "Please enter a key name"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1514
+#: src/strings.ts:1515
 msgid "Please enter a valid email address"
 msgstr ""
 
-#: src/strings.ts:1956
+#: src/strings.ts:1957
 msgid "Please enter a valid hex color (e.g. #ffffff)"
 msgstr ""
 
-#: src/strings.ts:1515
+#: src/strings.ts:1516
 msgid "Please enter a valid phone number with country code"
 msgstr ""
 
-#: src/strings.ts:1637
+#: src/strings.ts:1638
 msgid "Please enter a valid URL"
 msgstr ""
 
-#: src/strings.ts:1622
+#: src/strings.ts:1623
 msgid "Please enter password of this backup file"
 msgstr ""
 
-#: src/strings.ts:2245
+#: src/strings.ts:2246
 msgid "Please enter the password to decrypt and restore this backup."
 msgstr ""
 
-#: src/strings.ts:790
+#: src/strings.ts:791
 msgid "Please enter the password to unlock the PDF and view the content."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1867
+#: src/strings.ts:1868
 msgid "Please enter the password to unlock this note"
 msgstr ""
 
-#: src/strings.ts:1864
+#: src/strings.ts:1865
 msgid "Please enter the password to view this version"
-msgstr "<<<<<<< HEAD"
+msgstr "<<<<<<< HEAD<<<<<<< Updated upstream"
 
-#: src/strings.ts:2680
+#: src/strings.ts:2681
 msgid "Please enter your account password to view this API key."
 msgstr ""
 
-#: src/strings.ts:1023
+#: src/strings.ts:1024
 msgid "Please enter your app lock password to continue"
 msgstr ""
 
-#: src/strings.ts:1025
+#: src/strings.ts:1026
 msgid "Please enter your app lock pin to continue"
 msgstr ""
 
-#: src/strings.ts:1019
+#: src/strings.ts:1020
 msgid "Please enter your password to continue"
 msgstr ""
 
-#: src/strings.ts:1935
+#: src/strings.ts:1936
 msgid "Please enter your vault password to continue"
 msgstr ""
 
-#: src/strings.ts:768
+#: src/strings.ts:769
 msgid "Please fill all the fields to continue."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1558
+#: src/strings.ts:1559
 msgid "Please grant notifications permission to add new reminders."
 msgstr ""
 
-#: src/strings.ts:873
+#: src/strings.ts:874
 msgid "Please make sure you have saved the recovery key. Tap one more time to confirm."
 msgstr ""
 
 #: src/strings.ts:228
 msgid "Please note that we will respond to your issue on the given link. We recommend that you save it."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1767
+#: src/strings.ts:1768
 msgid "Please refer to the"
 msgstr ""
 
-#: src/strings.ts:1559
+#: src/strings.ts:1560
 msgid "Please select the day to repeat the reminder on"
 msgstr ""
 
-#: src/strings.ts:1398
+#: src/strings.ts:1399
 msgid "please send us an email from your registered email address"
 msgstr ""
 
-#: src/strings.ts:2393
+#: src/strings.ts:2394
 msgid "Please set a table size"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1560
+#: src/strings.ts:1561
 msgid "Please set title of the reminder"
 msgstr ""
 
-#: src/strings.ts:1989
+#: src/strings.ts:1990
 msgid "Please try again"
 msgstr ""
 
@@ -4913,18 +4921,18 @@ msgstr ""
 
 #: src/strings.ts:262
 msgid "Please wait"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1008
+#: src/strings.ts:1009
 msgid "Please wait before requesting a new code"
 msgstr ""
 
-#: src/strings.ts:1401
-#: src/strings.ts:1553
+#: src/strings.ts:1402
+#: src/strings.ts:1554
 msgid "Please wait before requesting another email"
 msgstr ""
 
-#: src/strings.ts:944
+#: src/strings.ts:945
 msgid "Please wait while we encrypt {name} for upload."
 msgstr ""
 
@@ -4934,74 +4942,74 @@ msgstr ""
 
 #: src/strings.ts:214
 msgid "Please wait while we export your notes."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1896
+#: src/strings.ts:1897
 msgid "Please wait while we finalize your account."
 msgstr ""
 
-#: src/strings.ts:1067
+#: src/strings.ts:1068
 msgid "Please wait while we load your subscription"
 msgstr ""
 
 #: src/strings.ts:404
 msgid "Please wait while we log you out."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1917
+#: src/strings.ts:1918
 msgid "Please wait while we reset your account password."
 msgstr ""
 
-#: src/strings.ts:1615
+#: src/strings.ts:1616
 msgid "Please wait while we restore your backup..."
 msgstr ""
 
-#: src/strings.ts:1899
+#: src/strings.ts:1900
 msgid "Please wait while we send you recovery instructions"
 msgstr ""
 
 #: src/strings.ts:260
 msgid "Please wait while we sync all your data."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1073
+#: src/strings.ts:1074
 msgid "Please wait while we verify your subscription"
 msgstr ""
 
-#: src/strings.ts:1785
-#: src/strings.ts:1892
+#: src/strings.ts:1786
+#: src/strings.ts:1893
 msgid "Please wait while you are authenticated."
 msgstr ""
 
-#: src/strings.ts:1904
+#: src/strings.ts:1905
 msgid "Please wait while your data is downloaded & decrypted."
 msgstr ""
 
-#: src/strings.ts:905
+#: src/strings.ts:906
 msgid "Preparing note for share"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1617
+#: src/strings.ts:1618
 msgid "Preparing to restore backup file..."
 msgstr ""
 
 #: src/strings.ts:428
 msgid "PRESETS"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2121
+#: src/strings.ts:2122
 msgid "Pressing \"—\" will hide the app in your system tray."
 msgstr ""
 
-#: src/strings.ts:2124
+#: src/strings.ts:2125
 msgid "Pressing \"X\" will hide the app in your system tray."
 msgstr ""
 
-#: src/strings.ts:2172
+#: src/strings.ts:2173
 msgid "Prevent note title from appearing in tab/window title."
 msgstr ""
 
-#: src/strings.ts:2314
+#: src/strings.ts:2315
 msgid "Preview attachment"
 msgstr ""
 
@@ -5009,43 +5017,43 @@ msgstr ""
 msgid "Preview not available, content is encrypted."
 msgstr ""
 
-#: src/strings.ts:2381
+#: src/strings.ts:2382
 msgid "Previous match"
 msgstr ""
 
-#: src/strings.ts:2446
+#: src/strings.ts:2447
 msgid "Previous tab"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2036
+#: src/strings.ts:2037
 msgid "Print"
 msgstr ""
 
-#: src/strings.ts:2146
+#: src/strings.ts:2147
 msgid "Privacy"
 msgstr ""
 
-#: src/strings.ts:1163
+#: src/strings.ts:1164
 msgid "Privacy & security"
 msgstr ""
 
-#: src/strings.ts:1657
+#: src/strings.ts:1658
 msgid "Privacy comes first."
 msgstr ""
 
-#: src/strings.ts:827
+#: src/strings.ts:828
 msgid "Privacy for everyone"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1182
+#: src/strings.ts:1183
 msgid "Privacy mode"
 msgstr ""
 
-#: src/strings.ts:2576
+#: src/strings.ts:2577
 msgid "privacy policy"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1287
+#: src/strings.ts:1288
 msgid "Privacy policy"
 msgstr ""
 
@@ -5057,59 +5065,59 @@ msgstr ""
 msgid "private analytics and bug reports."
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2699
+#: src/strings.ts:2700
 msgid "Private Key:"
 msgstr ""
 
-#: src/strings.ts:821
+#: src/strings.ts:822
 msgid "Private."
 msgstr ""
 
-#: src/strings.ts:829
+#: src/strings.ts:830
 msgid "privileged few"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1723
+#: src/strings.ts:1724
 msgid "Pro"
 msgstr ""
 
-#: src/strings.ts:2471
+#: src/strings.ts:2472
 msgid "Pro plan"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2049
+#: src/strings.ts:2050
 msgid "Processing {collection}..."
 msgstr ""
 
-#: src/strings.ts:2048
+#: src/strings.ts:2049
 msgid "Processing..."
 msgstr ""
 
-#: src/strings.ts:1242
+#: src/strings.ts:1243
 msgid "Productivity"
 msgstr ""
 
-#: src/strings.ts:2135
+#: src/strings.ts:2136
 msgid "Profile"
 msgstr ""
 
-#: src/strings.ts:1957
+#: src/strings.ts:1958
 msgid "Profile updated"
 msgstr ""
 
-#: src/strings.ts:1868
+#: src/strings.ts:1869
 msgid "Properties"
 msgstr ""
 
 #: src/strings.ts:401
 msgid "Protect your notes"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2183
+#: src/strings.ts:2184
 msgid "Proxy"
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2698
+#: src/strings.ts:2699
 msgid "Public Key:"
 msgstr ""
 
@@ -5121,15 +5129,15 @@ msgstr ""
 msgid "Publish note"
 msgstr ""
 
-#: src/strings.ts:2615
+#: src/strings.ts:2616
 msgid "Publish to the web"
 msgstr ""
 
 #: src/strings.ts:489
 msgid "Publish your note to share it with others. You can set a password to protect it."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:928
+#: src/strings.ts:929
 msgid "Published"
 msgstr ""
 
@@ -5145,95 +5153,95 @@ msgstr ""
 msgid "Published note link will be automatically deleted once it is viewed by someone."
 msgstr ""
 
-#: src/strings.ts:2569
+#: src/strings.ts:2570
 msgid "Purchase"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1373
+#: src/strings.ts:1374
 msgid "Quick note"
 msgstr ""
 
-#: src/strings.ts:1243
+#: src/strings.ts:1244
 msgid "Quick note notification"
 msgstr ""
 
-#: src/strings.ts:1694
+#: src/strings.ts:1695
 msgid "Quick note widgets"
 msgstr ""
 
-#: src/strings.ts:2442
+#: src/strings.ts:2443
 msgid "Quick open"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1245
+#: src/strings.ts:1246
 msgid "Quickly create a note from the notification"
 msgstr ""
 
-#: src/strings.ts:2334
+#: src/strings.ts:2335
 msgid "Quote"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1359
+#: src/strings.ts:1360
 msgid "Rate Notesnook on App Store"
 msgstr ""
 
-#: src/strings.ts:1360
+#: src/strings.ts:1361
 msgid "Rate Notesnook on Play Store"
 msgstr ""
 
-#: src/strings.ts:589
+#: src/strings.ts:590
 msgid "Rate now (It takes only a second)"
 msgstr ""
 
 #: src/strings.ts:386
 msgid "Read full release notes on Github"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:914
+#: src/strings.ts:915
 msgid "Read only"
 msgstr ""
 
-#: src/strings.ts:1267
+#: src/strings.ts:1268
 msgid "Read the documentation to learn more about Notesnook"
 msgstr ""
 
-#: src/strings.ts:1288
+#: src/strings.ts:1289
 msgid "Read the privacy policy"
 msgstr ""
 
-#: src/strings.ts:1286
+#: src/strings.ts:1287
 msgid "Read the terms of service"
 msgstr ""
 
-#: src/strings.ts:1618
+#: src/strings.ts:1619
 msgid "Reading backup file..."
 msgstr ""
 
-#: src/strings.ts:2546
+#: src/strings.ts:2547
 msgid "Ready to take the next step on your private note taking journey?"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2225
+#: src/strings.ts:2226
 msgid "Receipt"
 msgstr ""
 
-#: src/strings.ts:1613
+#: src/strings.ts:1614
 msgid "RECENT BACKUPS"
 msgstr ""
 
-#: src/strings.ts:2457
+#: src/strings.ts:2458
 msgid "Recents"
 msgstr ""
 
-#: src/strings.ts:2400
+#: src/strings.ts:2401
 msgid "Recheck all"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2003
+#: src/strings.ts:2004
 msgid "Rechecking failed"
 msgstr ""
 
-#: src/strings.ts:2425
+#: src/strings.ts:2426
 msgid "Recipes"
 msgstr ""
 
@@ -5241,21 +5249,13 @@ msgstr ""
 msgid "Recommended"
 msgstr ""
 
-#: src/strings.ts:2548
+#: src/strings.ts:2549
 msgid "Recommended by Privacy Guides"
 msgstr ""
 
 #: src/strings.ts:435
 msgid "Recover your account"
-msgstr ""
-
-#: src/strings.ts:1007
-msgid "Recovery codes copied!"
-msgstr ""
-
-#: src/strings.ts:1012
-msgid "Recovery codes saved!"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
 #: src/strings.ts:94
 msgid "Recovery email has been sent to your email address. Please check your inbox and follow the instructions to recover your account."
@@ -5265,55 +5265,55 @@ msgstr ""
 msgid "Recovery email sent!"
 msgstr ""
 
-#: src/strings.ts:876
+#: src/strings.ts:877
 msgid "Recovery key copied"
 msgstr ""
 
-#: src/strings.ts:874
+#: src/strings.ts:875
 msgid "Recovery key QR code saved"
 msgstr ""
 
-#: src/strings.ts:875
+#: src/strings.ts:876
 msgid "Recovery key text file saved"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1918
+#: src/strings.ts:1919
 msgid "Recovery successful!"
 msgstr ""
 
-#: src/strings.ts:2437
+#: src/strings.ts:2438
 msgid "Redeem"
 msgstr ""
 
-#: src/strings.ts:2598
+#: src/strings.ts:2599
 msgid "Redeem code"
 msgstr ""
 
-#: src/strings.ts:2434
+#: src/strings.ts:2435
 msgid "Redeem gift code"
 msgstr ""
 
-#: src/strings.ts:2436
+#: src/strings.ts:2437
 msgid "Redeeming gift code"
 msgstr ""
 
-#: src/strings.ts:521
+#: src/strings.ts:522
 msgid "Redo"
 msgstr ""
 
 #: src/strings.ts:372
 msgid "Referenced in"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:937
+#: src/strings.ts:938
 msgid "References"
 msgstr ""
 
-#: src/strings.ts:520
+#: src/strings.ts:521
 msgid "Regenerate"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2089
+#: src/strings.ts:2090
 msgid "Register"
 msgstr ""
 
@@ -5321,35 +5321,35 @@ msgstr ""
 msgid "Release notes"
 msgstr ""
 
-#: src/strings.ts:2459
+#: src/strings.ts:2460
 msgid "Release track"
 msgstr ""
 
-#: src/strings.ts:657
+#: src/strings.ts:658
 msgid "Relevance"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1672
+#: src/strings.ts:1673
 msgid "Reload app"
 msgstr ""
 
-#: src/strings.ts:1830
+#: src/strings.ts:1831
 msgid "Relogin to your account"
 msgstr ""
 
-#: src/strings.ts:1798
+#: src/strings.ts:1799
 msgid "Remembered your password?"
 msgstr ""
 
-#: src/strings.ts:927
+#: src/strings.ts:928
 msgid "Remind me"
 msgstr ""
 
 #: src/strings.ts:371
 msgid "Remind me in"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1508
+#: src/strings.ts:1509
 msgid "Remind me of..."
 msgstr ""
 
@@ -5359,13 +5359,13 @@ msgstr ""
 
 #: src/strings.ts:298
 msgid "Reminder"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1248
+#: src/strings.ts:1249
 msgid "Reminder notifications"
 msgstr ""
 
-#: src/strings.ts:1561
+#: src/strings.ts:1562
 msgid "Reminder time cannot be earlier than the current time."
 msgstr ""
 
@@ -5374,92 +5374,92 @@ msgid "reminders"
 msgstr ""
 
 #: src/strings.ts:318
-#: src/strings.ts:1246
-#: src/strings.ts:1524
+#: src/strings.ts:1247
+#: src/strings.ts:1525
 msgid "Reminders"
 msgstr ""
 
-#: src/strings.ts:1381
+#: src/strings.ts:1382
 msgid "Reminders cannot be set because notifications have been disabled from app settings. If you want to keep receiving reminder notifications, enable notifications for Notesnook from app settings."
 msgstr ""
 
-#: src/strings.ts:1955
+#: src/strings.ts:1956
 msgid "Reminders will not be active on this device as it does not support notifications."
 msgstr ""
 
-#: src/strings.ts:782
+#: src/strings.ts:783
 msgid "Remove"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1177
+#: src/strings.ts:1178
 msgid "Remove all notes from the vault."
 msgstr ""
 
-#: src/strings.ts:1204
+#: src/strings.ts:1205
 msgid "Remove app lock password"
 msgstr ""
 
-#: src/strings.ts:1208
+#: src/strings.ts:1209
 msgid "Remove app lock password, app lock will be disabled if no other security method is enabled."
 msgstr ""
 
-#: src/strings.ts:1203
+#: src/strings.ts:1204
 msgid "Remove app lock pin"
 msgstr ""
 
-#: src/strings.ts:1206
+#: src/strings.ts:1207
 msgid "Remove app lock pin, app lock will be disabled if no other security method is enabled."
 msgstr ""
 
-#: src/strings.ts:896
+#: src/strings.ts:897
 msgid "Remove as default"
 msgstr ""
 
-#: src/strings.ts:2318
+#: src/strings.ts:2319
 msgid "Remove attachment"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:933
+#: src/strings.ts:934
 msgid "Remove from all"
 msgstr ""
 
-#: src/strings.ts:906
+#: src/strings.ts:907
 msgid "Remove from notebook"
 msgstr ""
 
-#: src/strings.ts:2458
+#: src/strings.ts:2459
 msgid "Remove from recents"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1046
+#: src/strings.ts:1047
 msgid "Remove full name"
 msgstr ""
 
-#: src/strings.ts:2265
+#: src/strings.ts:2266
 msgid "Remove link"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1042
+#: src/strings.ts:1043
 msgid "Remove profile picture"
 msgstr ""
 
-#: src/strings.ts:1049
+#: src/strings.ts:1050
 msgid "Remove your full name from profile"
 msgstr ""
 
-#: src/strings.ts:1043
+#: src/strings.ts:1044
 msgid "Remove your profile picture"
 msgstr ""
 
-#: src/strings.ts:546
+#: src/strings.ts:547
 msgid "Rename"
 msgstr ""
 
-#: src/strings.ts:751
+#: src/strings.ts:752
 msgid "Rename file"
 msgstr ""
 
-#: src/strings.ts:891
+#: src/strings.ts:892
 msgid "Reorder"
 msgstr ""
 
@@ -5467,19 +5467,19 @@ msgstr ""
 msgid "Repeats daily at {date}"
 msgstr ""
 
-#: src/strings.ts:2378
+#: src/strings.ts:2379
 msgid "Replace"
 msgstr ""
 
-#: src/strings.ts:2379
+#: src/strings.ts:2380
 msgid "Replace all"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2166
+#: src/strings.ts:2167
 msgid "Report"
 msgstr ""
 
-#: src/strings.ts:1259
+#: src/strings.ts:1260
 msgid "Report an issue"
 msgstr ""
 
@@ -5492,95 +5492,95 @@ msgid "Resend code in ({seconds})"
 msgstr ""
 
 #. placeholder {0}: seconds ? ` in ${seconds}` : ""
-#: src/strings.ts:677
+#: src/strings.ts:678
 msgid "Resend code{0}"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1404
+#: src/strings.ts:1405
 msgid "Resend email"
 msgstr ""
 
-#: src/strings.ts:1822
+#: src/strings.ts:1823
 msgid "Reset"
 msgstr ""
 
-#: src/strings.ts:1914
+#: src/strings.ts:1915
 msgid "Reset account password"
 msgstr ""
 
-#: src/strings.ts:2485
+#: src/strings.ts:2486
 msgid "Reset homepage"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1823
+#: src/strings.ts:1824
 msgid "Reset selection"
 msgstr ""
 
-#: src/strings.ts:1650
+#: src/strings.ts:1651
 msgid "Reset server urls"
 msgstr ""
 
-#: src/strings.ts:2032
+#: src/strings.ts:2033
 msgid "Reset sidebar"
 msgstr ""
 
-#: src/strings.ts:1149
+#: src/strings.ts:1150
 msgid "Reset the toolbar to default settings"
 msgstr ""
 
-#: src/strings.ts:1148
+#: src/strings.ts:1149
 msgid "Reset toolbar"
 msgstr ""
 
-#: src/strings.ts:1916
+#: src/strings.ts:1917
 msgid "Resetting account password ({progress})"
 msgstr ""
 
-#: src/strings.ts:1991
+#: src/strings.ts:1992
 msgid "Restart now"
 msgstr ""
 
-#: src/strings.ts:1649
+#: src/strings.ts:1650
 msgid "Restart the app for changes to take effect."
 msgstr ""
 
-#: src/strings.ts:1320
+#: src/strings.ts:1321
 msgid "Restart the app to apply the changes"
 msgstr ""
 
-#: src/strings.ts:1595
+#: src/strings.ts:1596
 msgid "Restart the app."
 msgstr ""
 
-#: src/strings.ts:568
+#: src/strings.ts:569
 msgid "Restore"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1237
+#: src/strings.ts:1238
 msgid "Restore backup"
 msgstr ""
 
-#: src/strings.ts:2407
+#: src/strings.ts:2408
 msgid "Restore backup?"
 msgstr ""
 
-#: src/strings.ts:890
+#: src/strings.ts:891
 msgid "Restore failed"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1612
+#: src/strings.ts:1613
 msgid "Restore from files"
 msgstr ""
 
-#: src/strings.ts:1662
+#: src/strings.ts:1663
 msgid "Restore this version"
 msgstr ""
 
-#: src/strings.ts:1238
+#: src/strings.ts:1239
 msgid "Restore your data from a backup"
 msgstr ""
 
-#: src/strings.ts:849
+#: src/strings.ts:850
 msgid "Restored successfully"
 msgstr ""
 
@@ -5590,93 +5590,97 @@ msgstr ""
 
 #: src/strings.ts:377
 msgid "Restoring {collection}..."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1614
+#: src/strings.ts:1615
 msgid "Restoring backup..."
 msgstr ""
 
-#: src/strings.ts:686
+#: src/strings.ts:687
 msgid "Resubscribe from Playstore"
 msgstr ""
 
-#: src/strings.ts:687
+#: src/strings.ts:688
 msgid "Resubscribe to Pro"
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2671
+#: src/strings.ts:2672
 msgid "Retry"
 msgstr ""
 
-#: src/strings.ts:513
+#: src/strings.ts:514
 msgid "Reupload"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2022
+#: src/strings.ts:2023
 msgid "Reveal in list"
 msgstr ""
 
 #: src/strings.ts:152
 msgid "Revoke"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1181
+#: src/strings.ts:1182
 msgid "Revoke biometric unlocking"
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2685
+#: src/strings.ts:2686
 msgid "Revoke Inbox API Key - {name}"
 msgstr ""
 
 #: src/strings.ts:450
 msgid "Revoke vault fingerprint unlock"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1295
+#: src/strings.ts:1296
 msgid "Roadmap"
 msgstr ""
 
-#: src/strings.ts:2050
+#: src/strings.ts:2051
 msgid "Root"
 msgstr ""
 
-#: src/strings.ts:2029
+#: src/strings.ts:2030
 msgid "Rotate left"
 msgstr ""
 
-#: src/strings.ts:2030
+#: src/strings.ts:2031
 msgid "Rotate right"
 msgstr ""
 
-#: src/strings.ts:2288
+#: src/strings.ts:2289
 msgid "Row properties"
 msgstr ""
 
-#: src/strings.ts:545
+#: src/strings.ts:546
 msgid "Run file check"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2061
+#: src/strings.ts:2062
 msgid "Safe & encrypted notes"
 msgstr ""
 
-#: src/strings.ts:628
+#: src/strings.ts:629
 msgid "Sat"
 msgstr ""
 
-#: src/strings.ts:619
+#: src/strings.ts:620
 msgid "Saturday"
 msgstr ""
 
-#: src/strings.ts:574
+#: src/strings.ts:575
 msgid "Save"
+msgstr ""
+
+#: src/strings.ts:497
+msgid "Save 2FA backup codes"
 msgstr ""
 
 #: src/strings.ts:477
 msgid "Save a backup of your notes"
 msgstr ""
 
-#: src/strings.ts:564
+#: src/strings.ts:565
 msgid "Save a copy"
 msgstr ""
 
@@ -5684,104 +5688,100 @@ msgstr ""
 msgid "Save account recovery key"
 msgstr ""
 
-#: src/strings.ts:583
+#: src/strings.ts:584
 msgid "Save and continue"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1050
+#: src/strings.ts:1051
 msgid "Save data recovery key"
 msgstr ""
 
-#: src/strings.ts:955
+#: src/strings.ts:956
 msgid "Save failed. Vault is locked"
 msgstr ""
 
-#: src/strings.ts:592
+#: src/strings.ts:593
 msgid "Save QR code to gallery"
 msgstr ""
 
-#: src/strings.ts:497
-msgid "Save recovery codes"
-msgstr ""
-
-#: src/strings.ts:680
+#: src/strings.ts:681
 msgid "Save to file"
 msgstr ""
 
-#: src/strings.ts:593
+#: src/strings.ts:594
 msgid "Save to text file"
+msgstr "<<<<<<< Updated upstream"
+
+#: src/strings.ts:499
+msgid "Save your 2FA backup codes in a safe place. You will need them to log into your account in case you lose access to your two-factor authentication methods."
 msgstr ""
 
-#: src/strings.ts:1362
+#: src/strings.ts:1363
 msgid "Save your account recovery key"
 msgstr ""
 
 #: src/strings.ts:492
 msgid "Save your account recovery key in a safe place. You will need it to recover your account in case you forget your password."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1052
+#: src/strings.ts:1053
 msgid "Save your data recovery key in a safe place. You will need it to recover your data in case you forget your password."
-msgstr ""
+msgstr ">>>>>>> Stashed changes"
 
-#: src/strings.ts:499
-msgid "Save your recovery codes in a safe place. You will need them to recover your account in case you lose access to your two-factor authentication methods."
-msgstr ""
-
-#: src/strings.ts:2397
+#: src/strings.ts:2398
 msgid "Saved"
 msgstr ""
 
-#: src/strings.ts:2398
+#: src/strings.ts:2399
 msgid "Saving"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1590
+#: src/strings.ts:1591
 msgid "Saving this note is taking too long. Copy your changes and restart the app to prevent data loss. If the problem persists, please report it to us at support@streetwriters.co."
 msgstr ""
 
-#: src/strings.ts:796
+#: src/strings.ts:797
 msgid "Saving zip file ({progress}%). Please wait..."
 msgstr ""
 
-#: src/strings.ts:797
+#: src/strings.ts:798
 msgid "Saving zip file. Please wait..."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1724
+#: src/strings.ts:1725
 msgid "Scan the QR code with your authenticator app"
 msgstr ""
 
-#: src/strings.ts:2423
+#: src/strings.ts:2424
 msgid "School work"
 msgstr ""
 
-#: src/strings.ts:2496
+#: src/strings.ts:2497
 msgid "Scroll to bottom"
 msgstr ""
 
-#: src/strings.ts:2495
+#: src/strings.ts:2496
 msgid "Scroll to top"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1512
-#: src/strings.ts:1530
+#: src/strings.ts:1513
+#: src/strings.ts:1531
 msgid "Search"
 msgstr ""
 
-#: src/strings.ts:1507
+#: src/strings.ts:1508
 msgid "Search a note"
 msgstr ""
 
-#: src/strings.ts:1505
+#: src/strings.ts:1506
 msgid "Search a note to link to"
 msgstr ""
 
-#: src/strings.ts:2439
+#: src/strings.ts:2440
 msgid "Search for notes, notebooks, and tags..."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1540
+#: src/strings.ts:1541
 msgid "Search in {routeName}"
 msgstr ""
 
@@ -5833,91 +5833,91 @@ msgstr ""
 msgid "Search in Trash"
 msgstr ""
 
-#: src/strings.ts:2360
+#: src/strings.ts:2361
 msgid "Search languages"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1493
+#: src/strings.ts:1494
 msgid "Search notebooks"
 msgstr ""
 
-#: src/strings.ts:1506
+#: src/strings.ts:1507
 msgid "Search or add a tag"
 msgstr ""
 
-#: src/strings.ts:1836
+#: src/strings.ts:1837
 msgid "Search themes"
 msgstr ""
 
-#: src/strings.ts:1510
+#: src/strings.ts:1511
 msgid "Searching for {query}..."
 msgstr ""
 
-#: src/strings.ts:878
+#: src/strings.ts:879
 msgid "sec"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2145
+#: src/strings.ts:2146
 msgid "Security & privacy"
 msgstr ""
 
-#: src/strings.ts:2085
+#: src/strings.ts:2086
 msgid "Security key"
 msgstr ""
 
-#: src/strings.ts:1990
+#: src/strings.ts:1991
 msgid "Security key successfully registered."
 msgstr ""
 
-#: src/strings.ts:1296
+#: src/strings.ts:1297
 msgid "See what the future of Notesnook is going to be like."
 msgstr ""
 
-#: src/strings.ts:1336
+#: src/strings.ts:1337
 msgid "Select"
 msgstr ""
 
-#: src/strings.ts:1611
+#: src/strings.ts:1612
 msgid "Select a backup file from your device to restore backup"
 msgstr ""
 
-#: src/strings.ts:2490
+#: src/strings.ts:2491
 msgid "Select a notebook to move this notebook into, or unselect to move it to the root level."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2100
+#: src/strings.ts:2101
 msgid "Select a theme"
 msgstr ""
 
-#: src/strings.ts:1228
+#: src/strings.ts:1229
 msgid "Select backup directory"
 msgstr ""
 
-#: src/strings.ts:1857
+#: src/strings.ts:1858
 msgid "Select backup file"
 msgstr ""
 
-#: src/strings.ts:640
+#: src/strings.ts:641
 msgid "Select backups folder"
 msgstr ""
 
-#: src/strings.ts:630
+#: src/strings.ts:631
 msgid "Select date"
 msgstr ""
 
 #: src/strings.ts:338
 msgid "Select day of the week to repeat the reminder."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1765
+#: src/strings.ts:1766
 msgid "Select files to import"
 msgstr ""
 
-#: src/strings.ts:1608
+#: src/strings.ts:1609
 msgid "Select folder where Notesnook backup files are stored to view and restore them from the app"
 msgstr ""
 
-#: src/strings.ts:1609
+#: src/strings.ts:1610
 msgid "Select folder with backup files"
 msgstr ""
 
@@ -5925,7 +5925,7 @@ msgstr ""
 msgid "Select how you would like to recieve the code"
 msgstr ""
 
-#: src/strings.ts:2355
+#: src/strings.ts:2356
 msgid "Select language"
 msgstr ""
 
@@ -5941,31 +5941,31 @@ msgstr ""
 msgid "Select notebooks you want to add note(s) to."
 msgstr ""
 
-#: src/strings.ts:2478
+#: src/strings.ts:2479
 msgid "Select notes to link to \"{title}\""
 msgstr ""
 
 #: src/strings.ts:342
 msgid "Select nth day of the month to repeat the reminder."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1819
+#: src/strings.ts:1820
 msgid "Select profile picture"
 msgstr ""
 
-#: src/strings.ts:2484
+#: src/strings.ts:2485
 msgid "Select the default sidebar tab"
 msgstr ""
 
 #: src/strings.ts:374
 msgid "Select the folder that includes your backup files to list them here."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2132
+#: src/strings.ts:2133
 msgid "Select the languages the spell checker should check in."
 msgstr ""
 
-#: src/strings.ts:2460
+#: src/strings.ts:2461
 msgid "Select the release track for Notesnook."
 msgstr ""
 
@@ -5975,9 +5975,9 @@ msgstr ""
 
 #: src/strings.ts:269
 msgid "Self destruct"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2167
+#: src/strings.ts:2168
 msgid "Send"
 msgstr ""
 
@@ -5991,105 +5991,105 @@ msgstr ""
 
 #: src/strings.ts:130
 msgid "Send code via SMS"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1861
+#: src/strings.ts:1862
 msgid "Send recovery email"
 msgstr ""
 
-#: src/strings.ts:1897
+#: src/strings.ts:1898
 msgid "Sending recovery email"
 msgstr ""
 
-#: src/strings.ts:1648
+#: src/strings.ts:1649
 msgid "Server url changed"
 msgstr ""
 
-#: src/strings.ts:1651
+#: src/strings.ts:1652
 msgid "Server urls reset"
 msgstr ""
 
-#: src/strings.ts:1629
+#: src/strings.ts:1630
 msgid "Server used for login/sign up and authentication."
 msgstr ""
 
-#: src/strings.ts:1634
+#: src/strings.ts:1635
 msgid "Server used to host your published notes."
 msgstr ""
 
-#: src/strings.ts:1632
+#: src/strings.ts:1633
 msgid "Server used to receive important notifications & events."
 msgstr ""
 
-#: src/strings.ts:1627
+#: src/strings.ts:1628
 msgid "Server used to sync your notes & other data between devices."
 msgstr ""
 
-#: src/strings.ts:1640
+#: src/strings.ts:1641
 msgid "Server with host {host} not found."
 msgstr ""
 
-#: src/strings.ts:2140
+#: src/strings.ts:2141
 msgid "Servers"
 msgstr ""
 
-#: src/strings.ts:2141
+#: src/strings.ts:2142
 msgid "Servers configuration"
 msgstr ""
 
 #: src/strings.ts:97
 msgid "Session expired"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2193
+#: src/strings.ts:2194
 msgid "Sessions"
 msgstr ""
 
-#: src/strings.ts:978
+#: src/strings.ts:979
 msgid "Set a reminder"
 msgstr ""
 
-#: src/strings.ts:728
+#: src/strings.ts:729
 msgid "Set as dark theme"
 msgstr ""
 
-#: src/strings.ts:897
+#: src/strings.ts:898
 msgid "Set as default"
 msgstr ""
 
-#: src/strings.ts:2482
+#: src/strings.ts:2483
 msgid "Set as homepage"
 msgstr ""
 
-#: src/strings.ts:729
+#: src/strings.ts:730
 msgid "Set as light theme"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1335
+#: src/strings.ts:1336
 msgid "Set automatic trash cleanup interval from Settings > Behaviour > Clean trash interval."
 msgstr ""
 
-#: src/strings.ts:2632
+#: src/strings.ts:2633
 msgid "Set expiry"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1312
+#: src/strings.ts:1313
 msgid "Set full name"
 msgstr ""
 
-#: src/strings.ts:1254
+#: src/strings.ts:1255
 msgid "Set snooze time in minutes"
 msgstr ""
 
-#: src/strings.ts:1253
+#: src/strings.ts:1254
 msgid "Set the default time to snooze a reminder to when you press the snooze button on a notification."
 msgstr ""
 
-#: src/strings.ts:1225
+#: src/strings.ts:1226
 msgid "Set the interval to create a backup (with attachments) automatically."
 msgstr ""
 
-#: src/strings.ts:1222
+#: src/strings.ts:1223
 msgid "Set the interval to create a partial backup (without attachments) automatically."
 msgstr ""
 
@@ -6098,24 +6098,24 @@ msgid "Set your name"
 msgstr ""
 
 #: src/strings.ts:387
-#: src/strings.ts:1526
+#: src/strings.ts:1527
 msgid "Settings"
 msgstr ""
 
-#: src/strings.ts:1201
 #: src/strings.ts:1202
+#: src/strings.ts:1203
 msgid "Setup a new password for app lock"
 msgstr ""
 
-#: src/strings.ts:1198
+#: src/strings.ts:1199
 msgid "Setup a password to lock the app"
 msgstr ""
 
-#: src/strings.ts:1196
+#: src/strings.ts:1197
 msgid "Setup a pin to lock the app"
 msgstr ""
 
-#: src/strings.ts:2185
+#: src/strings.ts:2186
 msgid ""
 "Setup an HTTP/HTTPS/SOCKS proxy.\n"
 "\n"
@@ -6125,57 +6125,57 @@ msgid ""
 "http://username:password@foobar:80\n"
 "\n"
 "To remove the proxy, simply erase everything in the input."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1197
+#: src/strings.ts:1198
 msgid "Setup app lock password"
 msgstr ""
 
-#: src/strings.ts:1195
+#: src/strings.ts:1196
 msgid "Setup app lock pin"
 msgstr ""
 
-#: src/strings.ts:681
+#: src/strings.ts:682
 msgid "Setup secondary 2FA method"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:980
+#: src/strings.ts:981
 msgid "Setup using an Authenticator app"
 msgstr ""
 
-#: src/strings.ts:987
+#: src/strings.ts:988
 msgid "Setup using email"
 msgstr ""
 
-#: src/strings.ts:994
+#: src/strings.ts:995
 msgid "Setup using SMS"
 msgstr ""
 
 #: src/strings.ts:155
 msgid "Share"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1693
+#: src/strings.ts:1694
 msgid "Share & append to notes from anywhere"
 msgstr ""
 
-#: src/strings.ts:1343
+#: src/strings.ts:1344
 msgid "Share backup"
 msgstr ""
 
 #: src/strings.ts:453
 msgid "Share note"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1789
+#: src/strings.ts:1790
 msgid "Share Notesnook with friends!"
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2644
+#: src/strings.ts:2645
 msgid "Share things to Notesbook from anywhere using the Inbox API"
 msgstr ""
 
-#: src/strings.ts:594
+#: src/strings.ts:595
 msgid "Share to cloud"
 msgstr ""
 
@@ -6185,9 +6185,9 @@ msgstr ""
 
 #: src/strings.ts:302
 msgid "Shortcut"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2002
+#: src/strings.ts:2003
 msgid "Shortcut removed"
 msgstr ""
 
@@ -6201,13 +6201,13 @@ msgstr ""
 
 #: src/strings.ts:96
 msgid "Sign up"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1032
+#: src/strings.ts:1033
 msgid "Signed up on {date}"
 msgstr ""
 
-#: src/strings.ts:777
+#: src/strings.ts:778
 msgid "Signup failed"
 msgstr ""
 
@@ -6215,227 +6215,227 @@ msgstr ""
 msgid "Silent"
 msgstr ""
 
-#: src/strings.ts:2329
+#: src/strings.ts:2330
 msgid "Sink list item"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2043
+#: src/strings.ts:2044
 msgid "Size"
 msgstr ""
 
-#: src/strings.ts:550
+#: src/strings.ts:551
 msgid "Skip"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1831
+#: src/strings.ts:1832
 msgid "Skip & go directly to the app"
 msgstr ""
 
-#: src/strings.ts:673
+#: src/strings.ts:674
 msgid "Skip introduction"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1606
+#: src/strings.ts:1607
 msgid "Some exported notes are locked, Unlock to export them"
 msgstr ""
 
-#: src/strings.ts:1478
+#: src/strings.ts:1479
 msgid "Some notes are published"
 msgstr ""
 
-#: src/strings.ts:1668
+#: src/strings.ts:1669
 msgid "Something went wrong"
 msgstr ""
 
-#: src/strings.ts:2027
+#: src/strings.ts:2028
 msgid "Sort"
 msgstr ""
 
-#: src/strings.ts:536
+#: src/strings.ts:537
 msgid "Sort by"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2151
+#: src/strings.ts:2152
 msgid "Source code"
 msgstr ""
 
-#: src/strings.ts:2356
+#: src/strings.ts:2357
 msgid "Spaces"
 msgstr ""
 
-#: src/strings.ts:2591
+#: src/strings.ts:2592
 msgid "Special Offer"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2128
+#: src/strings.ts:2129
 msgid "Spell check"
 msgstr ""
 
-#: src/strings.ts:2295
+#: src/strings.ts:2296
 msgid "Split cells"
 msgstr ""
 
-#: src/strings.ts:2461
+#: src/strings.ts:2462
 msgid "Stable"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1114
+#: src/strings.ts:1115
 msgid "Start"
 msgstr ""
 
-#: src/strings.ts:1832
+#: src/strings.ts:1833
 msgid "Start account recovery"
 msgstr ""
 
-#: src/strings.ts:1827
+#: src/strings.ts:1828
 msgid "Start import"
 msgstr ""
 
-#: src/strings.ts:1824
+#: src/strings.ts:1825
 msgid "Start importing now"
 msgstr ""
 
-#: src/strings.ts:2116
+#: src/strings.ts:2117
 msgid "Start minimized"
 msgstr ""
 
-#: src/strings.ts:1759
+#: src/strings.ts:1760
 msgid "Start over"
 msgstr ""
 
-#: src/strings.ts:952
+#: src/strings.ts:953
 msgid "Start writing to create a new note"
 msgstr ""
 
 #: src/strings.ts:199
 msgid "Start writing to save your note."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1603
+#: src/strings.ts:1604
 msgid "Start writing your note..."
 msgstr ""
 
-#: src/strings.ts:2224
+#: src/strings.ts:2225
 msgid "Status"
 msgstr ""
 
-#: src/strings.ts:2474
+#: src/strings.ts:2475
 msgid "Storage"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1550
+#: src/strings.ts:1551
 msgid "Streaming not supported"
 msgstr ""
 
-#: src/strings.ts:2261
+#: src/strings.ts:2262
 msgid "Strikethrough"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2226
+#: src/strings.ts:2227
 msgid "Subgroup 1"
 msgstr ""
 
-#: src/strings.ts:1996
+#: src/strings.ts:1997
 msgid "Subgroup added"
 msgstr ""
 
-#: src/strings.ts:580
+#: src/strings.ts:581
 msgid "Submit"
 msgstr ""
 
-#: src/strings.ts:2570
+#: src/strings.ts:2571
 msgid "Subscribe"
 msgstr ""
 
-#: src/strings.ts:2571
+#: src/strings.ts:2572
 msgid "Subscribe and start free trial"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1027
+#: src/strings.ts:1028
 msgid "Subscribe to Pro"
 msgstr ""
 
-#: src/strings.ts:707
+#: src/strings.ts:708
 msgid "Subscribed on Android"
 msgstr ""
 
-#: src/strings.ts:700
+#: src/strings.ts:701
 msgid "Subscribed on iOS"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1307
+#: src/strings.ts:1308
 msgid "Subscribed on web"
 msgstr ""
 
-#: src/strings.ts:714
+#: src/strings.ts:715
 msgid "Subscribed on Web"
 msgstr ""
 
-#: src/strings.ts:720
+#: src/strings.ts:721
 msgid "Subscribed using gift card"
 msgstr ""
 
-#: src/strings.ts:2272
+#: src/strings.ts:2273
 msgid "Subscript"
 msgstr ""
 
-#: src/strings.ts:694
+#: src/strings.ts:695
 msgid "Subscription awarded from Streetwriters"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1031
+#: src/strings.ts:1032
 msgid "Subscription details"
 msgstr ""
 
-#: src/strings.ts:1065
+#: src/strings.ts:1066
 msgid "Subscription not activated?"
 msgstr ""
 
-#: src/strings.ts:622
+#: src/strings.ts:623
 msgid "Sun"
 msgstr ""
 
-#: src/strings.ts:613
+#: src/strings.ts:614
 msgid "Sunday"
 msgstr ""
 
-#: src/strings.ts:2273
+#: src/strings.ts:2274
 msgid "Superscript"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1471
+#: src/strings.ts:1472
 msgid "Switch to search/replace mode"
 msgstr ""
 
-#: src/strings.ts:2137
+#: src/strings.ts:2138
 msgid "Sync"
 msgstr ""
 
 #: src/strings.ts:393
 msgid "Sync failed"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1365
+#: src/strings.ts:1366
 msgid "Sync is disabled"
 msgstr ""
 
 #: src/strings.ts:392
 msgid "Sync now"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:915
+#: src/strings.ts:916
 msgid "Sync off"
 msgstr ""
 
-#: src/strings.ts:1625
+#: src/strings.ts:1626
 msgid "Sync server"
 msgstr ""
 
-#: src/strings.ts:1084
+#: src/strings.ts:1085
 msgid "Sync settings"
 msgstr ""
 
-#: src/strings.ts:1097
+#: src/strings.ts:1098
 msgid "Sync your notes in the background even when the app is closed. This is an experimental feature. If you face any issues, please turn it off."
 msgstr ""
 
@@ -6449,29 +6449,29 @@ msgstr ""
 
 #: src/strings.ts:259
 msgid "Syncing your data"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1704
+#: src/strings.ts:1705
 msgid "Syncing your notes"
 msgstr ""
 
-#: src/strings.ts:2341
+#: src/strings.ts:2342
 msgid "Table"
 msgstr ""
 
-#: src/strings.ts:538
+#: src/strings.ts:539
 msgid "Table of contents"
 msgstr ""
 
-#: src/strings.ts:2286
+#: src/strings.ts:2287
 msgid "Table settings"
 msgstr ""
 
-#: src/strings.ts:2535
+#: src/strings.ts:2536
 msgid "tables, outlines, block level note linking"
 msgstr ""
 
-#: src/strings.ts:529
+#: src/strings.ts:530
 msgid "Tabs"
 msgstr ""
 
@@ -6488,55 +6488,55 @@ msgid "tags"
 msgstr ""
 
 #: src/strings.ts:317
-#: src/strings.ts:1527
+#: src/strings.ts:1528
 msgid "Tags"
 msgstr ""
 
-#: src/strings.ts:1545
+#: src/strings.ts:1546
 msgid "Take a backup before logging out"
 msgstr ""
 
-#: src/strings.ts:1217
+#: src/strings.ts:1218
 msgid "Take a full backup of your data with all attachments"
 msgstr ""
 
-#: src/strings.ts:1219
+#: src/strings.ts:1220
 msgid "Take a partial backup of your data that does not include attachments"
 msgstr ""
 
-#: src/strings.ts:2340
+#: src/strings.ts:2341
 msgid "Take a photo using camera"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1375
+#: src/strings.ts:1376
 msgid "Take note"
 msgstr ""
 
-#: src/strings.ts:1658
+#: src/strings.ts:1659
 msgid "Take notes privately."
 msgstr ""
 
-#: src/strings.ts:674
+#: src/strings.ts:675
 msgid "Taking too long? Reload editor"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1459
+#: src/strings.ts:1460
 msgid "Tap here to change sorting"
 msgstr ""
 
-#: src/strings.ts:1463
+#: src/strings.ts:1464
 msgid "Tap here to jump to a section"
 msgstr ""
 
-#: src/strings.ts:1371
+#: src/strings.ts:1372
 msgid "Tap here to update to the latest version"
 msgstr ""
 
-#: src/strings.ts:1594
+#: src/strings.ts:1595
 msgid "Tap on \"Dismiss\" and copy the contents of your note so they are not lost."
 msgstr ""
 
-#: src/strings.ts:1374
+#: src/strings.ts:1375
 msgid "Tap on \"Take note\" to add a note."
 msgstr ""
 
@@ -6552,11 +6552,11 @@ msgstr ""
 msgid "Tap to deselect"
 msgstr ""
 
-#: src/strings.ts:668
+#: src/strings.ts:669
 msgid "Tap to stop reordering"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1355
+#: src/strings.ts:1356
 msgid "Tap to try again"
 msgstr ""
 
@@ -6564,19 +6564,19 @@ msgstr ""
 msgid "Tap twice to confirm you have saved the recovery key."
 msgstr ""
 
-#: src/strings.ts:2346
+#: src/strings.ts:2347
 msgid "Task list"
 msgstr ""
 
-#: src/strings.ts:2416
+#: src/strings.ts:2417
 msgid "Tasks"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1164
+#: src/strings.ts:1165
 msgid "Telemetry"
 msgstr ""
 
-#: src/strings.ts:1497
+#: src/strings.ts:1498
 msgid ""
 "Tell us more about the issue you are facing.\n"
 "\n"
@@ -6585,13 +6585,13 @@ msgid ""
 "- What did you expect to happen?\n"
 "- Steps to reproduce the issue\n"
 "- Things you have tried etc."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1496
+#: src/strings.ts:1497
 msgid "Tell us what happened"
 msgstr ""
 
-#: src/strings.ts:1285
+#: src/strings.ts:1286
 msgid "Terms of service"
 msgstr ""
 
@@ -6599,55 +6599,55 @@ msgstr ""
 msgid "Terms of Service "
 msgstr ""
 
-#: src/strings.ts:2578
+#: src/strings.ts:2579
 msgid "terms of use."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1624
+#: src/strings.ts:1625
 msgid "Test connection"
 msgstr ""
 
-#: src/strings.ts:1647
+#: src/strings.ts:1648
 msgid "Test connection before changing server urls"
 msgstr ""
 
-#: src/strings.ts:2284
+#: src/strings.ts:2285
 msgid "Text color"
 msgstr ""
 
-#: src/strings.ts:2282
+#: src/strings.ts:2283
 msgid "Text direction"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1788
+#: src/strings.ts:1789
 msgid "Thank you for choosing end-to-end encrypted note taking. Now you can sync your notes to unlimited devices."
 msgstr ""
 
-#: src/strings.ts:2052
+#: src/strings.ts:2053
 msgid "Thank you for reporting!"
 msgstr ""
 
-#: src/strings.ts:2552
+#: src/strings.ts:2553
 msgid "Thank you for subscribing"
 msgstr ""
 
-#: src/strings.ts:2586
+#: src/strings.ts:2587
 msgid "Thank you for the purchase"
 msgstr ""
 
 #: src/strings.ts:479
 msgid "Thank you for updating Notesnook! We will be applying some minor changes for a better note taking experience."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2077
+#: src/strings.ts:2078
 msgid "Thank you. You are the proof that privacy always comes first."
 msgstr ""
 
-#: src/strings.ts:1645
+#: src/strings.ts:1646
 msgid "The {title} at {url} is not compatible with this client."
 msgstr ""
 
-#: src/strings.ts:2631
+#: src/strings.ts:2632
 msgid "The incoming note could not be unlocked with the provided password. Enter the correct password for the incoming note"
 msgstr ""
 
@@ -6655,11 +6655,11 @@ msgstr ""
 msgid "The information above will be publically available at"
 msgstr ""
 
-#: src/strings.ts:2605
+#: src/strings.ts:2606
 msgid "The Notesnook Circle is exclusive to subscribers. Please consider subscribing to gain access to Notesnook Circle and enjoy additional benefits."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2084
+#: src/strings.ts:2085
 msgid "The password/pin for unlocking the app."
 msgstr ""
 
@@ -6669,21 +6669,21 @@ msgstr ""
 
 #: src/strings.ts:340
 msgid "The reminder will repeat every year on {date}."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1714
+#: src/strings.ts:1715
 msgid "The reminder will start on {date} at {time}."
 msgstr ""
 
-#: src/strings.ts:2087
+#: src/strings.ts:2088
 msgid "The security key for unlocking the app. This is the most secure method."
 msgstr ""
 
-#: src/strings.ts:1643
+#: src/strings.ts:1644
 msgid "The URL you have given ({url}) does not point to the {server}."
 msgstr ""
 
-#: src/strings.ts:1119
+#: src/strings.ts:1120
 msgid "Themes"
 msgstr ""
 
@@ -6691,72 +6691,72 @@ msgstr ""
 msgid "There are no blocks in this note."
 msgstr ""
 
-#: src/strings.ts:2239
+#: src/strings.ts:2240
 msgid "These items will be **kept in your Trash for {interval} days** after which they will be permanently deleted."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1922
+#: src/strings.ts:1923
 msgid "This action is IRREVERSIBLE."
 msgstr ""
 
 #: src/strings.ts:173
 msgid "This device"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1685
+#: src/strings.ts:1686
 msgid "This error can be fixed by rebuilding the search index. This action won't result in any kind of data loss."
 msgstr ""
 
-#: src/strings.ts:1677
+#: src/strings.ts:1678
 msgid "This error can only be fixed by wiping & reseting the database. Beware that this will wipe all your data inside the database with no way to recover it later on. This WILL NOT change/affect/delete/wipe your data on the server but ONLY on this device."
 msgstr ""
 
-#: src/strings.ts:1681
+#: src/strings.ts:1682
 msgid "This error can only be fixed by wiping & reseting the Key Store and the database. This WILL NOT change/affect/delete/wipe your data on the server but ONLY on this device."
 msgstr ""
 
-#: src/strings.ts:1679
+#: src/strings.ts:1680
 msgid "This error means the at rest encryption key could not be decrypted. This can be due to data corruption or implementation change."
 msgstr ""
 
-#: src/strings.ts:1675
+#: src/strings.ts:1676
 msgid "This error usually means the database file is either corrupt or it could not be decrypted."
 msgstr ""
 
-#: src/strings.ts:1683
+#: src/strings.ts:1684
 msgid "This error usually means the search index is corrupted."
-msgstr "<<<<<<< HEAD"
+msgstr "<<<<<<< HEAD<<<<<<< Updated upstream"
 
-#: src/strings.ts:2709
+#: src/strings.ts:2710
 msgid "This feature is not available on this plan."
 msgstr ""
 
-#: src/strings.ts:1936
+#: src/strings.ts:1937
 msgid "This image cannot be previewed"
 msgstr ""
 
-#: src/strings.ts:2572
+#: src/strings.ts:2573
 msgid "This is a one time purchase, no subscription."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2047
+#: src/strings.ts:2048
 msgid "This may take a while"
 msgstr ""
 
-#: src/strings.ts:1103
-#: src/strings.ts:1112
+#: src/strings.ts:1104
+#: src/strings.ts:1113
 msgid "This must only be used for troubleshooting. Using it regularly for sync is not recommended and will lead to unexpected data loss and other issues. If you are having persistent issues with sync, please report them to us at support@streetwriters.co."
 msgstr ""
 
-#: src/strings.ts:2637
+#: src/strings.ts:2638
 msgid "This note is empty"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1596
+#: src/strings.ts:1597
 msgid "This note is locked"
 msgstr ""
 
-#: src/strings.ts:954
+#: src/strings.ts:955
 msgid "This note is locked. Unlock note to save changes"
 msgstr ""
 
@@ -6770,131 +6770,131 @@ msgstr ""
 
 #: src/strings.ts:264
 msgid "This note will be published to a public URL."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2093
+#: src/strings.ts:2094
 msgid "This username will be used to distinguish between different credentials in your security key. Make sure it is unique."
 msgstr ""
 
-#: src/strings.ts:1305
+#: src/strings.ts:1306
 msgid "This version of Notesnook app does not support in-app purchases. Kindly login on the Notesnook web app to make the purchase."
 msgstr ""
 
-#: src/strings.ts:626
+#: src/strings.ts:627
 msgid "Thu"
 msgstr ""
 
-#: src/strings.ts:617
+#: src/strings.ts:618
 msgid "Thursday"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1844
+#: src/strings.ts:1845
 msgid "Time"
 msgstr ""
 
-#: src/strings.ts:1136
+#: src/strings.ts:1137
 msgid "Time format"
 msgstr ""
 
-#: src/strings.ts:671
+#: src/strings.ts:672
 msgid "TIP"
 msgstr ""
 
-#: src/strings.ts:649
-#: src/strings.ts:654
+#: src/strings.ts:650
+#: src/strings.ts:655
 msgid "Title"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1159
+#: src/strings.ts:1160
 msgid "Title format"
 msgstr ""
 
-#: src/strings.ts:1190
+#: src/strings.ts:1191
 msgid "To use app lock, you must enable biometrics such as Fingerprint lock or Face ID on your phone."
 msgstr ""
 
-#: src/strings.ts:1814
+#: src/strings.ts:1815
 msgid "Toggle dark/light mode"
 msgstr ""
 
-#: src/strings.ts:2464
+#: src/strings.ts:2465
 msgid "Toggle focus mode"
 msgstr ""
 
-#: src/strings.ts:2353
+#: src/strings.ts:2354
 msgid "Toggle indentation mode"
 msgstr ""
 
-#: src/strings.ts:2382
+#: src/strings.ts:2383
 msgid "Toggle replace"
 msgstr ""
 
-#: src/strings.ts:2453
+#: src/strings.ts:2454
 msgid "Toggle theme"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2134
+#: src/strings.ts:2135
 msgid "Toolbar"
 msgstr ""
 
-#: src/strings.ts:1150
+#: src/strings.ts:1151
 msgid "Toolbar reset to default preset"
 msgstr ""
 
-#: src/strings.ts:1328
-#: src/strings.ts:1525
+#: src/strings.ts:1329
+#: src/strings.ts:1526
 msgid "Trash"
 msgstr ""
 
-#: src/strings.ts:1327
+#: src/strings.ts:1328
 msgid "Trash cleared successfully!"
 msgstr ""
 
-#: src/strings.ts:1333
+#: src/strings.ts:1334
 msgid "Trash gets automatically cleaned up after {days} days"
 msgstr ""
 
-#: src/strings.ts:1331
+#: src/strings.ts:1332
 msgid "Trash gets automatically cleaned up daily"
 msgstr ""
 
-#: src/strings.ts:2542
+#: src/strings.ts:2543
 msgid "Try {plan} for free"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1467
+#: src/strings.ts:1468
 msgid "Try compact mode to fit more items on screen"
 msgstr ""
 
-#: src/strings.ts:1826
+#: src/strings.ts:1827
 msgid "Try free for 14 days"
 msgstr ""
 
-#: src/strings.ts:2528
+#: src/strings.ts:2529
 msgid "Try it for free"
 msgstr ""
 
-#: src/strings.ts:624
+#: src/strings.ts:625
 msgid "Tue"
 msgstr ""
 
-#: src/strings.ts:615
+#: src/strings.ts:616
 msgid "Tuesday"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1088
+#: src/strings.ts:1089
 msgid "Turn off automatic syncing. Changes from this client will be synced only when you run sync manually."
 msgstr ""
 
-#: src/strings.ts:892
+#: src/strings.ts:893
 msgid "Turn off reminder"
 msgstr ""
 
-#: src/strings.ts:893
+#: src/strings.ts:894
 msgid "Turn on reminder"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1094
+#: src/strings.ts:1095
 msgid "Turns off syncing completely on this device. Any changes made will remain local only and new changes from your other devices won't sync to this device."
 msgstr ""
 
@@ -6906,51 +6906,55 @@ msgstr ""
 msgid "Two-factor authentication"
 msgstr ""
 
-#: src/strings.ts:503
-msgid "Two-factor authentication enabled"
+#: src/strings.ts:504
+msgid "Two-factor authentication disabled"
 msgstr ""
 
-#: src/strings.ts:1504
+#: src/strings.ts:503
+msgid "Two-factor authentication enabled"
+msgstr "<<<<<<< Updated upstream"
+
+#: src/strings.ts:1505
 msgid "Type # to search for headings"
 msgstr ""
 
-#: src/strings.ts:1511
+#: src/strings.ts:1512
 msgid "Type a keyword"
 msgstr ""
 
-#: src/strings.ts:1551
+#: src/strings.ts:1552
 msgid "Unable to resolve download url"
 msgstr ""
 
-#: src/strings.ts:1554
+#: src/strings.ts:1555
 msgid "Unable to send 2FA code"
 msgstr ""
 
-#: src/strings.ts:2488
+#: src/strings.ts:2489
 msgid "Unarchive"
 msgstr ""
 
-#: src/strings.ts:2260
+#: src/strings.ts:2261
 msgid "Underline"
 msgstr ""
 
-#: src/strings.ts:566
+#: src/strings.ts:567
 msgid "Undo"
 msgstr ""
 
-#: src/strings.ts:854
+#: src/strings.ts:855
 msgid "Unfavorite"
 msgstr ""
 
-#: src/strings.ts:2582
+#: src/strings.ts:2583
 msgid "Unlimited"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:932
+#: src/strings.ts:933
 msgid "Unlink from all"
 msgstr ""
 
-#: src/strings.ts:853
+#: src/strings.ts:854
 msgid "Unlink notebook"
 msgstr ""
 
@@ -6958,151 +6962,151 @@ msgstr ""
 msgid "Unlock"
 msgstr ""
 
-#: src/strings.ts:2629
+#: src/strings.ts:2630
 msgid "Unlock incoming note"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1385
+#: src/strings.ts:1386
 msgid "Unlock more colors with Notesnook Pro"
 msgstr ""
 
 #: src/strings.ts:455
-#: src/strings.ts:558
+#: src/strings.ts:559
 msgid "Unlock note"
 msgstr ""
 
-#: src/strings.ts:888
+#: src/strings.ts:889
 msgid "Unlock note to delete it"
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2640
+#: src/strings.ts:2641
 msgid "Unlock note to merge conflicts"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1210
+#: src/strings.ts:1211
 msgid "Unlock the app with biometric authentication. This requires biometrics to be enabled on your device."
 msgstr ""
 
-#: src/strings.ts:1934
+#: src/strings.ts:1935
 msgid "Unlock vault"
 msgstr ""
 
-#: src/strings.ts:544
+#: src/strings.ts:545
 msgid "Unlock with biometrics"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1829
+#: src/strings.ts:1830
 msgid "Unlock with security key"
 msgstr ""
 
 #: src/strings.ts:57
 msgid "Unlock your notes"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1180
+#: src/strings.ts:1181
 msgid "Unlock your vault with biometric authentication"
 msgstr ""
 
-#: src/strings.ts:1712
+#: src/strings.ts:1713
 msgid "Unlocking"
 msgstr ""
 
-#: src/strings.ts:899
+#: src/strings.ts:900
 msgid "Unpin"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:929
+#: src/strings.ts:930
 msgid "Unpin notification"
 msgstr ""
 
-#: src/strings.ts:587
+#: src/strings.ts:588
 msgid "Unpublish"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1479
+#: src/strings.ts:1480
 msgid "Unpublish notes to delete them"
 msgstr ""
 
-#: src/strings.ts:2088
+#: src/strings.ts:2089
 msgid "Unregister"
 msgstr ""
 
-#: src/strings.ts:2633
+#: src/strings.ts:2634
 msgid "Unset expiry"
 msgstr ""
 
 #: src/strings.ts:210
-#: src/strings.ts:2362
+#: src/strings.ts:2363
 msgid "Untitled"
 msgstr ""
 
-#: src/strings.ts:588
+#: src/strings.ts:589
 msgid "Update"
 msgstr ""
 
 #: src/strings.ts:380
 msgid "Update available"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1372
+#: src/strings.ts:1373
 msgid "Update now"
 msgstr ""
 
-#: src/strings.ts:2502
+#: src/strings.ts:2503
 msgid "Upgrade"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1920
+#: src/strings.ts:1921
 msgid "Upgrade now"
 msgstr ""
 
-#: src/strings.ts:2501
+#: src/strings.ts:2502
 msgid "Upgrade plan"
 msgstr ""
 
-#: src/strings.ts:2527
+#: src/strings.ts:2528
 msgid "Upgrade plan to {plan} to use this feature."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1941
+#: src/strings.ts:1942
 msgid "Upgrade to Notesnook Pro to add colors."
 msgstr ""
 
-#: src/strings.ts:1942
+#: src/strings.ts:1943
 msgid "Upgrade to Notesnook Pro to create more tags."
 msgstr ""
 
-#: src/strings.ts:749
+#: src/strings.ts:750
 msgid "Upgrade to Pro"
 msgstr ""
 
-#: src/strings.ts:2597
+#: src/strings.ts:2598
 msgid "Upgrade to redeem"
 msgstr ""
 
-#: src/strings.ts:510
+#: src/strings.ts:511
 msgid "Upload"
 msgstr ""
 
-#: src/strings.ts:2339
+#: src/strings.ts:2340
 msgid "Upload from disk"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:511
-#: src/strings.ts:1653
+#: src/strings.ts:512
+#: src/strings.ts:1654
 msgid "Uploaded"
 msgstr ""
 
-#: src/strings.ts:799
+#: src/strings.ts:800
 msgid "Uploaded file verification failed."
 msgstr ""
 
 #: src/strings.ts:65
-#: src/strings.ts:512
+#: src/strings.ts:513
 msgid "Uploading"
 msgstr ""
 
-#: src/strings.ts:763
+#: src/strings.ts:764
 msgid "Uploads"
 msgstr ""
 
@@ -7110,67 +7114,67 @@ msgstr ""
 msgid "Urgent"
 msgstr ""
 
-#: src/strings.ts:2389
+#: src/strings.ts:2390
 msgid "URL"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1791
+#: src/strings.ts:1792
 msgid "Use"
 msgstr ""
 
 #: src/strings.ts:462
 msgid "Use {keyboardShortcut}+click to select multiple notebooks"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1804
+#: src/strings.ts:1805
 msgid "Use a backup file"
 msgstr ""
 
-#: src/strings.ts:1902
+#: src/strings.ts:1903
 msgid "Use a data recovery key to reset your account password."
 msgstr ""
 
-#: src/strings.ts:556
+#: src/strings.ts:557
 msgid "Use account password"
 msgstr ""
 
-#: src/strings.ts:2534
+#: src/strings.ts:2535
 msgid "Use advanced note taking features like"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:981
+#: src/strings.ts:982
 msgid "Use an authenticator app to generate 2FA codes."
 msgstr ""
 
-#: src/strings.ts:2174
+#: src/strings.ts:2175
 msgid "Use custom DNS"
 msgstr ""
 
-#: src/strings.ts:1125
+#: src/strings.ts:1126
 msgid "Use dark mode for the app"
 msgstr ""
 
-#: src/strings.ts:1623
+#: src/strings.ts:1624
 msgid "Use encryption key"
 msgstr ""
 
-#: src/strings.ts:1162
+#: src/strings.ts:1163
 msgid "Use markdown shortcuts in the editor"
 msgstr ""
 
-#: src/strings.ts:2127
+#: src/strings.ts:2128
 msgid "Use native OS titlebar instead of replacing it with a custom one. Requires app restart for changes to take effect."
 msgstr ""
 
-#: src/strings.ts:2125
+#: src/strings.ts:2126
 msgid "Use native titlebar"
 msgstr ""
 
-#: src/strings.ts:1801
+#: src/strings.ts:1802
 msgid "Use recovery key"
 msgstr ""
 
-#: src/strings.ts:1121
+#: src/strings.ts:1122
 msgid "Use system theme"
 msgstr ""
 
@@ -7185,89 +7189,89 @@ msgid ""
 "$count$: Number of notes + 1.\n"
 "$headline$: Use starting line of the note as title.\n"
 "$day$: Current day (eg. Monday)"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1101
+#: src/strings.ts:1102
 msgid "Use this if changes from other devices are not appearing on this device. This will overwrite the data on this device with the latest data from the server."
 msgstr ""
 
-#: src/strings.ts:1110
+#: src/strings.ts:1111
 msgid "Use this if changes made on this device are not appearing on other devices. This will overwrite the data on the server with the data from this device."
 msgstr ""
 
-#: src/strings.ts:2475
+#: src/strings.ts:2476
 msgid "used"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1020
+#: src/strings.ts:1021
 msgid "User verification failed"
 msgstr ""
 
-#: src/strings.ts:2256
+#: src/strings.ts:2257
 msgid "Using {instance} (v{version})"
 msgstr ""
 
-#: src/strings.ts:2254
+#: src/strings.ts:2255
 msgid "Using official Notesnook instance"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1711
+#: src/strings.ts:1712
 msgid "v{version} available"
-msgstr "<<<<<<< HEAD"
+msgstr "<<<<<<< HEAD<<<<<<< Updated upstream"
 
-#: src/strings.ts:2711
+#: src/strings.ts:2712
 msgid "Value must be between {min} and {max}"
 msgstr ""
 
-#: src/strings.ts:1173
+#: src/strings.ts:1174
 msgid "Vault"
 msgstr ""
 
-#: src/strings.ts:1994
+#: src/strings.ts:1995
 msgid "Vault cleared"
 msgstr ""
 
-#: src/strings.ts:813
+#: src/strings.ts:814
 msgid "Vault created"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1995
+#: src/strings.ts:1996
 msgid "Vault deleted"
 msgstr ""
 
 #: src/strings.ts:449
 msgid "Vault fingerprint unlock"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1933
+#: src/strings.ts:1934
 msgid "Vault locked"
 msgstr ""
 
-#: src/strings.ts:1932
+#: src/strings.ts:1933
 msgid "Vault unlocked"
 msgstr ""
 
-#: src/strings.ts:1402
+#: src/strings.ts:1403
 msgid "Verification email sent"
 msgstr ""
 
-#: src/strings.ts:575
+#: src/strings.ts:576
 msgid "Verify"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1071
+#: src/strings.ts:1072
 msgid "Verify subscription"
 msgstr ""
 
-#: src/strings.ts:1074
+#: src/strings.ts:1075
 msgid "Verify your subscription to Notesnook Pro"
 msgstr ""
 
-#: src/strings.ts:1905
+#: src/strings.ts:1906
 msgid "Verifying 2FA code"
 msgstr ""
 
-#: src/strings.ts:1891
+#: src/strings.ts:1892
 msgid "Verifying your email"
 msgstr ""
 
@@ -7279,197 +7283,197 @@ msgstr ""
 msgid "Vibrate"
 msgstr ""
 
-#: src/strings.ts:756
+#: src/strings.ts:757
 msgid "Videos"
 msgstr ""
 
-#: src/strings.ts:570
+#: src/strings.ts:1063
+msgid "View 2FA backup codes"
+msgstr ""
+
+#: src/strings.ts:571
 msgid "View all linked notebooks"
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2649
+#: src/strings.ts:2650
 msgid "View and edit your inbox public/private key pair"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2655
+#: src/strings.ts:2656
 msgid "View and manage inbox API keys"
 msgstr ""
 
-#: src/strings.ts:1272
+#: src/strings.ts:1273
 msgid "View and share debug logs"
 msgstr ""
 
-#: src/strings.ts:1749
+#: src/strings.ts:1750
 msgid "View receipt"
 msgstr ""
 
-#: src/strings.ts:1062
-msgid "View recovery codes"
-msgstr ""
-
-#: src/strings.ts:2154
+#: src/strings.ts:2155
 msgid "View source code"
 msgstr ""
 
-#: src/strings.ts:1064
-msgid "View your recovery codes to recover your account in case you lose access to your two-factor authentication methods."
+#: src/strings.ts:1065
+msgid "View your 2FA backup codes to log into your account in case you lose access to your two-factor authentication methods."
 msgstr ""
 
-#: src/strings.ts:2612
+#: src/strings.ts:2613
 msgid "Views"
 msgstr ""
 
 #: src/strings.ts:416
 msgid "Visit homepage"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1352
+#: src/strings.ts:1353
 msgid "Wait 30 seconds to try again"
 msgstr ""
 
-#: src/strings.ts:1654
+#: src/strings.ts:1655
 msgid "Waiting for upload"
 msgstr ""
 
-#: src/strings.ts:1913
+#: src/strings.ts:1914
 msgid "We are creating a backup of your data. Please wait..."
 msgstr ""
 
 #: src/strings.ts:474
 msgid "We are sorry, it seems that the app crashed due to an error. You can submit a bug report below so we can fix this asap."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1392
+#: src/strings.ts:1393
 msgid "We have sent you an email confirmation link. Please check your email inbox. If you cannot find the email, check your spam folder."
 msgstr ""
 
-#: src/strings.ts:2513
+#: src/strings.ts:2514
 msgid "We require credit card details to fight abuse and to make it seamless for you to upgrade. Your credit card is NOT charged until your free trial ends and your subscription starts. You will be notified via email of the upcoming charge before your trial ends."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2169
+#: src/strings.ts:2170
 msgid "We send you occasional promotional offers & product updates on your email (once every month)."
 msgstr ""
 
-#: src/strings.ts:1169
+#: src/strings.ts:1170
 msgid "We will send you occasional promotional offers & product updates on your email (sent once every month)."
 msgstr ""
 
-#: src/strings.ts:1356
+#: src/strings.ts:1357
 msgid "We would love to know what you think!"
 msgstr ""
 
-#: src/strings.ts:2554
+#: src/strings.ts:2555
 msgid "We’re setting up your plan right now. We’ll notify you as soon as everything is ready."
 msgstr ""
 
-#: src/strings.ts:2324
+#: src/strings.ts:2325
 msgid "Web clip settings"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2031
+#: src/strings.ts:2032
 msgid "Website"
 msgstr ""
 
-#: src/strings.ts:625
+#: src/strings.ts:626
 msgid "Wed"
 msgstr ""
 
-#: src/strings.ts:616
+#: src/strings.ts:617
 msgid "Wednesday"
 msgstr ""
 
-#: src/strings.ts:664
+#: src/strings.ts:665
 msgid "Week"
 msgstr ""
 
-#: src/strings.ts:2625
+#: src/strings.ts:2626
 msgid "Week format"
 msgstr ""
 
 #: src/strings.ts:168
-#: src/strings.ts:1571
+#: src/strings.ts:1572
 msgid "Weekly"
 msgstr ""
 
-#: src/strings.ts:780
+#: src/strings.ts:781
 msgid "Welcome back, {email}"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1890
+#: src/strings.ts:1891
 msgid "Welcome back!"
 msgstr ""
 
-#: src/strings.ts:2585
+#: src/strings.ts:2586
 msgid "Welcome to Notesnook {plan}"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2075
+#: src/strings.ts:2076
 msgid "Welcome to Notesnook Pro"
 msgstr ""
 
-#: src/strings.ts:1394
+#: src/strings.ts:1395
 msgid "What do I do if I am not getting the email?"
 msgstr ""
 
-#: src/strings.ts:2505
+#: src/strings.ts:2506
 msgid "What happens to my data if I switch plans?"
 msgstr ""
 
-#: src/strings.ts:2521
+#: src/strings.ts:2522
 msgid "What is your refund policy?"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1669
+#: src/strings.ts:1670
 msgid "What went wrong?"
 msgstr ""
 
-#: src/strings.ts:2511
+#: src/strings.ts:2512
 msgid "Why do you need my credit card details for a free trial?"
 msgstr ""
 
-#: src/strings.ts:2385
+#: src/strings.ts:2386
 msgid "Width"
 msgstr ""
 
-#: src/strings.ts:2491
+#: src/strings.ts:2492
 msgid "Words"
 msgstr ""
 
-#: src/strings.ts:2414
+#: src/strings.ts:2415
 msgid "Work & Office"
 msgstr ""
 
-#: src/strings.ts:823
+#: src/strings.ts:824
 msgid "Write notes with freedom, no spying, no tracking."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1376
+#: src/strings.ts:1377
 msgid "Write something..."
 msgstr ""
 
-#: src/strings.ts:1656
+#: src/strings.ts:1657
 msgid "Write with freedom."
 msgstr ""
 
-#: src/strings.ts:2063
+#: src/strings.ts:2064
 msgid "Write with freedom. Never compromise on privacy again."
 msgstr ""
 
-#: src/strings.ts:663
+#: src/strings.ts:664
 msgid "Year"
 msgstr ""
 
 #: src/strings.ts:170
-#: src/strings.ts:1573
+#: src/strings.ts:1574
 msgid "Yearly"
 msgstr ""
 
-#: src/strings.ts:548
+#: src/strings.ts:549
 msgid "Yes"
 msgstr ""
 
-#: src/strings.ts:2518
+#: src/strings.ts:2519
 msgid "Yes, you can cancel your trial anytime. No questions asked."
 msgstr ""
 
@@ -7477,67 +7481,67 @@ msgstr ""
 msgid "You also agree to recieve marketing emails from us which you can opt-out of from app settings."
 msgstr ""
 
-#: src/strings.ts:2590
+#: src/strings.ts:2591
 msgid "You are already subscribed to this plan."
 msgstr ""
 
-#: src/strings.ts:2241
+#: src/strings.ts:2242
 msgid "You are editing \"{notebookTitle}\"."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2045
+#: src/strings.ts:2046
 msgid "You are editing #{tag}"
 msgstr ""
 
-#: src/strings.ts:1783
+#: src/strings.ts:1784
 msgid "You are logging into the beta version of Notesnook. Switching between beta &amp; stable versions can cause weird issues including data loss. It is recommended that you do not use both simultaneously."
 msgstr ""
 
-#: src/strings.ts:1363
+#: src/strings.ts:1364
 msgid "You are not logged in"
 msgstr ""
 
-#: src/strings.ts:886
+#: src/strings.ts:887
 msgid "You are renaming color {color}"
 msgstr ""
 
 #: src/strings.ts:464
 msgid "You can also link a note to multiple Notebooks. Tap and hold any notebook to enable multi-select."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2066
+#: src/strings.ts:2067
 msgid "You can change the theme at any time from Settings or the side menu."
 msgstr ""
 
-#: src/strings.ts:2593
+#: src/strings.ts:2594
 msgid "You can change your subscription plan from the web app"
 msgstr ""
 
-#: src/strings.ts:2422
+#: src/strings.ts:2423
 msgid "You can create shortcuts of frequently accessed notebooks in the side menu"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2081
+#: src/strings.ts:2082
 msgid "You can import your notes from most other note taking apps."
 msgstr ""
 
-#: src/strings.ts:1438
+#: src/strings.ts:1439
 msgid "You can multi-select notes and move them to a notebook at once"
 msgstr ""
 
-#: src/strings.ts:1429
+#: src/strings.ts:1430
 msgid "You can pin frequently used Notebooks to the Side Menu to quickly access them."
 msgstr ""
 
-#: src/strings.ts:1172
+#: src/strings.ts:1173
 msgid "You can set a custom proxy URL to increase your privacy."
 msgstr ""
 
-#: src/strings.ts:1410
+#: src/strings.ts:1411
 msgid "You can swipe left anywhere in the app to start a new note."
 msgstr ""
 
-#: src/strings.ts:2055
+#: src/strings.ts:2056
 msgid ""
 "You can track your bug report at [{url}]({url}).\n"
 "\n"
@@ -7548,301 +7552,301 @@ msgstr ""
 
 #: src/strings.ts:226
 msgid "You can track your issue at "
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1030
+#: src/strings.ts:1031
 msgid "You can use all premium features for free for the next 14 days"
 msgstr ""
 
-#: src/strings.ts:1060
+#: src/strings.ts:1061
 msgid "You can use fallback 2FA method incase you are unable to login via primary method"
 msgstr ""
 
-#: src/strings.ts:1452
+#: src/strings.ts:1453
 msgid "You can view & restore older versions of any note by going to its properties -> History."
 msgstr ""
 
-#: src/strings.ts:1751
+#: src/strings.ts:1752
 msgid "You have {count} custom dictionary words."
 msgstr ""
 
-#: src/strings.ts:2200
+#: src/strings.ts:2201
 msgid "You have been logged out from all other devices."
 msgstr ""
 
-#: src/strings.ts:2194
+#: src/strings.ts:2195
 msgid "You have been logged out."
 msgstr ""
 
-#: src/strings.ts:2589
+#: src/strings.ts:2590
 msgid "You have made a one time purchase. To change your plan please contact support."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:966
+#: src/strings.ts:967
 msgid "You have not added any notebooks yet"
 msgstr ""
 
-#: src/strings.ts:965
+#: src/strings.ts:966
 msgid "You have not added any tags yet"
 msgstr ""
 
-#: src/strings.ts:964
+#: src/strings.ts:965
 msgid "You have not created any notes yet"
 msgstr ""
 
-#: src/strings.ts:963
+#: src/strings.ts:964
 msgid "You have not favorited any notes yet"
 msgstr ""
 
-#: src/strings.ts:968
+#: src/strings.ts:969
 msgid "You have not published any monographs yet"
 msgstr ""
 
-#: src/strings.ts:967
+#: src/strings.ts:968
 msgid "You have not set any reminders yet"
 msgstr ""
 
-#: src/strings.ts:1547
+#: src/strings.ts:1548
 msgid "You have unsynced notes. Take a backup or sync your notes to avoid losing your critical data."
 msgstr ""
 
-#: src/strings.ts:1636
+#: src/strings.ts:1637
 msgid "You must log out in order to change/reset server URLs."
 msgstr ""
 
-#: src/strings.ts:836
+#: src/strings.ts:837
 msgid "You simply cannot get any better of a note taking app than @notesnook. The UI is clean and slick, it is feature rich, encrypted, reasonably priced (esp. for students & educators) & open source"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1070
+#: src/strings.ts:1071
 msgid "You subscribed to Notesnook Pro on {date}. Verify this subscription?"
 msgstr ""
 
-#: src/strings.ts:709
+#: src/strings.ts:710
 msgid "You subscribed to Notesnook Pro on Android Phone/Tablet using Google In App Purchase."
 msgstr ""
 
-#: src/strings.ts:702
+#: src/strings.ts:703
 msgid "You subscribed to Notesnook Pro on iOS using Apple In App Purchase. You can cancel anytime with your iTunes Account settings."
 msgstr ""
 
-#: src/strings.ts:715
+#: src/strings.ts:716
 msgid "You subscribed to Notesnook Pro on the Web/Desktop App."
 msgstr ""
 
-#: src/strings.ts:721
+#: src/strings.ts:722
 msgid "You subscribed to Notesnook Pro using a gift card."
 msgstr ""
 
-#: src/strings.ts:696
+#: src/strings.ts:697
 msgid "You were awarded a subscription to Notesnook Pro by Streetwriters."
 msgstr ""
 
 #: src/strings.ts:468
 msgid "You will be logged out from all your devices"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1853
+#: src/strings.ts:1854
 msgid "You will receive instructions on how to recover your account on this email"
 msgstr ""
 
 #: src/strings.ts:467
 msgid "Your account email will be changed without affecting your subscription or any other settings."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1919
+#: src/strings.ts:1920
 msgid "Your account has been recovered."
 msgstr ""
 
 #: src/strings.ts:502
-#: src/strings.ts:1730
+#: src/strings.ts:1731
 msgid "Your account is now 100% secure against unauthorized logins."
 msgstr ""
 
-#: src/strings.ts:1858
+#: src/strings.ts:1859
 msgid "Your account password must be strong & unique."
 msgstr ""
 
-#: src/strings.ts:1036
+#: src/strings.ts:1037
 msgid "Your account will be downgraded in {days} days"
 msgstr ""
 
-#: src/strings.ts:1080
+#: src/strings.ts:1081
 msgid "Your account will be permanently deleted along with all your data, login credentials, and subscription information. This action is IRREVERSIBLE. Make sure you have saved a backup of your notes before proceeding."
 msgstr ""
 
-#: src/strings.ts:962
+#: src/strings.ts:963
 msgid "Your archive"
 msgstr ""
 
-#: src/strings.ts:2487
+#: src/strings.ts:2488
 msgid "Your archive is empty"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1931
+#: src/strings.ts:1932
 msgid "Your backup is ready to download"
 msgstr ""
 
-#: src/strings.ts:1588
+#: src/strings.ts:1589
 msgid "Your changes could not be saved"
 msgstr ""
 
-#: src/strings.ts:1778
+#: src/strings.ts:1779
 msgid "Your changes have been saved and will be reflected after the app has refreshed."
 msgstr ""
 
-#: src/strings.ts:2101
+#: src/strings.ts:2102
 msgid "Your current 2FA method is {method}"
 msgstr ""
 
-#: src/strings.ts:2596
+#: src/strings.ts:2597
 msgid "Your current subscription does not allow changing plans"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1803
+#: src/strings.ts:1804
 msgid "Your data recovery key is basically a hashed version of your password (plus some random salt). It can be used to decrypt your data for re-encryption."
 msgstr ""
 
-#: src/strings.ts:1856
+#: src/strings.ts:1857
 msgid "Your data recovery key will be used to decrypt your data"
 msgstr ""
 
-#: src/strings.ts:2507
+#: src/strings.ts:2508
 msgid "Your data remains 100% accessible regardless of what plan you are on. That includes your notes, notebooks, attachments, and anything else you might have created."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1786
+#: src/strings.ts:1787
 msgid "Your email has been confirmed."
 msgstr ""
 
-#: src/strings.ts:2498
+#: src/strings.ts:2499
 msgid "Your email has been confirmed. You can now securely sync your encrypted notes across all devices."
 msgstr ""
 
-#: src/strings.ts:766
+#: src/strings.ts:767
 msgid "Your email is not confirmed. Please confirm your email address to change account password."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:956
+#: src/strings.ts:957
 msgid "Your favorites"
 msgstr ""
 
-#: src/strings.ts:1033
+#: src/strings.ts:1034
 msgid "Your free trial ends on {date}"
 msgstr ""
 
-#: src/strings.ts:1406
+#: src/strings.ts:1407
 msgid "Your free trial has expired"
 msgstr ""
 
-#: src/strings.ts:1028
+#: src/strings.ts:1029
 msgid "Your free trial has started"
 msgstr ""
 
-#: src/strings.ts:1405
+#: src/strings.ts:1406
 msgid "Your free trial is ending soon"
 msgstr ""
 
-#: src/strings.ts:2624
+#: src/strings.ts:2625
 msgid "Your free trial is on-going. Your subscription will start on {trialExpiryDate}"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1780
+#: src/strings.ts:1781
 msgid "Your full name"
 msgstr ""
 
-#: src/strings.ts:961
+#: src/strings.ts:962
 msgid "Your monographs"
 msgstr ""
 
-#: src/strings.ts:1314
+#: src/strings.ts:1315
 msgid "Your name is stored 100% end-to-end encrypted and only visible to you."
 msgstr ""
 
-#: src/strings.ts:561
+#: src/strings.ts:562
 msgid "Your note will be unencrypted and removed from the vault."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:959
+#: src/strings.ts:960
 msgid "Your notebooks"
 msgstr ""
 
-#: src/strings.ts:957
+#: src/strings.ts:958
 msgid "Your notes"
 msgstr ""
 
-#: src/strings.ts:1894
+#: src/strings.ts:1895
 msgid "Your password is always hashed before leaving this device."
 msgstr ""
 
-#: src/strings.ts:832
+#: src/strings.ts:833
 msgid "Your privacy matters to us, no matter who you are. In a world where everyone is trying to spy on you, Notesnook encrypts all your data before it leaves your device. With Notesnook no one can ever sell your data again."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1311
+#: src/strings.ts:1312
 msgid "Your profile pictrure is stored 100% end-to-end encrypted and only visible to you."
 msgstr ""
 
-#: src/strings.ts:1999
+#: src/strings.ts:2000
 msgid "Your refund has been issued. Please wait 24 hours before reaching out to us in case you do not receive your funds."
 msgstr ""
 
-#: src/strings.ts:960
+#: src/strings.ts:961
 msgid "Your reminders"
 msgstr ""
 
 #: src/strings.ts:99
 msgid "Your session has expired. Please enter password for {obfuscatedEmail} to continue."
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:1037
+#: src/strings.ts:1038
 msgid "Your subscription ends on {date}"
 msgstr ""
 
-#: src/strings.ts:1997
+#: src/strings.ts:1998
 msgid "Your subscription has been canceled."
 msgstr ""
 
-#: src/strings.ts:1034
+#: src/strings.ts:1035
 msgid "Your subscription has ended"
 msgstr ""
 
-#: src/strings.ts:1038
+#: src/strings.ts:1039
 msgid "Your subscription renews on {date}"
 msgstr ""
 
-#: src/strings.ts:958
+#: src/strings.ts:959
 msgid "Your tags"
 msgstr ""
 
-#: src/strings.ts:690
+#: src/strings.ts:691
 msgid "yr"
 msgstr ""
 
-#: src/strings.ts:648
+#: src/strings.ts:649
 msgid "Z to A"
 msgstr ""
 
-#: src/strings.ts:793
+#: src/strings.ts:794
 msgid "Zipping"
 msgstr ""
 
-#: src/strings.ts:2463
+#: src/strings.ts:2464
 msgid "Zoom"
-msgstr ""
+msgstr "<<<<<<< Updated upstream"
 
-#: src/strings.ts:2095
+#: src/strings.ts:2096
 msgid "Zoom factor"
 msgstr ""
 
-#: src/strings.ts:1702
+#: src/strings.ts:1703
 msgid "Zoom in"
 msgstr ""
 
-#: src/strings.ts:2096
+#: src/strings.ts:2097
 msgid "Zoom in or out the app content."
 msgstr ""
 
-#: src/strings.ts:1701
+#: src/strings.ts:1702
 msgid "Zoom out"
 msgstr ""

--- a/packages/intl/src/strings.ts
+++ b/packages/intl/src/strings.ts
@@ -117,20 +117,20 @@ export const strings = {
       t`Enter the 6 digit code sent to your phone number to continue logging in`,
     app: () =>
       t`Enter the 6 digit code from your authenticator app to continue logging in`,
-    recoveryCode: () => t`Enter the recovery code to continue logging in`
+    recoveryCode: () => t`Enter the 2FA backup code to continue logging in`
   },
   "2faCodeSecondaryMethodText": {
     email: () => t`I don't have access to email`,
     sms: () => t`I don't have access to my phone`,
     app: () => t`I don't have access to authenticator app`,
-    recoveryCode: () => t`I don't have recovery codes`
+    recoveryCode: () => t`I don't have 2FA backup codes`
   },
   resend2faCode: (seconds: string) => t`Resend code in (${seconds})`,
   sendCode: () => t`Send code`,
   sendCodeSms: () => t`Send code via SMS`,
   sendCodeEmail: () => t`Send code via email`,
   authAppCode: () => t`Enter code from authenticator app`,
-  recoveryCode: () => t`I have a recovery code`,
+  recoveryCode: () => t`I have a 2FA backup code`,
   attachImageHeading: (count: number) =>
     plural(count, {
       one: "Attach image",
@@ -397,7 +397,7 @@ export const strings = {
     t`If the editor fails to load even after reloading. Try restarting the app.`,
   gettingInformation: () => t`Getting information`,
   enterSixDigitCode: () => t`Enter 6 digit code`,
-  gettingRecoveryCodes: () => t`Getting recovery codes`,
+  gettingRecoveryCodes: () => t`Getting 2FA backup codes`,
   protectNotes: () => t`Protect your notes`,
   protectNotesDesc: () => t`Choose how you want to secure your notes locally.`,
   loggingOut: () => t`Logging out. Please wait...`,
@@ -494,13 +494,14 @@ $day$: Current day (eg. Monday)`,
   twoFactorAuth: () => t`Two-factor authentication`,
   twoFactorAuthDesc: () =>
     t`Enable two-factor authentication to add an extra layer of security to your account.`,
-  saveRecoveryCodes: () => t`Save recovery codes`,
+  saveRecoveryCodes: () => t`Save 2FA backup codes`,
   saveRecoveryCodesDesc: () =>
-    t`Save your recovery codes in a safe place. You will need them to recover your account in case you lose access to your two-factor authentication methods.`,
+    t`Save your 2FA backup codes in a safe place. You will need them to log into your account in case you lose access to your two-factor authentication methods.`,
   fallbackMethodEnabled: () => t`Fallback method for 2FA enabled`,
   accountIsSecure: () =>
     t`Your account is now 100% secure against unauthorized logins.`,
   twoFactorAuthEnabled: () => t`Two-factor authentication enabled`,
+  twoFactorAuthDisabled: () => t`Two-factor authentication disabled`,
   listOf: () => t`List of`,
   network: {
     downloading: (progress?: string | number) =>
@@ -1001,15 +1002,15 @@ $day$: Current day (eg. Monday)`,
   mfaSmsInstructions: () => t`It may take a minute to receive your code.`,
   mfaSmsSelector: () => t`Don't have access to your phone number?`,
   mfaRecoveryCodeSubtitle: () =>
-    t`Please confirm your identity by entering a recovery code.`,
-  mfaRecoveryCodeSelector: () => t`Don't have your recovery codes?`,
-  enterRecoveryCode: () => t`Enter recovery code`,
-  codesCopied: () => t`Recovery codes copied!`,
+    t`Please confirm your identity by entering a 2FA backup code.`,
+  mfaRecoveryCodeSelector: () => t`Don't have your 2FA backup codes?`,
+  enterRecoveryCode: () => t`Enter 2FA backup code`,
+  codesCopied: () => t`2FA backup codes copied!`,
   resendCodeWait: () => t`Please wait before requesting a new code`,
   phoneNumberNotEntered: () => t`Phone number not entered`,
   "2faCodeSentVia": (method: string) => t`2FA code sent via ${method}`,
   errorSend2fa: () => t`Error sending 2FA code`,
-  codesSaved: () => t`Recovery codes saved!`,
+  codesSaved: () => t`2FA backup codes saved!`,
   logsCopied: () => t`Debug log copied!`,
   logsDownloaded: () => t`Debug logs downloaded`,
   clearLogs: () => t`Clear logs`,
@@ -1059,9 +1060,9 @@ $day$: Current day (eg. Monday)`,
   addFallback2faMethodDesc: () =>
     t`You can use fallback 2FA method incase you are unable to login via primary method`,
   change2faFallbackMethod: () => t`Change 2FA fallback method`,
-  viewRecoveryCodes: () => t`View recovery codes`,
+  viewRecoveryCodes: () => t`View 2FA backup codes`,
   viewRecoveryCodesDesc: () =>
-    t`View your recovery codes to recover your account in case you lose access to your two-factor authentication methods.`,
+    t`View your 2FA backup codes to log into your account in case you lose access to your two-factor authentication methods.`,
   subscriptionNotActivated: () => t`Subscription not activated?`,
   loadingSubscription: () => t`Loading subscription details`,
   loadingSubscriptionDesc: () => t`Please wait while we load your subscription`,
@@ -2705,7 +2706,7 @@ Use this if changes from other devices are not appearing on this device. This wi
     `How long should the vault stay unlocked before automatically locking?`,
   back: () => t`Back`,
   invalidRecoveryKey: () =>
-    t`Invalid recovery key. Make sure to input your account recovery key, not a 2FA recovery code.`,
+    t`Invalid recovery key. Make sure to input your account recovery key, not a 2FA backup code.`,
   featureNotAvailable: () => t`This feature is not available on this plan.`,
   valueMustBeBetween: (min: number, max: number) =>
     t`Value must be between ${min} and ${max}`

--- a/packages/intl/src/strings.ts
+++ b/packages/intl/src/strings.ts
@@ -2709,5 +2709,8 @@ Use this if changes from other devices are not appearing on this device. This wi
     t`Invalid recovery key. Make sure to input your account recovery key, not a 2FA backup code.`,
   featureNotAvailable: () => t`This feature is not available on this plan.`,
   valueMustBeBetween: (min: number, max: number) =>
-    t`Value must be between ${min} and ${max}`
+    t`Value must be between ${min} and ${max}`,
+  twoFactorDisableWarning: () =>
+    t`This will reset your current two-factor authentication setup. Do you want to proceed?`,
+  twoFactorEnable: () => t`Enable two factor authentication`
 };


### PR DESCRIPTION
## Description

This PR adds support for disabling 2FA. 2FA is still enabled by default for all new users.

This change is dependent on https://github.com/streetwriters/notesnook-sync-server/pull/94

Closes #9560

## Type of Change
- [ ] Bug fix
- [x] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [ ] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [x] Web
- [x] Mobile
- [x] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed


