### PR TITLE
desktop: fix app not appearing in alt-tab switcher

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -165,6 +165,14 @@ async function createWindow() {
   );
   mainWindow.webContents.session.setProxy({ proxyRules: config.proxyRules });
 
+  mainWindow.on("show", () =>
+    /**
+     * We may set `skipTaskbar` to true at startup.
+     * This also removes the window from the Alt-Tab switcher.
+     * To fix that, whenever the app is shown, we set `skipTaskbar` to false.
+     */
+    mainWindow.setSkipTaskbar(false)
+  );
   mainWindow.once("closed", () => {
     globalThis.window = null;
   });

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -161,6 +161,14 @@ async function createWindow() {
   );
   mainWindow.webContents.session.setProxy({ proxyRules: config.proxyRules });
 
+  mainWindow.on("show", () =>
+    /**
+     * We may set `skipTaskbar` to true at startup.
+     * This also removes the window from the Alt-Tab switcher.
+     * To fix that, whenever the app is shown, we set `skipTaskbar` to false.
+     */
+    mainWindow.setSkipTaskbar(false)
+  );
   mainWindow.once("closed", () => {
     globalThis.window = null;
   });


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Closes #10077
Closes #9906
Closes #9624
Closes #9524
Closes #8936
Closes #8927
Closes #8062

When autostart and start as minimized is enabled in the desktop app, starting the computer would autostart the app in the system tray. But after opening the app, it wouldn't appear in the alt-tab switcher. This PR fixes that.

## QA Scope

Needs to be tested on desktop only

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [X] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [ ] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
