### PR TITLE
Show confirm dialog before deleting attachment in attachment manager

### DIFF
--- a/apps/mobile/app/components/attachments/actions.tsx
+++ b/apps/mobile/app/components/attachments/actions.tsx
@@ -191,6 +191,10 @@ const Actions = ({
                   .to(attachment, "note")
                   .get();
                 await db.attachments.remove(attachment.hash, false);
+                ToastManager.show({
+                  type: "success",
+                  message: strings.attachmentDeleted()
+                });
                 setAttachments();
                 eSendEvent(eDBItemUpdate, attachment.id);
                 relations

--- a/apps/mobile/app/components/attachments/actions.tsx
+++ b/apps/mobile/app/components/attachments/actions.tsx
@@ -177,26 +177,48 @@ const Actions = ({
     {
       name: strings.delete(),
       onPress: async () => {
-        const relations = await db.relations.to(attachment, "note").get();
-        await db.attachments.remove(attachment.hash, false);
-        setAttachments();
-        eSendEvent(eDBItemUpdate, attachment.id);
-        relations
-          .map((relation) => relation.fromId)
-          .forEach(async (id) => {
-            useTabStore.getState().forEachNoteTab(id, async (tab) => {
-              const isFocused = useTabStore.getState().currentTab === tab.id;
-              if (isFocused) {
-                eSendEvent(eOnLoadNote, {
-                  item: await db.notes.note(id),
-                  forced: true
-                });
-              } else {
-                editorController.current.commands.setLoading(true, tab.id);
-              }
-            });
-          });
         close?.();
+        setTimeout(() => {
+          presentDialog({
+            title: strings.deleteAttachment(),
+            paragraph: strings.deleteAttachmentConfirm(),
+            positiveText: strings.yes(),
+            negativeText: strings.no(),
+            positiveType: "errorShade",
+            positivePress: async () => {
+              try {
+                const relations = await db.relations
+                  .to(attachment, "note")
+                  .get();
+                await db.attachments.remove(attachment.hash, false);
+                setAttachments();
+                eSendEvent(eDBItemUpdate, attachment.id);
+                relations
+                  .map((relation) => relation.fromId)
+                  .forEach(async (id) => {
+                    useTabStore.getState().forEachNoteTab(id, async (tab) => {
+                      const isFocused =
+                        useTabStore.getState().currentTab === tab.id;
+                      if (isFocused) {
+                        eSendEvent(eOnLoadNote, {
+                          item: await db.notes.note(id),
+                          forced: true
+                        });
+                      } else {
+                        editorController.current.commands.setLoading(
+                          true,
+                          tab.id
+                        );
+                      }
+                    });
+                  });
+                return true;
+              } catch (e) {
+                return false;
+              }
+            }
+          });
+        }, 500);
       },
       icon: "delete-outline"
     }

--- a/apps/mobile/app/components/dialog/base-dialog.tsx
+++ b/apps/mobile/app/components/dialog/base-dialog.tsx
@@ -136,7 +136,7 @@ const BaseDialog = ({
               ? background
               : transparent
                 ? "transparent"
-                : "rgba(0,0,0,0.3)"
+                : "rgba(0,0,0,0.1)"
           }}
         >
           <KeyboardAvoidingView

--- a/apps/mobile/app/components/dialog/index.tsx
+++ b/apps/mobile/app/components/dialog/index.tsx
@@ -173,7 +173,7 @@ export const Dialog = ({ context = "global" }: { context?: string }) => {
       closeOnTouch={!dialogInfo.disableBackdropClosing}
       background={dialogInfo.background}
       transparent={
-        dialogInfo.transparent === undefined ? true : dialogInfo.transparent
+        dialogInfo.transparent === undefined ? false : dialogInfo.transparent
       }
       onShow={async () => {
         if (dialogInfo.input && !dialogInfo.form) {

--- a/packages/intl/locale/en.po
+++ b/packages/intl/locale/en.po
@@ -935,6 +935,10 @@ msgstr "Are you sure you want to clear all logs from {key}?"
 msgid "Are you sure you want to clear trash?"
 msgstr "Are you sure you want to clear trash?"
 
+#: src/strings.ts:2666
+msgid "Are you sure you want to delete this attachment?"
+msgstr "Are you sure you want to delete this attachment?"
+
 #: src/strings.ts:1542
 msgid "Are you sure you want to logout and clear all data stored on THIS DEVICE?"
 msgstr "Are you sure you want to logout and clear all data stored on THIS DEVICE?"
@@ -2141,6 +2145,10 @@ msgstr "Delete"
 #: src/strings.ts:1076
 msgid "Delete account"
 msgstr "Delete account"
+
+#: src/strings.ts:2664
+msgid "Delete attachment"
+msgstr "Delete attachment"
 
 #: src/strings.ts:1319
 msgid "Delete collapsed section"

--- a/packages/intl/locale/en.po
+++ b/packages/intl/locale/en.po
@@ -992,6 +992,10 @@ msgstr "attachment"
 msgid "Attachment"
 msgstr "Attachment"
 
+#: src/strings.ts:2663
+msgid "Attachment deleted"
+msgstr "Attachment deleted"
+
 #: src/strings.ts:2458
 msgid "Attachment manager"
 msgstr "Attachment manager"

--- a/packages/intl/locale/pseudo-LOCALE.po
+++ b/packages/intl/locale/pseudo-LOCALE.po
@@ -992,6 +992,10 @@ msgstr ""
 msgid "Attachment"
 msgstr ""
 
+#: src/strings.ts:2663
+msgid "Attachment deleted"
+msgstr ""
+
 #: src/strings.ts:2458
 msgid "Attachment manager"
 msgstr ""

--- a/packages/intl/locale/pseudo-LOCALE.po
+++ b/packages/intl/locale/pseudo-LOCALE.po
@@ -935,6 +935,10 @@ msgstr ""
 msgid "Are you sure you want to clear trash?"
 msgstr ""
 
+#: src/strings.ts:2666
+msgid "Are you sure you want to delete this attachment?"
+msgstr ""
+
 #: src/strings.ts:1542
 msgid "Are you sure you want to logout and clear all data stored on THIS DEVICE?"
 msgstr ""
@@ -2129,6 +2133,10 @@ msgstr ""
 
 #: src/strings.ts:1076
 msgid "Delete account"
+msgstr ""
+
+#: src/strings.ts:2664
+msgid "Delete attachment"
 msgstr ""
 
 #: src/strings.ts:1319

--- a/packages/intl/src/strings.ts
+++ b/packages/intl/src/strings.ts
@@ -2660,5 +2660,8 @@ Use this if changes from other devices are not appearing on this device. This wi
   passwordRequired: () => t`Password required`,
   confirmPasswordRequired: () => t`Confirm password required`,
   enterAValidEmailAddress: () => t`Please enter a valid email address`,
-  giftCodeRequired: () => t`Gift code required`
+  giftCodeRequired: () => t`Gift code required`,
+  deleteAttachment: () => t`Delete attachment`,
+  deleteAttachmentConfirm: () =>
+    t`Are you sure you want to delete this attachment?`
 };

--- a/packages/intl/src/strings.ts
+++ b/packages/intl/src/strings.ts
@@ -2663,5 +2663,6 @@ Use this if changes from other devices are not appearing on this device. This wi
   giftCodeRequired: () => t`Gift code required`,
   deleteAttachment: () => t`Delete attachment`,
   deleteAttachmentConfirm: () =>
-    t`Are you sure you want to delete this attachment?`
+    t`Are you sure you want to delete this attachment?`,
+  attachmentDeleted: () => t`Attachment deleted`
 };


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

1. Show confirmation dialog to user before deleting an attachment.
2. Show toast message after attachment is deleted.

<img width="374" height="305" alt="Screenshot 2026-05-06 at 10 38 31 AM" src="https://github.com/user-attachments/assets/da3ce476-324b-46d6-aaeb-f56fd575dc67" />

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [x] Attached relevant screenshots / screen recording / GIF
- [] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
