### PR TITLE
core: clear key cache & fix private key encoding in saveInboxKeys()

### DIFF
--- a/packages/core/src/api/user-manager.ts
+++ b/packages/core/src/api/user-manager.ts
@@ -538,10 +538,11 @@ class UserManager {
         public: keys.publicKey,
         private: await this.db
           .storage()
-          .encrypt(userEncryptionKey, JSON.stringify(keys.privateKey))
+          .encrypt(userEncryptionKey, keys.privateKey)
       }
     };
     await this.updateUser(updatePayload);
+    this.keyManager.clearCache();
   }
 
   async sendVerificationEmail(newEmail?: string) {


### PR DESCRIPTION


## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

core: clear key cache & fix private key encoding in saveInboxKeys()

* after saving new keys, we didn't clear the cache so getInboxKeys() was still returning old keys
* remove unnecessary JSON.stringify on private key in saveInboxKeys()

## QA Scope

Needs to be tested on web only. Changing the inbox PGP keys should work as expected.

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [X] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [X] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
