### PR TITLE
web: Don't show input box in "too many Inbox keys" dialog.

### DIFF
--- a/apps/web/src/dialogs/settings/components/inbox-api-keys.tsx
+++ b/apps/web/src/dialogs/settings/components/inbox-api-keys.tsx
@@ -34,7 +34,6 @@ import { BaseDialogProps, DialogManager } from "../../../common/dialog-manager";
 import Dialog from "../../../components/dialog";
 import { usePromise } from "@notesnook/common";
 import { ConfirmDialog } from "../../confirm";
-import { PromptDialog } from "../../prompt";
 import { showPasswordDialog } from "../../password-dialog";
 import { strings } from "@notesnook/intl";
 
@@ -74,10 +73,12 @@ export function InboxApiKeys() {
             variant="accent"
             onClick={() => {
               if (apiKeys.length >= 10) {
-                PromptDialog.show({
+                ConfirmDialog.show({
                   title: "API Keys Limit Reached",
-                  description:
-                    "Cannot create more than 10 api keys at a time. Please revoke some existing keys before creating new ones."
+                  subtitle:
+                    "Cannot create more than 10 api keys at a time. Please revoke some existing keys before creating new ones.",
+                  positiveButtonText:
+                    strings.ok()
                 });
               } else {
                 AddApiKeyDialog.show({


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->
Removes the input box from the dialog as it is out of place & unnecessary. 
## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [x] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

Before:
<img width="764" height="364" alt="image" src="https://github.com/user-attachments/assets/3ebe5431-0568-4549-972b-5987ce05e8de" />
After:
<img width="764" height="364" alt="image" src="https://github.com/user-attachments/assets/2dc78bd2-7bdf-4426-986b-a07d67359122" />

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [x] Web
- [ ] Mobile
- [x] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
