### PR TITLE
Fix desktop app gets uninstalled automatically 

### DIFF
--- a/apps/desktop/src/utils/autoupdater.ts
+++ b/apps/desktop/src/utils/autoupdater.ts
@@ -37,7 +37,11 @@ async function configureAutoUpdater() {
     config.releaseTrack === "stable" &&
     autoUpdater.currentVersion.prerelease.length > 0;
   autoUpdater.allowPrerelease = false;
-  autoUpdater.autoInstallOnAppQuit = true;
+  // Do NOT auto-install on quit. On Windows, if the system shuts down while
+  // the NSIS installer is running, it first removes all old files and then
+  // gets killed before copying new ones — leaving an empty install directory.
+  // Updates should only be installed when the user explicitly triggers it.
+  autoUpdater.autoInstallOnAppQuit = false;
   autoUpdater.disableWebInstaller = true;
 }
 


### PR DESCRIPTION
## Description

This PR fixes a persistent bug on Windows (and other OSes) where the app got uninstalled during update installation due to a race condition. The desktop app will no longer install updates automatically on app quit and instead it will wait for the user to explicitly trigger "Install updates and restart".

Closes #9598 

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [ ] Mobile
- [x] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
