### PR TITLE
mobile: fix saving incoming note in merge conflict dialog does not work

### DIFF
--- a/apps/mobile/app/components/merge-conflicts/index.tsx
+++ b/apps/mobile/app/components/merge-conflicts/index.tsx
@@ -76,7 +76,9 @@ const MergeConflicts = () => {
   const applyChanges = async () => {
     const contentToSave = selectedContent;
     if (!contentToSave) return;
-    const note = await db.notes.note(contentToSave.noteId);
+    const note = await db.notes.note(
+      (content.current as UnencryptedContentItem).noteId
+    );
     if (!note) return;
     await db.notes.add({
       id: note.id,


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Closes https://github.com/streetwriters/notesnook/issues/9746

## QA Scope
Test on Android or iOS, one device is sufficient to test this merge conflicts are resolved properly.

### Create a merge conflict
1. Login on two devices, Phone and Browser using the same account.
2. Create a note and lock it, ensure both devices have the note synced.
3. Turn off internet on Phone
4. Make edits to the note on Browser and wait for about 2 minutes
5. Edit the note on phone now and turn on internet again
6. A conflict is created and should show up on top of the notes list on mobile

### What to test
Resolving merge conflicts and all cases of Discard/Save a copy/Keep will work for both incoming and local note versions.


## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
