### PR TITLE
ui: fix submenu cutting off when there are a lot of lazy items

### DIFF
--- a/apps/web/src/components/note/index.tsx
+++ b/apps/web/src/components/note/index.tsx
@@ -713,7 +713,7 @@ function colorsToMenuItems(
             const isChecked = !!noteColor && noteColor.id === color.id;
             return {
               type: "button",
-              key: color.title,
+              key: color.id,
               title: color.title,
               icon: Circle.path,
               styles: { icon: { color: color.colorCode } },

--- a/packages/ui/src/components/menu/index.tsx
+++ b/packages/ui/src/components/menu/index.tsx
@@ -21,8 +21,8 @@ import React, {
   useCallback,
   useRef,
   useEffect,
-  PropsWithChildren,
-  useState
+  useState,
+  PropsWithChildren
 } from "react";
 import { Box, FlexProps, Text } from "@theme-ui/components";
 import { getPosition } from "../../utils/position.js";
@@ -68,6 +68,7 @@ export function Menu(props: MenuProps) {
   const focusedItem = items[focusIndex];
 
   const subMenuRef = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
     const item = items[focusIndex];
     if (!item || !subMenuRef.current) return;
@@ -80,15 +81,23 @@ export function Menu(props: MenuProps) {
       return;
     }
 
-    const { top, left } = getPosition(subMenuRef.current, {
-      // yOffset: menuItemElement.offsetHeight,
-      target: menuItemElement,
-      location: "right"
-    });
+    function repositionSubmenu() {
+      if (!subMenuRef.current || !menuItemElement) return;
 
+      const { top, left } = getPosition(subMenuRef.current, {
+        target: menuItemElement,
+        location: "right"
+      });
+      subMenuRef.current.style.top = `${top}px`;
+      subMenuRef.current.style.left = `${left}px`;
+    }
+
+    repositionSubmenu();
     subMenuRef.current.style.visibility = "visible";
-    subMenuRef.current.style.top = `${top}px`;
-    subMenuRef.current.style.left = `${left}px`;
+
+    const observer = new ResizeObserver(() => repositionSubmenu());
+    observer.observe(subMenuRef.current);
+    return () => observer.disconnect();
   }, [isSubmenuOpen, focusIndex, items]);
 
   return (


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

### before

<img width="700" height="693" alt="image" src="https://github.com/user-attachments/assets/fa715786-f634-46c4-b03b-b6fcce566c78" />


### after

<img width="718" height="717" alt="image" src="https://github.com/user-attachments/assets/1086ce90-c7b4-4eb0-87c3-f4df3bec1db6" />

## QA Scope

Needs to be tested only on web.

Steps to verify:

1. Create 20+ colors and add 20+ notebook shortcuts
2. Right click on note item
3. Observe the "Assign color" and "Add notebook" sub menus
4. Ensure the entire list is visible and nothing is cutoff

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [X] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [ ] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
