### PR TITLE
web: use expire verbiage in subscription subtitle when provider is gift card

### DIFF
--- a/apps/web/src/dialogs/settings/components/subscription-status.tsx
+++ b/apps/web/src/dialogs/settings/components/subscription-status.tsx
@@ -32,6 +32,7 @@ import {
   getFeaturesUsage,
   usePromise
 } from "@notesnook/common";
+import { SubscriptionProvider } from "@notesnook/core";
 
 export function SubscriptionStatus() {
   const user = useUserStore((store) => store.user);
@@ -44,6 +45,8 @@ export function SubscriptionStatus() {
       ? ""
       : trial
       ? `Your free trial is on-going. Your subscription will start on ${trialExpiryDate}.`
+      : user?.subscription.provider === SubscriptionProvider.GIFT_CARD
+      ? `Your subscription will expire on ${expiryDate}.`
       : autoRenew
       ? `Your subscription will auto renew on ${expiryDate}.`
       : expiryDate

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -588,7 +588,8 @@ export enum SubscriptionProvider {
   STREETWRITERS = 0,
   APPLE = 1,
   GOOGLE = 2,
-  PADDLE = 3
+  PADDLE = 3,
+  GIFT_CARD = 4
 }
 
 export type User = {


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Closes https://github.com/streetwriters/notesnook/issues/9617

For gift cards, say "Your subscription will expire on xyz-date"

<img width="1214" height="632" alt="image" src="https://github.com/user-attachments/assets/2e08c98e-ab9f-4651-9b64-5574efa6ac16" />


## QA Scope

Needs to be tested on web only

## Type of Change
- [ ] Bug fix
- [ ] Feature

## Visuals
- [X] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [ ] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
