### PR TITLE
web: show copied text when monograph link is copied

### DIFF
--- a/apps/web/src/components/publish-view/index.tsx
+++ b/apps/web/src/components/publish-view/index.tsx
@@ -60,6 +60,7 @@ function PublishView(props: PublishViewProps) {
   const publishNote = useStore((store) => store.publish);
   const unpublishNote = useStore((store) => store.unpublish);
   const [monograph, setMonograph] = useState(props.monograph);
+  const [copied, setCopied] = useState(false);
   const monographAnalytics = useIsFeatureAvailable("monographAnalytics");
   const analytics = usePromise(async () => {
     if (!monographAnalytics?.isAllowed || !monograph) return { totalViews: 0 };
@@ -110,12 +111,15 @@ function PublishView(props: PublishViewProps) {
           <Button
             variant="secondary"
             className="copyPublishLink"
-            sx={{ flexShrink: 0, m: 0 }}
+            sx={{ flexShrink: 0, m: 0, color: copied ? "accent" : "initial" }}
             onClick={() => {
               writeText(`${hosts.MONOGRAPH_HOST}/${monograph?.id}`);
+              setCopied(true);
+              setTimeout(() => setCopied(false), 2000);
             }}
+            disabled={copied}
           >
-            {strings.copy()}
+            {copied ? strings.copied() : strings.copy()}
           </Button>
         </Flex>
       ) : null}


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

<img width="425" height="227" alt="image" src="https://github.com/user-attachments/assets/e4c29fee-587f-4055-a624-7fc1f9415d80" />


## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [X] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [ ] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
