### PR TITLE
Fix Archive screen does not show correct date/time on note based on Sorting Type

### DIFF
--- a/apps/mobile/app/app.tsx
+++ b/apps/mobile/app/app.tsx
@@ -44,7 +44,6 @@ import { useUserStore } from "./stores/use-user-store";
 import RNBootSplash from "react-native-bootsplash";
 import AppLocked from "./components/app-lock";
 import { useSettingStore } from "./stores/use-setting-store";
-import ScreenGuardModule from "react-native-screenguard";
 I18nManager.allowRTL(false);
 I18nManager.forceRTL(false);
 I18nManager.swapLeftAndRightInRTL(false);
@@ -52,7 +51,6 @@ const { appLockEnabled, appLockMode } = SettingsService.get();
 if (appLockEnabled || appLockMode !== "none") {
   useUserStore.getState().lockApp(true);
 }
-ScreenGuardModule.initSettings();
 RNBootSplash.hide({
   fade: true
 });

--- a/apps/mobile/app/components/list-items/headers/section-header.tsx
+++ b/apps/mobile/app/components/list-items/headers/section-header.tsx
@@ -17,7 +17,12 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { GroupHeader, GroupOptions, ItemType } from "@notesnook/core";
+import {
+  GroupHeader,
+  GroupingKey,
+  GroupOptions,
+  ItemType
+} from "@notesnook/core";
 import { strings } from "@notesnook/intl";
 import { useThemeColors } from "@notesnook/theme";
 import React from "react";
@@ -40,6 +45,7 @@ type SectionHeaderProps = {
   color?: string;
   screen?: RouteName;
   groupOptions: GroupOptions;
+  group: GroupingKey;
   onOpenJumpToDialog: () => void;
 };
 
@@ -53,6 +59,7 @@ export const SectionHeader = React.memo<
     color,
     screen,
     groupOptions,
