### PR TITLE
core: Limit note subtitle length.

### DIFF
--- a/packages/core/__tests__/notes.test.ts
+++ b/packages/core/__tests__/notes.test.ts
@@ -234,6 +234,18 @@ test("note should get headline from first paragraph in content", () =>
     expect(note?.headline).toBe("This is a very colorful existence.");
   }));
 
+test("note headline should be capped at 350 characters", () =>
+  noteTest({
+    content: {
+      type: TEST_NOTE.content.type,
+      data: `<p>${"a".repeat(400)}</p>`
+    }
+  }).then(async ({ db, id }) => {
+    const note = await db.notes.note(id);
+    expect(note?.headline).toHaveLength(350);
+    expect(note?.headline).toBe("a".repeat(350));
+  }));
+
 test("note should not get headline if there is no p tag", () =>
   noteTest({
     ...TEST_NOTE,

--- a/packages/core/src/content-types/tiptap.ts
+++ b/packages/core/src/content-types/tiptap.ts
@@ -90,7 +90,7 @@ export class Tiptap {
   }
 
   toHeadline() {
-    return extractHeadline(this.data);
+    return extractHeadline(this.data, 350);
   }
 
   toTitle() {

--- a/packages/core/src/utils/html-parser.ts
+++ b/packages/core/src/utils/html-parser.ts
@@ -44,7 +44,7 @@ function wrapIntoHTMLDocument(input: string) {
   return `<!doctype html><html lang="en"><head><title>Document Fragment</title></head><body>${input}</body></html>`;
 }
 
-export function extractHeadline(html: string) {
+export function extractHeadline(html: string, characterLimit: number) {
   let text = "";
   let start = false;
   const parser = new Parser(
@@ -60,7 +60,14 @@ export function extractHeadline(html: string) {
         }
       },
       ontext: (data) => {
-        if (start) text += data;
+        if (start) {
+          text += data
+          if (text.length > characterLimit){
+            text = text.slice(0, characterLimit);
+            parser.pause()
+            parser.end()
+          }
+        }
       }
     },
     {


### PR DESCRIPTION
## Description
This PR prevents note headlines from being too long, which may be a significant cause of app slowdowns or freezes, especially with the inbox api allowing users to import large amounts of text, which may only be formatted by a singular `<p>` and `</p>` tag.


## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [x] Added/updated tests for this change (if needed)
- [ ] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
I added a test for note headlines/subtitles being capped at 350 characters. I have not been able to run them because I did development on a non-x64 computer. The test *probably* works though. The patch definitely does (I tested it in app).

## Platform
<!-- Describe which platforms this PR is related to -->

- [x] Web
- [x] Mobile
- [x] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
