### PR TITLE
editor: expand collapsed nodes on search scroll if search text inside callout

### DIFF
--- a/packages/editor/src/extensions/search-replace/search-replace.ts
+++ b/packages/editor/src/extensions/search-replace/search-replace.ts
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { Extension } from "@tiptap/core";
-import { Decoration, DecorationSet } from "prosemirror-view";
+import { Decoration, DecorationSet, EditorView } from "prosemirror-view";
 import {
   EditorState,
   Plugin,
@@ -28,7 +28,7 @@ import {
 } from "prosemirror-state";
 import { SearchSettings } from "../../toolbar/stores/search-store.js";
 import { tiptapKeys } from "@notesnook/common";
-import { findParentNodeClosestToPos } from "../../utils/prosemirror.js";
+import { toggleNodesUnderPos } from "../heading/index.js";
 
 type DispatchFn = (tr: Transaction) => void;
 declare module "@tiptap/core" {
@@ -296,14 +296,13 @@ export const SearchReplace = Extension.create<SearchOptions, SearchStorage>({
             )
           );
 
-          expandCollapsedCallout(tr, from);
-
-          const domNode = this.editor.view.domAtPos(from).node;
-          scrollIntoView(domNode);
+          expandCollapsedParents(tr, from);
 
           this.storage.selectedIndex = nextIndex;
           tr.setMeta("selectedIndex", nextIndex);
           if (dispatch) updateView(state, dispatch);
+
+          scrollIntoView(this.editor.view, from);
           return true;
         },
       moveToPreviousResult:
@@ -325,15 +324,13 @@ export const SearchReplace = Extension.create<SearchOptions, SearchStorage>({
             )
           );
 
-          expandCollapsedCallout(tr, from);
-
-          const domNode = this.editor.view.domAtPos(from).node;
-          scrollIntoView(domNode);
+          expandCollapsedParents(tr, from);
 
           this.storage.selectedIndex = prevIndex;
           tr.setMeta("selectedIndex", prevIndex);
           if (dispatch) updateView(state, dispatch);
 
+          scrollIntoView(this.editor.view, from);
           return true;
         },
       replace:
@@ -481,20 +478,75 @@ export const SearchReplace = Extension.create<SearchOptions, SearchStorage>({
   }
 });
 