+    group,
     onOpenJumpToDialog
   }: SectionHeaderProps) {
     const { colors } = useThemeColors();
@@ -133,6 +140,7 @@ export const SectionHeader = React.memo<
                         <Sort
                           screen={screen}
                           type={dataType}
+                          group={group}
                           hideGroupOptions={
                             screen === "Reminders" || screen === "Search"
                           }

--- a/apps/mobile/app/components/list/index.tsx
+++ b/apps/mobile/app/components/list/index.tsx
@@ -74,13 +74,15 @@ export default function List(props: ListProps) {
     notebooksListMode === "compact";
 
   const groupType =
-    props.renderedInRoute === "Notes"
-      ? "home"
-      : props.renderedInRoute === "Favorites"
-        ? "favorites"
-        : props.renderedInRoute === "Trash" || props.dataType === "trash"
-          ? "trash"
-          : `${props.dataType}s`;
+    props.renderedInRoute === "Archive"
+      ? "archive"
+      : props.renderedInRoute === "Notes"
+        ? "home"
+        : props.renderedInRoute === "Favorites"
+          ? "favorites"
+          : props.renderedInRoute === "Trash" || props.dataType === "trash"
+            ? "trash"
+            : `${props.dataType}s`;
 
   const groupOptions = useGroupOptions(groupType);
 

--- a/apps/mobile/app/components/list/index.tsx
+++ b/apps/mobile/app/components/list/index.tsx
@@ -53,6 +53,7 @@ type ListProps = {
   isRenderedInActionSheet?: boolean;
   CustomListComponent?: React.JSX.ElementType;
   placeholder?: PlaceholderData;
+  groupType: GroupingKey;
   id?: string;
 };
 
@@ -73,18 +74,7 @@ export default function List(props: ListProps) {
     props.dataType === "notebook" ||
     notebooksListMode === "compact";
 
-  const groupType =
-    props.renderedInRoute === "Archive"
-      ? "archive"
-      : props.renderedInRoute === "Notes"
-        ? "home"
-        : props.renderedInRoute === "Favorites"
-          ? "favorites"
-          : props.renderedInRoute === "Trash" || props.dataType === "trash"
-            ? "trash"
-            : `${props.dataType}s`;
-
-  const groupOptions = useGroupOptions(groupType);
+  const groupOptions = useGroupOptions(props.groupType);
 
   const _onRefresh = async () => {
     Sync.run("global", false, "full", () => {
@@ -107,7 +97,7 @@ export default function List(props: ListProps) {
           isSheet={props.isRenderedInActionSheet || false}
           items={props.data}
           groupOptions={groupOptions}
-          group={groupType as GroupingKey}
+          group={props.groupType as GroupingKey}
           renderedInRoute={props.renderedInRoute}
           customAccentColor={props.customAccentColor}
           dataType={props.dataType}
@@ -117,7 +107,7 @@ export default function List(props: ListProps) {
     },
     [
       groupOptions,
-      groupType,
+      props.groupType,
       props.customAccentColor,
       props.data,
       props.dataType,

--- a/apps/mobile/app/components/list/list-item.wrapper.tsx
+++ b/apps/mobile/app/components/list/list-item.wrapper.tsx
@@ -53,7 +53,7 @@ import TagItem from "../list-items/tag";
 import { SearchResult } from "../list-items/search-result";
 
 type ListItemWrapperProps<TItem = Item> = {
-  group?: GroupingKey;
+  group: GroupingKey;
   items: VirtualizedGrouping<TItem> | undefined;
   isSheet: boolean;
   index: number;
@@ -182,6 +182,7 @@ export function ListItemWrapper(props: ListItemWrapperProps) {
               item={groupHeader}
               index={index}
               dataType={item.type}
+              group={group}
               color={props.customAccentColor}
               groupOptions={groupOptions}
               onOpenJumpToDialog={() => {
@@ -218,6 +219,7 @@ export function ListItemWrapper(props: ListItemWrapperProps) {
               item={groupHeader}
               index={index}
               dataType={item.type}
+              group={group}
               color={props.customAccentColor}
               groupOptions={groupOptions}
               onOpenJumpToDialog={() => {
@@ -245,6 +247,7 @@ export function ListItemWrapper(props: ListItemWrapperProps) {
               screen={props.renderedInRoute}
               item={groupHeader}
               index={index}
+              group={group}
               dataType={item.type}
               color={props.customAccentColor}
               groupOptions={groupOptions}
@@ -271,6 +274,7 @@ export function ListItemWrapper(props: ListItemWrapperProps) {
               screen={props.renderedInRoute}
               item={groupHeader}
               index={index}
+              group={group}
               dataType={item.type}
               color={props.customAccentColor}
               groupOptions={groupOptions}
@@ -297,6 +301,7 @@ export function ListItemWrapper(props: ListItemWrapperProps) {
               screen={props.renderedInRoute}
               item={groupHeader}
               index={index}
+              group={group}
               dataType={item.type}
               color={props.customAccentColor}
               groupOptions={groupOptions}

--- a/apps/mobile/app/components/sheets/relations-list/index.tsx
+++ b/apps/mobile/app/components/sheets/relations-list/index.tsx
@@ -121,6 +121,17 @@ export const RelationsList = ({
         <List
           data={items}
           loading={false}
+          groupType={
+            referenceType === "note"
+              ? "notes"
+              : referenceType === "tag"
+                ? "tags"
+                : referenceType === "notebook"
+                  ? "notebooks"
+                  : referenceType === "reminder"
+                    ? "reminders"
+                    : "notes"
+          }
           dataType={referenceType as any}
           isRenderedInActionSheet={true}
         />

--- a/apps/mobile/app/components/sheets/reminder-notify/index.tsx
+++ b/apps/mobile/app/components/sheets/reminder-notify/index.tsx
@@ -181,6 +181,7 @@ export default function ReminderNotify({
             data={references}
             loading={false}
             dataType="note"
+            groupType="notes"
             isRenderedInActionSheet={true}
           />
         </View>

--- a/apps/mobile/app/components/sheets/sort/index.tsx
+++ b/apps/mobile/app/components/sheets/sort/index.tsx
@@ -45,24 +45,15 @@ import Paragraph from "../../ui/typography/paragraph";
 const Sort = ({
   type,
   screen,
-  hideGroupOptions
+  hideGroupOptions,
+  group: groupType
 }: {
   type: ItemType;
   screen?: RouteName;
+  group: GroupingKey;
   hideGroupOptions?: boolean;
 }) => {
   const { colors } = useThemeColors();
-
-  const groupType =
-    screen === "Archive"
-      ? "archive"
-      : screen === "Search"
-      ? "search"
-      : screen === "Notes"
-      ? "home"
-      : screen === "Trash" || type === "trash"
-      ? "trash"
-      : ((type + "s") as GroupingKey);
 
   const [groupOptions, setGroupOptions] = useState(
     db.settings.getGroupOptions(groupType)

--- a/apps/mobile/app/components/sheets/sort/index.tsx
+++ b/apps/mobile/app/components/sheets/sort/index.tsx
@@ -148,10 +148,15 @@ const Sort = ({
       >
         {Object.keys(SORT).map((item) => {
           const sortOptionVisibility = {
-            relevance: screen === "Search",
-            dueDate: screen === "Reminders",
-            dateModified: screen === "Tags" || screen === "Reminders",
-            dateEdited: screen !== "Tags" && screen !== "Reminders"
+            dateCreated: groupType !== "trash",
+            relevance: groupType === "search",
+            dueDate: groupType === "reminders",
+            dateModified: groupType === "reminders" || groupType === "tags",
+            dateEdited:
+              groupType !== "tags" &&
+              groupType !== "reminders" &&
+              groupType !== "trash",
+            dateDeleted: groupType === "trash"
           };
 
           // Check if this sort option should be skipped for the current screen
@@ -179,10 +184,7 @@ const Sort = ({
               onPress={async () => {
                 const _groupOptions: GroupOptions = {
                   ...groupOptions,
-                  sortBy:
-                    type === "trash"
-                      ? "dateDeleted"
-                      : (item as SortOptions["sortBy"])
+                  sortBy: item as SortOptions["sortBy"]
                 };
                 await updateGroupOptions(_groupOptions);
               }}

--- a/apps/mobile/app/components/side-menu/index.tsx
+++ b/apps/mobile/app/components/side-menu/index.tsx
@@ -433,7 +433,7 @@ const TabBar = (props: SimpleTabBarProps) => {
                       name="plus"
                       testID="sidebar-add-button"
                       size={AppFontSize.lg - 2}
-                       top={10}
+                      top={10}
                       color={colors.primary.icon}
                       onPress={async () => {
                         if (props.navigationState.index === 1) {
@@ -497,6 +497,11 @@ const TabBar = (props: SimpleTabBarProps) => {
                                 props.navigationState.index === 1
                                   ? "notebook"
                                   : "tag"
+                              }
+                              group={
+                                props.navigationState.index === 1
+                                  ? "notebooks"
+                                  : "tags"
                               }
                               hideGroupOptions
                             />

--- a/apps/mobile/app/screens/archive/index.tsx
+++ b/apps/mobile/app/screens/archive/index.tsx
@@ -70,6 +70,7 @@ export const Archive = ({ navigation, route }: NavigationProps<"Archive">) => {
           onRefresh={() => {
             refresh();
           }}
+          groupType="archive"
           renderedInRoute="Archive"
           loading={loading}
           placeholder={{

--- a/apps/mobile/app/screens/favorites/index.tsx
+++ b/apps/mobile/app/screens/favorites/index.tsx
@@ -70,6 +70,7 @@ export const Favorites = ({
         <List
           data={favorites}
           dataType="note"
+          groupType="favorites"
           onRefresh={() => {
             refresh();
           }}

--- a/apps/mobile/app/screens/home/index.tsx
+++ b/apps/mobile/app/screens/home/index.tsx
@@ -70,6 +70,7 @@ export const Home = ({ navigation, route }: NavigationProps<"Notes">) => {
         <List
           data={notes}
           dataType="note"
+          groupType="home"
           renderedInRoute={route.name}
           loading={loading || !isFocused}
           headerTitle={strings.routes[route.name]()}

--- a/apps/mobile/app/screens/notebook/index.tsx
+++ b/apps/mobile/app/screens/notebook/index.tsx
@@ -185,6 +185,7 @@ const NotebookScreen = ({ route, navigation }: NavigationProps<"Notebook">) => {
         <List
           data={notes}
           dataType="note"
+          groupType="notes"
           onRefresh={() => {
             onRequestUpdate();
           }}

--- a/apps/mobile/app/screens/notes/index.tsx
+++ b/apps/mobile/app/screens/notes/index.tsx
@@ -214,6 +214,7 @@ const NotesPage = ({
         <List
           data={notes}
           dataType="note"
+          groupType="notes"
           onRefresh={onRequestUpdate}
           loading={false}
           renderedInRoute={route.name}

--- a/apps/mobile/app/screens/reminders/index.tsx
+++ b/apps/mobile/app/screens/reminders/index.tsx
@@ -90,6 +90,7 @@ export const Reminders = ({
         <List
           data={reminders}
           dataType="reminder"
+          groupType="reminders"
           headerTitle={strings.routes[route.name]()}
           renderedInRoute="Reminders"
           loading={loading}
@@ -98,9 +99,8 @@ export const Reminders = ({
             paragraph: strings.remindersEmpty(),
             button: strings.setReminder(),
             action: async () => {
-              const reminderFeature = await isFeatureAvailable(
-                "activeReminders"
-              );
+              const reminderFeature =
+                await isFeatureAvailable("activeReminders");
               if (!reminderFeature.isAllowed) {
                 ToastManager.show({
                   type: "info",

--- a/apps/mobile/app/screens/search/index.tsx
+++ b/apps/mobile/app/screens/search/index.tsx
@@ -154,6 +154,7 @@ export const Search = ({ route, navigation }: NavigationProps<"Search">) => {
         data={results}
         dataType={route.params?.type}
         renderedInRoute={route.name}
+        groupType="search"
         loading={loading}
         placeholder={{
           title: route.name,

--- a/apps/mobile/app/screens/trash/index.tsx
+++ b/apps/mobile/app/screens/trash/index.tsx
@@ -98,6 +98,7 @@ export const Trash = ({ navigation, route }: NavigationProps<"Trash">) => {
         <List
           data={trash}
           dataType="trash"
+          groupType="trash"
           renderedInRoute="Trash"
           loading={!isFocused}
           placeholder={PLACEHOLDER_DATA(db.settings.getTrashCleanupInterval())}

--- a/apps/mobile/app/services/settings.ts
+++ b/apps/mobile/app/services/settings.ts
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { NativeModules, Platform } from "react-native";
+import { Platform } from "react-native";
 import { MMKV } from "../common/database/mmkv";
 import {
   SettingStore,
@@ -29,6 +29,7 @@ import { scale, updateSize } from "../utils/size";
 import { DatabaseLogger } from "../common/database";
 import { useUserStore } from "../stores/use-user-store";
 import ScreenGuardModule from "react-native-screenguard";
+ScreenGuardModule.initSettings();
 
 function reset() {
   const settings = get();

--- a/apps/mobile/app/utils/constants.ts
+++ b/apps/mobile/app/utils/constants.ts
@@ -48,7 +48,8 @@ export const SORT = {
   dateCreated: "Date created",
   title: "Title",
   dueDate: "Due date",
-  relevance: "Relevance"
+  relevance: "Relevance",
+  dateDeleted: "Date deleted"
 };
 
 export const itemSkus = [


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Archive screen should show correct date on each note based on based on sorting settings.

Closes https://github.com/streetwriters/notesnook/issues/9766

## QA Scope

Date on each note in the archive list should be based on the current sort settings. If notes are sorted by Date Edited, then each note should show last edited date and same for Date Created. Testing on one platform is enough.

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [x] QA passed
- [ ] UI/UX passed
