### PR TITLE
web: show correct message when user provided pgp private key is encrypted

### DIFF
--- a/apps/web/src/dialogs/inbox-pgp-keys-dialog.tsx
+++ b/apps/web/src/dialogs/inbox-pgp-keys-dialog.tsx
@@ -69,15 +69,12 @@ export const InboxPGPKeysDialog = DialogManager.register(
 
       try {
         setIsLoading(true);
-        const isValid = await db.storage().validatePGPKeyPair({
+        const result = await db.storage().validatePGPKeyPair({
           publicKey: trimmedPublicKey,
           privateKey: trimmedPrivateKey
         });
-        if (!isValid) {
-          showToast(
-            "error",
-            "Invalid PGP key pair. Please check your keys and try again."
-          );
+        if (!result.isValid) {
+          showToast("error", result.message);
           return;
         }
 

--- a/apps/web/src/interfaces/storage.ts
+++ b/apps/web/src/interfaces/storage.ts
@@ -34,6 +34,7 @@ import { isFeatureSupported } from "../utils/feature-check";
 import { IKeyStore } from "./key-store";
 import { User } from "@notesnook/core";
 import * as openpgp from "openpgp";
+import { strings } from "@notesnook/intl";
 
 type EncryptedKey = { iv: Uint8Array; cipher: BufferSource };
 export type DatabasePersistence = "memory" | "db";
@@ -140,8 +141,21 @@ export class NNStorage implements IStorage {
     return { publicKey: keys.publicKey, privateKey: keys.privateKey };
   }
 
-  async validatePGPKeyPair(keys: SerializedKeyPair): Promise<boolean> {
+  async validatePGPKeyPair(keys: SerializedKeyPair): Promise<{
+    isValid: boolean;
+    message: string;
+  }> {
     try {
+      const privateKey = await openpgp.readPrivateKey({
+        armoredKey: keys.privateKey
+      });
+      if (!privateKey.isDecrypted()) {
+        return {
+          isValid: false,
+          message: strings.pgpPrivateKeyProtected()
+        };
+      }
+
       const dummyData = JSON.stringify({
         favorite: true,
         title: "Hello world"
@@ -149,27 +163,27 @@ export class NNStorage implements IStorage {
 
       const publicKey = await openpgp.readKey({ armoredKey: keys.publicKey });
       const encrypted = await openpgp.encrypt({
-        message: await openpgp.createMessage({
-          text: dummyData
-        }),
+        message: await openpgp.createMessage({ text: dummyData }),
         encryptionKeys: publicKey
       });
 
-      const message = await openpgp.readMessage({
-        armoredMessage: encrypted
-      });
-      const privateKey = await openpgp.readPrivateKey({
-        armoredKey: keys.privateKey
-      });
+      const message = await openpgp.readMessage({ armoredMessage: encrypted });
       const decrypted = await openpgp.decrypt({
         message,
         decryptionKeys: privateKey
       });
 
-      return decrypted.data === dummyData;
+      const isValid = decrypted.data === dummyData;
+      return {
+        isValid,
+        message: isValid ? "" : strings.invalidPgpKeyPair()
+      };
     } catch (e) {
       console.error("PGP key pair validation error:", e);
-      return false;
+      return {
+        isValid: false,
+        message: strings.invalidPgpKeyPair()
+      };
     }
   }
 

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -75,7 +75,10 @@ export interface IStorage {
     privateKeyArmored: string,
     encryptedMessage: string
   ): Promise<string>;
-  validatePGPKeyPair(keys: SerializedKeyPair): Promise<boolean>;
+  validatePGPKeyPair(keys: SerializedKeyPair): Promise<{
+    isValid: boolean;
+    message: string;
+  }>;
 
   generateCryptoKeyFallback(
     password: string,

--- a/packages/intl/locale/en.po
+++ b/packages/intl/locale/en.po
@@ -5081,6 +5081,10 @@ msgstr "Privacy Policy. "
 msgid "private analytics and bug reports."
 msgstr "private analytics and bug reports."
 
+#: src/strings.ts:2727
+msgid "Private key is passphrase-protected. Please provide the decrypted key or a key without a passphrase."
+msgstr "Private key is passphrase-protected. Please provide the decrypted key or a key without a passphrase."
+
 #: src/strings.ts:2713
 msgid "Private Key:"
 msgstr "Private Key:"

--- a/packages/intl/locale/pseudo-LOCALE.po
+++ b/packages/intl/locale/pseudo-LOCALE.po
@@ -5055,6 +5055,10 @@ msgstr ""
 msgid "private analytics and bug reports."
 msgstr "<<<<<<< HEAD"
 
+#: src/strings.ts:2727
+msgid "Private key is passphrase-protected. Please provide the decrypted key or a key without a passphrase."
+msgstr ""
+
 #: src/strings.ts:2713
 msgid "Private Key:"
 msgstr ""

--- a/packages/intl/src/strings.ts
+++ b/packages/intl/src/strings.ts
@@ -2722,5 +2722,7 @@ Use this if changes from other devices are not appearing on this device. This wi
     t`Invalid recovery key. Make sure to input your account recovery key, not a 2FA recovery code.`,
   featureNotAvailable: () => t`This feature is not available on this plan.`,
   valueMustBeBetween: (min: number, max: number) =>
-    t`Value must be between ${min} and ${max}`
+    t`Value must be between ${min} and ${max}`,
+  pgpPrivateKeyProtected: () =>
+    t`Private key is passphrase-protected. Please provide the decrypted key or a key without a passphrase.`
 };


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

web: show correct message when user provided pgp private key is encrypted

## QA Scope

If user provided PGP keys have a passphrase, this error should be shown "Private key is passphrase-protected. Please provide the decrypted key or a key without a passphrase".
If user provided PGP keys are invalid, this error should be shown "Invalid PGP key pair. Please check your keys and try again."

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [X] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [X] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