-function expandCollapsedCallout(tr: Transaction, pos: number) {
-  const $pos = tr.doc.resolve(pos);
-  const calloutParent = findParentNodeClosestToPos(
-    $pos,
-    (node) => node.type.name === "callout"
-  );
-  if (!calloutParent || !calloutParent.node.attrs.collapsed) return;
+function expandCollapsedParents(tr: Transaction, pos: number) {
+  try {
+    let changed = false;
 
-  tr.setMeta("preventSave", true);
-  tr.setNodeAttribute(calloutParent.pos, "collapsed", false);
+    let expandedSomething = true;
+    while (expandedSomething) {
+      const $pos = tr.doc.resolve(pos);
+      expandedSomething = false;
+
+      for (let depth = 1; depth <= $pos.depth; depth++) {
+        const node = $pos.node(depth);
+        const nodePos = $pos.before(depth);
+
+        if (
+          (node.type.name === "callout" ||
+            node.type.name === "outlineListItem") &&
+          node.attrs.collapsed
+        ) {
+          tr.setNodeAttribute(nodePos, "collapsed", false);
+          changed = true;
+          expandedSomething = true;
+        }
+
+        // expand collapsed heading that hid this node via hidden attribute
+        if (node.attrs.hidden) {
+          const parentNode = $pos.node(depth - 1);
+          const parentContentStart =
+            depth === 1 ? 0 : $pos.before(depth - 1) + 1;
+
+          let collapsedHeadingPos = -1;
+          let collapsedHeadingLevel = -1;
+
+          parentNode.forEach((child, offset) => {
+            const childAbsPos = parentContentStart + offset;
+            if (childAbsPos >= nodePos) return;
+            if (
+              child.type.name === "heading" &&
+              child.attrs.collapsed &&
+              !child.attrs.hidden
+            ) {
+              collapsedHeadingPos = childAbsPos;
+              collapsedHeadingLevel = child.attrs.level;
+            }
+          });
+
+          if (collapsedHeadingPos !== -1) {
+            tr.setNodeAttribute(collapsedHeadingPos, "collapsed", false);
+            toggleNodesUnderPos(
+              tr,
+              collapsedHeadingPos,
+              collapsedHeadingLevel,
+              false
+            );
+            changed = true;
+            expandedSomething = true;
+          }
+        }
+      }
+    }
+
+    if (changed) tr.setMeta("preventSave", true);
+  } catch (e) {
+    console.error("Error expanding collapsed parents: ", e);
+  }
 }
 
-function scrollIntoView(domNode: Node) {
+function scrollIntoView(view: EditorView, pos: number) {
   setTimeout(() => {
+    const domNode = view.domAtPos(pos).node;
     if ("scrollIntoView" in domNode) {
       (domNode as Element).scrollIntoView({
         behavior: "instant",

--- a/packages/editor/src/extensions/search-replace/search-replace.ts
+++ b/packages/editor/src/extensions/search-replace/search-replace.ts
@@ -297,6 +297,7 @@ export const SearchReplace = Extension.create<SearchOptions, SearchStorage>({
           );
 
           this.storage.selectedIndex = nextIndex;
+          tr.setMeta("isSearching", true);
           tr.setMeta("selectedIndex", nextIndex);
           if (dispatch) updateView(state, dispatch);
 
@@ -322,6 +323,7 @@ export const SearchReplace = Extension.create<SearchOptions, SearchStorage>({
           );
 
           this.storage.selectedIndex = prevIndex;
+          tr.setMeta("isSearching", true);
           tr.setMeta("selectedIndex", prevIndex);
           if (dispatch) updateView(state, dispatch);
 
@@ -468,10 +470,12 @@ export const SearchReplace = Extension.create<SearchOptions, SearchStorage>({
           }
         },
         appendTransaction: (transactions, oldState, newState) => {
-          const { isSearching } = key.getState(newState);
+          const isSearchTransaction = transactions.find((t) =>
+            t.getMeta("isSearching")
+          );
           const selectedResult =
             this.storage.results?.[this.storage.selectedIndex];
-          if (!isSearching || !selectedResult) return;
+          if (!isSearchTransaction || !selectedResult) return;
 
           const tr = newState.tr;
           if (expandCollapsedParents(tr, selectedResult.from)) {

--- a/packages/editor/src/extensions/search-replace/search-replace.ts
+++ b/packages/editor/src/extensions/search-replace/search-replace.ts
@@ -478,8 +478,9 @@ export const SearchReplace = Extension.create<SearchOptions, SearchStorage>({
           if (!isSearchTransaction || !selectedResult) return;
 
           const tr = newState.tr;
+
+          scrollIntoView(this.editor.view, selectedResult.from);
           if (expandCollapsedParents(tr, selectedResult.from)) {
-            scrollIntoView(this.editor.view, selectedResult.from);
             return tr;
           }
         }

--- a/packages/editor/src/extensions/search-replace/search-replace.ts
+++ b/packages/editor/src/extensions/search-replace/search-replace.ts
@@ -296,13 +296,10 @@ export const SearchReplace = Extension.create<SearchOptions, SearchStorage>({
             )
           );
 
-          expandCollapsedParents(tr, from);
-
           this.storage.selectedIndex = nextIndex;
           tr.setMeta("selectedIndex", nextIndex);
           if (dispatch) updateView(state, dispatch);
 
-          scrollIntoView(this.editor.view, from);
           return true;
         },
       moveToPreviousResult:
@@ -324,13 +321,10 @@ export const SearchReplace = Extension.create<SearchOptions, SearchStorage>({
             )
           );
 
-          expandCollapsedParents(tr, from);
-
           this.storage.selectedIndex = prevIndex;
           tr.setMeta("selectedIndex", prevIndex);
           if (dispatch) updateView(state, dispatch);
 
-          scrollIntoView(this.editor.view, from);
           return true;
         },
       replace:
@@ -472,6 +466,18 @@ export const SearchReplace = Extension.create<SearchOptions, SearchStorage>({
           decorations(state) {
             return key.getState(state).results;
           }
+        },
+        appendTransaction: (transactions, oldState, newState) => {
+          const { isSearching } = key.getState(newState);
+          const selectedResult =
+            this.storage.results?.[this.storage.selectedIndex];
+          if (!isSearching || !selectedResult) return;
+
+          const tr = newState.tr;
+          if (expandCollapsedParents(tr, selectedResult.from)) {
+            scrollIntoView(this.editor.view, selectedResult.from);
+            return tr;
+          }
         }
       })
     ];
@@ -482,63 +488,57 @@ function expandCollapsedParents(tr: Transaction, pos: number) {
   try {
     let changed = false;
 
-    let expandedSomething = true;
-    while (expandedSomething) {
-      const $pos = tr.doc.resolve(pos);
-      expandedSomething = false;
+    const $pos = tr.doc.resolve(pos);
 
-      for (let depth = 1; depth <= $pos.depth; depth++) {
-        const node = $pos.node(depth);
-        const nodePos = $pos.before(depth);
+    for (let depth = 1; depth <= $pos.depth; depth++) {
+      const node = $pos.node(depth);
+      const nodePos = $pos.before(depth);
 
-        if (
-          (node.type.name === "callout" ||
-            node.type.name === "outlineListItem") &&
-          node.attrs.collapsed
-        ) {
-          tr.setNodeAttribute(nodePos, "collapsed", false);
-          changed = true;
-          expandedSomething = true;
-        }
+      if (
+        (node.type.name === "callout" ||
+          node.type.name === "outlineListItem") &&
+        node.attrs.collapsed
+      ) {
+        tr.setNodeAttribute(nodePos, "collapsed", false);
+        changed = true;
+      }
 
-        // expand collapsed heading that hid this node via hidden attribute
-        if (node.attrs.hidden) {
-          const parentNode = $pos.node(depth - 1);
-          const parentContentStart =
-            depth === 1 ? 0 : $pos.before(depth - 1) + 1;
+      // expand collapsed heading that hid this node via hidden attribute
+      if (node.attrs.hidden) {
+        const parentNode = $pos.node(depth - 1);
+        const parentContentStart = depth === 1 ? 0 : $pos.before(depth - 1) + 1;
 
-          let collapsedHeadingPos = -1;
-          let collapsedHeadingLevel = -1;
+        let collapsedHeadingPos = -1;
+        let collapsedHeadingLevel = -1;
 
-          parentNode.forEach((child, offset) => {
-            const childAbsPos = parentContentStart + offset;
-            if (childAbsPos >= nodePos) return;
-            if (
-              child.type.name === "heading" &&
-              child.attrs.collapsed &&
-              !child.attrs.hidden
-            ) {
-              collapsedHeadingPos = childAbsPos;
-              collapsedHeadingLevel = child.attrs.level;
-            }
-          });
-
-          if (collapsedHeadingPos !== -1) {
-            tr.setNodeAttribute(collapsedHeadingPos, "collapsed", false);
-            toggleNodesUnderPos(
-              tr,
-              collapsedHeadingPos,
-              collapsedHeadingLevel,
-              false
-            );
-            changed = true;
-            expandedSomething = true;
+        parentNode.forEach((child, offset) => {
+          const childAbsPos = parentContentStart + offset;
+          if (childAbsPos >= nodePos) return;
+          if (
+            child.type.name === "heading" &&
+            child.attrs.collapsed &&
+            !child.attrs.hidden
+          ) {
+            collapsedHeadingPos = childAbsPos;
+            collapsedHeadingLevel = child.attrs.level;
           }
+        });
+
+        if (collapsedHeadingPos !== -1) {
+          tr.setNodeAttribute(collapsedHeadingPos, "collapsed", false);
+          toggleNodesUnderPos(
+            tr,
+            collapsedHeadingPos,
+            collapsedHeadingLevel,
+            false
+          );
+          changed = true;
         }
       }
     }
 
     if (changed) tr.setMeta("preventSave", true);
+    return changed;
   } catch (e) {
     console.error("Error expanding collapsed parents: ", e);
   }

--- a/packages/editor/src/extensions/search-replace/search-replace.ts
+++ b/packages/editor/src/extensions/search-replace/search-replace.ts
@@ -28,6 +28,7 @@ import {
 } from "prosemirror-state";
 import { SearchSettings } from "../../toolbar/stores/search-store.js";
 import { tiptapKeys } from "@notesnook/common";
+import { findParentNodeClosestToPos } from "../../utils/prosemirror.js";
 
 type DispatchFn = (tr: Transaction) => void;
 declare module "@tiptap/core" {
@@ -295,6 +296,8 @@ export const SearchReplace = Extension.create<SearchOptions, SearchStorage>({
             )
           );
 
+          expandCollapsedCallout(tr, from);
+
           const domNode = this.editor.view.domAtPos(from).node;
           scrollIntoView(domNode);
 
@@ -321,6 +324,8 @@ export const SearchReplace = Extension.create<SearchOptions, SearchStorage>({
               tr.mapping.map(to)
             )
           );
+
+          expandCollapsedCallout(tr, from);
 
           const domNode = this.editor.view.domAtPos(from).node;
           scrollIntoView(domNode);
@@ -475,6 +480,18 @@ export const SearchReplace = Extension.create<SearchOptions, SearchStorage>({
     ];
   }
 });
+
+function expandCollapsedCallout(tr: Transaction, pos: number) {
+  const $pos = tr.doc.resolve(pos);
+  const calloutParent = findParentNodeClosestToPos(
+    $pos,
+    (node) => node.type.name === "callout"
+  );
+  if (!calloutParent || !calloutParent.node.attrs.collapsed) return;
+
+  tr.setMeta("preventSave", true);
+  tr.setNodeAttribute(calloutParent.pos, "collapsed", false);
+}
 
 function scrollIntoView(domNode: Node) {
   setTimeout(() => {

--- a/packages/editor/src/toolbar/popups/search-replace.tsx
+++ b/packages/editor/src/toolbar/popups/search-replace.tsx
@@ -25,6 +25,7 @@ import { ToolButton } from "../components/tool-button.js";
 import { Editor } from "../../types.js";
 import { useEditorSearchStore } from "../stores/search-store.js";
 import { strings } from "@notesnook/intl";
+import { inlineDebounce } from "@notesnook/common";
 
 export type SearchReplacePopupProps = { editor: Editor };
 export function SearchReplacePopup(props: SearchReplacePopupProps) {
@@ -94,7 +95,7 @@ export function SearchReplacePopup(props: SearchReplacePopupProps) {
               sx={{ p: 0, fontFamily: "monospace" }}
               value={searchTerm}
               onChange={(e) => {
-                search(e.target.value);
+                inlineDebounce("search", () => search(e.target.value), 100);
                 useEditorSearchStore.setState({ searchTerm: e.target.value });
               }}
               onKeyDown={(e) => {


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Closes https://github.com/streetwriters/notesnook/issues/7095

editor: expand collapsed nodes on search scroll if search text inside callout

## QA Scope

Needs to be tested on web and mobile.

In the in-editor search, if the search result is inside a collapsed callout/otline list/heading, using next/previous buttons should expand the callout.

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [X] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [X] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
