### PR TITLE
web: allow notebook/tag/color level group&sort preferences

### DIFF
--- a/apps/mobile/app/components/list-items/headers/section-header.tsx
+++ b/apps/mobile/app/components/list-items/headers/section-header.tsx
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import {
   GroupHeader,
+  GroupingByIdKey,
   GroupingKey,
   GroupOptions,
   ItemType
@@ -46,6 +47,8 @@ type SectionHeaderProps = {
   screen?: RouteName;
   groupOptions: GroupOptions;
   group: GroupingKey;
+  groupId?: string;
+  type?: GroupingByIdKey;
   onOpenJumpToDialog: () => void;
   itemCount?: number;
 };
@@ -62,7 +65,9 @@ export const SectionHeader = React.memo<
     groupOptions,
     group,
     onOpenJumpToDialog,
-    itemCount
+    itemCount,
+    groupId,
+    type
   }: SectionHeaderProps) {
     const { colors } = useThemeColors();
     const isCompactModeEnabled = useIsCompactModeEnabled(
@@ -143,8 +148,10 @@ export const SectionHeader = React.memo<
                       component: (
                         <Sort
                           screen={screen}
-                          type={dataType}
+                          dataType={dataType}
+                          type={type}
                           group={group}
+                          groupId={groupId}
                           hideGroupOptions={
                             screen === "Reminders" || screen === "Search"
                           }

--- a/apps/mobile/app/components/list/index.tsx
+++ b/apps/mobile/app/components/list/index.tsx
@@ -17,7 +17,12 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { GroupingKey, Item, VirtualizedGrouping } from "@notesnook/core";
+import {
+  GroupingByIdKey,
+  GroupingKey,
+  Item,
+  VirtualizedGrouping
+} from "@notesnook/core";
 import { useThemeColors } from "@notesnook/theme";
 import { LegendList, LegendListRenderItemProps } from "@legendapp/list";
 import React, { useEffect, useRef } from "react";
@@ -55,6 +60,7 @@ type ListProps = {
   placeholder?: PlaceholderData;
   groupType: GroupingKey;
   id?: string;
+  type?: GroupingByIdKey;
 };
 
 const onMomentumScrollEnd = () => {
@@ -74,7 +80,7 @@ export default function List(props: ListProps) {
     props.dataType === "notebook" ||
     notebooksListMode === "compact";
 
-  const groupOptions = useGroupOptions(props.groupType);
+  const groupOptions = useGroupOptions(props.groupType, props.id, props.type);
 
   const _onRefresh = async () => {
     Sync.run("global", false, "full", () => {
@@ -96,23 +102,27 @@ export default function List(props: ListProps) {
           index={itemProps.index}
           isSheet={props.isRenderedInActionSheet || false}
           items={props.data}
+          groupId={props.id}
           groupOptions={groupOptions}
           group={props.groupType as GroupingKey}
           renderedInRoute={props.renderedInRoute}
           customAccentColor={props.customAccentColor}
           dataType={props.dataType}
+          type={props.type}
           scrollRef={scrollRef}
         />
       );
     },
     [
-      groupOptions,
-      props.groupType,
-      props.customAccentColor,
-      props.data,
-      props.dataType,
       props.isRenderedInActionSheet,
-      props.renderedInRoute
+      props.data,
+      props.id,
+      props.groupType,
+      props.renderedInRoute,
+      props.customAccentColor,
+      props.dataType,
+      groupOptions,
+      props.type
     ]
   );
 

--- a/apps/mobile/app/components/list/list-item.wrapper.tsx
+++ b/apps/mobile/app/components/list/list-item.wrapper.tsx
@@ -26,6 +26,7 @@ import {
   Color,
   GroupHeader,
   GroupOptions,
+  GroupingByIdKey,
   GroupingKey,
   HighlightedResult,
   Item,
@@ -40,7 +41,7 @@ import {
 } from "@notesnook/core";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { View } from "react-native";
-import { db } from "../../common/database";
+import { getGroupOptions } from "../../hooks/use-group-options";
 import { useIsCompactModeEnabled } from "../../hooks/use-is-compact-mode-enabled";
 import { eSendEvent } from "../../services/event-manager";
 import { RouteName } from "../../stores/use-navigation-store";
@@ -49,8 +50,8 @@ import { SectionHeader } from "../list-items/headers/section-header";
 import { NoteWrapper } from "../list-items/note/wrapper";
 import { NotebookWrapper } from "../list-items/notebook/wrapper";
 import ReminderItem from "../list-items/reminder";
-import TagItem from "../list-items/tag";
 import { SearchResult } from "../list-items/search-result";
+import TagItem from "../list-items/tag";
 
 type ListItemWrapperProps<TItem = Item> = {
   group: GroupingKey;
@@ -62,6 +63,8 @@ type ListItemWrapperProps<TItem = Item> = {
   dataType: string;
   scrollRef: any;
   groupOptions: GroupOptions;
+  groupId?: string;
+  type?: GroupingByIdKey;
 };
 
 export function ListItemWrapper(props: ListItemWrapperProps) {
@@ -183,6 +186,8 @@ export function ListItemWrapper(props: ListItemWrapperProps) {
               index={index}
               dataType={item.type}
               group={group}
+              groupId={props.groupId}
+              type={props.type}
               color={props.customAccentColor}
               groupOptions={groupOptions}
               onOpenJumpToDialog={() => {
@@ -220,6 +225,8 @@ export function ListItemWrapper(props: ListItemWrapperProps) {
               index={index}
               dataType={item.type}
               group={group}
+              groupId={props.groupId}
+              type={props.type}
               color={props.customAccentColor}
               groupOptions={groupOptions}
               onOpenJumpToDialog={() => {
@@ -250,6 +257,8 @@ export function ListItemWrapper(props: ListItemWrapperProps) {
               group={group}
               dataType={item.type}
               color={props.customAccentColor}
+              type={props.type}
+              groupId={props.groupId}
               groupOptions={groupOptions}
               onOpenJumpToDialog={() => {
                 eSendEvent(eOpenJumpToDialog, {
@@ -276,6 +285,8 @@ export function ListItemWrapper(props: ListItemWrapperProps) {
               index={index}
               group={group}
               dataType={item.type}
+              groupId={props.groupId}
+              type={props.type}
               color={props.customAccentColor}
               groupOptions={groupOptions}
               onOpenJumpToDialog={() => {
@@ -303,6 +314,8 @@ export function ListItemWrapper(props: ListItemWrapperProps) {
               index={index}
               group={group}
               dataType={item.type}
+              groupId={props.groupId}
+              type={props.type}
               color={props.customAccentColor}
               groupOptions={groupOptions}
               itemCount={items?.placeholders.length}
@@ -322,11 +335,16 @@ export function ListItemWrapper(props: ListItemWrapperProps) {
   }
 }
 
-function getDate(item: Notebook | Note, groupType?: GroupingKey): number {
+function getDate(
+  item: Notebook | Note,
+  groupType?: GroupingKey,
+  id?: string,
+  type?: GroupingByIdKey
+): number {
   return (
     getSortValue(
       groupType
-        ? db.settings.getGroupOptions(groupType)
+        ? getGroupOptions(groupType, id, type)
         : {
             sortBy: "dateEdited",
             sortDirection: "desc"

--- a/apps/mobile/app/components/sheets/sort/index.tsx
+++ b/apps/mobile/app/components/sheets/sort/index.tsx
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 import {
+  GroupingByIdKey,
   GroupingKey,
   GroupOptions,
   ItemType,
@@ -27,7 +28,10 @@ import { strings } from "@notesnook/intl";
 import { useThemeColors } from "@notesnook/theme";
 import React, { useState } from "react";
 import { View } from "react-native";
-import { db } from "../../../common/database";
+import {
+  getGroupOptions,
+  setGroupOptionsById
+} from "../../../hooks/use-group-options";
 import { eSendEvent } from "../../../services/event-manager";
 import Navigation from "../../../services/navigation";
 import { RouteName } from "../../../stores/use-navigation-store";
@@ -43,20 +47,24 @@ import { Pressable } from "../../ui/pressable";
 import Heading from "../../ui/typography/heading";
 import Paragraph from "../../ui/typography/paragraph";
 const Sort = ({
-  type,
+  dataType,
   screen,
   hideGroupOptions,
-  group: groupType
+  group: groupType,
+  groupId,
+  type
 }: {
-  type: ItemType;
+  dataType: ItemType;
+  type?: GroupingByIdKey;
   screen?: RouteName;
   group: GroupingKey;
   hideGroupOptions?: boolean;
+  groupId?: string;
 }) => {
   const { colors } = useThemeColors();
 
   const [groupOptions, setGroupOptions] = useState(
-    db.settings.getGroupOptions(groupType)
+    getGroupOptions(groupType, groupId, type)
   );
 
   const getSortButtonTitle = () => {
@@ -79,16 +87,17 @@ const Sort = ({
   };
 
   const updateGroupOptions = async (_groupOptions: GroupOptions) => {
-    await db.settings.setGroupOptions(groupType, _groupOptions);
+    console.log(groupId, type);
+    setGroupOptionsById(groupType, _groupOptions, groupId, type);
     setGroupOptions(_groupOptions);
     setTimeout(() => {
       if (screen) Navigation.queueRoutesForUpdate(screen);
-      if (type === "notebook") {
+      if (dataType === "notebook") {
         useNotebookStore.getState().refresh();
-      } else if (type === "tag") {
+      } else if (dataType === "tag") {
         useTagStore.getState().refresh();
       }
-      eSendEvent(eGroupOptionsUpdated, groupType);
+      eSendEvent(eGroupOptionsUpdated, groupType, groupId, type);
       eSendEvent(refreshNotesPage);
     }, 1);
   };

--- a/apps/mobile/app/components/side-menu/index.tsx
+++ b/apps/mobile/app/components/side-menu/index.tsx
@@ -493,7 +493,7 @@ const TabBar = (props: SimpleTabBarProps) => {
                         presentSheet({
                           component: (
                             <Sort
-                              type={
+                              dataType={
                                 props.navigationState.index === 1
                                   ? "notebook"
                                   : "tag"

--- a/apps/mobile/app/hooks/use-group-options.ts
+++ b/apps/mobile/app/hooks/use-group-options.ts
@@ -16,28 +16,61 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { db } from "../common/database";
 import { eSubscribeEvent, eUnSubscribeEvent } from "../services/event-manager";
 import Navigation from "../services/navigation";
 import { eGroupOptionsUpdated } from "../utils/events";
 import { useSettingStore } from "../stores/use-setting-store";
+import { GroupingByIdKey, GroupingKey, GroupOptions } from "@notesnook/core";
 
-export function useGroupOptions(type: any) {
+export function getGroupOptions(
+  groupingKey: GroupingKey,
+  id?: string,
+  type?: GroupingByIdKey
+) {
+  return id && type
+    ? db.settings?.getGroupOptionsById(id, type)
+    : db.settings?.getGroupOptions(groupingKey);
+}
+
+export function setGroupOptionsById(
+  groupingKey: GroupingKey,
+  groupOptions: GroupOptions,
+  id?: string,
+  type?: GroupingByIdKey
+) {
+  return id && type
+    ? db.settings?.setGroupOptionsById(id, type, groupOptions)
+    : db.settings?.setGroupOptions(groupingKey, groupOptions);
+}
+
+export function useGroupOptions(
+  groupingKey: GroupingKey,
+  id?: string,
+  type?: GroupingByIdKey
+) {
   const appLoading = useSettingStore((state) => state.isAppLoading);
   const [groupOptions, setGroupOptions] = useState(
-    db.settings?.getGroupOptions(type)
+    getGroupOptions(groupingKey, id, type)
   );
+  console.log(groupingKey, id, type, groupOptions, "options");
+  const groupOptionsRef = useRef(groupOptions);
+  groupOptionsRef.current = groupOptions;
+
   useEffect(() => {
-    const onUpdate = (groupType: string) => {
-      if (groupType !== type) return;
-      const options = db.settings?.getGroupOptions(type) as any;
+    const onUpdate = (_groupingKey: string, _id?: string, _type?: string) => {
+      if (_groupingKey !== groupingKey) return;
+      if (_id && _type && _id !== id && _type !== type) return;
+
+      const options = getGroupOptions(groupingKey, id, type);
       if (!options) return;
       if (
-        groupOptions?.groupBy !== options.groupBy ||
-        groupOptions?.sortBy !== options.sortBy ||
-        groupOptions?.sortDirection !== groupOptions?.sortDirection
+        groupOptionsRef.current?.groupBy !== options.groupBy ||
+        groupOptionsRef.current?.sortBy !== options.sortBy ||
+        groupOptionsRef.current?.sortDirection !== options?.sortDirection
       ) {
+        console.log("onUpdate", _id, _type);
         setGroupOptions({ ...options });
         Navigation.queueRoutesForUpdate();
       }
@@ -46,13 +79,13 @@ export function useGroupOptions(type: any) {
     eSubscribeEvent(eGroupOptionsUpdated, onUpdate);
 
     if (!appLoading) {
-      onUpdate(type);
+      onUpdate(groupingKey);
     }
 
     return () => {
       eUnSubscribeEvent(eGroupOptionsUpdated, onUpdate);
     };
-  }, [type, groupOptions, appLoading]);
+  }, [groupingKey, appLoading, id, type]);
 
   return groupOptions;
 }

--- a/apps/mobile/app/screens/notebook/index.tsx
+++ b/apps/mobile/app/screens/notebook/index.tsx
@@ -41,6 +41,7 @@ import { View } from "react-native";
 import { Notebooks } from "../../components/sheets/notebooks";
 import { useSettingStore } from "../../stores/use-setting-store";
 import { rootNavigatorRef } from "../../utils/global-refs";
+import { getGroupOptions } from "../../hooks/use-group-options";
 
 const NotebookScreen = ({ route, navigation }: NavigationProps<"Notebook">) => {
   const [notes, setNotes] = useState<VirtualizedGrouping<Note>>();
@@ -120,7 +121,9 @@ const NotebookScreen = ({ route, navigation }: NavigationProps<"Notebook">) => {
           params.current.id = notebook.id;
           const notes = await db.relations
             .from(notebook, "note")
-            .selector.grouped(db.settings.getGroupOptions("notes"));
+            .selector.grouped(
+              getGroupOptions("notes", notebook.id, "notebook")
+            );
           setNotes(notes);
           await notes.item(0, resolveItems);
           syncWithNavigation();
@@ -190,6 +193,7 @@ const NotebookScreen = ({ route, navigation }: NavigationProps<"Notebook">) => {
             onRequestUpdate();
           }}
           id={params.current?.id}
+          type="notebook"
           renderedInRoute="Notebook"
           headerTitle={notebook?.title}
           loading={loading}

--- a/apps/mobile/app/screens/notes/colored.tsx
+++ b/apps/mobile/app/screens/notes/colored.tsx
@@ -26,6 +26,7 @@ import useNavigationStore, {
   NotesScreenParams
 } from "../../stores/use-navigation-store";
 import { PLACEHOLDER_DATA, openEditor } from "./common";
+import { getGroupOptions } from "../../hooks/use-group-options";
 export const ColoredNotes = ({
   navigation,
   route
@@ -52,7 +53,7 @@ ColoredNotes.get = async (params: NotesScreenParams, grouped = true) => {
 
   return await db.relations
     .from({ id: params.id, type: "color" }, "note")
-    .selector.grouped(db.settings.getGroupOptions("notes"));
+    .selector.grouped(getGroupOptions("notes", params.id, "color"));
 };
 
 ColoredNotes.navigate = (item: Color, canGoBack: boolean) => {

--- a/apps/mobile/app/screens/notes/index.tsx
+++ b/apps/mobile/app/screens/notes/index.tsx
@@ -172,7 +172,7 @@ const NotesPage = ({
     if (loadingNotes) {
       onRequestUpdate(params.current);
     }
-  }, [loadingNotes, get, isAppLoading]);
+  }, [loadingNotes, get, isAppLoading, onRequestUpdate]);
 
   useEffect(() => {
     eSubscribeEvent(route.name, onRequestUpdate);
@@ -222,6 +222,7 @@ const NotesPage = ({
           loading={false}
           renderedInRoute={route.name}
           id={params.current?.id}
+          type={params.current?.item?.type}
           headerTitle={title || "Monographs"}
           customAccentColor={accentColor}
           placeholder={placeholder}

--- a/apps/mobile/app/screens/notes/tagged.tsx
+++ b/apps/mobile/app/screens/notes/tagged.tsx
@@ -26,6 +26,7 @@ import useNavigationStore, {
   NotesScreenParams
 } from "../../stores/use-navigation-store";
 import { PLACEHOLDER_DATA, openEditor } from "./common";
+import { getGroupOptions } from "../../hooks/use-group-options";
 
 export const TaggedNotes = ({
   navigation,
@@ -53,7 +54,7 @@ TaggedNotes.get = async (params: NotesScreenParams, grouped = true) => {
 
   return await db.relations
     .from({ id: params.id, type: "tag" }, "note")
-    .selector.grouped(db.settings.getGroupOptions("notes"));
+    .selector.grouped(getGroupOptions("notes", params.id, "tag"));
 };
 
 TaggedNotes.navigate = (item: Tag, canGoBack?: boolean) => {

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@notesnook/mobile",
-  "version": "3.3.23",
+  "version": "3.3.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@notesnook/mobile",
-      "version": "3.3.23",
+      "version": "3.3.24",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/apps/web/src/components/group-header/index.tsx
+++ b/apps/web/src/components/group-header/index.tsx
@@ -45,6 +45,7 @@ import {
 } from "@notesnook/core";
 import { strings } from "@notesnook/intl";
 import { useStore as useSearchStore } from "../../stores/search-store";
+import type { Context } from "../list-container/types";
 
 const groupByToTitleMap = {
   none: "None",
@@ -61,6 +62,7 @@ type GroupingMenuOptions = {
   groupingKey: GroupingKey;
   refresh: () => void;
   isSearching?: boolean;
+  context?: Context;
 };
 
 const groupByMenu: (options: GroupingMenuOptions) => MenuItem | null = (
@@ -192,6 +194,33 @@ export function showSortMenu(groupingKey: GroupingKey, refresh: () => void) {
   );
 }
 
+function getGroupOptions(
+  context: Context | undefined,
+  isSearching: boolean | undefined,
+  groupingKey: GroupingKey
+): GroupOptions {
+  return isSearching
+    ? db.settings.getGroupOptions("search")
+    : context?.type === "notebook"
+    ? db.settings.getNotebookGroupOptions(context.id)
+    : context?.type === "tag"
+    ? db.settings.getTagGroupOptions(context.id)
+    : db.settings.getGroupOptions(groupingKey);
+}
+
+async function setGroupOptions(
+  options: GroupingMenuOptions,
+  groupOptions: GroupOptions
+) {
+  if (options.context?.type === "notebook") {
+    await db.settings.setNotebookGroupOptions(options.context.id, groupOptions);
+  } else if (options.context?.type === "tag") {
+    await db.settings.setTagGroupOptions(options.context.id, groupOptions);
+  } else {
+    await db.settings.setGroupOptions(options.groupingKey, groupOptions);
+  }
+}
+
 async function changeGroupOptions(
   options: GroupingMenuOptions,
   item: Omit<MenuButtonItem, "type">
@@ -207,7 +236,9 @@ async function changeGroupOptions(
         ? "dateModified"
         : groupOptions.sortBy;
   }
-  await db.settings.setGroupOptions(options.groupingKey, groupOptions);
+
+  await setGroupOptions(options, groupOptions);
+
   if (options.groupingKey === "search")
     useSearchStore.setState({ sortOptions: groupOptions });
   options.refresh();
@@ -235,6 +266,7 @@ type GroupHeaderProps = {
   onSelectGroup: () => void;
   isFocused: boolean;
   isSearching?: boolean;
+  context?: Context;
 };
 function GroupHeader(props: GroupHeaderProps) {
   const {
@@ -246,10 +278,12 @@ function GroupHeader(props: GroupHeaderProps) {
     refresh,
     onSelectGroup,
     isFocused,
-    isSearching
+    isSearching,
+    context
   } = props;
+
   const [groupOptions, setGroupOptions] = useState(
-    db.settings.getGroupOptions(isSearching ? "search" : groupingKey)
+    getGroupOptions(context, isSearching, groupingKey)
   );
   const groupHeaderRef = useRef<HTMLDivElement>(null);
   const { openMenu, target } = useMenuTrigger();
@@ -359,8 +393,10 @@ function GroupHeader(props: GroupHeaderProps) {
                 groupByToTitleMap[groupOptions.groupBy || "default"]
               }`}
               onClick={() => {
-                const groupOptions = db.settings.getGroupOptions(
-                  isSearching ? "search" : groupingKey
+                const groupOptions = getGroupOptions(
+                  context,
+                  isSearching,
+                  groupingKey
                 );
                 setGroupOptions(groupOptions);
 
@@ -368,7 +404,8 @@ function GroupHeader(props: GroupHeaderProps) {
                   groupingKey: isSearching ? "search" : groupingKey,
                   groupOptions,
                   refresh,
-                  isSearching
+                  isSearching,
+                  context
                 };
                 const groupBy = groupByMenu({
                   ...menuOptions,

--- a/apps/web/src/components/group-header/index.tsx
+++ b/apps/web/src/components/group-header/index.tsx
@@ -201,10 +201,10 @@ function getGroupOptions(
 ): GroupOptions {
   return isSearching
     ? db.settings.getGroupOptions("search")
-    : context?.type === "notebook"
-    ? db.settings.getNotebookGroupOptions(context.id)
-    : context?.type === "tag"
-    ? db.settings.getTagGroupOptions(context.id)
+    : context?.type === "notebook" ||
+      context?.type === "tag" ||
+      context?.type === "color"
+    ? db.settings.getGroupOptionsById(context.id, context.type)
     : db.settings.getGroupOptions(groupingKey);
 }
 
@@ -212,10 +212,16 @@ async function setGroupOptions(
   options: GroupingMenuOptions,
   groupOptions: GroupOptions
 ) {
-  if (options.context?.type === "notebook") {
-    await db.settings.setNotebookGroupOptions(options.context.id, groupOptions);
-  } else if (options.context?.type === "tag") {
-    await db.settings.setTagGroupOptions(options.context.id, groupOptions);
+  if (
+    options.context?.type === "notebook" ||
+    options.context?.type === "tag" ||
+    options.context?.type === "color"
+  ) {
+    await db.settings.setGroupOptionsById(
+      options.context.id,
+      options.context.type,
+      groupOptions
+    );
   } else {
     await db.settings.setGroupOptions(options.groupingKey, groupOptions);
   }

--- a/apps/web/src/components/list-container/index.tsx
+++ b/apps/web/src/components/list-container/index.tsx
@@ -370,6 +370,7 @@ function ItemRenderer({
           title={resolvedItem.group.title}
           isFocused={index === focusedGroupIndex}
           index={index}
+          context={itemContext}
           onSelectGroup={async () => {
             if (!items.groups) return;
 

--- a/apps/web/src/stores/note-store.ts
+++ b/apps/web/src/stores/note-store.ts
@@ -58,10 +58,10 @@ class NoteStore extends BaseStore<NoteStore> {
 
   setContext = async (context?: Context) => {
     const groupOptions =
-      context?.type === "notebook"
-        ? db.settings.getNotebookGroupOptions(context.id)
-        : context?.type === "tag"
-        ? db.settings.getTagGroupOptions(context.id)
+      context?.type === "notebook" ||
+      context?.type === "tag" ||
+      context?.type === "color"
+        ? db.settings.getGroupOptionsById(context.id, context.type)
         : db.settings.getGroupOptions(
             context?.type === "favorite"
               ? "favorites"

--- a/apps/web/src/stores/note-store.ts
+++ b/apps/web/src/stores/note-store.ts
@@ -57,18 +57,23 @@ class NoteStore extends BaseStore<NoteStore> {
   };
 
   setContext = async (context?: Context) => {
+    const groupOptions =
+      context?.type === "notebook"
+        ? db.settings.getNotebookGroupOptions(context.id)
+        : context?.type === "tag"
+        ? db.settings.getTagGroupOptions(context.id)
+        : db.settings.getGroupOptions(
+            context?.type === "favorite"
+              ? "favorites"
+              : context?.type === "archive"
+              ? "archive"
+              : "notes"
+          );
+
     this.set({
       context,
       contextNotes: context
-        ? await notesFromContext(context).grouped(
-            db.settings.getGroupOptions(
-              context.type === "favorite"
-                ? "favorites"
-                : context.type === "archive"
-                ? "archive"
-                : "notes"
-            )
-          )
+        ? await notesFromContext(context).grouped(groupOptions)
         : undefined
     });
   };

--- a/packages/core/__tests__/settings.test.js
+++ b/packages/core/__tests__/settings.test.js
@@ -47,3 +47,45 @@ test("save trash cleanup interval", () =>
     await db.settings.setTrashCleanupInterval(interval);
     expect(db.settings.getTrashCleanupInterval()).toBe(interval);
   }));
+
+test("get notebook group options", () =>
+  databaseTest().then(async (db) => {
+    const notebookId = "test-notebook-id";
+    const groupOptions = {
+      groupBy: "year",
+      sortBy: "title",
+      sortDirection: "asc"
+    };
+    await db.settings.setNotebookGroupOptions(notebookId, groupOptions);
+    expect(db.settings.getNotebookGroupOptions(notebookId)).toMatchObject(
+      groupOptions
+    );
+  }));
+
+test("get notebook group options fallback to notes options", () =>
+  databaseTest().then(async (db) => {
+    const notebookId = "non-existent-notebook-id";
+    const defaultNotesOptions = db.settings.getGroupOptions("notes");
+    const result = db.settings.getNotebookGroupOptions(notebookId);
+    expect(result).toMatchObject(defaultNotesOptions);
+  }));
+
+test("get tag group options", () =>
+  databaseTest().then(async (db) => {
+    const tagId = "test-tag-id";
+    const groupOptions = {
+      groupBy: "year",
+      sortBy: "title",
+      sortDirection: "asc"
+    };
+    await db.settings.setTagGroupOptions(tagId, groupOptions);
+    expect(db.settings.getTagGroupOptions(tagId)).toMatchObject(groupOptions);
+  }));
+
+test("get tag group options fallback to notes options", () =>
+  databaseTest().then(async (db) => {
+    const tagId = "non-existent-tag-id";
+    const defaultTagsOptions = db.settings.getGroupOptions("notes");
+    const result = db.settings.getTagGroupOptions(tagId);
+    expect(result).toMatchObject(defaultTagsOptions);
+  }));

--- a/packages/core/__tests__/settings.test.js
+++ b/packages/core/__tests__/settings.test.js
@@ -48,44 +48,28 @@ test("save trash cleanup interval", () =>
     expect(db.settings.getTrashCleanupInterval()).toBe(interval);
   }));
 
-test("get notebook group options", () =>
-  databaseTest().then(async (db) => {
-    const notebookId = "test-notebook-id";
-    const groupOptions = {
-      groupBy: "year",
-      sortBy: "title",
-      sortDirection: "asc"
-    };
-    await db.settings.setNotebookGroupOptions(notebookId, groupOptions);
-    expect(db.settings.getNotebookGroupOptions(notebookId)).toMatchObject(
-      groupOptions
-    );
-  }));
+const GROUP_OPTIONS_BY_ID_TESTS = ["notebook", "tag", "color"];
 
-test("get notebook group options fallback to notes options", () =>
-  databaseTest().then(async (db) => {
-    const notebookId = "non-existent-notebook-id";
-    const defaultNotesOptions = db.settings.getGroupOptions("notes");
-    const result = db.settings.getNotebookGroupOptions(notebookId);
-    expect(result).toMatchObject(defaultNotesOptions);
-  }));
+for (const type of GROUP_OPTIONS_BY_ID_TESTS) {
+  test(`get ${type} id group options`, () =>
+    databaseTest().then(async (db) => {
+      const id = `test-${type}-id`;
+      const groupOptions = {
+        groupBy: "year",
+        sortBy: "title",
+        sortDirection: "asc"
+      };
+      await db.settings.setGroupOptionsById(id, type, groupOptions);
+      expect(db.settings.getGroupOptionsById(id, type)).toMatchObject(
+        groupOptions
+      );
+    }));
 
-test("get tag group options", () =>
-  databaseTest().then(async (db) => {
-    const tagId = "test-tag-id";
-    const groupOptions = {
-      groupBy: "year",
-      sortBy: "title",
-      sortDirection: "asc"
-    };
-    await db.settings.setTagGroupOptions(tagId, groupOptions);
-    expect(db.settings.getTagGroupOptions(tagId)).toMatchObject(groupOptions);
-  }));
-
-test("get tag group options fallback to notes options", () =>
-  databaseTest().then(async (db) => {
-    const tagId = "non-existent-tag-id";
-    const defaultTagsOptions = db.settings.getGroupOptions("notes");
-    const result = db.settings.getTagGroupOptions(tagId);
-    expect(result).toMatchObject(defaultTagsOptions);
-  }));
+  test(`get ${type} id group options fallback to notes group options`, () =>
+    databaseTest().then(async (db) => {
+      const id = `non-existent-${type}-id`;
+      const defaultOptions = db.settings.getGroupOptions("notes");
+      const result = db.settings.getGroupOptionsById(id, type);
+      expect(result).toMatchObject(defaultOptions);
+    }));
+}

--- a/packages/core/src/collections/settings.ts
+++ b/packages/core/src/collections/settings.ts
@@ -32,7 +32,8 @@ import {
   TrashCleanupInterval,
   TimeFormat,
   DayFormat,
-  WeekFormat
+  WeekFormat,
+  GroupingByIdKey
 } from "../types.js";
 import { ICollection } from "./collection.js";
 import { SQLCachedCollection } from "../database/sql-cached-collection.js";
@@ -66,6 +67,7 @@ const defaultSettings: SettingItemMap = {
 
   "groupOptions:notes:notebooks": {},
   "groupOptions:notes:tags": {},
+  "groupOptions:notes:colors": {},
   "groupOptions:trash": DEFAULT_GROUP_OPTIONS("trash"),
   "groupOptions:tags": DEFAULT_GROUP_OPTIONS("tags"),
   "groupOptions:notes": DEFAULT_GROUP_OPTIONS("notes"),
@@ -152,29 +154,32 @@ export class Settings implements ICollection {
     return this.set(`groupOptions:${key}`, groupOptions);
   }
 
-  getNotebookGroupOptions(notebookId: string) {
-    const notebookOptions = this.get("groupOptions:notes:notebooks");
-    return notebookOptions[notebookId] || this.get("groupOptions:notes");
-  }
-
-  async setNotebookGroupOptions(
-    notebookId: string,
+  async setGroupOptionsById(
+    id: string,
+    type: GroupingByIdKey,
     groupOptions: GroupOptions
   ) {
-    const notebookOptions = this.get("groupOptions:notes:notebooks");
-    notebookOptions[notebookId] = groupOptions;
-    return this.set("groupOptions:notes:notebooks", notebookOptions);
+    const groupOptionsKey =
+      type === "notebook"
+        ? "groupOptions:notes:notebooks"
+        : type === "tag"
+        ? "groupOptions:notes:tags"
+        : "groupOptions:notes:colors";
+
+    const groupOptionsMap = this.get(groupOptionsKey);
+    groupOptionsMap[id] = groupOptions;
+    return this.set(groupOptionsKey, groupOptionsMap);
   }
 
-  getTagGroupOptions(tagId: string) {
-    const tagOptions = this.get("groupOptions:notes:tags");
-    return tagOptions[tagId] || this.get("groupOptions:notes");
-  }
-
-  async setTagGroupOptions(tagId: string, groupOptions: GroupOptions) {
-    const tagOptions = this.get("groupOptions:notes:tags");
-    tagOptions[tagId] = groupOptions;
-    return this.set("groupOptions:notes:tags", tagOptions);
+  getGroupOptionsById(id: string, type: GroupingByIdKey) {
+    const groupOptions = this.get(
+      type === "notebook"
+        ? "groupOptions:notes:notebooks"
+        : type === "tag"
+        ? "groupOptions:notes:tags"
+        : "groupOptions:notes:colors"
+    );
+    return groupOptions[id] || this.get("groupOptions:notes");
   }
 
   setToolbarConfig(platform: ToolbarConfigPlatforms, config: ToolbarConfig) {

--- a/packages/core/src/collections/settings.ts
+++ b/packages/core/src/collections/settings.ts
@@ -64,6 +64,8 @@ const defaultSettings: SettingItemMap = {
   trashCleanupInterval: 7,
   profile: undefined,
 
+  "groupOptions:notes:notebooks": {},
+  "groupOptions:notes:tags": {},
   "groupOptions:trash": DEFAULT_GROUP_OPTIONS("trash"),
   "groupOptions:tags": DEFAULT_GROUP_OPTIONS("tags"),
   "groupOptions:notes": DEFAULT_GROUP_OPTIONS("notes"),
@@ -148,6 +150,31 @@ export class Settings implements ICollection {
 
   setGroupOptions(key: GroupingKey, groupOptions: GroupOptions) {
     return this.set(`groupOptions:${key}`, groupOptions);
+  }
+
+  getNotebookGroupOptions(notebookId: string) {
+    const notebookOptions = this.get("groupOptions:notes:notebooks");
+    return notebookOptions[notebookId] || this.get("groupOptions:notes");
+  }
+
+  async setNotebookGroupOptions(
+    notebookId: string,
+    groupOptions: GroupOptions
+  ) {
+    const notebookOptions = this.get("groupOptions:notes:notebooks");
+    notebookOptions[notebookId] = groupOptions;
+    return this.set("groupOptions:notes:notebooks", notebookOptions);
+  }
+
+  getTagGroupOptions(tagId: string) {
+    const tagOptions = this.get("groupOptions:notes:tags");
+    return tagOptions[tagId] || this.get("groupOptions:notes");
+  }
+
+  async setTagGroupOptions(tagId: string, groupOptions: GroupOptions) {
+    const tagOptions = this.get("groupOptions:notes:tags");
+    tagOptions[tagId] = groupOptions;
+    return this.set("groupOptions:notes:tags", tagOptions);
   }
 
   setToolbarConfig(platform: ToolbarConfigPlatforms, config: ToolbarConfig) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -57,6 +57,7 @@ export const GroupingKey = [
   "search"
 ] as const;
 export type GroupingKey = (typeof GroupingKey)[number];
+export type GroupingByIdKey = "notebook" | "tag" | "color";
 
 export type ValueOf<T> = T[keyof T];
 export type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
@@ -487,7 +488,9 @@ export type SettingItemMap = {
   profile: Profile | undefined;
 } & Record<`groupOptions:${GroupingKey}`, GroupOptions> &
   Record<
-    `groupOptions:notes:notebooks` | `groupOptions:notes:tags`,
+    | `groupOptions:notes:notebooks`
+    | `groupOptions:notes:tags`
+    | `groupOptions:notes:colors`,
     Record<string, GroupOptions>
   > &
   Record<`toolbarConfig:${ToolbarConfigPlatforms}`, ToolbarConfig | undefined> &

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -486,6 +486,10 @@ export type SettingItemMap = {
   defaultTag: string | undefined;
   profile: Profile | undefined;
 } & Record<`groupOptions:${GroupingKey}`, GroupOptions> &
+  Record<
+    `groupOptions:notes:notebooks` | `groupOptions:notes:tags`,
+    Record<string, GroupOptions>
+  > &
   Record<`toolbarConfig:${ToolbarConfigPlatforms}`, ToolbarConfig | undefined> &
   Record<`sideBarOrder:${SideBarSection}`, string[]> &
   Record<`sideBarHiddenItems:${SideBarHideableSection}`, string[]>;


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Closes https://github.com/streetwriters/notesnook/issues/5863

web: allow notebook/tag level group&sort preferences

## QA Scope

Needs to be tested on web and mobile. The group&sort preferences on notes should be independent for individual notebooks, colors, and tags

## Type of Change
- [ ] Bug fix
- [X] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [X] Added/updated tests for this change (if needed)
- [ ] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [X] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
