### PR TITLE
editor: fix crash in backspace handler

### DIFF
--- a/packages/editor/src/extensions/quirks/quirks.ts
+++ b/packages/editor/src/extensions/quirks/quirks.ts
@@ -83,7 +83,7 @@ export const Quirks = Extension.create<QuirksOptions>({
         ) {
           const node = $anchor.nodeAfter;
           return this.editor.commands.command(({ tr }) => {
-            tr.delete($anchor.pos + 1, $anchor.pos + 1 + node.nodeSize);
+            tr.delete($anchor.pos, $anchor.pos + node.nodeSize);
             return true;
           });
         }

--- a/packages/editor/src/extensions/quirks/quirks.ts
+++ b/packages/editor/src/extensions/quirks/quirks.ts
@@ -58,7 +58,6 @@ export const Quirks = Extension.create<QuirksOptions>({
       Backspace: ({ editor }) => {
         const { empty, $anchor } = editor.state.selection;
 
-        const nextNode = editor.state.doc.nodeAt($anchor.pos + 1);
         const node = findFromParentNode(
           editor.state,
           this.options.irremovableNodesOnBackspace
@@ -76,14 +75,15 @@ export const Quirks = Extension.create<QuirksOptions>({
         // manually handle this case.
         else if (
           isAndroid &&
-          nextNode &&
+          $anchor.nodeAfter &&
           this.options.irremovableNodesOnBackspace.includes(
-            nextNode.type.name
+            $anchor.nodeAfter.type.name
           ) &&
-          !nextNode.textContent.length
+          !$anchor.nodeAfter.textContent.length
         ) {
+          const node = $anchor.nodeAfter;
           return this.editor.commands.command(({ tr }) => {
-            tr.delete($anchor.pos + 1, $anchor.pos + 1 + nextNode.nodeSize);
+            tr.delete($anchor.pos + 1, $anchor.pos + 1 + node.nodeSize);
             return true;
           });
         }


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Closes https://github.com/streetwriters/notesnook/issues/9517

editor: fix crash in backspace handler


## QA Scope

Should be tested on web and mobile

Apart from the crash in the ticket, we also need to test if the following blocks can be removed via backspace key at the start of the document on mobile
- Code blocks
- Task list
- Checklist
- Table
- Attachments

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [X] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [X] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
