### PR TITLE
core: handle invalid input in formatDate without leaking 'Invalid Date'

### DIFF
--- a/packages/core/src/utils/__tests__/date.test.ts
+++ b/packages/core/src/utils/__tests__/date.test.ts
@@ -1,0 +1,95 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { test, expect, describe } from "vitest";
+import { formatDate } from "../date.js";
+
+describe("formatDate", () => {
+  describe("with valid input", () => {
+    const FIXED_EPOCH = 1700000000000; // 2023-11-14T22:13:20.000Z
+
+    test("formats a numeric epoch as date-time", () => {
+      expect(
+        formatDate(FIXED_EPOCH, {
+          type: "date-time",
+          dateFormat: "DD-MM-YYYY",
+          timeFormat: "24-hour"
+        })
+      ).toMatch(/\d{2}-\d{2}-\d{4} \d{2}:\d{2}/);
+    });
+
+    test("formats a Date instance as date", () => {
+      expect(
+        formatDate(new Date(FIXED_EPOCH), {
+          type: "date",
+          dateFormat: "YYYY-MM-DD"
+        })
+      ).toBe("2023-11-14");
+    });
+
+    test("formats an ISO string as time", () => {
+      const result = formatDate("2023-11-14T22:13:20.000Z", {
+        type: "time",
+        timeFormat: "24-hour"
+      });
+      expect(result).toMatch(/^\d{2}:\d{2}$/);
+    });
+  });
+
+  describe("with invalid input", () => {
+    test("returns empty string for null", () => {
+      expect(formatDate(null)).toBe("");
+    });
+
+    test("returns empty string for undefined", () => {
+      expect(formatDate(undefined)).toBe("");
+    });
+
+    test("returns empty string for an unparseable string", () => {
+      expect(formatDate("not-a-real-date")).toBe("");
+    });
+
+    test("returns empty string regardless of options.type", () => {
+      expect(
+        formatDate(null, {
+          type: "date",
+          dateFormat: "DD-MM-YYYY"
+        })
+      ).toBe("");
+      expect(
+        formatDate(null, {
+          type: "time",
+          timeFormat: "12-hour"
+        })
+      ).toBe("");
+      expect(formatDate(null, { type: "timezone" })).toBe("");
+    });
+
+    test("does NOT leak the literal string 'Invalid Date'", () => {
+      // This is the regression we're fixing. Before this PR, formatDate(null)
+      // returned "Invalid Date" (or "Invalid Date Invalid Date" depending on
+      // the date-time format). Once this string lands in an exported markdown
+      // frontmatter / HTML <meta> tag / reminder dropdown, there is no signal
+      // anything went wrong.
+      expect(formatDate(null)).not.toContain("Invalid");
+      expect(formatDate(undefined)).not.toContain("Invalid");
+      expect(formatDate("garbage")).not.toContain("Invalid");
+    });
+  });
+});

--- a/packages/core/src/utils/date.ts
+++ b/packages/core/src/utils/date.ts
@@ -113,23 +113,26 @@ export function formatDate(
     type: "date-time"
   }
 ) {
+  if (date === null || date === undefined) return "";
+  const d = dayjs(date);
+  if (!d.isValid()) return "";
   switch (options.type) {
     case "date-time-timezone":
-      return dayjs(date).format(
+      return d.format(
         `${options.dateFormat} ${getTimeFormat(options.timeFormat)} z`
       );
     case "date-time":
-      return dayjs(date).format(
+      return d.format(
         `${options.dateFormat} ${getTimeFormat(options.timeFormat)}`
       );
     case "time":
-      return dayjs(date).format(getTimeFormat(options.timeFormat));
+      return d.format(getTimeFormat(options.timeFormat));
     case "date":
-      return dayjs(date).format(options.dateFormat);
+      return d.format(options.dateFormat);
     case "day":
-      return dayjs(date).format(getDayFormat(options.dayFormat));
+      return d.format(getDayFormat(options.dayFormat));
     case "timezone":
-      return dayjs(date).format("ZZ");
+      return d.format("ZZ");
   }
 }
 


### PR DESCRIPTION
## Description

`packages/core/src/utils/date.ts:formatDate(date, options)` declares its signature as:

```ts
export function formatDate(
  date: string | number | Date | null | undefined,
  options: FormatDateOptions = { ... }
)
```

The signature explicitly accepts `null` and `undefined`, but the body doesn't honor that contract — it passes the argument straight into `dayjs(date).format(...)`. The result depends on which "invalid" value the caller passes:

- `dayjs(null).format(...)` → literal string `"Invalid Date"`
- `dayjs(undefined).format(...)` → **today's date** (because `dayjs(undefined) === dayjs()`, which returns "now")
- `dayjs("").format(...)` → `"Invalid Date"`
- `dayjs("not-a-date").format(...)` → `"Invalid Date"`

So today, calling `formatDate(null)` returns `"Invalid Date"`, and `formatDate(undefined)` silently returns a fresh timestamp for today — neither of which matches the implicit contract suggested by accepting those types in the signature.

Most callers in the repo are defensively guarded already (`note.expiryDate?.value && formatDate(...)`, `apiKey.lastUsedAt ? formatDate(...) : "Never used"`, etc.), and the upstream TypeScript types claim most date fields are non-nullable `number`. So this isn't a user-reported bug — it's a contract-honesty fix. The function says it accepts `null | undefined`; this PR makes it actually do something sensible when it gets them.

## Solution

Two guards at the top of `formatDate`:

1. An explicit `null`/`undefined` short-circuit returning `""`. Needed because `dayjs(undefined)` is the no-arg constructor, which returns the current time and reports `.isValid() === true` — so a single `.isValid()` check is not enough to cover `undefined`.
2. A `dayjs(date).isValid()` check returning `""` for unparseable strings, empty strings, and `NaN`.

The fix mirrors the `.isValid()` pattern already used in this package at `packages/core/src/utils/query-transformer.ts:116` (`return date?.isValid() ? date.toDate().getTime() : null;`).

The `dayjs(date)` construction is hoisted to a `const d` and reused across all six switch branches — small side-effect win, also keeps the diff visually localised.

Empty string `""` is chosen as the sentinel because every existing caller consumes the return value directly into a template literal or a React `text` prop, both of which render `""` invisibly. Returning `null` would change the type from `string` to `string | null` and break ~12 call sites in 4 files.

No signature change. No new imports. No new dependencies. Valid inputs produce byte-identical output.

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [x] Added/updated tests for this change (if needed)
- [ ] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why

Tests were added at `packages/core/src/utils/__tests__/date.test.ts` covering:

1. Valid numeric epoch → date-time format (round-trip)
2. Valid `Date` instance → date format
3. Valid ISO string → time format
4. `null` input → `""`
5. `undefined` input → `""` (regression guard for the `dayjs(undefined) === dayjs()` idiosyncrasy)
6. Unparseable string → `""`
7. Invalid input regardless of `options.type` (`date`, `time`, `timezone`)
8. Regression guard: output never contains the substring `"Invalid"`

Run with `npm run test:core` (or `npx vitest run src/utils/__tests__/date.test.ts` from inside `packages/core`). All 8 new tests pass; full `packages/core/src/utils/__tests__/` suite passes 99/99 (no regression to fuzzy, query-transformer, content-block, internal-link, set, html-diff, title-format, virtualized-grouping).

## Platform
- [x] Web
- [x] Mobile
- [x] Desktop

(`@notesnook/core` ships in all three apps; this fix takes effect everywhere `formatDate` is called.)

## Sign-off
- [x] QA passed
- [x] UI/UX passed