### PR TITLE
Fix copy button text is cut in 2fa settings page

### DIFF
--- a/apps/mobile/app/screens/settings/2fa.tsx
+++ b/apps/mobile/app/screens/settings/2fa.tsx
@@ -322,8 +322,8 @@ export const MFASetup = ({
                 method?.id === "email"
                   ? user?.email
                   : method?.id === "app"
-                  ? authenticatorDetails?.sharedKey || ""
-                  : undefined
+                    ? authenticatorDetails?.sharedKey || ""
+                    : undefined
               }
               multiline={method.id === "app"}
               onChangeText={(value) => {
@@ -352,16 +352,20 @@ export const MFASetup = ({
                   <Button
                     onPress={onSendCode}
                     loading={sending}
+                    style={{
+                      paddingVertical: 0,
+                      paddingHorizontal: 0
+                    }}
                     title={
                       sending
                         ? null
                         : method.id === "app"
-                        ? strings.copy()
-                        : `${
-                            seconds
-                              ? strings.resendCode(seconds as number)
-                              : strings.sendCode()
-                          }`
+                          ? strings.copy()
+                          : `${
+                              seconds
+                                ? strings.resendCode(seconds as number)
+                                : strings.sendCode()
+                            }`
                     }
                   />
                 )


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Fix copy button padding causing the button text to get hidden.

<img width="377" height="308" alt="Screenshot 2026-05-07 at 9 24 38 AM" src="https://github.com/user-attachments/assets/3d8a384c-e2af-42ab-b92b-679db1e37f72" />

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [x] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
