### PR TITLE
mobile: fix app crashes on upgrade from v2.6.x to v3

### DIFF
--- a/apps/mobile/app/services/settings.ts
+++ b/apps/mobile/app/services/settings.ts
@@ -26,7 +26,6 @@ import {
 } from "../stores/use-setting-store";
 import { NotesnookModule } from "../utils/notesnook-module";
 import { scale, updateSize } from "../utils/size";
-import { DatabaseLogger } from "../common/database";
 import { useUserStore } from "../stores/use-user-store";
 import ScreenGuardModule from "react-native-screenguard";
 ScreenGuardModule.initSettings();
@@ -89,7 +88,6 @@ function migrateAppLock() {
       biometricsAuthEnabled: true
     });
   }
-  DatabaseLogger.debug("App lock Migrated");
 }
 
 function migrateSettings(settings: SettingStore["settings"]) {


### PR DESCRIPTION
Crash was happening due to cyclic import.

Closes https://github.com/streetwriters/notesnook/issues/9785

QA not required/possible atm.