### PR TITLE
web: fix never expiring inbox api key being shown as expired

### DIFF
--- a/apps/web/src/dialogs/settings/components/inbox-api-keys.tsx
+++ b/apps/web/src/dialogs/settings/components/inbox-api-keys.tsx
@@ -77,8 +77,7 @@ export function InboxApiKeys() {
                   title: "API Keys Limit Reached",
                   subtitle:
                     "Cannot create more than 10 api keys at a time. Please revoke some existing keys before creating new ones.",
-                  positiveButtonText:
-                    strings.ok()
+                  positiveButtonText: strings.ok()
                 });
               } else {
                 AddApiKeyDialog.show({
@@ -191,7 +190,8 @@ function ApiKeyItem({ apiKey, onRevoke, isAtEnd }: ApiKeyItemProps) {
     }
   }, [viewing]);
 
-  const isApiKeyExpired = Date.now() > apiKey.expiryDate;
+  const isApiKeyExpired =
+    apiKey.expiryDate === -1 ? false : Date.now() > apiKey.expiryDate;
 
   return (
     <Box


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

web: fix never expiring inbox api key being shown as expired

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [ ] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [ ] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
