### PR TITLE
core: use ISO formatted dates in frontmatter in markdown export

### DIFF
--- a/packages/core/src/utils/templates/md.ts
+++ b/packages/core/src/utils/templates/md.ts
@@ -18,7 +18,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { TemplateData } from "./index.js";
-import { formatDate } from "../date.js";
 
 export const buildMarkdown = (data: TemplateData) => `# ${data.title}
 
@@ -35,8 +34,8 @@ ${data.content}`;
 function buildFrontmatter(data: TemplateData) {
   const lines = [
     `title: ${JSON.stringify(data.title || "")}`,
-    `created_at: ${formatDate(data.dateCreated)}`,
-    `updated_at: ${formatDate(data.dateEdited)}`
+    `created_at: ${new Date(data.dateCreated).toISOString()}`,
+    `updated_at: ${new Date(data.dateEdited).toISOString()}`
   ];
   if (data.pinned) lines.push(`pinned: ${data.pinned}`);
   if (data.favorite) lines.push(`favorite: ${data.favorite}`);


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Related https://github.com/streetwriters/notesnook/issues/9427

## QA Scope

Needs to be tested on web only. Make sure that when a note is exported as Markdown with Frontmatter and then imported back in, its created and edited date should be correct

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [X] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [ ] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
