### PR TITLE
web: disable expand sidebar button on small screens

### DIFF
--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -215,7 +215,10 @@ function DesktopAppContents() {
                 zIndex: 3
               }}
             >
-              <NavigationMenu onExpand={() => navPane.current?.reset(0)} />
+              <NavigationMenu
+                onExpand={() => navPane.current?.reset(0)}
+                canExpand={!isTablet}
+              />
             </Pane>
           )}
           {isFocusMode ? null : (

--- a/apps/web/src/components/navigation-menu/index.tsx
+++ b/apps/web/src/components/navigation-menu/index.tsx
@@ -228,7 +228,13 @@ const tabs: NavigationTabItem[] = [
   }
 ] as const;
 
-function NavigationMenu({ onExpand }: { onExpand?: () => void }) {
+function NavigationMenu({
+  onExpand,
+  canExpand
+}: {
+  onExpand?: () => void;
+  canExpand: boolean;
+}) {
   const isFocusMode = useAppStore((store) => store.isFocusMode);
   const navigationTab = useAppStore((store) => store.navigationTab);
   const setNavigationTab = useAppStore((store) => store.setNavigationTab);
@@ -352,6 +358,7 @@ function NavigationMenu({ onExpand }: { onExpand?: () => void }) {
                 sx={{ p: 1, bg: "transparent" }}
                 onClick={onExpand}
                 title={strings.expandSidebar()}
+                disabled={!canExpand}
               >
                 <ExpandSidebar size={13} color="icon" />
               </Button>


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Disable expand sidebar button on small screens. On small screen, the sidebar is automatically collapsed and we want it to stay collapsed. It doesn't make sense to have the expand sidebar button visible. Clicking the expand sidebar button would make the next pane's content shift slightly towards the left and be cut-off anyways.

<img width="352" height="203" alt="image" src="https://github.com/user-attachments/assets/7b1000c2-9413-42d2-ac57-84142ab800bb" />


## QA Scope

Needs to be tested only on web. The expand sidebar button should be disabled on small screens.

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [X] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [ ] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
