### PR TITLE
mobile: add success message after note duplication

### DIFF
--- a/apps/mobile/app/hooks/use-actions.tsx
+++ b/apps/mobile/app/hooks/use-actions.tsx
@@ -784,6 +784,12 @@ export const useActions = ({
     const duplicateNote = async () => {
       await db.notes.duplicate(item.id);
       Navigation.queueRoutesForUpdate();
+      ToastManager.show({
+        heading: strings.noteDuplicated(),
+        type: "success",
+        context: "local"
+      });
+      await sleep(500);
       close();
     };
 

--- a/packages/intl/locale/en.po
+++ b/packages/intl/locale/en.po
@@ -14,7 +14,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/strings.ts:2421
+#: src/strings.ts:2422
 msgid " \"Notebook > Notes\""
 msgstr " \"Notebook > Notes\""
 
@@ -22,27 +22,27 @@ msgstr " \"Notebook > Notes\""
 msgid " Unlock with password once to enable biometric access."
 msgstr " Unlock with password once to enable biometric access."
 
-#: src/strings.ts:1941
+#: src/strings.ts:1942
 msgid " Upgrade to Notesnook Pro to add more notebooks."
 msgstr " Upgrade to Notesnook Pro to add more notebooks."
 
-#: src/strings.ts:1944
+#: src/strings.ts:1945
 msgid " Upgrade to Notesnook Pro to customize the toolbar."
 msgstr " Upgrade to Notesnook Pro to customize the toolbar."
 
-#: src/strings.ts:1943
+#: src/strings.ts:1944
 msgid " Upgrade to Notesnook Pro to use custom toolbar presets."
 msgstr " Upgrade to Notesnook Pro to use custom toolbar presets."
 
-#: src/strings.ts:1942
+#: src/strings.ts:1943
 msgid " Upgrade to Notesnook Pro to use the notes vault."
 msgstr " Upgrade to Notesnook Pro to use the notes vault."
 
-#: src/strings.ts:1945
+#: src/strings.ts:1946
 msgid " Upgrade to Notesnook Pro to use this feature."
 msgstr " Upgrade to Notesnook Pro to use this feature."
 
-#: src/strings.ts:828
+#: src/strings.ts:829
 msgid "— not just the"
 msgstr "— not just the"
 
@@ -70,19 +70,19 @@ msgid "{0} Highlights 🎉"
 msgstr "{0} Highlights 🎉"
 
 #. placeholder {0}: platform === "ios" ? "Apple" : "Google"
-#: src/strings.ts:2577
+#: src/strings.ts:2578
 msgid "{0} will remind you before your trial ends"
 msgstr "{0} will remind you before your trial ends"
 
-#: src/strings.ts:1753
+#: src/strings.ts:1754
 msgid "{count, plural, one {# error occured} other {# errors occured}}"
 msgstr "{count, plural, one {# error occured} other {# errors occured}}"
 
-#: src/strings.ts:1759
+#: src/strings.ts:1760
 msgid "{count, plural, one {# file ready for import} other {# files ready for import}}"
 msgstr "{count, plural, one {# file ready for import} other {# files ready for import}}"
 
-#: src/strings.ts:1714
+#: src/strings.ts:1715
 msgid "{count, plural, one {# file} other {# files}}"
 msgstr "{count, plural, one {# file} other {# files}}"
 
@@ -90,11 +90,11 @@ msgstr "{count, plural, one {# file} other {# files}}"
 msgid "{count, plural, one {# note} other {# notes}}"
 msgstr "{count, plural, one {# note} other {# notes}}"
 
-#: src/strings.ts:1578
+#: src/strings.ts:1579
 msgid "{count, plural, one {1 hour} other {# hours}}"
 msgstr "{count, plural, one {1 hour} other {# hours}}"
 
-#: src/strings.ts:1573
+#: src/strings.ts:1574
 msgid "{count, plural, one {1 minute} other {# minutes}}"
 msgstr "{count, plural, one {1 minute} other {# minutes}}"
 
@@ -135,7 +135,7 @@ msgstr "{count, plural, one {Are you sure you want to delete this tag?} other {A
 msgid "{count, plural, one {Are you sure you want to download all attachments of this note?} other {Are you sure you want to download all attachments?}}"
 msgstr "{count, plural, one {Are you sure you want to download all attachments of this note?} other {Are you sure you want to download all attachments?}}"
 
-#: src/strings.ts:863
+#: src/strings.ts:864
 msgid "{count, plural, one {Are you sure you want to move this notebook to {selectedNotebookTitle}?} other {Are you sure you want to move these # notebooks {selectedNotebookTitle}?}}"
 msgstr "{count, plural, one {Are you sure you want to move this notebook to {selectedNotebookTitle}?} other {Are you sure you want to move these # notebooks {selectedNotebookTitle}?}}"
 
@@ -294,11 +294,11 @@ msgstr "{count, plural, one {Item restored} other {# items restored}}"
 msgid "{count, plural, one {Item unpublished} other {# items unpublished}}"
 msgstr "{count, plural, one {Item unpublished} other {# items unpublished}}"
 
-#: src/strings.ts:2438
+#: src/strings.ts:2439
 msgid "{count, plural, one {Move all notes in this notebook to trash} other {Move all notes in these notebooks to trash}}"
 msgstr "{count, plural, one {Move all notes in this notebook to trash} other {Move all notes in these notebooks to trash}}"
 
-#: src/strings.ts:861
+#: src/strings.ts:862
 msgid "{count, plural, one {Move notebook} other {Move # notebooks}}"
 msgstr "{count, plural, one {Move notebook} other {Move # notebooks}}"
 
@@ -342,7 +342,7 @@ msgstr "{count, plural, one {Note restored} other {# notes restored}}"
 msgid "{count, plural, one {Note unpublished} other {# notes unpublished}}"
 msgstr "{count, plural, one {Note unpublished} other {# notes unpublished}}"
 
-#: src/strings.ts:920
+#: src/strings.ts:921
 msgid "{count, plural, one {Note will be automatically deleted from all other devices & any future changes won't get synced. Are you sure you want to continue?} other {# notes will be automatically deleted from all other devices & any future changes won't get synced. Are you sure you want to continue?}}"
 msgstr "{count, plural, one {Note will be automatically deleted from all other devices & any future changes won't get synced. Are you sure you want to continue?} other {# notes will be automatically deleted from all other devices & any future changes won't get synced. Are you sure you want to continue?}}"
 
@@ -396,7 +396,7 @@ msgstr "{count, plural, one {Pin note} other {Pin # notes}}"
 msgid "{count, plural, one {Pin notebook} other {Pin # notebooks}}"
 msgstr "{count, plural, one {Pin notebook} other {Pin # notebooks}}"
 
-#: src/strings.ts:915
+#: src/strings.ts:916
 msgid "{count, plural, one {Prevent note from syncing} other {Prevent # notes from syncing}}"
 msgstr "{count, plural, one {Prevent note from syncing} other {Prevent # notes from syncing}}"
 
@@ -497,15 +497,15 @@ msgstr "{count, plural, one {Unpublish item} other {Unpublish # items}}"
 msgid "{count, plural, one {Unpublish note} other {Unpublish # notes}}"
 msgstr "{count, plural, one {Unpublish note} other {Unpublish # notes}}"
 
-#: src/strings.ts:2508
+#: src/strings.ts:2509
 msgid "{count} characters"
 msgstr "{count} characters"
 
-#: src/strings.ts:1564
+#: src/strings.ts:1565
 msgid "{days, plural, one {1 day} other {# days}}"
 msgstr "{days, plural, one {1 day} other {# days}}"
 
-#: src/strings.ts:2568
+#: src/strings.ts:2569
 msgid "{days} days free"
 msgstr "{days} days free"
 
@@ -545,19 +545,19 @@ msgstr "{mode, select, day {Daily} week {Weekly} month {Monthly} year {Yearly} o
 msgid "{mode, select, repeat {Repeat} once {Once} permanent {Permanent} other {Unknown mode}}"
 msgstr "{mode, select, repeat {Repeat} once {Once} permanent {Permanent} other {Unknown mode}}"
 
-#: src/strings.ts:1976
+#: src/strings.ts:1977
 msgid "{n} {added, plural, one {added to 1 notebook} other {added to # notebooks}} and {removed, plural, one {removed from 1 notebook} other {removed from # notebooks}}."
 msgstr "{n} {added, plural, one {added to 1 notebook} other {added to # notebooks}} and {removed, plural, one {removed from 1 notebook} other {removed from # notebooks}}."
 
-#: src/strings.ts:1971
+#: src/strings.ts:1972
 msgid "{n} {added, plural, one {added to 1 notebook} other {added to # notebooks}}."
 msgstr "{n} {added, plural, one {added to 1 notebook} other {added to # notebooks}}."
 
-#: src/strings.ts:1966
+#: src/strings.ts:1967
 msgid "{n} {removed, plural, one {removed from 1 notebook} other {removed from # notebooks}}."
 msgstr "{n} {removed, plural, one {removed from 1 notebook} other {removed from # notebooks}}."
 
-#: src/strings.ts:1961
+#: src/strings.ts:1962
 msgid "{notes, plural, one {1 note} other {# notes}}"
 msgstr "{notes, plural, one {1 note} other {# notes}}"
 
@@ -565,11 +565,11 @@ msgstr "{notes, plural, one {1 note} other {# notes}}"
 msgid "{notes, plural, one {Export note} other {Export # notes}}"
 msgstr "{notes, plural, one {Export note} other {Export # notes}}"
 
-#: src/strings.ts:1706
+#: src/strings.ts:1707
 msgid "{percentage}% updating..."
 msgstr "{percentage}% updating..."
 
-#: src/strings.ts:2552
+#: src/strings.ts:2553
 msgid "{plan} plan"
 msgstr "{plan} plan"
 
@@ -577,11 +577,11 @@ msgstr "{plan} plan"
 msgid "{platform, select, android {{name} saved to selected path} other {{name} saved to File Manager/Notesnook/downloads}}"
 msgstr "{platform, select, android {{name} saved to selected path} other {{name} saved to File Manager/Notesnook/downloads}}"
 
-#: src/strings.ts:1337
+#: src/strings.ts:1338
 msgid "{platform, select, android {Backup file saved in \"Notesnook backups\" folder on your phone.} other {Backup file is saved in File Manager/Notesnook folder}}"
 msgstr "{platform, select, android {Backup file saved in \"Notesnook backups\" folder on your phone.} other {Backup file is saved in File Manager/Notesnook folder}}"
 
-#: src/strings.ts:2368
+#: src/strings.ts:2369
 msgid "{selected} selected"
 msgstr "{selected} selected"
 
@@ -601,43 +601,43 @@ msgstr "{type, select, upload {Uploading} download {Downloading} sync {Syncing} 
 msgid "{type} does not match"
 msgstr "{type} does not match"
 
-#: src/strings.ts:1599
+#: src/strings.ts:1600
 msgid "{words, plural, one {# word} other {# words}}"
 msgstr "{words, plural, one {# word} other {# words}}"
 
-#: src/strings.ts:1662
+#: src/strings.ts:1663
 msgid "{words, plural, other {# selected}}"
 msgstr "{words, plural, other {# selected}}"
 
-#: src/strings.ts:1790
+#: src/strings.ts:1791
 msgid "#notesnook"
 msgstr "#notesnook"
 
-#: src/strings.ts:1583
+#: src/strings.ts:1584
 msgid "12-hour"
 msgstr "12-hour"
 
-#: src/strings.ts:1584
+#: src/strings.ts:1585
 msgid "24-hour"
 msgstr "24-hour"
 
-#: src/strings.ts:1904
+#: src/strings.ts:1905
 msgid "2FA code is required()"
 msgstr "2FA code is required()"
 
-#: src/strings.ts:1008
+#: src/strings.ts:1009
 msgid "2FA code sent via {method}"
 msgstr "2FA code sent via {method}"
 
-#: src/strings.ts:2595
+#: src/strings.ts:2596
 msgid "5 year plan (One time purchase)"
 msgstr "5 year plan (One time purchase)"
 
-#: src/strings.ts:1845
+#: src/strings.ts:1846
 msgid "6 digit code"
 msgstr "6 digit code"
 
-#: src/strings.ts:1431
+#: src/strings.ts:1432
 msgid "A notebook can have unlimited topics with unlimited notes."
 msgstr "A notebook can have unlimited topics with unlimited notes."
 
@@ -653,35 +653,35 @@ msgstr "A vault stores your notes in an encrypted storage."
 msgid "Abc"
 msgstr "Abc"
 
-#: src/strings.ts:1289
+#: src/strings.ts:1290
 msgid "About"
 msgstr "About"
 
-#: src/strings.ts:1024
+#: src/strings.ts:1025
 msgid "Account"
 msgstr "Account"
 
-#: src/strings.ts:1847
+#: src/strings.ts:1848
 msgid "Account password"
 msgstr "Account password"
 
-#: src/strings.ts:2463
+#: src/strings.ts:2464
 msgid "Actions for note: {title}"
 msgstr "Actions for note: {title}"
 
-#: src/strings.ts:2464
+#: src/strings.ts:2465
 msgid "Actions for notebook: {title}"
 msgstr "Actions for notebook: {title}"
 
-#: src/strings.ts:2465
+#: src/strings.ts:2466
 msgid "Actions for tag: {title}"
 msgstr "Actions for tag: {title}"
 
-#: src/strings.ts:2037
+#: src/strings.ts:2038
 msgid "Activate"
 msgstr "Activate"
 
-#: src/strings.ts:1823
+#: src/strings.ts:1824
 msgid "Activating trial"
 msgstr "Activating trial"
 
@@ -689,15 +689,15 @@ msgstr "Activating trial"
 msgid "Add"
 msgstr "Add"
 
-#: src/strings.ts:1056
+#: src/strings.ts:1057
 msgid "Add 2FA fallback method"
 msgstr "Add 2FA fallback method"
 
-#: src/strings.ts:1507
+#: src/strings.ts:1508
 msgid "Add a short note"
 msgstr "Add a short note"
 
-#: src/strings.ts:1600
+#: src/strings.ts:1601
 msgid "Add a tag"
 msgstr "Add a tag"
 
@@ -705,11 +705,11 @@ msgstr "Add a tag"
 msgid "Add color"
 msgstr "Add color"
 
-#: src/strings.ts:895
+#: src/strings.ts:896
 msgid "Add notebook"
 msgstr "Add notebook"
 
-#: src/strings.ts:2490
+#: src/strings.ts:2491
 msgid "Add notes"
 msgstr "Add notes"
 
@@ -717,7 +717,7 @@ msgstr "Add notes"
 msgid "Add notes to {title}"
 msgstr "Add notes to {title}"
 
-#: src/strings.ts:894
+#: src/strings.ts:895
 msgid "Add shortcut"
 msgstr "Add shortcut"
 
@@ -729,55 +729,55 @@ msgstr "Add shortcuts for notebooks and tags here."
 msgid "Add tag"
 msgstr "Add tag"
 
-#: src/strings.ts:933
+#: src/strings.ts:934
 msgid "Add tags"
 msgstr "Add tags"
 
-#: src/strings.ts:934
+#: src/strings.ts:935
 msgid "Add tags to multiple notes at once"
 msgstr "Add tags to multiple notes at once"
 
-#: src/strings.ts:2255
+#: src/strings.ts:2256
 msgid "Add to dictionary"
 msgstr "Add to dictionary"
 
-#: src/strings.ts:2628
+#: src/strings.ts:2629
 msgid "Add to home"
 msgstr "Add to home"
 
-#: src/strings.ts:2488
+#: src/strings.ts:2489
 msgid "Add to notebook"
 msgstr "Add to notebook"
 
-#: src/strings.ts:974
+#: src/strings.ts:975
 msgid "Add your first note"
 msgstr "Add your first note"
 
-#: src/strings.ts:975
+#: src/strings.ts:976
 msgid "Add your first notebook"
 msgstr "Add your first notebook"
 
-#: src/strings.ts:2631
+#: src/strings.ts:2632
 msgid "Adjust the line height of the editor"
 msgstr "Adjust the line height of the editor"
 
-#: src/strings.ts:2181
+#: src/strings.ts:2182
 msgid "Advanced"
 msgstr "Advanced"
 
-#: src/strings.ts:1726
+#: src/strings.ts:1727
 msgid "After scanning the QR code image, the app will display a code that you can enter below."
 msgstr "After scanning the QR code image, the app will display a code that you can enter below."
 
-#: src/strings.ts:2320
+#: src/strings.ts:2321
 msgid "Align left"
 msgstr "Align left"
 
-#: src/strings.ts:2321
+#: src/strings.ts:2322
 msgid "Align right"
 msgstr "Align right"
 
-#: src/strings.ts:2290
+#: src/strings.ts:2291
 msgid "Alignment"
 msgstr "Alignment"
 
@@ -789,7 +789,7 @@ msgstr "All"
 msgid "All attachments are end-to-end encrypted."
 msgstr "All attachments are end-to-end encrypted."
 
-#: src/strings.ts:2415
+#: src/strings.ts:2416
 msgid "All cached attachments have been cleared."
 msgstr "All cached attachments have been cleared."
 
@@ -801,7 +801,7 @@ msgstr "All fields are required"
 msgid "All files"
 msgstr "All files"
 
-#: src/strings.ts:1174
+#: src/strings.ts:1175
 msgid "All locked notes will be re-encrypted with the new password."
 msgstr "All locked notes will be re-encrypted with the new password."
 
@@ -809,15 +809,15 @@ msgstr "All locked notes will be re-encrypted with the new password."
 msgid "All logs are local only and are not sent to any server. You can share the logs from here with us if you face an issue to help us find the root cause."
 msgstr "All logs are local only and are not sent to any server. You can share the logs from here with us if you face an issue to help us find the root cause."
 
-#: src/strings.ts:1637
+#: src/strings.ts:1638
 msgid "All server urls are required."
 msgstr "All server urls are required."
 
-#: src/strings.ts:1906
+#: src/strings.ts:1907
 msgid "All the data in your account will be overwritten with the data in the backup file. There is no way to reverse this action."
 msgstr "All the data in your account will be overwritten with the data in the backup file. There is no way to reverse this action."
 
-#: src/strings.ts:2161
+#: src/strings.ts:2162
 msgid "All the source code for Notesnook is available & open for everyone on GitHub."
 msgstr "All the source code for Notesnook is available & open for everyone on GitHub."
 
@@ -825,15 +825,15 @@ msgstr "All the source code for Notesnook is available & open for everyone on Gi
 msgid "All tools are grouped"
 msgstr "All tools are grouped"
 
-#: src/strings.ts:1321
+#: src/strings.ts:1322
 msgid "All tools in the collapsed section will be removed"
 msgstr "All tools in the collapsed section will be removed"
 
-#: src/strings.ts:1316
+#: src/strings.ts:1317
 msgid "All tools in this group will be removed from the toolbar."
 msgstr "All tools in this group will be removed from the toolbar."
 
-#: src/strings.ts:1346
+#: src/strings.ts:1347
 msgid "All your backups are stored in 'Phone Storage/Notesnook/backups/' folder"
 msgstr "All your backups are stored in 'Phone Storage/Notesnook/backups/' folder"
 
@@ -841,7 +841,7 @@ msgstr "All your backups are stored in 'Phone Storage/Notesnook/backups/' folder
 msgid "Already have an account?"
 msgstr "Already have an account?"
 
-#: src/strings.ts:2231
+#: src/strings.ts:2232
 msgid "Amount"
 msgstr "Amount"
 
@@ -849,7 +849,7 @@ msgstr "Amount"
 msgid "An error occurred while migrating your data. You can logout of your account and try to relogin. However this is not recommended as it may result in some data loss if your data was not synced."
 msgstr "An error occurred while migrating your data. You can logout of your account and try to relogin. However this is not recommended as it may result in some data loss if your data was not synced."
 
-#: src/strings.ts:2589
+#: src/strings.ts:2590
 msgid "and"
 msgstr "and"
 
@@ -857,19 +857,19 @@ msgstr "and"
 msgid "and "
 msgstr "and "
 
-#: src/strings.ts:1791
+#: src/strings.ts:1792
 msgid "and get a chance to win free promo codes."
 msgstr "and get a chance to win free promo codes."
 
-#: src/strings.ts:2545
+#: src/strings.ts:2546
 msgid "and much more."
 msgstr "and much more."
 
-#: src/strings.ts:1397
+#: src/strings.ts:1398
 msgid "and we will manually confirm your account."
 msgstr "and we will manually confirm your account."
 
-#: src/strings.ts:2606
+#: src/strings.ts:2607
 msgid "ANNOUNCEMENT"
 msgstr "ANNOUNCEMENT"
 
@@ -877,29 +877,29 @@ msgstr "ANNOUNCEMENT"
 msgid "App data has been cleared. Kindly relaunch the app to login again."
 msgstr "App data has been cleared. Kindly relaunch the app to login again."
 
-#: src/strings.ts:1183
-#: src/strings.ts:1693
+#: src/strings.ts:1184
+#: src/strings.ts:1694
 msgid "App lock"
 msgstr "App lock"
 
 #: src/strings.ts:781
-#: src/strings.ts:1209
+#: src/strings.ts:1210
 msgid "App lock disabled"
 msgstr "App lock disabled"
 
-#: src/strings.ts:1189
+#: src/strings.ts:1190
 msgid "App lock timeout"
 msgstr "App lock timeout"
 
-#: src/strings.ts:1300
+#: src/strings.ts:1301
 msgid "App version"
 msgstr "App version"
 
-#: src/strings.ts:1774
+#: src/strings.ts:1775
 msgid "App will reload in {sec} seconds"
 msgstr "App will reload in {sec} seconds"
 
-#: src/strings.ts:1114
+#: src/strings.ts:1115
 msgid "Appearance"
 msgstr "Appearance"
 
@@ -915,32 +915,32 @@ msgstr "Applied as light theme"
 msgid "Apply changes"
 msgstr "Apply changes"
 
-#: src/strings.ts:2044
+#: src/strings.ts:2045
 msgid "Applying changes"
 msgstr "Applying changes"
 
-#: src/strings.ts:1530
-#: src/strings.ts:2495
+#: src/strings.ts:1531
+#: src/strings.ts:2496
 msgid "Archive"
 msgstr "Archive"
 
-#: src/strings.ts:1445
+#: src/strings.ts:1446
 msgid "Are you scrolling a lot to find a specific note? Pin it to the top from Note properties."
 msgstr "Are you scrolling a lot to find a specific note? Pin it to the top from Note properties."
 
-#: src/strings.ts:1016
+#: src/strings.ts:1017
 msgid "Are you sure you want to clear all logs from {key}?"
 msgstr "Are you sure you want to clear all logs from {key}?"
 
-#: src/strings.ts:1324
+#: src/strings.ts:1325
 msgid "Are you sure you want to clear trash?"
 msgstr "Are you sure you want to clear trash?"
 
-#: src/strings.ts:2666
+#: src/strings.ts:2667
 msgid "Are you sure you want to delete this attachment?"
 msgstr "Are you sure you want to delete this attachment?"
 
-#: src/strings.ts:1542
+#: src/strings.ts:1543
 msgid "Are you sure you want to logout and clear all data stored on THIS DEVICE?"
 msgstr "Are you sure you want to logout and clear all data stored on THIS DEVICE?"
 
@@ -948,31 +948,31 @@ msgstr "Are you sure you want to logout and clear all data stored on THIS DEVICE
 msgid "Are you sure you want to logout from this device? Any unsynced changes will be lost."
 msgstr "Are you sure you want to logout from this device? Any unsynced changes will be lost."
 
-#: src/strings.ts:2687
+#: src/strings.ts:2688
 msgid "Are you sure you want to open this file: {filePath}?"
 msgstr "Are you sure you want to open this file: {filePath}?"
 
-#: src/strings.ts:1046
+#: src/strings.ts:1047
 msgid "Are you sure you want to remove your name?"
 msgstr "Are you sure you want to remove your name?"
 
-#: src/strings.ts:1043
+#: src/strings.ts:1044
 msgid "Are you sure you want to remove your profile picture?"
 msgstr "Are you sure you want to remove your profile picture?"
 
-#: src/strings.ts:1323
+#: src/strings.ts:1324
 msgid "Are you sure?"
 msgstr "Are you sure?"
 
-#: src/strings.ts:1130
+#: src/strings.ts:1131
 msgid "Ask every time"
 msgstr "Ask every time"
 
-#: src/strings.ts:2033
+#: src/strings.ts:2034
 msgid "Assign color"
 msgstr "Assign color"
 
-#: src/strings.ts:932
+#: src/strings.ts:933
 msgid "Assign to..."
 msgstr "Assign to..."
 
@@ -980,15 +980,15 @@ msgstr "Assign to..."
 msgid "Atleast 8 characters required"
 msgstr "Atleast 8 characters required"
 
-#: src/strings.ts:2357
+#: src/strings.ts:2358
 msgid "Attach image from URL"
 msgstr "Attach image from URL"
 
-#: src/strings.ts:908
+#: src/strings.ts:909
 msgid "Attached files"
 msgstr "Attached files"
 
-#: src/strings.ts:2678
+#: src/strings.ts:2679
 msgid "Attaching files"
 msgstr "Attaching files"
 
@@ -997,27 +997,27 @@ msgid "attachment"
 msgstr "attachment"
 
 #: src/strings.ts:300
-#: src/strings.ts:2354
+#: src/strings.ts:2355
 msgid "Attachment"
 msgstr "Attachment"
 
-#: src/strings.ts:2667
+#: src/strings.ts:2668
 msgid "Attachment deleted"
 msgstr "Attachment deleted"
 
-#: src/strings.ts:2458
+#: src/strings.ts:2459
 msgid "Attachment manager"
 msgstr "Attachment manager"
 
-#: src/strings.ts:1935
+#: src/strings.ts:1936
 msgid "Attachment preview failed"
 msgstr "Attachment preview failed"
 
-#: src/strings.ts:2408
+#: src/strings.ts:2409
 msgid "Attachment recheck cancelled"
 msgstr "Attachment recheck cancelled"
 
-#: src/strings.ts:2325
+#: src/strings.ts:2326
 msgid "Attachment settings"
 msgstr "Attachment settings"
 
@@ -1026,15 +1026,15 @@ msgid "attachments"
 msgstr "attachments"
 
 #: src/strings.ts:320
-#: src/strings.ts:907
+#: src/strings.ts:908
 msgid "Attachments"
 msgstr "Attachments"
 
-#: src/strings.ts:1884
+#: src/strings.ts:1885
 msgid "Attachments cache cleared!"
 msgstr "Attachments cache cleared!"
 
-#: src/strings.ts:2410
+#: src/strings.ts:2411
 msgid "Attachments recheck complete"
 msgstr "Attachments recheck complete"
 
@@ -1042,160 +1042,160 @@ msgstr "Attachments recheck complete"
 msgid "Audios"
 msgstr "Audios"
 
-#: src/strings.ts:1626
+#: src/strings.ts:1627
 msgid "Auth server"
 msgstr "Auth server"
 
-#: src/strings.ts:1795
+#: src/strings.ts:1796
 msgid "Authenticated as {email}"
 msgstr "Authenticated as {email}"
 
-#: src/strings.ts:1898
+#: src/strings.ts:1899
 msgid "Authenticating user"
 msgstr "Authenticating user"
 
-#: src/strings.ts:2144
+#: src/strings.ts:2145
 msgid "Authentication"
 msgstr "Authentication"
 
-#: src/strings.ts:1730
+#: src/strings.ts:1731
 msgid "authentication app"
 msgstr "authentication app"
 
-#: src/strings.ts:1351
+#: src/strings.ts:1352
 msgid "Authentication cancelled by user"
 msgstr "Authentication cancelled by user"
 
-#: src/strings.ts:1352
+#: src/strings.ts:1353
 msgid "Authentication failed"
 msgstr "Authentication failed"
 
-#: src/strings.ts:2107
+#: src/strings.ts:2108
 msgid "Auto"
 msgstr "Auto"
 
-#: src/strings.ts:1661
+#: src/strings.ts:1662
 msgid "Auto save: off"
 msgstr "Auto save: off"
 
-#: src/strings.ts:2121
+#: src/strings.ts:2122
 msgid "Auto start on system startup"
 msgstr "Auto start on system startup"
 
-#: src/strings.ts:1218
-#: src/strings.ts:1689
+#: src/strings.ts:1219
+#: src/strings.ts:1690
 msgid "Automatic backups"
 msgstr "Automatic backups"
 
-#: src/strings.ts:1365
+#: src/strings.ts:1366
 msgid "Automatic backups are off"
 msgstr "Automatic backups are off"
 
-#: src/strings.ts:2005
+#: src/strings.ts:2006
 msgid "Automatic backups disabled"
 msgstr "Automatic backups disabled"
 
-#: src/strings.ts:1221
+#: src/strings.ts:1222
 msgid "Automatic backups with attachments"
 msgstr "Automatic backups with attachments"
 
-#: src/strings.ts:2117
+#: src/strings.ts:2118
 msgid "Automatic updates"
 msgstr "Automatic updates"
 
-#: src/strings.ts:1138
+#: src/strings.ts:1139
 msgid "Automatically clear trash after a certain period of time"
 msgstr "Automatically clear trash after a certain period of time"
 
-#: src/strings.ts:2119
+#: src/strings.ts:2120
 msgid "Automatically download & install updates in the background without prompting first."
 msgstr "Automatically download & install updates in the background without prompting first."
 
-#: src/strings.ts:1191
+#: src/strings.ts:1192
 msgid "Automatically lock the app after a certain period"
 msgstr "Automatically lock the app after a certain period"
 
-#: src/strings.ts:1121
+#: src/strings.ts:1122
 msgid "Automatically switch between light and dark themes based on your system settings"
 msgstr "Automatically switch between light and dark themes based on your system settings"
 
-#: src/strings.ts:2164
+#: src/strings.ts:2165
 msgid "Available on iOS"
 msgstr "Available on iOS"
 
-#: src/strings.ts:2165
+#: src/strings.ts:2166
 msgid "Available on iOS & Android"
 msgstr "Available on iOS & Android"
 
-#: src/strings.ts:2654
+#: src/strings.ts:2655
 msgid "Back"
 msgstr "Back"
 
-#: src/strings.ts:2313
+#: src/strings.ts:2314
 msgid "Background color"
 msgstr "Background color"
 
-#: src/strings.ts:1093
+#: src/strings.ts:1094
 msgid "Background sync (experimental)"
 msgstr "Background sync (experimental)"
 
-#: src/strings.ts:2113
+#: src/strings.ts:2114
 msgid "Backup"
 msgstr "Backup"
 
-#: src/strings.ts:2151
+#: src/strings.ts:2152
 msgid "Backup & export"
 msgstr "Backup & export"
 
-#: src/strings.ts:1210
+#: src/strings.ts:1211
 msgid "Backup & restore"
 msgstr "Backup & restore"
 
-#: src/strings.ts:1335
+#: src/strings.ts:1336
 msgid "Backup complete"
 msgstr "Backup complete"
 
-#: src/strings.ts:1561
+#: src/strings.ts:1562
 msgid "Backup directory not selected"
 msgstr "Backup directory not selected"
 
-#: src/strings.ts:1233
+#: src/strings.ts:1234
 msgid "Backup encryption"
 msgstr "Backup encryption"
 
-#: src/strings.ts:1858
+#: src/strings.ts:1859
 msgid "Backup files have .nnbackup extension"
 msgstr "Backup files have .nnbackup extension"
 
-#: src/strings.ts:882
+#: src/strings.ts:883
 msgid "Backup is encrypted"
 msgstr "Backup is encrypted"
 
-#: src/strings.ts:1614
+#: src/strings.ts:1615
 msgid "Backup is encrypted, decrypting..."
 msgstr "Backup is encrypted, decrypting..."
 
-#: src/strings.ts:1212
+#: src/strings.ts:1213
 msgid "Backup now"
 msgstr "Backup now"
 
-#: src/strings.ts:1213
+#: src/strings.ts:1214
 msgid "Backup now with attachments"
 msgstr "Backup now with attachments"
 
-#: src/strings.ts:889
+#: src/strings.ts:890
 msgid "Backup restored"
 msgstr "Backup restored"
 
-#: src/strings.ts:1919
+#: src/strings.ts:1920
 msgid "Backup saved at {path}"
 msgstr "Backup saved at {path}"
 
-#: src/strings.ts:1347
+#: src/strings.ts:1348
 msgid "Backup successful"
 msgstr "Backup successful"
 
-#: src/strings.ts:2114
+#: src/strings.ts:2115
 msgid "Backup with attachments"
 msgstr "Backup with attachments"
 
@@ -1207,47 +1207,47 @@ msgstr "Backups"
 msgid "Basic"
 msgstr "Basic"
 
-#: src/strings.ts:1793
+#: src/strings.ts:1794
 msgid "Because where's the fun in nookin' alone?"
 msgstr "Because where's the fun in nookin' alone?"
 
-#: src/strings.ts:1124
+#: src/strings.ts:1125
 msgid "Behavior"
 msgstr "Behavior"
 
-#: src/strings.ts:2146
+#: src/strings.ts:2147
 msgid "Behaviour"
 msgstr "Behaviour"
 
-#: src/strings.ts:2482
+#: src/strings.ts:2483
 msgid "Believer plan"
 msgstr "Believer plan"
 
-#: src/strings.ts:2592
+#: src/strings.ts:2593
 msgid "Best value"
 msgstr "Best value"
 
-#: src/strings.ts:2471
+#: src/strings.ts:2472
 msgid "Beta"
 msgstr "Beta"
 
-#: src/strings.ts:2271
+#: src/strings.ts:2272
 msgid "Bi-directional note link"
 msgstr "Bi-directional note link"
 
-#: src/strings.ts:2565
+#: src/strings.ts:2566
 msgid "billed annually at {price}"
 msgstr "billed annually at {price}"
 
-#: src/strings.ts:2566
+#: src/strings.ts:2567
 msgid "billed monthly at {price}"
 msgstr "billed monthly at {price}"
 
-#: src/strings.ts:2212
+#: src/strings.ts:2213
 msgid "Billing history"
 msgstr "Billing history"
 
-#: src/strings.ts:1177
+#: src/strings.ts:1178
 msgid "Biometric unlocking"
 msgstr "Biometric unlocking"
 
@@ -1259,27 +1259,27 @@ msgstr "Biometric unlocking disabled"
 msgid "Biometric unlocking enabled"
 msgstr "Biometric unlocking enabled"
 
-#: src/strings.ts:1349
+#: src/strings.ts:1350
 msgid "Biometrics authentication failed. Please try again."
 msgstr "Biometrics authentication failed. Please try again."
 
-#: src/strings.ts:1186
+#: src/strings.ts:1187
 msgid "Biometrics not enrolled"
 msgstr "Biometrics not enrolled"
 
-#: src/strings.ts:2267
+#: src/strings.ts:2268
 msgid "Bold"
 msgstr "Bold"
 
-#: src/strings.ts:2420
+#: src/strings.ts:2421
 msgid "Boost your productivity with Notebooks and organize your notes."
 msgstr "Boost your productivity with Notebooks and organize your notes."
 
-#: src/strings.ts:1809
+#: src/strings.ts:1810
 msgid "Browse"
 msgstr "Browse"
 
-#: src/strings.ts:2284
+#: src/strings.ts:2285
 msgid "Bullet list"
 msgstr "Bullet list"
 
@@ -1287,7 +1287,7 @@ msgstr "Bullet list"
 msgid "By"
 msgstr "By"
 
-#: src/strings.ts:2587
+#: src/strings.ts:2588
 msgid "By joining you agree to our"
 msgstr "By joining you agree to our"
 
@@ -1295,11 +1295,11 @@ msgstr "By joining you agree to our"
 msgid "By signing up, you agree to our "
 msgstr "By signing up, you agree to our "
 
-#: src/strings.ts:2345
+#: src/strings.ts:2346
 msgid "Callout"
 msgstr "Callout"
 
-#: src/strings.ts:2525
+#: src/strings.ts:2526
 msgid "Can I cancel my free trial anytime?"
 msgstr "Can I cancel my free trial anytime?"
 
@@ -1307,11 +1307,11 @@ msgstr "Can I cancel my free trial anytime?"
 msgid "Cancel"
 msgstr "Cancel"
 
-#: src/strings.ts:2585
+#: src/strings.ts:2586
 msgid "Cancel anytime, subscription auto-renews."
 msgstr "Cancel anytime, subscription auto-renews."
 
-#: src/strings.ts:2547
+#: src/strings.ts:2548
 msgid "Cancel anytime."
 msgstr "Cancel anytime."
 
@@ -1323,7 +1323,7 @@ msgstr "Cancel download"
 msgid "Cancel login"
 msgstr "Cancel login"
 
-#: src/strings.ts:1826
+#: src/strings.ts:1827
 msgid "Cancel subscription"
 msgstr "Cancel subscription"
 
@@ -1331,24 +1331,24 @@ msgstr "Cancel subscription"
 msgid "Cancel upload"
 msgstr "Cancel upload"
 
-#: src/strings.ts:2312
+#: src/strings.ts:2313
 msgid "Cell background color"
 msgstr "Cell background color"
 
-#: src/strings.ts:2314
+#: src/strings.ts:2315
 msgid "Cell border color"
 msgstr "Cell border color"
 
-#: src/strings.ts:2316
 #: src/strings.ts:2317
+#: src/strings.ts:2318
 msgid "Cell border width"
 msgstr "Cell border width"
 
-#: src/strings.ts:2298
+#: src/strings.ts:2299
 msgid "Cell properties"
 msgstr "Cell properties"
 
-#: src/strings.ts:2315
+#: src/strings.ts:2316
 msgid "Cell text color"
 msgstr "Cell text color"
 
@@ -1356,7 +1356,7 @@ msgstr "Cell text color"
 msgid "Change"
 msgstr "Change"
 
-#: src/strings.ts:1059
+#: src/strings.ts:1060
 msgid "Change 2FA fallback method"
 msgstr "Change 2FA fallback method"
 
@@ -1364,15 +1364,15 @@ msgstr "Change 2FA fallback method"
 msgid "Change 2FA method"
 msgstr "Change 2FA method"
 
-#: src/strings.ts:1198
+#: src/strings.ts:1199
 msgid "Change app lock password"
 msgstr "Change app lock password"
 
-#: src/strings.ts:1197
+#: src/strings.ts:1198
 msgid "Change app lock pin"
 msgstr "Change app lock pin"
 
-#: src/strings.ts:1232
+#: src/strings.ts:1233
 msgid "Change backup directory"
 msgstr "Change backup directory"
 
@@ -1380,15 +1380,15 @@ msgstr "Change backup directory"
 msgid "Change email address"
 msgstr "Change email address"
 
-#: src/strings.ts:1125
+#: src/strings.ts:1126
 msgid "Change how the app behaves in different situations"
 msgstr "Change how the app behaves in different situations"
 
-#: src/strings.ts:2363
+#: src/strings.ts:2364
 msgid "Change language"
 msgstr "Change language"
 
-#: src/strings.ts:1253
+#: src/strings.ts:1254
 msgid "Change notification sound"
 msgstr "Change notification sound"
 
@@ -1396,23 +1396,23 @@ msgstr "Change notification sound"
 msgid "Change password"
 msgstr "Change password"
 
-#: src/strings.ts:2599
+#: src/strings.ts:2600
 msgid "Change plan"
 msgstr "Change plan"
 
-#: src/strings.ts:1818
+#: src/strings.ts:1819
 msgid "Change profile picture"
 msgstr "Change profile picture"
 
-#: src/strings.ts:2190
+#: src/strings.ts:2191
 msgid "Change proxy"
 msgstr "Change proxy"
 
-#: src/strings.ts:2211
+#: src/strings.ts:2212
 msgid "Change the payment method you used to purchase this subscription."
 msgstr "Change the payment method you used to purchase this subscription."
 
-#: src/strings.ts:1255
+#: src/strings.ts:1256
 msgid "Change the sound that plays when you receive a notification"
 msgstr "Change the sound that plays when you receive a notification"
 
@@ -1420,15 +1420,15 @@ msgstr "Change the sound that plays when you receive a notification"
 msgid "Change vault password"
 msgstr "Change vault password"
 
-#: src/strings.ts:1053
+#: src/strings.ts:1054
 msgid "Change your account password"
 msgstr "Change your account password"
 
-#: src/strings.ts:1055
+#: src/strings.ts:1056
 msgid "Change your primary two-factor authentication method"
 msgstr "Change your primary two-factor authentication method"
 
-#: src/strings.ts:1089
+#: src/strings.ts:1090
 msgid "Changes from other devices won't be updated in the editor in real-time."
 msgstr "Changes from other devices won't be updated in the editor in real-time."
 
@@ -1436,27 +1436,27 @@ msgstr "Changes from other devices won't be updated in the editor in real-time."
 msgid "Changing password is an irreversible process. You will be logged out from all your devices. Please make sure you do not close the app while your password is changing and have good internet connection."
 msgstr "Changing password is an irreversible process. You will be logged out from all your devices. Please make sure you do not close the app while your password is changing and have good internet connection."
 
-#: src/strings.ts:2501
+#: src/strings.ts:2502
 msgid "Characters"
 msgstr "Characters"
 
-#: src/strings.ts:1296
+#: src/strings.ts:1297
 msgid "Check for new version of Notesnook"
 msgstr "Check for new version of Notesnook"
 
-#: src/strings.ts:1299
+#: src/strings.ts:1300
 msgid "Check for new version of the app available on app launch"
 msgstr "Check for new version of the app available on app launch"
 
-#: src/strings.ts:1295
+#: src/strings.ts:1296
 msgid "Check for updates"
 msgstr "Check for updates"
 
-#: src/strings.ts:1297
+#: src/strings.ts:1298
 msgid "Check for updates automatically"
 msgstr "Check for updates automatically"
 
-#: src/strings.ts:2163
+#: src/strings.ts:2164
 msgid "Check roadmap"
 msgstr "Check roadmap"
 
@@ -1464,7 +1464,7 @@ msgstr "Check roadmap"
 msgid "Check your spam folder if you haven't received an email yet."
 msgstr "Check your spam folder if you haven't received an email yet."
 
-#: src/strings.ts:2412
+#: src/strings.ts:2413
 msgid "Checking all attachments"
 msgstr "Checking all attachments"
 
@@ -1472,51 +1472,51 @@ msgstr "Checking all attachments"
 msgid "Checking for new version"
 msgstr "Checking for new version"
 
-#: src/strings.ts:1705
+#: src/strings.ts:1706
 msgid "Checking for updates"
 msgstr "Checking for updates"
 
-#: src/strings.ts:2411
+#: src/strings.ts:2412
 msgid "Checking note attachments"
 msgstr "Checking note attachments"
 
-#: src/strings.ts:2286
+#: src/strings.ts:2287
 msgid "Checklist"
 msgstr "Checklist"
 
-#: src/strings.ts:2340
+#: src/strings.ts:2341
 msgid "Choose a block to insert"
 msgstr "Choose a block to insert"
 
-#: src/strings.ts:1797
+#: src/strings.ts:1798
 msgid "Choose a recovery method"
 msgstr "Choose a recovery method"
 
-#: src/strings.ts:2112
+#: src/strings.ts:2113
 msgid "Choose backup format"
 msgstr "Choose backup format"
 
-#: src/strings.ts:2376
+#: src/strings.ts:2377
 msgid "Choose custom color"
 msgstr "Choose custom color"
 
-#: src/strings.ts:1118
+#: src/strings.ts:1119
 msgid "Choose from pre-built themes or create your own"
 msgstr "Choose from pre-built themes or create your own"
 
-#: src/strings.ts:1133
+#: src/strings.ts:1134
 msgid "Choose how dates are displayed in the app"
 msgstr "Choose how dates are displayed in the app"
 
-#: src/strings.ts:2634
+#: src/strings.ts:2635
 msgid "Choose how day is displayed in the app"
 msgstr "Choose how day is displayed in the app"
 
-#: src/strings.ts:1158
+#: src/strings.ts:1159
 msgid "Choose how the new note titles are formatted"
 msgstr "Choose how the new note titles are formatted"
 
-#: src/strings.ts:1135
+#: src/strings.ts:1136
 msgid "Choose how time is displayed in the app"
 msgstr "Choose how time is displayed in the app"
 
@@ -1524,67 +1524,67 @@ msgstr "Choose how time is displayed in the app"
 msgid "Choose how you want to secure your notes locally."
 msgstr "Choose how you want to secure your notes locally."
 
-#: src/strings.ts:2639
+#: src/strings.ts:2640
 msgid "Choose what day to display as the first day of the week"
 msgstr "Choose what day to display as the first day of the week"
 
-#: src/strings.ts:1228
+#: src/strings.ts:1229
 msgid "Choose where to save your backups"
 msgstr "Choose where to save your backups"
 
-#: src/strings.ts:2072
+#: src/strings.ts:2073
 msgid "Choose your style"
 msgstr "Choose your style"
 
-#: src/strings.ts:1617
+#: src/strings.ts:1618
 msgid "cleaningUp"
 msgstr "cleaningUp"
 
-#: src/strings.ts:1014
+#: src/strings.ts:1015
 msgid "Clear"
 msgstr "Clear"
 
-#: src/strings.ts:1870
+#: src/strings.ts:1871
 msgid "Clear all cached attachments. Current cache size: {cacheSize}"
 msgstr "Clear all cached attachments. Current cache size: {cacheSize}"
 
-#: src/strings.ts:2280
+#: src/strings.ts:2281
 msgid "Clear all formatting"
 msgstr "Clear all formatting"
 
-#: src/strings.ts:1871
+#: src/strings.ts:1872
 msgid "Clear attachments cache?"
 msgstr "Clear attachments cache?"
 
-#: src/strings.ts:1868
+#: src/strings.ts:1869
 msgid "Clear cache"
 msgstr "Clear cache"
 
-#: src/strings.ts:2374
+#: src/strings.ts:2375
 msgid "Clear completed tasks"
 msgstr "Clear completed tasks"
 
-#: src/strings.ts:1805
+#: src/strings.ts:1806
 msgid "Clear data & reset account"
 msgstr "Clear data & reset account"
 
-#: src/strings.ts:1139
+#: src/strings.ts:1140
 msgid "Clear default notebook"
 msgstr "Clear default notebook"
 
-#: src/strings.ts:1013
+#: src/strings.ts:1014
 msgid "Clear logs"
 msgstr "Clear logs"
 
-#: src/strings.ts:2206
+#: src/strings.ts:2207
 msgid "clear sessions"
 msgstr "clear sessions"
 
-#: src/strings.ts:1322
+#: src/strings.ts:1323
 msgid "Clear trash"
 msgstr "Clear trash"
 
-#: src/strings.ts:1136
+#: src/strings.ts:1137
 msgid "Clear trash interval"
 msgstr "Clear trash interval"
 
@@ -1592,7 +1592,7 @@ msgstr "Clear trash interval"
 msgid "Clear vault"
 msgstr "Clear vault"
 
-#: src/strings.ts:1873
+#: src/strings.ts:1874
 msgid ""
 "Clearing attachments cache will perform the following actions:\n"
 "\n"
@@ -1618,11 +1618,11 @@ msgstr ""
 "\n"
 "**Only use this for troubleshooting purposes. If you are having persistent issues, it is recommended that you reach out to us via support@streetwriters.co so we can help you resolve it permanently.**"
 
-#: src/strings.ts:2239
+#: src/strings.ts:2240
 msgid "Clearing trash will permanently delete all the items in your trash. This action is IRREVERSIBLE."
 msgstr "Clearing trash will permanently delete all the items in your trash. This action is IRREVERSIBLE."
 
-#: src/strings.ts:2621
+#: src/strings.ts:2622
 msgid "Click here to directly claim the promotion."
 msgstr "Click here to directly claim the promotion."
 
@@ -1630,75 +1630,75 @@ msgstr "Click here to directly claim the promotion."
 msgid "Click to deselect"
 msgstr "Click to deselect"
 
-#: src/strings.ts:1867
+#: src/strings.ts:1868
 msgid "Click to preview"
 msgstr "Click to preview"
 
-#: src/strings.ts:1772
+#: src/strings.ts:1773
 msgid "Click to remove"
 msgstr "Click to remove"
 
-#: src/strings.ts:2403
+#: src/strings.ts:2404
 msgid "Click to reset {title}"
 msgstr "Click to reset {title}"
 
-#: src/strings.ts:2629
+#: src/strings.ts:2630
 msgid "Click to save"
 msgstr "Click to save"
 
-#: src/strings.ts:2625
+#: src/strings.ts:2626
 msgid "Click to update"
 msgstr "Click to update"
 
-#: src/strings.ts:1381
+#: src/strings.ts:1382
 msgid "Close"
 msgstr "Close"
 
-#: src/strings.ts:2679
+#: src/strings.ts:2680
 msgid "Close ({seconds})"
 msgstr "Close ({seconds})"
 
-#: src/strings.ts:2019
+#: src/strings.ts:2020
 msgid "Close all"
 msgstr "Close all"
 
-#: src/strings.ts:2461
+#: src/strings.ts:2462
 msgid "Close all tabs"
 msgstr "Close all tabs"
 
-#: src/strings.ts:2460
+#: src/strings.ts:2461
 msgid "Close current tab"
 msgstr "Close current tab"
 
-#: src/strings.ts:2016
+#: src/strings.ts:2017
 msgid "Close others"
 msgstr "Close others"
 
-#: src/strings.ts:2130
+#: src/strings.ts:2131
 msgid "Close to system tray"
 msgstr "Close to system tray"
 
-#: src/strings.ts:2018
+#: src/strings.ts:2019
 msgid "Close to the left"
 msgstr "Close to the left"
 
-#: src/strings.ts:2017
+#: src/strings.ts:2018
 msgid "Close to the right"
 msgstr "Close to the right"
 
-#: src/strings.ts:2539
+#: src/strings.ts:2540
 msgid "cloud storage space for storing images and files."
 msgstr "cloud storage space for storing images and files."
 
-#: src/strings.ts:2278
+#: src/strings.ts:2279
 msgid "Code"
 msgstr "Code"
 
-#: src/strings.ts:2342
+#: src/strings.ts:2343
 msgid "Code block"
 msgstr "Code block"
 
-#: src/strings.ts:2279
+#: src/strings.ts:2280
 msgid "Code remove"
 msgstr "Code remove"
 
@@ -1711,7 +1711,7 @@ msgid "color"
 msgstr "color"
 
 #: src/strings.ts:299
-#: src/strings.ts:1844
+#: src/strings.ts:1845
 msgid "Color"
 msgstr "Color"
 
@@ -1719,11 +1719,11 @@ msgstr "Color"
 msgid "Color #{color} already exists"
 msgstr "Color #{color} already exists"
 
-#: src/strings.ts:2105
+#: src/strings.ts:2106
 msgid "Color scheme"
 msgstr "Color scheme"
 
-#: src/strings.ts:1489
+#: src/strings.ts:1490
 msgid "Color title"
 msgstr "Color title"
 
@@ -1735,19 +1735,19 @@ msgstr "colors"
 msgid "Colors"
 msgstr "Colors"
 
-#: src/strings.ts:2296
+#: src/strings.ts:2297
 msgid "Column properties"
 msgstr "Column properties"
 
-#: src/strings.ts:2452
+#: src/strings.ts:2453
 msgid "Command palette"
 msgstr "Command palette"
 
-#: src/strings.ts:1271
+#: src/strings.ts:1272
 msgid "Community"
 msgstr "Community"
 
-#: src/strings.ts:2559
+#: src/strings.ts:2560
 msgid "Compare plans"
 msgstr "Compare plans"
 
@@ -1759,7 +1759,7 @@ msgstr "Completed"
 msgid "Compress"
 msgstr "Compress"
 
-#: src/strings.ts:1129
+#: src/strings.ts:1130
 msgid "Compress images before uploading"
 msgstr "Compress images before uploading"
 
@@ -1767,19 +1767,19 @@ msgstr "Compress images before uploading"
 msgid "Compressed images are uploaded in Full HD resolution and usually are good enough for most use cases."
 msgstr "Compressed images are uploaded in Full HD resolution and usually are good enough for most use cases."
 
-#: src/strings.ts:2680
+#: src/strings.ts:2681
 msgid "Compressing"
 msgstr "Compressing"
 
-#: src/strings.ts:2684
+#: src/strings.ts:2685
 msgid "Compression failed"
 msgstr "Compression failed"
 
-#: src/strings.ts:2262
+#: src/strings.ts:2263
 msgid "Configure"
 msgstr "Configure"
 
-#: src/strings.ts:2417
+#: src/strings.ts:2418
 msgid "Configure server URLs for Notesnook"
 msgstr "Configure server URLs for Notesnook"
 
@@ -1787,43 +1787,43 @@ msgstr "Configure server URLs for Notesnook"
 msgid "Confirm email"
 msgstr "Confirm email"
 
-#: src/strings.ts:903
+#: src/strings.ts:904
 msgid "Confirm email to publish note"
 msgstr "Confirm email to publish note"
 
-#: src/strings.ts:1488
+#: src/strings.ts:1489
 msgid "Confirm new password"
 msgstr "Confirm new password"
 
-#: src/strings.ts:1483
+#: src/strings.ts:1484
 msgid "Confirm password"
 msgstr "Confirm password"
 
-#: src/strings.ts:2661
+#: src/strings.ts:2662
 msgid "Confirm password required"
 msgstr "Confirm password required"
 
-#: src/strings.ts:1487
+#: src/strings.ts:1488
 msgid "Confirm pin"
 msgstr "Confirm pin"
 
-#: src/strings.ts:2653
+#: src/strings.ts:2654
 msgid "Confirmation email sent"
 msgstr "Confirmation email sent"
 
-#: src/strings.ts:2090
+#: src/strings.ts:2091
 msgid "Congratulations!"
 msgstr "Congratulations!"
 
-#: src/strings.ts:1636
+#: src/strings.ts:1637
 msgid "Connected to all servers sucessfully."
 msgstr "Connected to all servers sucessfully."
 
-#: src/strings.ts:1671
+#: src/strings.ts:1672
 msgid "Contact support"
 msgstr "Contact support"
 
-#: src/strings.ts:1262
+#: src/strings.ts:1263
 msgid "Contact us directly via support@streetwriters.co for any help or support"
 msgstr "Contact us directly via support@streetwriters.co for any help or support"
 
@@ -1831,15 +1831,15 @@ msgstr "Contact us directly via support@streetwriters.co for any help or support
 msgid "Continue"
 msgstr "Continue"
 
-#: src/strings.ts:1164
+#: src/strings.ts:1165
 msgid "Contribute towards a better Notesnook. All tracking information is anonymous."
 msgstr "Contribute towards a better Notesnook. All tracking information is anonymous."
 
-#: src/strings.ts:1248
+#: src/strings.ts:1249
 msgid "Controls whether this device should receive reminder notifications."
 msgstr "Controls whether this device should receive reminder notifications."
 
-#: src/strings.ts:1990
+#: src/strings.ts:1991
 msgid "Copied"
 msgstr "Copied"
 
@@ -1848,7 +1848,7 @@ msgid "Copy"
 msgstr "Copy"
 
 #. placeholder {0}: format ? " " + format : ""
-#: src/strings.ts:2036
+#: src/strings.ts:2037
 msgid "Copy as{0}"
 msgstr "Copy as{0}"
 
@@ -1856,15 +1856,15 @@ msgstr "Copy as{0}"
 msgid "Copy codes"
 msgstr "Copy codes"
 
-#: src/strings.ts:2258
+#: src/strings.ts:2259
 msgid "Copy image"
 msgstr "Copy image"
 
-#: src/strings.ts:910
+#: src/strings.ts:911
 msgid "Copy link"
 msgstr "Copy link"
 
-#: src/strings.ts:2257
+#: src/strings.ts:2258
 msgid "Copy link text"
 msgstr "Copy link text"
 
@@ -1876,27 +1876,27 @@ msgstr "Copy note"
 msgid "Copy to clipboard"
 msgstr "Copy to clipboard"
 
-#: src/strings.ts:1619
+#: src/strings.ts:1620
 msgid "Copying backup files to cache"
 msgstr "Copying backup files to cache"
 
-#: src/strings.ts:1168
+#: src/strings.ts:1169
 msgid "CORS bypass"
 msgstr "CORS bypass"
 
-#: src/strings.ts:1986
+#: src/strings.ts:1987
 msgid "Could not activate trial. Please try again later."
 msgstr "Could not activate trial. Please try again later."
 
-#: src/strings.ts:2004
+#: src/strings.ts:2005
 msgid "Could not clear trash."
 msgstr "Could not clear trash."
 
-#: src/strings.ts:1639
+#: src/strings.ts:1640
 msgid "Could not connect to {server}."
 msgstr "Could not connect to {server}."
 
-#: src/strings.ts:1951
+#: src/strings.ts:1952
 msgid "Could not convert note to {format}."
 msgstr "Could not convert note to {format}."
 
@@ -1916,11 +1916,11 @@ msgstr "Create"
 msgid "Create a group"
 msgstr "Create a group"
 
-#: src/strings.ts:938
+#: src/strings.ts:939
 msgid "Create a new note"
 msgstr "Create a new note"
 
-#: src/strings.ts:951
+#: src/strings.ts:952
 msgid "Create a note first"
 msgstr "Create a note first"
 
@@ -1932,7 +1932,7 @@ msgstr "Create a shortcut"
 msgid "Create a tag to group related notes together."
 msgstr "Create a tag to group related notes together."
 
-#: src/strings.ts:1849
+#: src/strings.ts:1850
 msgid "Create account"
 msgstr "Create account"
 
@@ -1940,19 +1940,19 @@ msgstr "Create account"
 msgid "Create link"
 msgstr "Create link"
 
-#: src/strings.ts:1473
+#: src/strings.ts:1474
 msgid "Create shortcut of this notebook in side menu"
 msgstr "Create shortcut of this notebook in side menu"
 
-#: src/strings.ts:1387
+#: src/strings.ts:1388
 msgid "Create unlimited notebooks with Notesnook Pro"
 msgstr "Create unlimited notebooks with Notesnook Pro"
 
-#: src/strings.ts:1386
+#: src/strings.ts:1387
 msgid "Create unlimited tags with Notesnook Pro"
 msgstr "Create unlimited tags with Notesnook Pro"
 
-#: src/strings.ts:1388
+#: src/strings.ts:1389
 msgid "Create unlimited vaults with Notesnook Pro"
 msgstr "Create unlimited vaults with Notesnook Pro"
 
@@ -1964,12 +1964,12 @@ msgstr "Create vault"
 msgid "Create your account"
 msgstr "Create your account"
 
-#: src/strings.ts:2240
+#: src/strings.ts:2241
 msgid "Created at"
 msgstr "Created at"
 
 #. placeholder {0}: type === "full" ? " full" : ""
-#: src/strings.ts:1344
+#: src/strings.ts:1345
 msgid "Creating a{0} backup"
 msgstr "Creating a{0} backup"
 
@@ -1978,10 +1978,11 @@ msgid "Creation date cannot be after last edited date"
 msgstr "Creation date cannot be after last edited date"
 
 #: src/strings.ts:2049
+#: src/strings.ts:2050
 msgid "Credentials"
 msgstr "Credentials"
 
-#: src/strings.ts:2075
+#: src/strings.ts:2076
 msgid "Cross platform & 100% encrypted"
 msgstr "Cross platform & 100% encrypted"
 
@@ -1989,65 +1990,65 @@ msgstr "Cross platform & 100% encrypted"
 msgid "Curate the toolbar that fits your needs and matches your personality."
 msgstr "Curate the toolbar that fits your needs and matches your personality."
 
-#: src/strings.ts:1836
+#: src/strings.ts:1837
 msgid "Current note"
 msgstr "Current note"
 
-#: src/strings.ts:1479
-#: src/strings.ts:1485
+#: src/strings.ts:1480
+#: src/strings.ts:1486
 msgid "Current password"
 msgstr "Current password"
 
-#: src/strings.ts:2670
+#: src/strings.ts:2671
 msgid "Current password required"
 msgstr "Current password required"
 
-#: src/strings.ts:1229
+#: src/strings.ts:1230
 msgid "Current path: {path}"
 msgstr "Current path: {path}"
 
-#: src/strings.ts:1484
+#: src/strings.ts:1485
 msgid "Current pin"
 msgstr "Current pin"
 
-#: src/strings.ts:1773
+#: src/strings.ts:1774
 msgid "CURRENT PLAN"
 msgstr "CURRENT PLAN"
 
-#: src/strings.ts:2010
+#: src/strings.ts:2011
 msgid "Custom"
 msgstr "Custom"
 
-#: src/strings.ts:2141
+#: src/strings.ts:2142
 msgid "Custom dictionary words"
 msgstr "Custom dictionary words"
 
-#: src/strings.ts:1113
+#: src/strings.ts:1114
 msgid "Customization"
 msgstr "Customization"
 
-#: src/strings.ts:1116
+#: src/strings.ts:1117
 msgid "Customize the appearance of the app with custom themes"
 msgstr "Customize the appearance of the app with custom themes"
 
-#: src/strings.ts:1143
+#: src/strings.ts:1144
 msgid "Customize the note editor"
 msgstr "Customize the note editor"
 
-#: src/strings.ts:1145
+#: src/strings.ts:1146
 msgid "Customize the toolbar in the note editor"
 msgstr "Customize the toolbar in the note editor"
 
-#: src/strings.ts:1144
+#: src/strings.ts:1145
 msgid "Customize toolbar"
 msgstr "Customize toolbar"
 
-#: src/strings.ts:2256
+#: src/strings.ts:2257
 msgid "Cut"
 msgstr "Cut"
 
 #: src/strings.ts:167
-#: src/strings.ts:1568
+#: src/strings.ts:1569
 msgid "Daily"
 msgstr "Daily"
 
@@ -2055,23 +2056,23 @@ msgstr "Daily"
 msgid "Dark"
 msgstr "Dark"
 
-#: src/strings.ts:1122
+#: src/strings.ts:1123
 msgid "Dark mode"
 msgstr "Dark mode"
 
-#: src/strings.ts:2106
+#: src/strings.ts:2107
 msgid "Dark or light, we won't judge."
 msgstr "Dark or light, we won't judge."
 
-#: src/strings.ts:1547
+#: src/strings.ts:1548
 msgid "Database setup failed, could not get database key"
 msgstr "Database setup failed, could not get database key"
 
-#: src/strings.ts:1839
+#: src/strings.ts:1840
 msgid "Date"
 msgstr "Date"
 
-#: src/strings.ts:2115
+#: src/strings.ts:2116
 msgid "Date & time"
 msgstr "Date & time"
 
@@ -2087,7 +2088,7 @@ msgstr "Date deleted"
 msgid "Date edited"
 msgstr "Date edited"
 
-#: src/strings.ts:1132
+#: src/strings.ts:1133
 msgid "Date format"
 msgstr "Date format"
 
@@ -2095,80 +2096,80 @@ msgstr "Date format"
 msgid "Date modified"
 msgstr "Date modified"
 
-#: src/strings.ts:2042
+#: src/strings.ts:2043
 msgid "Date uploaded"
 msgstr "Date uploaded"
 
-#: src/strings.ts:1841
+#: src/strings.ts:1842
 msgid "Day"
 msgstr "Day"
 
-#: src/strings.ts:2633
+#: src/strings.ts:2634
 msgid "Day format"
 msgstr "Day format"
 
-#: src/strings.ts:2038
+#: src/strings.ts:2039
 msgid "Deactivate"
 msgstr "Deactivate"
 
-#: src/strings.ts:1011
+#: src/strings.ts:1012
 msgid "Debug log copied!"
 msgstr "Debug log copied!"
 
-#: src/strings.ts:1269
+#: src/strings.ts:1270
 msgid "Debug logs"
 msgstr "Debug logs"
 
-#: src/strings.ts:1012
+#: src/strings.ts:1013
 msgid "Debug logs downloaded"
 msgstr "Debug logs downloaded"
 
-#: src/strings.ts:1266
+#: src/strings.ts:1267
 msgid "Debugging"
 msgstr "Debugging"
 
-#: src/strings.ts:2405
+#: src/strings.ts:2406
 msgid "Decrease {title}"
 msgstr "Decrease {title}"
 
 #: src/strings.ts:660
-#: src/strings.ts:2008
+#: src/strings.ts:2009
 msgid "Default"
 msgstr "Default"
 
-#: src/strings.ts:1155
+#: src/strings.ts:1156
 msgid "Default font family"
 msgstr "Default font family"
 
-#: src/strings.ts:1156
+#: src/strings.ts:1157
 msgid "Default font family in editor"
 msgstr "Default font family in editor"
 
-#: src/strings.ts:1153
+#: src/strings.ts:1154
 msgid "Default font size"
 msgstr "Default font size"
 
-#: src/strings.ts:1154
+#: src/strings.ts:1155
 msgid "Default font size in editor"
 msgstr "Default font size in editor"
 
-#: src/strings.ts:1141
+#: src/strings.ts:1142
 msgid "Default notebook cleared"
 msgstr "Default notebook cleared"
 
-#: src/strings.ts:1127
+#: src/strings.ts:1128
 msgid "Default screen to open on app launch"
 msgstr "Default screen to open on app launch"
 
-#: src/strings.ts:2492
+#: src/strings.ts:2493
 msgid "Default sidebar tab"
 msgstr "Default sidebar tab"
 
-#: src/strings.ts:1249
+#: src/strings.ts:1250
 msgid "Default snooze time"
 msgstr "Default snooze time"
 
-#: src/strings.ts:1301
+#: src/strings.ts:1302
 msgid "Default sound"
 msgstr "Default sound"
 
@@ -2176,31 +2177,31 @@ msgstr "Default sound"
 msgid "Delete"
 msgstr "Delete"
 
-#: src/strings.ts:1076
+#: src/strings.ts:1077
 msgid "Delete account"
 msgstr "Delete account"
 
-#: src/strings.ts:2664
+#: src/strings.ts:2665
 msgid "Delete attachment"
 msgstr "Delete attachment"
 
-#: src/strings.ts:1319
+#: src/strings.ts:1320
 msgid "Delete collapsed section"
 msgstr "Delete collapsed section"
 
-#: src/strings.ts:2303
+#: src/strings.ts:2304
 msgid "Delete column"
 msgstr "Delete column"
 
-#: src/strings.ts:2650
+#: src/strings.ts:2651
 msgid "Delete data"
 msgstr "Delete data"
 
-#: src/strings.ts:1314
+#: src/strings.ts:1315
 msgid "Delete group"
 msgstr "Delete group"
 
-#: src/strings.ts:2377
+#: src/strings.ts:2378
 msgid "Delete mode"
 msgstr "Delete mode"
 
@@ -2212,11 +2213,11 @@ msgstr "Delete notes in this vault"
 msgid "Delete permanently"
 msgstr "Delete permanently"
 
-#: src/strings.ts:2310
+#: src/strings.ts:2311
 msgid "Delete row"
 msgstr "Delete row"
 
-#: src/strings.ts:2311
+#: src/strings.ts:2312
 msgid "Delete table"
 msgstr "Delete table"
 
@@ -2224,7 +2225,7 @@ msgstr "Delete table"
 msgid "Delete vault"
 msgstr "Delete vault"
 
-#: src/strings.ts:1176
+#: src/strings.ts:1177
 msgid "Delete vault (and optionally remove all notes)."
 msgstr "Delete vault (and optionally remove all notes)."
 
@@ -2232,43 +2233,43 @@ msgstr "Delete vault (and optionally remove all notes)."
 msgid "Deleted on {date}"
 msgstr "Deleted on {date}"
 
-#: src/strings.ts:1928
+#: src/strings.ts:1929
 msgid "Deleting"
 msgstr "Deleting"
 
-#: src/strings.ts:1838
+#: src/strings.ts:1839
 msgid "Description"
 msgstr "Description"
 
-#: src/strings.ts:2116
+#: src/strings.ts:2117
 msgid "Desktop app"
 msgstr "Desktop app"
 
-#: src/strings.ts:2120
+#: src/strings.ts:2121
 msgid "Desktop integration"
 msgstr "Desktop integration"
 
-#: src/strings.ts:871
+#: src/strings.ts:872
 msgid "Did you save recovery key?"
 msgstr "Did you save recovery key?"
 
-#: src/strings.ts:1376
+#: src/strings.ts:1377
 msgid "Disable"
 msgstr "Disable"
 
-#: src/strings.ts:1084
+#: src/strings.ts:1085
 msgid "Disable auto sync"
 msgstr "Disable auto sync"
 
-#: src/strings.ts:2011
+#: src/strings.ts:2012
 msgid "Disable editor margins"
 msgstr "Disable editor margins"
 
-#: src/strings.ts:1087
+#: src/strings.ts:1088
 msgid "Disable realtime sync"
 msgstr "Disable realtime sync"
 
-#: src/strings.ts:1090
+#: src/strings.ts:1091
 msgid "Disable sync"
 msgstr "Disable sync"
 
@@ -2280,11 +2281,11 @@ msgstr "Disabled"
 msgid "Discard"
 msgstr "Discard"
 
-#: src/strings.ts:1597
+#: src/strings.ts:1598
 msgid "Dismiss"
 msgstr "Dismiss"
 
-#: src/strings.ts:1650
+#: src/strings.ts:1651
 msgid "Dismiss announcement"
 msgstr "Dismiss announcement"
 
@@ -2296,7 +2297,7 @@ msgstr "Disputed"
 msgid "Do you enjoy using Notesnook?"
 msgstr "Do you enjoy using Notesnook?"
 
-#: src/strings.ts:1263
+#: src/strings.ts:1264
 msgid "Documentation"
 msgstr "Documentation"
 
@@ -2304,15 +2305,15 @@ msgstr "Documentation"
 msgid "Documents"
 msgstr "Documents"
 
-#: src/strings.ts:984
+#: src/strings.ts:985
 msgid "Don't have access to your authenticator app?"
 msgstr "Don't have access to your authenticator app?"
 
-#: src/strings.ts:991
+#: src/strings.ts:992
 msgid "Don't have access to your email address?"
 msgstr "Don't have access to your email address?"
 
-#: src/strings.ts:1000
+#: src/strings.ts:1001
 msgid "Don't have access to your phone number?"
 msgstr "Don't have access to your phone number?"
 
@@ -2320,23 +2321,23 @@ msgstr "Don't have access to your phone number?"
 msgid "Don't have an account?"
 msgstr "Don't have an account?"
 
-#: src/strings.ts:1832
+#: src/strings.ts:1833
 msgid "Don't have backup file?"
 msgstr "Don't have backup file?"
 
-#: src/strings.ts:1831
+#: src/strings.ts:1832
 msgid "Don't have your account recovery key?"
 msgstr "Don't have your account recovery key?"
 
-#: src/strings.ts:1003
+#: src/strings.ts:1004
 msgid "Don't have your recovery codes?"
 msgstr "Don't have your recovery codes?"
 
-#: src/strings.ts:1810
+#: src/strings.ts:1811
 msgid "Don't show again"
 msgstr "Don't show again"
 
-#: src/strings.ts:1811
+#: src/strings.ts:1812
 msgid "Don't show again on this device?"
 msgstr "Don't show again on this device?"
 
@@ -2344,7 +2345,7 @@ msgstr "Don't show again on this device?"
 msgid "Done"
 msgstr "Done"
 
-#: src/strings.ts:1149
+#: src/strings.ts:1150
 msgid "Double spaced lines"
 msgstr "Double spaced lines"
 
@@ -2352,15 +2353,15 @@ msgstr "Double spaced lines"
 msgid "Download"
 msgstr "Download"
 
-#: src/strings.ts:1816
+#: src/strings.ts:1817
 msgid "Download all attachments"
 msgstr "Download all attachments"
 
-#: src/strings.ts:2326
+#: src/strings.ts:2327
 msgid "Download attachment"
 msgstr "Download attachment"
 
-#: src/strings.ts:1860
+#: src/strings.ts:1861
 msgid "Download backup file"
 msgstr "Download backup file"
 
@@ -2368,11 +2369,11 @@ msgstr "Download backup file"
 msgid "Download cancelled"
 msgstr "Download cancelled"
 
-#: src/strings.ts:2218
+#: src/strings.ts:2219
 msgid "Download everything including attachments on sync"
 msgstr "Download everything including attachments on sync"
 
-#: src/strings.ts:1290
+#: src/strings.ts:1291
 msgid "Download on desktop"
 msgstr "Download on desktop"
 
@@ -2405,23 +2406,23 @@ msgstr "Downloading ({progress})"
 msgid "Downloading attachments"
 msgstr "Downloading attachments"
 
-#: src/strings.ts:1704
+#: src/strings.ts:1705
 msgid "Downloading images"
 msgstr "Downloading images"
 
-#: src/strings.ts:1770
+#: src/strings.ts:1771
 msgid "Drag & drop files here, or click to select files"
 msgstr "Drag & drop files here, or click to select files"
 
-#: src/strings.ts:1769
+#: src/strings.ts:1770
 msgid "Drop the files here"
 msgstr "Drop the files here"
 
-#: src/strings.ts:1663
+#: src/strings.ts:1664
 msgid "Drop your files here to attach"
 msgstr "Drop your files here to attach"
 
-#: src/strings.ts:2569
+#: src/strings.ts:2570
 msgid "Due {date}"
 msgstr "Due {date}"
 
@@ -2429,11 +2430,11 @@ msgstr "Due {date}"
 msgid "Due date"
 msgstr "Due date"
 
-#: src/strings.ts:2567
+#: src/strings.ts:2568
 msgid "Due today"
 msgstr "Due today"
 
-#: src/strings.ts:924
+#: src/strings.ts:925
 msgid "Duplicate"
 msgstr "Duplicate"
 
@@ -2441,15 +2442,15 @@ msgstr "Duplicate"
 msgid "Earliest first"
 msgstr "Earliest first"
 
-#: src/strings.ts:2429
+#: src/strings.ts:2430
 msgid "Easy access"
 msgstr "Easy access"
 
-#: src/strings.ts:1777
+#: src/strings.ts:1778
 msgid "Edit"
 msgstr "Edit"
 
-#: src/strings.ts:2640
+#: src/strings.ts:2641
 msgid "Edit creation date"
 msgstr "Edit creation date"
 
@@ -2457,37 +2458,37 @@ msgstr "Edit creation date"
 msgid "Edit internal link"
 msgstr "Edit internal link"
 
-#: src/strings.ts:2245
-#: src/strings.ts:2273
+#: src/strings.ts:2246
+#: src/strings.ts:2274
 msgid "Edit link"
 msgstr "Edit link"
 
-#: src/strings.ts:2485
+#: src/strings.ts:2486
 msgid "Edit profile"
 msgstr "Edit profile"
 
-#: src/strings.ts:1307
+#: src/strings.ts:1308
 msgid "Edit profile picture"
 msgstr "Edit profile picture"
 
-#: src/strings.ts:1819
+#: src/strings.ts:1820
 msgid "Edit your full name"
 msgstr "Edit your full name"
 
-#: src/strings.ts:1142
-#: src/strings.ts:1526
+#: src/strings.ts:1143
+#: src/strings.ts:1527
 msgid "Editor"
 msgstr "Editor"
 
-#: src/strings.ts:2596
+#: src/strings.ts:2597
 msgid "Education plan"
 msgstr "Education plan"
 
-#: src/strings.ts:1481
+#: src/strings.ts:1482
 msgid "Email"
 msgstr "Email"
 
-#: src/strings.ts:2442
+#: src/strings.ts:2443
 msgid "Email copied"
 msgstr "Email copied"
 
@@ -2499,27 +2500,27 @@ msgstr "Email is required"
 msgid "Email not confirmed"
 msgstr "Email not confirmed"
 
-#: src/strings.ts:1553
+#: src/strings.ts:1554
 msgid "Email or password incorrect"
 msgstr "Email or password incorrect"
 
-#: src/strings.ts:1260
+#: src/strings.ts:1261
 msgid "Email support"
 msgstr "Email support"
 
-#: src/strings.ts:857
+#: src/strings.ts:858
 msgid "Email updated to {email}"
 msgstr "Email updated to {email}"
 
-#: src/strings.ts:2352
+#: src/strings.ts:2353
 msgid "Embed"
 msgstr "Embed"
 
-#: src/strings.ts:2332
+#: src/strings.ts:2333
 msgid "Embed properties"
 msgstr "Embed properties"
 
-#: src/strings.ts:2328
+#: src/strings.ts:2329
 msgid "Embed settings"
 msgstr "Embed settings"
 
@@ -2527,27 +2528,27 @@ msgstr "Embed settings"
 msgid "Enable"
 msgstr "Enable"
 
-#: src/strings.ts:1131
+#: src/strings.ts:1132
 msgid "Enable (Recommended)"
 msgstr "Enable (Recommended)"
 
-#: src/strings.ts:1185
+#: src/strings.ts:1186
 msgid "Enable app lock"
 msgstr "Enable app lock"
 
-#: src/strings.ts:2012
+#: src/strings.ts:2013
 msgid "Enable editor margins"
 msgstr "Enable editor margins"
 
-#: src/strings.ts:2476
+#: src/strings.ts:2477
 msgid "Enable ligatures for common symbols like →, ←, etc"
 msgstr "Enable ligatures for common symbols like →, ←, etc"
 
-#: src/strings.ts:2392
+#: src/strings.ts:2393
 msgid "Enable regex"
 msgstr "Enable regex"
 
-#: src/strings.ts:2137
+#: src/strings.ts:2138
 msgid "Enable spell checker"
 msgstr "Enable spell checker"
 
@@ -2555,7 +2556,7 @@ msgstr "Enable spell checker"
 msgid "Enable two-factor authentication to add an extra layer of security to your account."
 msgstr "Enable two-factor authentication to add an extra layer of security to your account."
 
-#: src/strings.ts:1234
+#: src/strings.ts:1235
 msgid "Encrypt your backups for added security"
 msgstr "Encrypt your backups for added security"
 
@@ -2563,27 +2564,27 @@ msgstr "Encrypt your backups for added security"
 msgid "Encrypted and synced"
 msgstr "Encrypted and synced"
 
-#: src/strings.ts:2252
+#: src/strings.ts:2253
 msgid "Encrypted backup"
 msgstr "Encrypted backup"
 
-#: src/strings.ts:1657
+#: src/strings.ts:1658
 msgid "Encrypted, private, secure."
 msgstr "Encrypted, private, secure."
 
-#: src/strings.ts:2681
+#: src/strings.ts:2682
 msgid "Encrypting"
 msgstr "Encrypting"
 
-#: src/strings.ts:940
+#: src/strings.ts:941
 msgid "Encrypting attachment"
 msgstr "Encrypting attachment"
 
-#: src/strings.ts:1843
+#: src/strings.ts:1844
 msgid "Encryption key"
 msgstr "Encryption key"
 
-#: src/strings.ts:820
+#: src/strings.ts:821
 msgid "End to end encrypted."
 msgstr "End to end encrypted."
 
@@ -2591,23 +2592,23 @@ msgstr "End to end encrypted."
 msgid "Enter 6 digit code"
 msgstr "Enter 6 digit code"
 
-#: src/strings.ts:1079
+#: src/strings.ts:1080
 msgid "Enter account password"
 msgstr "Enter account password"
 
-#: src/strings.ts:1080
+#: src/strings.ts:1081
 msgid "Enter account password to proceed."
 msgstr "Enter account password to proceed."
 
-#: src/strings.ts:1852
+#: src/strings.ts:1853
 msgid "Enter account recovery key"
 msgstr "Enter account recovery key"
 
-#: src/strings.ts:1019
+#: src/strings.ts:1020
 msgid "Enter app lock password"
 msgstr "Enter app lock password"
 
-#: src/strings.ts:1022
+#: src/strings.ts:1023
 msgid "Enter app lock pin"
 msgstr "Enter app lock pin"
 
@@ -2615,27 +2616,27 @@ msgstr "Enter app lock pin"
 msgid "Enter code from authenticator app"
 msgstr "Enter code from authenticator app"
 
-#: src/strings.ts:1511
+#: src/strings.ts:1512
 msgid "Enter email address"
 msgstr "Enter email address"
 
-#: src/strings.ts:2380
+#: src/strings.ts:2381
 msgid "Enter embed source URL"
 msgstr "Enter embed source URL"
 
-#: src/strings.ts:1313
+#: src/strings.ts:1314
 msgid "Enter full name"
 msgstr "Enter full name"
 
-#: src/strings.ts:1701
+#: src/strings.ts:1702
 msgid "Enter fullscreen"
 msgstr "Enter fullscreen"
 
-#: src/strings.ts:1490
+#: src/strings.ts:1491
 msgid "Enter notebook description"
 msgstr "Enter notebook description"
 
-#: src/strings.ts:856
+#: src/strings.ts:857
 msgid "Enter notebook title"
 msgstr "Enter notebook title"
 
@@ -2643,11 +2644,11 @@ msgstr "Enter notebook title"
 msgid "Enter password"
 msgstr "Enter password"
 
-#: src/strings.ts:2098
+#: src/strings.ts:2099
 msgid "Enter pin or password to enable app lock."
 msgstr "Enter pin or password to enable app lock."
 
-#: src/strings.ts:1004
+#: src/strings.ts:1005
 msgid "Enter recovery code"
 msgstr "Enter recovery code"
 
@@ -2663,7 +2664,7 @@ msgstr "Enter the 6 digit code sent to your email to continue logging in"
 msgid "Enter the 6 digit code sent to your phone number to continue logging in"
 msgstr "Enter the 6 digit code sent to your phone number to continue logging in"
 
-#: src/strings.ts:2444
+#: src/strings.ts:2445
 msgid "Enter the gift code to redeem your subscription."
 msgstr "Enter the gift code to redeem your subscription."
 
@@ -2671,27 +2672,27 @@ msgstr "Enter the gift code to redeem your subscription."
 msgid "Enter the recovery code to continue logging in"
 msgstr "Enter the recovery code to continue logging in"
 
-#: src/strings.ts:2632
+#: src/strings.ts:2633
 msgid "Enter title"
 msgstr "Enter title"
 
-#: src/strings.ts:1493
+#: src/strings.ts:1494
 msgid "Enter verification code sent to your new email"
 msgstr "Enter verification code sent to your new email"
 
-#: src/strings.ts:1492
+#: src/strings.ts:1493
 msgid "Enter your new email"
 msgstr "Enter your new email"
 
-#: src/strings.ts:2099
+#: src/strings.ts:2100
 msgid "Enter your username"
 msgstr "Enter your username"
 
-#: src/strings.ts:2436
+#: src/strings.ts:2437
 msgid "Error"
 msgstr "Error"
 
-#: src/strings.ts:1554
+#: src/strings.ts:1555
 msgid "Error applying promo code"
 msgstr "Error applying promo code"
 
@@ -2699,7 +2700,7 @@ msgstr "Error applying promo code"
 msgid "Error downloading file: {message}"
 msgstr "Error downloading file: {message}"
 
-#: src/strings.ts:1514
+#: src/strings.ts:1515
 msgid "Error getting codes"
 msgstr "Error getting codes"
 
@@ -2707,11 +2708,11 @@ msgstr "Error getting codes"
 msgid "Error loading themes"
 msgstr "Error loading themes"
 
-#: src/strings.ts:1075
+#: src/strings.ts:1076
 msgid "Error logging out"
 msgstr "Error logging out"
 
-#: src/strings.ts:1009
+#: src/strings.ts:1010
 msgid "Error sending 2FA code"
 msgstr "Error sending 2FA code"
 
@@ -2719,55 +2720,55 @@ msgstr "Error sending 2FA code"
 msgid "Errors"
 msgstr "Errors"
 
-#: src/strings.ts:1696
+#: src/strings.ts:1697
 msgid "Errors in {count} attachments"
 msgstr "Errors in {count} attachments"
 
-#: src/strings.ts:2481
+#: src/strings.ts:2482
 msgid "Essential plan"
 msgstr "Essential plan"
 
-#: src/strings.ts:1628
+#: src/strings.ts:1629
 msgid "Events server"
 msgstr "Events server"
 
-#: src/strings.ts:2422
+#: src/strings.ts:2423
 msgid "Every Notebook can have notes and sub notebooks."
 msgstr "Every Notebook can have notes and sub notebooks."
 
-#: src/strings.ts:2424
+#: src/strings.ts:2425
 msgid "Everything related to my job in one place."
 msgstr "Everything related to my job in one place."
 
-#: src/strings.ts:2433
+#: src/strings.ts:2434
 msgid "Everything related to my school in one place."
 msgstr "Everything related to my school in one place."
 
-#: src/strings.ts:2450
+#: src/strings.ts:2451
 msgid "Execute"
 msgstr "Execute"
 
-#: src/strings.ts:2449
+#: src/strings.ts:2450
 msgid "Execute a command..."
 msgstr "Execute a command..."
 
-#: src/strings.ts:2013
+#: src/strings.ts:2014
 msgid "Exit fullscreen"
 msgstr "Exit fullscreen"
 
-#: src/strings.ts:2384
+#: src/strings.ts:2385
 msgid "Expand"
 msgstr "Expand"
 
-#: src/strings.ts:2477
+#: src/strings.ts:2478
 msgid "Expand sidebar"
 msgstr "Expand sidebar"
 
-#: src/strings.ts:2082
+#: src/strings.ts:2083
 msgid "Experience the next level of private note taking\""
 msgstr "Experience the next level of private note taking\""
 
-#: src/strings.ts:2646
+#: src/strings.ts:2647
 msgid "Expiry date"
 msgstr "Expiry date"
 
@@ -2784,6 +2785,7 @@ msgid "Expiry date set"
 msgstr "Expiry date set"
 
 #: src/strings.ts:2550
+#: src/strings.ts:2551
 msgid "Explore all plans"
 msgstr "Explore all plans"
 
@@ -2795,24 +2797,24 @@ msgstr "Export"
 msgid "Export again"
 msgstr "Export again"
 
-#: src/strings.ts:1237
+#: src/strings.ts:1238
 msgid "Export all notes"
 msgstr "Export all notes"
 
-#: src/strings.ts:1239
+#: src/strings.ts:1240
 msgid "Export all notes as pdf, markdown, html or text in a single zip file"
 msgstr "Export all notes as pdf, markdown, html or text in a single zip file"
 
 #. placeholder {0}: format ? " " + format : ""
-#: src/strings.ts:2035
+#: src/strings.ts:2036
 msgid "Export as{0}"
 msgstr "Export as{0}"
 
-#: src/strings.ts:2647
+#: src/strings.ts:2648
 msgid "Export CSV"
 msgstr "Export CSV"
 
-#: src/strings.ts:1385
+#: src/strings.ts:1386
 msgid "Export notes as PDF, Markdown and HTML with Notesnook Pro"
 msgstr "Export notes as PDF, Markdown and HTML with Notesnook Pro"
 
@@ -2820,39 +2822,39 @@ msgstr "Export notes as PDF, Markdown and HTML with Notesnook Pro"
 msgid "Exporting \"{title}\""
 msgstr "Exporting \"{title}\""
 
-#: src/strings.ts:1618
+#: src/strings.ts:1619
 msgid "Extracting files..."
 msgstr "Extracting files..."
 
-#: src/strings.ts:1807
+#: src/strings.ts:1808
 msgid "EXTREMELY DANGEROUS! This action is irreversible. All your data including notes, notebooks, attachments & settings will be deleted. This is a full account reset. Proceed with caution."
 msgstr "EXTREMELY DANGEROUS! This action is irreversible. All your data including notes, notebooks, attachments & settings will be deleted. This is a full account reset. Proceed with caution."
 
-#: src/strings.ts:1259
+#: src/strings.ts:1260
 msgid "Faced an issue or have a suggestion? Click here to create a bug report"
 msgstr "Faced an issue or have a suggestion? Click here to create a bug report"
 
-#: src/strings.ts:2414
+#: src/strings.ts:2415
 msgid "Failed"
 msgstr "Failed"
 
-#: src/strings.ts:2651
+#: src/strings.ts:2652
 msgid "Failed to attach file"
 msgstr "Failed to attach file"
 
-#: src/strings.ts:1936
+#: src/strings.ts:1937
 msgid "Failed to copy note"
 msgstr "Failed to copy note"
 
-#: src/strings.ts:1560
+#: src/strings.ts:1561
 msgid "Failed to decrypt backup"
 msgstr "Failed to decrypt backup"
 
-#: src/strings.ts:2002
+#: src/strings.ts:2003
 msgid "Failed to delete"
 msgstr "Failed to delete"
 
-#: src/strings.ts:1081
+#: src/strings.ts:1082
 msgid "Failed to delete account"
 msgstr "Failed to delete account"
 
@@ -2860,19 +2862,19 @@ msgstr "Failed to delete account"
 msgid "Failed to download file"
 msgstr "Failed to download file"
 
-#: src/strings.ts:1998
+#: src/strings.ts:1999
 msgid "Failed to install theme."
 msgstr "Failed to install theme."
 
-#: src/strings.ts:948
+#: src/strings.ts:949
 msgid "Failed to open"
 msgstr "Failed to open"
 
-#: src/strings.ts:867
+#: src/strings.ts:868
 msgid "Failed to publish note"
 msgstr "Failed to publish note"
 
-#: src/strings.ts:2003
+#: src/strings.ts:2004
 msgid "Failed to register task"
 msgstr "Failed to register task"
 
@@ -2884,23 +2886,23 @@ msgstr "Failed to resolve download url"
 msgid "Failed to send recovery email"
 msgstr "Failed to send recovery email"
 
-#: src/strings.ts:1401
+#: src/strings.ts:1402
 msgid "Failed to send verification email"
 msgstr "Failed to send verification email"
 
-#: src/strings.ts:937
+#: src/strings.ts:938
 msgid "Failed to subscribe"
 msgstr "Failed to subscribe"
 
-#: src/strings.ts:2213
+#: src/strings.ts:2214
 msgid "Failed to take backup"
 msgstr "Failed to take backup"
 
-#: src/strings.ts:2215
+#: src/strings.ts:2216
 msgid "Failed to take backup of your data. Do you want to continue logging out?"
 msgstr "Failed to take backup of your data. Do you want to continue logging out?"
 
-#: src/strings.ts:868
+#: src/strings.ts:869
 msgid "Failed to unpublish note"
 msgstr "Failed to unpublish note"
 
@@ -2912,28 +2914,28 @@ msgstr "Failed to zip files"
 msgid "Fallback method for 2FA enabled"
 msgstr "Fallback method for 2FA enabled"
 
-#: src/strings.ts:2560
+#: src/strings.ts:2561
 msgid "FAQs"
 msgstr "FAQs"
 
-#: src/strings.ts:2032
+#: src/strings.ts:2033
 msgid "Favorite"
 msgstr "Favorite"
 
 #: src/strings.ts:321
-#: src/strings.ts:1521
+#: src/strings.ts:1522
 msgid "Favorites"
 msgstr "Favorites"
 
-#: src/strings.ts:2558
+#: src/strings.ts:2559
 msgid "Featured on"
 msgstr "Featured on"
 
-#: src/strings.ts:2426
+#: src/strings.ts:2427
 msgid "February 2022 Week 2"
 msgstr "February 2022 Week 2"
 
-#: src/strings.ts:2427
+#: src/strings.ts:2428
 msgid "February 2022 Week 3"
 msgstr "February 2022 Week 3"
 
@@ -2953,107 +2955,107 @@ msgstr "File length is 0. Please upload this file again from the attachment mana
 msgid "File length mismatch. Expected {expectedSize} but got {currentSize} bytes. Please upload this file again from the attachment manager."
 msgstr "File length mismatch. Expected {expectedSize} but got {currentSize} bytes. Please upload this file again from the attachment manager."
 
-#: src/strings.ts:2689
+#: src/strings.ts:2690
 msgid "File links cannot be opened in browsers. Please use the Notesnook desktop app."
 msgstr "File links cannot be opened in browsers. Please use the Notesnook desktop app."
 
-#: src/strings.ts:949
+#: src/strings.ts:950
 msgid "File mismatch"
 msgstr "File mismatch"
 
-#: src/strings.ts:2683
+#: src/strings.ts:2684
 msgid "File size limit exceeded. Please upgrade your plan."
 msgstr "File size limit exceeded. Please upgrade your plan."
 
-#: src/strings.ts:945
+#: src/strings.ts:946
 msgid "File size should be less than {sizeInMB}"
 msgstr "File size should be less than {sizeInMB}"
 
-#: src/strings.ts:943
+#: src/strings.ts:944
 msgid "File too big"
 msgstr "File too big"
 
-#: src/strings.ts:1478
+#: src/strings.ts:1479
 msgid "Filter attachments by filename, type or hash"
 msgstr "Filter attachments by filename, type or hash"
 
-#: src/strings.ts:1833
+#: src/strings.ts:1834
 msgid "Filter languages"
 msgstr "Filter languages"
 
-#: src/strings.ts:2618
+#: src/strings.ts:2619
 msgid "Finish your purchase in the browser."
 msgstr "Finish your purchase in the browser."
 
-#: src/strings.ts:1669
+#: src/strings.ts:1670
 msgid "Fix it"
 msgstr "Fix it"
 
-#: src/strings.ts:2015
+#: src/strings.ts:2016
 msgid "Focus mode"
 msgstr "Focus mode"
 
-#: src/strings.ts:2173
+#: src/strings.ts:2174
 msgid "Follow"
 msgstr "Follow"
 
-#: src/strings.ts:1275
+#: src/strings.ts:1276
 msgid "Follow us on Mastodon"
 msgstr "Follow us on Mastodon"
 
-#: src/strings.ts:1277
+#: src/strings.ts:1278
 msgid "Follow us on Mastodon for updates and news about Notesnook"
 msgstr "Follow us on Mastodon for updates and news about Notesnook"
 
-#: src/strings.ts:1278
+#: src/strings.ts:1279
 msgid "Follow us on X"
 msgstr "Follow us on X"
 
-#: src/strings.ts:1279
+#: src/strings.ts:1280
 msgid "Follow us on X for updates and news about Notesnook"
 msgstr "Follow us on X for updates and news about Notesnook"
 
-#: src/strings.ts:2287
+#: src/strings.ts:2288
 msgid "Font family"
 msgstr "Font family"
 
-#: src/strings.ts:2474
+#: src/strings.ts:2475
 msgid "Font ligatures"
 msgstr "Font ligatures"
 
-#: src/strings.ts:2288
+#: src/strings.ts:2289
 msgid "Font size"
 msgstr "Font size"
 
-#: src/strings.ts:2532
+#: src/strings.ts:2533
 msgid "For a monthly subscription, you can get a refund within 7 days of purchase. For a yearly subscription, we offer a full refund within 14 days of purchase. For a 5 year subscription, you can request a refund within 30 days of purchase."
 msgstr "For a monthly subscription, you can get a refund within 7 days of purchase. For a yearly subscription, we offer a full refund within 14 days of purchase. For a 5 year subscription, you can request a refund within 30 days of purchase."
 
-#: src/strings.ts:1686
+#: src/strings.ts:1687
 msgid "For a more integrated user experience, try out Notesnook for {platform}"
 msgstr "For a more integrated user experience, try out Notesnook for {platform}"
 
-#: src/strings.ts:1767
+#: src/strings.ts:1768
 msgid "for help regarding how to use the Notesnook Importer."
 msgstr "for help regarding how to use the Notesnook Importer."
 
-#: src/strings.ts:2541
+#: src/strings.ts:2542
 msgid "for locking your notes as soon as app enters background"
 msgstr "for locking your notes as soon as app enters background"
 
-#: src/strings.ts:2205
+#: src/strings.ts:2206
 msgid "Force logout from all your other logged in devices."
 msgstr "Force logout from all your other logged in devices."
 
-#: src/strings.ts:1096
+#: src/strings.ts:1097
 msgid "Force pull changes"
 msgstr "Force pull changes"
 
-#: src/strings.ts:1105
+#: src/strings.ts:1106
 msgid "Force push changes"
 msgstr "Force push changes"
 
-#: src/strings.ts:2222
+#: src/strings.ts:2223
 msgid ""
 "Force push:\n"
 "Use this if changes made on this device are not appearing on other devices. This will overwrite the data on the server with the data from this device.\n"
@@ -3075,11 +3077,11 @@ msgstr ""
 msgid "Forgot password?"
 msgstr "Forgot password?"
 
-#: src/strings.ts:2575
+#: src/strings.ts:2576
 msgid "Free {duration} day trial, cancel any time"
 msgstr "Free {duration} day trial, cancel any time"
 
-#: src/strings.ts:2479
+#: src/strings.ts:2480
 msgid "Free plan"
 msgstr "Free plan"
 
@@ -3091,55 +3093,55 @@ msgstr "Fri"
 msgid "Friday"
 msgstr "Friday"
 
-#: src/strings.ts:2382
+#: src/strings.ts:2383
 msgid "From code"
 msgstr "From code"
 
-#: src/strings.ts:2379
+#: src/strings.ts:2380
 msgid "From URL"
 msgstr "From URL"
 
-#: src/strings.ts:1999
+#: src/strings.ts:2000
 msgid "Full name updated"
 msgstr "Full name updated"
 
-#: src/strings.ts:2216
+#: src/strings.ts:2217
 msgid "Full offline mode"
 msgstr "Full offline mode"
 
-#: src/strings.ts:2334
+#: src/strings.ts:2335
 msgid "Full screen"
 msgstr "Full screen"
 
-#: src/strings.ts:2102
+#: src/strings.ts:2103
 msgid "General"
 msgstr "General"
 
-#: src/strings.ts:1268
+#: src/strings.ts:1269
 msgid "Get helpful debug info about the app to help us find bugs."
 msgstr "Get helpful debug info about the app to help us find bugs."
 
-#: src/strings.ts:1292
+#: src/strings.ts:1293
 msgid "Get Notesnook app on your desktop and access all notes"
 msgstr "Get Notesnook app on your desktop and access all notes"
 
-#: src/strings.ts:2167
+#: src/strings.ts:2168
 msgid "Get Notesnook app on your iPhone and access all your notes on the go."
 msgstr "Get Notesnook app on your iPhone and access all your notes on the go."
 
-#: src/strings.ts:2169
+#: src/strings.ts:2170
 msgid "Get Notesnook app on your iPhone or Android device and access all your notes on the go."
 msgstr "Get Notesnook app on your iPhone or Android device and access all your notes on the go."
 
-#: src/strings.ts:1382
+#: src/strings.ts:1383
 msgid "Get Notesnook Pro"
 msgstr "Get Notesnook Pro"
 
-#: src/strings.ts:1367
+#: src/strings.ts:1368
 msgid "Get Notesnook Pro to enable automatic backups"
 msgstr "Get Notesnook Pro to enable automatic backups"
 
-#: src/strings.ts:2418
+#: src/strings.ts:2419
 msgid "Get Priority support"
 msgstr "Get Priority support"
 
@@ -3151,11 +3153,11 @@ msgstr "Get Pro"
 msgid "Get started"
 msgstr "Get started"
 
-#: src/strings.ts:2538
+#: src/strings.ts:2539
 msgid "Get this and so much more:"
 msgstr "Get this and so much more:"
 
-#: src/strings.ts:1885
+#: src/strings.ts:1886
 msgid "Getting encryption key..."
 msgstr "Getting encryption key..."
 
@@ -3167,55 +3169,55 @@ msgstr "Getting information"
 msgid "Getting recovery codes"
 msgstr "Getting recovery codes"
 
-#: src/strings.ts:2663
+#: src/strings.ts:2664
 msgid "Gift code required"
 msgstr "Gift code required"
 
-#: src/strings.ts:2172
+#: src/strings.ts:2173
 msgid "GNU GENERAL PUBLIC LICENSE Version 3"
 msgstr "GNU GENERAL PUBLIC LICENSE Version 3"
 
-#: src/strings.ts:2619
+#: src/strings.ts:2620
 msgid "Go back"
 msgstr "Go back"
 
-#: src/strings.ts:2457
+#: src/strings.ts:2458
 msgid "Go back in tab"
 msgstr "Go back in tab"
 
-#: src/strings.ts:2235
+#: src/strings.ts:2236
 msgid "Go back to notebooks"
 msgstr "Go back to notebooks"
 
-#: src/strings.ts:2236
+#: src/strings.ts:2237
 msgid "Go back to tags"
 msgstr "Go back to tags"
 
-#: src/strings.ts:2456
+#: src/strings.ts:2457
 msgid "Go forward in tab"
 msgstr "Go forward in tab"
 
-#: src/strings.ts:1813
+#: src/strings.ts:1814
 msgid "Go to"
 msgstr "Go to"
 
-#: src/strings.ts:1814
+#: src/strings.ts:1815
 msgid "Go to #{tag}"
 msgstr "Go to #{tag}"
 
-#: src/strings.ts:1697
+#: src/strings.ts:1698
 msgid "Go to next page"
 msgstr "Go to next page"
 
-#: src/strings.ts:1698
+#: src/strings.ts:1699
 msgid "Go to previous page"
 msgstr "Go to previous page"
 
-#: src/strings.ts:1304
+#: src/strings.ts:1305
 msgid "Go to web app"
 msgstr "Go to web app"
 
-#: src/strings.ts:2549
+#: src/strings.ts:2550
 msgid "Google will remind you 2 days before your trial ends."
 msgstr "Google will remind you 2 days before your trial ends."
 
@@ -3227,7 +3229,7 @@ msgstr "Got it"
 msgid "GROUP"
 msgstr "GROUP"
 
-#: src/strings.ts:1887
+#: src/strings.ts:1888
 msgid "Group added successfully"
 msgstr "Group added successfully"
 
@@ -3239,27 +3241,27 @@ msgstr "Group by"
 msgid "Hash copied"
 msgstr "Hash copied"
 
-#: src/strings.ts:2219
+#: src/strings.ts:2220
 msgid "Having problems with sync?"
 msgstr "Having problems with sync?"
 
-#: src/strings.ts:2564
+#: src/strings.ts:2565
 msgid "hdImages"
 msgstr "hdImages"
 
-#: src/strings.ts:2360
+#: src/strings.ts:2361
 msgid "Heading {level}"
 msgstr "Heading {level}"
 
-#: src/strings.ts:2289
+#: src/strings.ts:2290
 msgid "Headings"
 msgstr "Headings"
 
-#: src/strings.ts:2395
+#: src/strings.ts:2396
 msgid "Height"
 msgstr "Height"
 
-#: src/strings.ts:1256
+#: src/strings.ts:1257
 msgid "Help and support"
 msgstr "Help and support"
 
@@ -3267,55 +3269,55 @@ msgstr "Help and support"
 msgid "Help improve Notesnook by sending completely anonymized"
 msgstr "Help improve Notesnook by sending completely anonymized"
 
-#: src/strings.ts:1375
+#: src/strings.ts:1376
 msgid "Hide"
 msgstr "Hide"
 
-#: src/strings.ts:1182
+#: src/strings.ts:1183
 msgid "Hide app contents when you switch to other apps. This will also disable screenshot taking in the app."
 msgstr "Hide app contents when you switch to other apps. This will also disable screenshot taking in the app."
 
-#: src/strings.ts:2178
+#: src/strings.ts:2179
 msgid "Hide note title"
 msgstr "Hide note title"
 
-#: src/strings.ts:2292
+#: src/strings.ts:2293
 msgid "Highlight"
 msgstr "Highlight"
 
-#: src/strings.ts:909
+#: src/strings.ts:910
 msgid "History"
 msgstr "History"
 
-#: src/strings.ts:1527
+#: src/strings.ts:1528
 msgid "Home"
 msgstr "Home"
 
-#: src/strings.ts:1126
+#: src/strings.ts:1127
 msgid "Homepage"
 msgstr "Homepage"
 
-#: src/strings.ts:1317
+#: src/strings.ts:1318
 msgid "Homepage changed to {name}"
 msgstr "Homepage changed to {name}"
 
-#: src/strings.ts:2341
+#: src/strings.ts:2342
 msgid "Horizontal rule"
 msgstr "Horizontal rule"
 
-#: src/strings.ts:1798
+#: src/strings.ts:1799
 msgid "How do you want to recover your account?"
 msgstr "How do you want to recover your account?"
 
-#: src/strings.ts:1668
+#: src/strings.ts:1669
 msgid "How to fix it?"
 msgstr "How to fix it?"
 
-#: src/strings.ts:880
+#: src/strings.ts:881
 msgid "hr"
 msgstr "hr"
 
-#: src/strings.ts:2509
+#: src/strings.ts:2510
 msgid "I already have an account"
 msgstr "I already have an account"
 
@@ -3339,15 +3341,15 @@ msgstr "I don't have recovery codes"
 msgid "I have a recovery code"
 msgstr "I have a recovery code"
 
-#: src/strings.ts:1886
+#: src/strings.ts:1887
 msgid "I have saved my key"
 msgstr "I have saved my key"
 
-#: src/strings.ts:2435
+#: src/strings.ts:2436
 msgid "I love cooking and collecting recipes."
 msgstr "I love cooking and collecting recipes."
 
-#: src/strings.ts:2220
+#: src/strings.ts:2221
 msgid "I understand"
 msgstr "I understand"
 
@@ -3363,19 +3365,19 @@ msgstr "If the editor fails to load even after reloading. Try restarting the app
 msgid "If this continues to happen, please reach out to us via"
 msgstr "If this continues to happen, please reach out to us via"
 
-#: src/strings.ts:2123
+#: src/strings.ts:2124
 msgid "If true, Notesnook will automatically start up when you turn on & login to your system."
 msgstr "If true, Notesnook will automatically start up when you turn on & login to your system."
 
-#: src/strings.ts:2126
+#: src/strings.ts:2127
 msgid "If true, Notesnook will start minimized to either the system tray or your system taskbar/dock. This setting only works with Auto start on system startup is enabled."
 msgstr "If true, Notesnook will start minimized to either the system tray or your system taskbar/dock. This setting only works with Auto start on system startup is enabled."
 
-#: src/strings.ts:1724
+#: src/strings.ts:1725
 msgid "If you can't scan the QR code above, enter this text instead (spaces don't matter)"
 msgstr "If you can't scan the QR code above, enter this text instead (spaces don't matter)"
 
-#: src/strings.ts:1394
+#: src/strings.ts:1395
 msgid ""
 "If you didn't get an email from us or the confirmation link isn't\n"
 "            working,"
@@ -3383,11 +3385,11 @@ msgstr ""
 "If you didn't get an email from us or the confirmation link isn't\n"
 "            working,"
 
-#: src/strings.ts:1804
+#: src/strings.ts:1805
 msgid "If you don't have a recovery key, you can recover your data by restoring a Notesnook data backup file (.nnbackup)."
 msgstr "If you don't have a recovery key, you can recover your data by restoring a Notesnook data backup file (.nnbackup)."
 
-#: src/strings.ts:2087
+#: src/strings.ts:2088
 msgid "If you face any issue, you can reach out to us anytime."
 msgstr "If you face any issue, you can reach out to us anytime."
 
@@ -3395,23 +3397,23 @@ msgstr "If you face any issue, you can reach out to us anytime."
 msgid "If you want to ask something in general or need some assistance, we would suggest that you"
 msgstr "If you want to ask something in general or need some assistance, we would suggest that you"
 
-#: src/strings.ts:2346
+#: src/strings.ts:2347
 msgid "Image"
 msgstr "Image"
 
-#: src/strings.ts:1128
+#: src/strings.ts:1129
 msgid "Image Compression"
 msgstr "Image Compression"
 
-#: src/strings.ts:2322
+#: src/strings.ts:2323
 msgid "Image properties"
 msgstr "Image properties"
 
-#: src/strings.ts:2318
+#: src/strings.ts:2319
 msgid "Image settings"
 msgstr "Image settings"
 
-#: src/strings.ts:947
+#: src/strings.ts:948
 msgid "Image size should be less than {sizeInMB}"
 msgstr "Image size should be less than {sizeInMB}"
 
@@ -3423,23 +3425,23 @@ msgstr "Images"
 msgid "Images uploaded without compression are slow to load and take more bandwidth. We recommend compressing images unless you need image in original quality."
 msgstr "Images uploaded without compression are slow to load and take more bandwidth. We recommend compressing images unless you need image in original quality."
 
-#: src/strings.ts:1582
+#: src/strings.ts:1583
 msgid "Immediately"
 msgstr "Immediately"
 
-#: src/strings.ts:2150
+#: src/strings.ts:2151
 msgid "Import & export"
 msgstr "Import & export"
 
-#: src/strings.ts:1751
+#: src/strings.ts:1752
 msgid "Import completed"
 msgstr "Import completed"
 
-#: src/strings.ts:2648
+#: src/strings.ts:2649
 msgid "Import CSV"
 msgstr "Import CSV"
 
-#: src/strings.ts:1766
+#: src/strings.ts:1767
 msgid "import guide"
 msgstr "import guide"
 
@@ -3447,7 +3449,7 @@ msgstr "import guide"
 msgid "Incoming"
 msgstr "Incoming"
 
-#: src/strings.ts:1837
+#: src/strings.ts:1838
 msgid "Incoming note"
 msgstr "Incoming note"
 
@@ -3455,59 +3457,59 @@ msgstr "Incoming note"
 msgid "Incorrect {type}"
 msgstr "Incorrect {type}"
 
-#: src/strings.ts:2404
+#: src/strings.ts:2405
 msgid "Increase {title}"
 msgstr "Increase {title}"
 
-#: src/strings.ts:2246
+#: src/strings.ts:2247
 msgid "Insert"
 msgstr "Insert"
 
-#: src/strings.ts:2401
+#: src/strings.ts:2402
 msgid "Insert a {rows}x{columns} table"
 msgstr "Insert a {rows}x{columns} table"
 
-#: src/strings.ts:2351
+#: src/strings.ts:2352
 msgid "Insert a table"
 msgstr "Insert a table"
 
-#: src/strings.ts:2353
+#: src/strings.ts:2354
 msgid "Insert an embed"
 msgstr "Insert an embed"
 
-#: src/strings.ts:2347
+#: src/strings.ts:2348
 msgid "Insert an image"
 msgstr "Insert an image"
 
-#: src/strings.ts:2299
+#: src/strings.ts:2300
 msgid "Insert column left"
 msgstr "Insert column left"
 
-#: src/strings.ts:2300
+#: src/strings.ts:2301
 msgid "Insert column right"
 msgstr "Insert column right"
 
-#: src/strings.ts:2244
+#: src/strings.ts:2245
 msgid "Insert link"
 msgstr "Insert link"
 
-#: src/strings.ts:2306
+#: src/strings.ts:2307
 msgid "Insert row above"
 msgstr "Insert row above"
 
-#: src/strings.ts:2307
+#: src/strings.ts:2308
 msgid "Insert row below"
 msgstr "Insert row below"
 
-#: src/strings.ts:1684
+#: src/strings.ts:1685
 msgid "Install Notesnook"
 msgstr "Install Notesnook"
 
-#: src/strings.ts:2158
+#: src/strings.ts:2159
 msgid "Install update"
 msgstr "Install update"
 
-#: src/strings.ts:1719
+#: src/strings.ts:1720
 msgid "installs"
 msgstr "installs"
 
@@ -3515,15 +3517,15 @@ msgstr "installs"
 msgid "Invalid {type}"
 msgstr "Invalid {type}"
 
-#: src/strings.ts:1991
+#: src/strings.ts:1992
 msgid "Invalid CORS proxy url"
 msgstr "Invalid CORS proxy url"
 
-#: src/strings.ts:1482
+#: src/strings.ts:1483
 msgid "Invalid email"
 msgstr "Invalid email"
 
-#: src/strings.ts:2656
+#: src/strings.ts:2657
 msgid "Invalid recovery key. Make sure to input your account recovery key, not a 2FA recovery code."
 msgstr "Invalid recovery key. Make sure to input your account recovery key, not a 2FA recovery code."
 
@@ -3531,12 +3533,12 @@ msgstr "Invalid recovery key. Make sure to input your account recovery key, not 
 msgid "Issue created"
 msgstr "Issue created"
 
-#: src/strings.ts:990
-#: src/strings.ts:999
+#: src/strings.ts:991
+#: src/strings.ts:1000
 msgid "It may take a minute to receive your code."
 msgstr "It may take a minute to receive your code."
 
-#: src/strings.ts:1590
+#: src/strings.ts:1591
 msgid "It seems that your changes could not be saved. What to do next:"
 msgstr "It seems that your changes could not be saved. What to do next:"
 
@@ -3544,7 +3546,7 @@ msgstr "It seems that your changes could not be saved. What to do next:"
 msgid "It took us a year to bring Notesnook to life. Share your experience and suggestions to help us improve it."
 msgstr "It took us a year to bring Notesnook to life. Share your experience and suggestions to help us improve it."
 
-#: src/strings.ts:2268
+#: src/strings.ts:2269
 msgid "Italic"
 msgstr "Italic"
 
@@ -3557,7 +3559,7 @@ msgid "Item"
 msgstr "Item"
 
 #: src/strings.ts:311
-#: src/strings.ts:1703
+#: src/strings.ts:1704
 msgid "items"
 msgstr "items"
 
@@ -3565,7 +3567,7 @@ msgstr "items"
 msgid "Items"
 msgstr "Items"
 
-#: src/strings.ts:2170
+#: src/strings.ts:2171
 msgid "Join community"
 msgstr "Join community"
 
@@ -3573,27 +3575,27 @@ msgstr "Join community"
 msgid "join our community on Discord."
 msgstr "join our community on Discord."
 
-#: src/strings.ts:1280
+#: src/strings.ts:1281
 msgid "Join our Discord server"
 msgstr "Join our Discord server"
 
-#: src/strings.ts:1282
+#: src/strings.ts:1283
 msgid "Join our Discord server to chat with other users and the team"
 msgstr "Join our Discord server to chat with other users and the team"
 
-#: src/strings.ts:1272
+#: src/strings.ts:1273
 msgid "Join our Telegram group"
 msgstr "Join our Telegram group"
 
-#: src/strings.ts:1274
+#: src/strings.ts:1275
 msgid "Join our Telegram group to chat with other users and the team"
 msgstr "Join our Telegram group to chat with other users and the team"
 
-#: src/strings.ts:2078
+#: src/strings.ts:2079
 msgid "Join the cause"
 msgstr "Join the cause"
 
-#: src/strings.ts:2026
+#: src/strings.ts:2027
 msgid "Jump to group"
 msgstr "Jump to group"
 
@@ -3601,19 +3603,19 @@ msgstr "Jump to group"
 msgid "Keep"
 msgstr "Keep"
 
-#: src/strings.ts:2021
+#: src/strings.ts:2022
 msgid "Keep open"
 msgstr "Keep open"
 
-#: src/strings.ts:1359
+#: src/strings.ts:1360
 msgid "Keep your data safe"
 msgstr "Keep your data safe"
 
-#: src/strings.ts:2138
+#: src/strings.ts:2139
 msgid "Languages"
 msgstr "Languages"
 
-#: src/strings.ts:2241
+#: src/strings.ts:2242
 msgid "Last edited at"
 msgstr "Last edited at"
 
@@ -3633,7 +3635,7 @@ msgstr "Learn how this works."
 msgid "Learn more"
 msgstr "Learn more"
 
-#: src/strings.ts:977
+#: src/strings.ts:978
 msgid "Learn more about Monographs"
 msgstr "Learn more about Monographs"
 
@@ -3645,7 +3647,7 @@ msgstr "Learn more about Notesnook Monograph"
 msgid "Least relevant first"
 msgstr "Least relevant first"
 
-#: src/strings.ts:1562
+#: src/strings.ts:1563
 msgid "Legal"
 msgstr "Legal"
 
@@ -3653,15 +3655,15 @@ msgstr "Legal"
 msgid "Let us know if you have faced any issue/bug while using Notesnook. We will try to fix it as soon as possible."
 msgstr "Let us know if you have faced any issue/bug while using Notesnook. We will try to fix it as soon as possible."
 
-#: src/strings.ts:2171
+#: src/strings.ts:2172
 msgid "License"
 msgstr "License"
 
-#: src/strings.ts:1720
+#: src/strings.ts:1721
 msgid "Licensed under {license}"
 msgstr "Licensed under {license}"
 
-#: src/strings.ts:2337
+#: src/strings.ts:2338
 msgid "Lift list item"
 msgstr "Lift list item"
 
@@ -3669,39 +3671,39 @@ msgstr "Lift list item"
 msgid "Light"
 msgstr "Light"
 
-#: src/strings.ts:2367
+#: src/strings.ts:2368
 msgid "Line {line}, Column {column}"
 msgstr "Line {line}, Column {column}"
 
-#: src/strings.ts:2630
+#: src/strings.ts:2631
 msgid "Line height"
 msgstr "Line height"
 
-#: src/strings.ts:1152
+#: src/strings.ts:1153
 msgid "Line spacing changed"
 msgstr "Line spacing changed"
 
-#: src/strings.ts:2272
+#: src/strings.ts:2273
 msgid "Link"
 msgstr "Link"
 
-#: src/strings.ts:911
+#: src/strings.ts:912
 msgid "Link copied"
 msgstr "Link copied"
 
-#: src/strings.ts:929
+#: src/strings.ts:930
 msgid "Link notebooks"
 msgstr "Link notebooks"
 
-#: src/strings.ts:2486
+#: src/strings.ts:2487
 msgid "Link notes"
 msgstr "Link notes"
 
-#: src/strings.ts:2277
+#: src/strings.ts:2278
 msgid "Link settings"
 msgstr "Link settings"
 
-#: src/strings.ts:2397
+#: src/strings.ts:2398
 msgid "Link text"
 msgstr "Link text"
 
@@ -3713,7 +3715,7 @@ msgstr "LINK TO A SECTION"
 msgid "Link to note"
 msgstr "Link to note"
 
-#: src/strings.ts:851
+#: src/strings.ts:852
 msgid "Link to notebook"
 msgstr "Link to notebook"
 
@@ -3721,7 +3723,7 @@ msgstr "Link to notebook"
 msgid "Linked notes"
 msgstr "Linked notes"
 
-#: src/strings.ts:1596
+#: src/strings.ts:1597
 msgid "Linking to a specific block is not available for locked notes."
 msgstr "Linking to a specific block is not available for locked notes."
 
@@ -3733,7 +3735,7 @@ msgstr "List of"
 msgid "Load from file"
 msgstr "Load from file"
 
-#: src/strings.ts:1695
+#: src/strings.ts:1696
 msgid "Loading"
 msgstr "Loading"
 
@@ -3742,11 +3744,11 @@ msgstr "Loading"
 msgid "Loading {0}, please wait..."
 msgstr "Loading {0}, please wait..."
 
-#: src/strings.ts:1664
+#: src/strings.ts:1665
 msgid "Loading editor. Please wait..."
 msgstr "Loading editor. Please wait..."
 
-#: src/strings.ts:1064
+#: src/strings.ts:1065
 msgid "Loading subscription details"
 msgstr "Loading subscription details"
 
@@ -3754,35 +3756,35 @@ msgstr "Loading subscription details"
 msgid "Loading themes..."
 msgstr "Loading themes..."
 
-#: src/strings.ts:1327
+#: src/strings.ts:1328
 msgid "Loading trash"
 msgstr "Loading trash"
 
-#: src/strings.ts:973
+#: src/strings.ts:974
 msgid "Loading your archive"
 msgstr "Loading your archive"
 
-#: src/strings.ts:967
+#: src/strings.ts:968
 msgid "Loading your favorites"
 msgstr "Loading your favorites"
 
-#: src/strings.ts:972
+#: src/strings.ts:973
 msgid "Loading your monographs"
 msgstr "Loading your monographs"
 
-#: src/strings.ts:970
+#: src/strings.ts:971
 msgid "Loading your notebooks"
 msgstr "Loading your notebooks"
 
-#: src/strings.ts:968
+#: src/strings.ts:969
 msgid "Loading your notes"
 msgstr "Loading your notes"
 
-#: src/strings.ts:971
+#: src/strings.ts:972
 msgid "Loading your reminders"
 msgstr "Loading your reminders"
 
-#: src/strings.ts:969
+#: src/strings.ts:970
 msgid "Loading your tags"
 msgstr "Loading your tags"
 
@@ -3794,19 +3796,19 @@ msgstr "Lock"
 msgid "Lock note"
 msgstr "Lock note"
 
-#: src/strings.ts:1184
+#: src/strings.ts:1185
 msgid "Lock the app with a password or pin"
 msgstr "Lock the app with a password or pin"
 
-#: src/strings.ts:901
+#: src/strings.ts:902
 msgid "Locked notes cannot be pinned"
 msgstr "Locked notes cannot be pinned"
 
-#: src/strings.ts:904
+#: src/strings.ts:905
 msgid "Locked notes cannot be published"
 msgstr "Locked notes cannot be published"
 
-#: src/strings.ts:2203
+#: src/strings.ts:2204
 msgid "Log out from all other devices"
 msgstr "Log out from all other devices"
 
@@ -3814,7 +3816,7 @@ msgstr "Log out from all other devices"
 msgid "Logged in as {email}"
 msgstr "Logged in as {email}"
 
-#: src/strings.ts:1074
+#: src/strings.ts:1075
 msgid "Logging out will clear all data stored on THIS DEVICE. Make sure you have synced all your changes before logging out."
 msgstr "Logging out will clear all data stored on THIS DEVICE. Make sure you have synced all your changes before logging out."
 
@@ -3822,7 +3824,7 @@ msgstr "Logging out will clear all data stored on THIS DEVICE. Make sure you hav
 msgid "Logging out. Please wait..."
 msgstr "Logging out. Please wait..."
 
-#: src/strings.ts:1782
+#: src/strings.ts:1783
 msgid "Logging you in"
 msgstr "Logging you in"
 
@@ -3834,11 +3836,11 @@ msgstr "Login"
 msgid "Login failed"
 msgstr "Login failed"
 
-#: src/strings.ts:902
+#: src/strings.ts:903
 msgid "Login required"
 msgstr "Login required"
 
-#: src/strings.ts:2671
+#: src/strings.ts:2672
 msgid "Login required to restore attachments"
 msgstr "Login required to restore attachments"
 
@@ -3846,11 +3848,11 @@ msgstr "Login required to restore attachments"
 msgid "Login successful"
 msgstr "Login successful"
 
-#: src/strings.ts:1362
+#: src/strings.ts:1363
 msgid "Login to encrypt and sync notes"
 msgstr "Login to encrypt and sync notes"
 
-#: src/strings.ts:2623
+#: src/strings.ts:2624
 msgid "Login to upload attachments. [Read more](https://help.notesnook.com/faqs/login-to-upload-attachments)"
 msgstr "Login to upload attachments. [Read more](https://help.notesnook.com/faqs/login-to-upload-attachments)"
 
@@ -3870,19 +3872,19 @@ msgstr "Logout and clear data"
 msgid "Logout from this device"
 msgstr "Logout from this device"
 
-#: src/strings.ts:1412
+#: src/strings.ts:1413
 msgid "Long press on any item in list to enter multi-select mode."
 msgstr "Long press on any item in list to enter multi-select mode."
 
-#: src/strings.ts:2372
+#: src/strings.ts:2373
 msgid "Make task list readonly"
 msgstr "Make task list readonly"
 
-#: src/strings.ts:1038
+#: src/strings.ts:1039
 msgid "Manage account"
 msgstr "Manage account"
 
-#: src/strings.ts:1051
+#: src/strings.ts:1052
 msgid "Manage attachments"
 msgstr "Manage attachments"
 
@@ -3890,75 +3892,75 @@ msgstr "Manage attachments"
 msgid "Manage subscription on desktop"
 msgstr "Manage subscription on desktop"
 
-#: src/strings.ts:850
+#: src/strings.ts:851
 msgid "Manage tags"
 msgstr "Manage tags"
 
-#: src/strings.ts:1039
+#: src/strings.ts:1040
 msgid "Manage your account related settings here"
 msgstr "Manage your account related settings here"
 
-#: src/strings.ts:1052
+#: src/strings.ts:1053
 msgid "Manage your attachments in one place"
 msgstr "Manage your attachments in one place"
 
-#: src/strings.ts:1211
+#: src/strings.ts:1212
 msgid "Manage your backups and restore data"
 msgstr "Manage your backups and restore data"
 
-#: src/strings.ts:1245
+#: src/strings.ts:1246
 msgid "Manage your reminders"
 msgstr "Manage your reminders"
 
-#: src/strings.ts:1083
+#: src/strings.ts:1084
 msgid "Manage your sync settings here"
 msgstr "Manage your sync settings here"
 
-#: src/strings.ts:1440
+#: src/strings.ts:1441
 msgid "Mark important notes by adding them to favorites."
 msgstr "Mark important notes by adding them to favorites."
 
-#: src/strings.ts:1159
+#: src/strings.ts:1160
 msgid "Markdown shortcuts"
 msgstr "Markdown shortcuts"
 
-#: src/strings.ts:1165
+#: src/strings.ts:1166
 msgid "Marketing emails"
 msgstr "Marketing emails"
 
-#: src/strings.ts:2385
+#: src/strings.ts:2386
 msgid "Match case"
 msgstr "Match case"
 
-#: src/strings.ts:2386
+#: src/strings.ts:2387
 msgid "Match whole word"
 msgstr "Match whole word"
 
-#: src/strings.ts:2294
+#: src/strings.ts:2295
 msgid "Math (inline)"
 msgstr "Math (inline)"
 
-#: src/strings.ts:2344
+#: src/strings.ts:2345
 msgid "Math & formulas"
 msgstr "Math & formulas"
 
-#: src/strings.ts:2040
+#: src/strings.ts:2041
 msgid "Maximize"
 msgstr "Maximize"
 
-#: src/strings.ts:2080
+#: src/strings.ts:2081
 msgid "Meet other privacy-minded people & talk to us directly about your concerns, issues and suggestions."
 msgstr "Meet other privacy-minded people & talk to us directly about your concerns, issues and suggestions."
 
-#: src/strings.ts:2428
+#: src/strings.ts:2429
 msgid "Meetings"
 msgstr "Meetings"
 
-#: src/strings.ts:1779
+#: src/strings.ts:1780
 msgid "Member since {date}"
 msgstr "Member since {date}"
 
-#: src/strings.ts:2305
+#: src/strings.ts:2306
 msgid "Merge cells"
 msgstr "Merge cells"
 
@@ -3972,19 +3974,19 @@ msgstr "Migrating {0} {1}... please wait"
 msgid "Migration failed"
 msgstr "Migration failed"
 
-#: src/strings.ts:879
+#: src/strings.ts:880
 msgid "min"
 msgstr "min"
 
-#: src/strings.ts:2009
+#: src/strings.ts:2010
 msgid "Minimal"
 msgstr "Minimal"
 
-#: src/strings.ts:2039
+#: src/strings.ts:2040
 msgid "Minimize"
 msgstr "Minimize"
 
-#: src/strings.ts:2127
+#: src/strings.ts:2128
 msgid "Minimize to system tray"
 msgstr "Minimize to system tray"
 
@@ -4000,39 +4002,39 @@ msgstr "Mon"
 msgid "Monday"
 msgstr "Monday"
 
-#: src/strings.ts:1631
+#: src/strings.ts:1632
 msgid "Monograph server"
 msgstr "Monograph server"
 
-#: src/strings.ts:870
+#: src/strings.ts:871
 msgid "Monograph URL copied"
 msgstr "Monograph URL copied"
 
 #: src/strings.ts:322
-#: src/strings.ts:939
-#: src/strings.ts:1529
+#: src/strings.ts:940
+#: src/strings.ts:1530
 msgid "Monographs"
 msgstr "Monographs"
 
-#: src/strings.ts:1422
+#: src/strings.ts:1423
 msgid "Monographs can be encrypted with a secret key and shared with anyone."
 msgstr "Monographs can be encrypted with a secret key and shared with anyone."
 
-#: src/strings.ts:1417
+#: src/strings.ts:1418
 msgid "Monographs enable you to share your notes in a secure and private way."
 msgstr "Monographs enable you to share your notes in a secure and private way."
 
 #: src/strings.ts:665
-#: src/strings.ts:1840
+#: src/strings.ts:1841
 msgid "Month"
 msgstr "Month"
 
 #: src/strings.ts:169
-#: src/strings.ts:1570
+#: src/strings.ts:1571
 msgid "Monthly"
 msgstr "Monthly"
 
-#: src/strings.ts:2324
+#: src/strings.ts:2325
 msgid "More"
 msgstr "More"
 
@@ -4040,35 +4042,35 @@ msgstr "More"
 msgid "Most relevant first"
 msgstr "Most relevant first"
 
-#: src/strings.ts:852
+#: src/strings.ts:853
 msgid "Move"
 msgstr "Move"
 
-#: src/strings.ts:2373
+#: src/strings.ts:2374
 msgid "Move all checked tasks to bottom"
 msgstr "Move all checked tasks to bottom"
 
-#: src/strings.ts:2301
+#: src/strings.ts:2302
 msgid "Move column left"
 msgstr "Move column left"
 
-#: src/strings.ts:2302
+#: src/strings.ts:2303
 msgid "Move column right"
 msgstr "Move column right"
 
-#: src/strings.ts:936
+#: src/strings.ts:937
 msgid "Move notebook"
 msgstr "Move notebook"
 
-#: src/strings.ts:898
+#: src/strings.ts:899
 msgid "Move notes"
 msgstr "Move notes"
 
-#: src/strings.ts:2309
+#: src/strings.ts:2310
 msgid "Move row down"
 msgstr "Move row down"
 
-#: src/strings.ts:2308
+#: src/strings.ts:2309
 msgid "Move row up"
 msgstr "Move row up"
 
@@ -4080,27 +4082,27 @@ msgstr "Move selected notes"
 msgid "Move to top"
 msgstr "Move to top"
 
-#: src/strings.ts:855
+#: src/strings.ts:856
 msgid "Move to trash"
 msgstr "Move to trash"
 
-#: src/strings.ts:1172
+#: src/strings.ts:1173
 msgid "Multi-layer encryption to most important notes"
 msgstr "Multi-layer encryption to most important notes"
 
-#: src/strings.ts:887
+#: src/strings.ts:888
 msgid "Name"
 msgstr "Name"
 
-#: src/strings.ts:2669
+#: src/strings.ts:2670
 msgid "Name is required."
 msgstr "Name is required."
 
-#: src/strings.ts:1688
+#: src/strings.ts:1689
 msgid "Native high-performance encryption"
 msgstr "Native high-performance encryption"
 
-#: src/strings.ts:2453
+#: src/strings.ts:2454
 msgid "Navigate"
 msgstr "Navigate"
 
@@ -4108,11 +4110,11 @@ msgstr "Navigate"
 msgid "Never"
 msgstr "Never"
 
-#: src/strings.ts:1342
+#: src/strings.ts:1343
 msgid "Never ask again"
 msgstr "Never ask again"
 
-#: src/strings.ts:1037
+#: src/strings.ts:1038
 msgid "Never hesitate to choose privacy"
 msgstr "Never hesitate to choose privacy"
 
@@ -4128,11 +4130,11 @@ msgstr "New - old"
 msgid "New color"
 msgstr "New color"
 
-#: src/strings.ts:1846
+#: src/strings.ts:1847
 msgid "New Email"
 msgstr "New Email"
 
-#: src/strings.ts:1151
+#: src/strings.ts:1152
 msgid "New lines will be double spaced (old ones won't be affected)."
 msgstr "New lines will be double spaced (old ones won't be affected)."
 
@@ -4144,11 +4146,11 @@ msgstr "New note"
 msgid "New notebook"
 msgstr "New notebook"
 
-#: src/strings.ts:1480
+#: src/strings.ts:1481
 msgid "New password"
 msgstr "New password"
 
-#: src/strings.ts:1486
+#: src/strings.ts:1487
 msgid "New pin"
 msgstr "New pin"
 
@@ -4160,11 +4162,11 @@ msgstr "New reminder"
 msgid "New tab"
 msgstr "New tab"
 
-#: src/strings.ts:2459
+#: src/strings.ts:2460
 msgid "New tag"
 msgstr "New tag"
 
-#: src/strings.ts:1368
+#: src/strings.ts:1369
 msgid "New update available"
 msgstr "New update available"
 
@@ -4172,11 +4174,11 @@ msgstr "New update available"
 msgid "New version"
 msgstr "New version"
 
-#: src/strings.ts:2024
+#: src/strings.ts:2025
 msgid "Newest - oldest"
 msgstr "Newest - oldest"
 
-#: src/strings.ts:1140
+#: src/strings.ts:1141
 msgid "Newly created notes will be uncategorized"
 msgstr "Newly created notes will be uncategorized"
 
@@ -4184,11 +4186,11 @@ msgstr "Newly created notes will be uncategorized"
 msgid "Next"
 msgstr "Next"
 
-#: src/strings.ts:2389
+#: src/strings.ts:2390
 msgid "Next match"
 msgstr "Next match"
 
-#: src/strings.ts:2454
+#: src/strings.ts:2455
 msgid "Next tab"
 msgstr "Next tab"
 
@@ -4196,7 +4198,7 @@ msgstr "Next tab"
 msgid "No"
 msgstr "No"
 
-#: src/strings.ts:859
+#: src/strings.ts:860
 msgid "No application found to open {fileToOpen}"
 msgstr "No application found to open {fileToOpen}"
 
@@ -4216,7 +4218,7 @@ msgstr "No blocks linked"
 msgid "No color selected"
 msgstr "No color selected"
 
-#: src/strings.ts:1231
+#: src/strings.ts:1232
 msgid "No directory selected"
 msgstr "No directory selected"
 
@@ -4224,11 +4226,11 @@ msgstr "No directory selected"
 msgid "No downloads in progress."
 msgstr "No downloads in progress."
 
-#: src/strings.ts:1984
+#: src/strings.ts:1985
 msgid "No encryption key found"
 msgstr "No encryption key found"
 
-#: src/strings.ts:1665
+#: src/strings.ts:1666
 msgid "No headings found"
 msgstr "No headings found"
 
@@ -4244,7 +4246,7 @@ msgstr "No links found"
 msgid "No note history available for this device."
 msgstr "No note history available for this device."
 
-#: src/strings.ts:2503
+#: src/strings.ts:2504
 msgid "No notebooks selected to move"
 msgstr "No notebooks selected to move"
 
@@ -4252,7 +4254,7 @@ msgstr "No notebooks selected to move"
 msgid "No one can view this {type} except you."
 msgstr "No one can view this {type} except you."
 
-#: src/strings.ts:2626
+#: src/strings.ts:2627
 msgid "No password"
 msgstr "No password"
 
@@ -4260,7 +4262,7 @@ msgstr "No password"
 msgid "No references found of this note"
 msgstr "No references found of this note"
 
-#: src/strings.ts:1516
+#: src/strings.ts:1517
 msgid "No results found"
 msgstr "No results found"
 
@@ -4268,7 +4270,7 @@ msgstr "No results found"
 msgid "No results found for \"{query}\""
 msgstr "No results found for \"{query}\""
 
-#: src/strings.ts:1516
+#: src/strings.ts:1517
 msgid "No results found for {query}"
 msgstr "No results found for {query}"
 
@@ -4284,7 +4286,7 @@ msgstr "No updates available"
 msgid "None"
 msgstr "None"
 
-#: src/strings.ts:2014
+#: src/strings.ts:2015
 msgid "Normal mode"
 msgstr "Normal mode"
 
@@ -4305,9 +4307,13 @@ msgstr "Note"
 msgid "Note copied to clipboard"
 msgstr "Note copied to clipboard"
 
-#: src/strings.ts:1949
+#: src/strings.ts:1950
 msgid "Note does not exist"
 msgstr "Note does not exist"
+
+#: src/strings.ts:816
+msgid "Note duplicated"
+msgstr "Note duplicated"
 
 #: src/strings.ts:458
 msgid "Note history"
@@ -4317,11 +4323,11 @@ msgstr "Note history"
 msgid "Note locked"
 msgstr "Note locked"
 
-#: src/strings.ts:845
+#: src/strings.ts:846
 msgid "Note restored from history"
 msgstr "Note restored from history"
 
-#: src/strings.ts:1585
+#: src/strings.ts:1586
 msgid "Note title"
 msgstr "Note title"
 
@@ -4333,7 +4339,7 @@ msgstr "Note unlocked"
 msgid "Note version history is local only."
 msgstr "Note version history is local only."
 
-#: src/strings.ts:1224
+#: src/strings.ts:1225
 msgid "NOTE: Creating a backup with attachments can take a while, and also fail completely. The app will try to resume/restart the backup in case of interruptions."
 msgstr "NOTE: Creating a backup with attachments can take a while, and also fail completely. The app will try to resume/restart the backup in case of interruptions."
 
@@ -4342,11 +4348,11 @@ msgid "notebook"
 msgstr "notebook"
 
 #: src/strings.ts:296
-#: src/strings.ts:1520
+#: src/strings.ts:1521
 msgid "Notebook"
 msgstr "Notebook"
 
-#: src/strings.ts:2489
+#: src/strings.ts:2490
 msgid "Notebook added"
 msgstr "Notebook added"
 
@@ -4356,15 +4362,15 @@ msgstr "notebooks"
 
 #: src/strings.ts:258
 #: src/strings.ts:316
-#: src/strings.ts:1519
+#: src/strings.ts:1520
 msgid "Notebooks"
 msgstr "Notebooks"
 
-#: src/strings.ts:1794
+#: src/strings.ts:1795
 msgid "NOTEBOOKS"
 msgstr "NOTEBOOKS"
 
-#: src/strings.ts:2251
+#: src/strings.ts:2252
 msgid "Notebooks are the best way to organize your notes."
 msgstr "Notebooks are the best way to organize your notes."
 
@@ -4373,7 +4379,7 @@ msgid "notes"
 msgstr "notes"
 
 #: src/strings.ts:315
-#: src/strings.ts:1518
+#: src/strings.ts:1519
 msgid "Notes"
 msgstr "Notes"
 
@@ -4381,35 +4387,35 @@ msgstr "Notes"
 msgid "Notes exported as {path} successfully"
 msgstr "Notes exported as {path} successfully"
 
-#: src/strings.ts:1750
+#: src/strings.ts:1751
 msgid "notes imported"
 msgstr "notes imported"
 
-#: src/strings.ts:2553
+#: src/strings.ts:2554
 msgid "Notesnook"
 msgstr "Notesnook"
 
-#: src/strings.ts:2611
+#: src/strings.ts:2612
 msgid "Notesnook Circle"
 msgstr "Notesnook Circle"
 
-#: src/strings.ts:2613
+#: src/strings.ts:2614
 msgid "Notesnook Circle brings together trusted partners who share our commitment to privacy, transparency, and user freedom."
 msgstr "Notesnook Circle brings together trusted partners who share our commitment to privacy, transparency, and user freedom."
 
-#: src/strings.ts:2077
+#: src/strings.ts:2078
 msgid "Notesnook encrypts everything offline before syncing to your other devices. This means that no one can read your notes except you. Not even us."
 msgstr "Notesnook encrypts everything offline before syncing to your other devices. This means that no one can read your notes except you. Not even us."
 
-#: src/strings.ts:2152
+#: src/strings.ts:2153
 msgid "Notesnook Importer"
 msgstr "Notesnook Importer"
 
-#: src/strings.ts:1066
+#: src/strings.ts:1067
 msgid "Notesnook Pro"
 msgstr "Notesnook Pro"
 
-#: src/strings.ts:2184
+#: src/strings.ts:2185
 msgid ""
 "Notesnook uses the following DNS providers:\n"
 "\n"
@@ -4425,31 +4431,31 @@ msgstr ""
 "\n"
 "This can sometimes bypass local ISP blockages on Notesnook traffic. Disable this if you want the app to use system's DNS settings."
 
-#: src/strings.ts:987
+#: src/strings.ts:988
 msgid "Notesnook will send you a 2FA code on your email when prompted"
 msgstr "Notesnook will send you a 2FA code on your email when prompted"
 
-#: src/strings.ts:994
+#: src/strings.ts:995
 msgid "Notesnook will send you an SMS with a 2FA code when prompted"
 msgstr "Notesnook will send you an SMS with a 2FA code when prompted"
 
-#: src/strings.ts:2147
+#: src/strings.ts:2148
 msgid "Notifications"
 msgstr "Notifications"
 
-#: src/strings.ts:1377
+#: src/strings.ts:1378
 msgid "Notifications disabled"
 msgstr "Notifications disabled"
 
-#: src/strings.ts:2285
+#: src/strings.ts:2286
 msgid "Numbered list"
 msgstr "Numbered list"
 
-#: src/strings.ts:1718
+#: src/strings.ts:1719
 msgid "of"
 msgstr "of"
 
-#: src/strings.ts:1602
+#: src/strings.ts:1603
 msgid "Off"
 msgstr "Off"
 
@@ -4457,7 +4463,7 @@ msgstr "Off"
 msgid "Offline"
 msgstr "Offline"
 
-#: src/strings.ts:2237
+#: src/strings.ts:2238
 msgid "Okay"
 msgstr "Okay"
 
@@ -4465,11 +4471,11 @@ msgstr "Okay"
 msgid "Old - new"
 msgstr "Old - new"
 
-#: src/strings.ts:1835
+#: src/strings.ts:1836
 msgid "Older version"
 msgstr "Older version"
 
-#: src/strings.ts:2023
+#: src/strings.ts:2024
 msgid "Oldest - newest"
 msgstr "Oldest - newest"
 
@@ -4477,11 +4483,11 @@ msgstr "Oldest - newest"
 msgid "Once your password is changed, please make sure to save the new account recovery key"
 msgstr "Once your password is changed, please make sure to save the new account recovery key"
 
-#: src/strings.ts:2571
+#: src/strings.ts:2572
 msgid "One time purchase, no auto-renewal"
 msgstr "One time purchase, no auto-renewal"
 
-#: src/strings.ts:1771
+#: src/strings.ts:1772
 msgid "Only .zip files are supported."
 msgstr "Only .zip files are supported."
 
@@ -4497,11 +4503,11 @@ msgstr "Open file location"
 msgid "Open in browser"
 msgstr "Open in browser"
 
-#: src/strings.ts:1306
+#: src/strings.ts:1307
 msgid "Open in browser to manage subscription"
 msgstr "Open in browser to manage subscription"
 
-#: src/strings.ts:2335
+#: src/strings.ts:2336
 msgid "Open in new tab"
 msgstr "Open in new tab"
 
@@ -4509,43 +4515,43 @@ msgstr "Open in new tab"
 msgid "Open issue"
 msgstr "Open issue"
 
-#: src/strings.ts:2275
+#: src/strings.ts:2276
 msgid "Open link"
 msgstr "Open link"
 
-#: src/strings.ts:1863
+#: src/strings.ts:1864
 msgid "Open note"
 msgstr "Open note"
 
-#: src/strings.ts:1380
+#: src/strings.ts:1381
 msgid "Open settings"
 msgstr "Open settings"
 
-#: src/strings.ts:2336
+#: src/strings.ts:2337
 msgid "Open source"
 msgstr "Open source"
 
-#: src/strings.ts:1288
+#: src/strings.ts:1289
 msgid "Open source libraries used in Notesnook"
 msgstr "Open source libraries used in Notesnook"
 
-#: src/strings.ts:1287
+#: src/strings.ts:1288
 msgid "Open source licenses"
 msgstr "Open source licenses"
 
-#: src/strings.ts:819
+#: src/strings.ts:820
 msgid "Open source."
 msgstr "Open source."
 
-#: src/strings.ts:983
+#: src/strings.ts:984
 msgid "Open the two-factor authentication (TOTP) app to view your authentication code."
 msgstr "Open the two-factor authentication (TOTP) app to view your authentication code."
 
-#: src/strings.ts:2685
+#: src/strings.ts:2686
 msgid "Opening local file"
 msgstr "Opening local file"
 
-#: src/strings.ts:1857
+#: src/strings.ts:1858
 msgid "Optional"
 msgstr "Optional"
 
@@ -4553,11 +4559,11 @@ msgstr "Optional"
 msgid "or email us at"
 msgstr "or email us at"
 
-#: src/strings.ts:2022
+#: src/strings.ts:2023
 msgid "Order by"
 msgstr "Order by"
 
-#: src/strings.ts:2230
+#: src/strings.ts:2231
 msgid "Order ID"
 msgstr "Order ID"
 
@@ -4566,23 +4572,23 @@ msgstr "Order ID"
 msgid "Orphaned"
 msgstr "Orphaned"
 
-#: src/strings.ts:2155
+#: src/strings.ts:2156
 msgid "Other"
 msgstr "Other"
 
-#: src/strings.ts:2356
+#: src/strings.ts:2357
 msgid "Outline list"
 msgstr "Outline list"
 
-#: src/strings.ts:2359
+#: src/strings.ts:2360
 msgid "Paragraph"
 msgstr "Paragraph"
 
-#: src/strings.ts:2502
+#: src/strings.ts:2503
 msgid "Paragraphs"
 msgstr "Paragraphs"
 
-#: src/strings.ts:2111
+#: src/strings.ts:2112
 msgid "Partial backups contain all your data except attachments. They are created from data already available on your device and do not require an Internet connection."
 msgstr "Partial backups contain all your data except attachments. They are created from data already available on your device and do not require an Internet connection."
 
@@ -4590,11 +4596,11 @@ msgstr "Partial backups contain all your data except attachments. They are creat
 msgid "Partially refunded"
 msgstr "Partially refunded"
 
-#: src/strings.ts:2413
+#: src/strings.ts:2414
 msgid "Passed"
 msgstr "Passed"
 
-#: src/strings.ts:883
+#: src/strings.ts:884
 msgid "Password"
 msgstr "Password"
 
@@ -4622,7 +4628,7 @@ msgstr "Password not entered"
 msgid "Password protection"
 msgstr "Password protection"
 
-#: src/strings.ts:2660
+#: src/strings.ts:2661
 msgid "Password required"
 msgstr "Password required"
 
@@ -4630,35 +4636,35 @@ msgstr "Password required"
 msgid "Password updated"
 msgstr "Password updated"
 
-#: src/strings.ts:2091
+#: src/strings.ts:2092
 msgid "Password/pin"
 msgstr "Password/pin"
 
-#: src/strings.ts:2259
+#: src/strings.ts:2260
 msgid "Paste"
 msgstr "Paste"
 
-#: src/strings.ts:2260
+#: src/strings.ts:2261
 msgid "Paste and match style"
 msgstr "Paste and match style"
 
-#: src/strings.ts:2381
+#: src/strings.ts:2382
 msgid "Paste embed code here. Only iframes are supported."
 msgstr "Paste embed code here. Only iframes are supported."
 
-#: src/strings.ts:2396
+#: src/strings.ts:2397
 msgid "Paste image URL here"
 msgstr "Paste image URL here"
 
-#: src/strings.ts:2261
+#: src/strings.ts:2262
 msgid "Paste without formatting"
 msgstr "Paste without formatting"
 
-#: src/strings.ts:2572
+#: src/strings.ts:2573
 msgid "Pay once and use for 5 years"
 msgstr "Pay once and use for 5 years"
 
-#: src/strings.ts:2209
+#: src/strings.ts:2210
 msgid "Payment method"
 msgstr "Payment method"
 
@@ -4666,27 +4672,27 @@ msgstr "Payment method"
 msgid "PDF is password protected"
 msgstr "PDF is password protected"
 
-#: src/strings.ts:1729
+#: src/strings.ts:1730
 msgid "phone number"
 msgstr "phone number"
 
-#: src/strings.ts:1848
+#: src/strings.ts:1849
 msgid "Phone number"
 msgstr "Phone number"
 
-#: src/strings.ts:1007
+#: src/strings.ts:1008
 msgid "Phone number not entered"
 msgstr "Phone number not entered"
 
-#: src/strings.ts:900
+#: src/strings.ts:901
 msgid "Pin"
 msgstr "Pin"
 
-#: src/strings.ts:1690
+#: src/strings.ts:1691
 msgid "Pin notes in notifications drawer"
 msgstr "Pin notes in notifications drawer"
 
-#: src/strings.ts:928
+#: src/strings.ts:929
 msgid "Pin notification"
 msgstr "Pin notification"
 
@@ -4694,66 +4700,66 @@ msgstr "Pin notification"
 msgid "Pinned"
 msgstr "Pinned"
 
-#: src/strings.ts:2593
+#: src/strings.ts:2594
 msgid "Plan limits"
 msgstr "Plan limits"
 
-#: src/strings.ts:2553
+#: src/strings.ts:2554
 msgid "Plans"
 msgstr "Plans"
 
-#: src/strings.ts:1364
+#: src/strings.ts:1365
 msgid "Please confirm your email to sync notes"
 msgstr "Please confirm your email to sync notes"
 
-#: src/strings.ts:1002
+#: src/strings.ts:1003
 msgid "Please confirm your identity by entering a recovery code."
 msgstr "Please confirm your identity by entering a recovery code."
 
-#: src/strings.ts:981
-#: src/strings.ts:2243
+#: src/strings.ts:982
+#: src/strings.ts:2244
 msgid "Please confirm your identity by entering the authentication code from your authenticator app."
 msgstr "Please confirm your identity by entering the authentication code from your authenticator app."
 
 #. placeholder {0}: phoneNumber ? phoneNumber : "your registered phone number."
-#: src/strings.ts:996
+#: src/strings.ts:997
 msgid "Please confirm your identity by entering the authentication code sent to {0}."
 msgstr "Please confirm your identity by entering the authentication code sent to {0}."
 
-#: src/strings.ts:989
+#: src/strings.ts:990
 msgid "Please confirm your identity by entering the authentication code sent to your email address."
 msgstr "Please confirm your identity by entering the authentication code sent to your email address."
 
-#: src/strings.ts:1909
+#: src/strings.ts:1910
 msgid "Please download a backup of your data as your account will be cleared before recovery."
 msgstr "Please download a backup of your data as your account will be cleared before recovery."
 
-#: src/strings.ts:2007
+#: src/strings.ts:2008
 msgid "Please enable automatic backups to avoid losing important data."
 msgstr "Please enable automatic backups to avoid losing important data."
 
-#: src/strings.ts:1512
-#: src/strings.ts:2662
+#: src/strings.ts:1513
+#: src/strings.ts:2663
 msgid "Please enter a valid email address"
 msgstr "Please enter a valid email address"
 
-#: src/strings.ts:1954
+#: src/strings.ts:1955
 msgid "Please enter a valid hex color (e.g. #ffffff)"
 msgstr "Please enter a valid hex color (e.g. #ffffff)"
 
-#: src/strings.ts:1513
+#: src/strings.ts:1514
 msgid "Please enter a valid phone number with country code"
 msgstr "Please enter a valid phone number with country code"
 
-#: src/strings.ts:1635
+#: src/strings.ts:1636
 msgid "Please enter a valid URL"
 msgstr "Please enter a valid URL"
 
-#: src/strings.ts:1620
+#: src/strings.ts:1621
 msgid "Please enter password of this backup file"
 msgstr "Please enter password of this backup file"
 
-#: src/strings.ts:2254
+#: src/strings.ts:2255
 msgid "Please enter the password to decrypt and restore this backup."
 msgstr "Please enter the password to decrypt and restore this backup."
 
@@ -4761,27 +4767,27 @@ msgstr "Please enter the password to decrypt and restore this backup."
 msgid "Please enter the password to unlock the PDF and view the content."
 msgstr "Please enter the password to unlock the PDF and view the content."
 
-#: src/strings.ts:1865
+#: src/strings.ts:1866
 msgid "Please enter the password to unlock this note"
 msgstr "Please enter the password to unlock this note"
 
-#: src/strings.ts:1862
+#: src/strings.ts:1863
 msgid "Please enter the password to view this version"
 msgstr "Please enter the password to view this version"
 
-#: src/strings.ts:1021
+#: src/strings.ts:1022
 msgid "Please enter your app lock password to continue"
 msgstr "Please enter your app lock password to continue"
 
-#: src/strings.ts:1023
+#: src/strings.ts:1024
 msgid "Please enter your app lock pin to continue"
 msgstr "Please enter your app lock pin to continue"
 
-#: src/strings.ts:1017
+#: src/strings.ts:1018
 msgid "Please enter your password to continue"
 msgstr "Please enter your password to continue"
 
-#: src/strings.ts:1933
+#: src/strings.ts:1934
 msgid "Please enter your vault password to continue"
 msgstr "Please enter your vault password to continue"
 
@@ -4789,15 +4795,15 @@ msgstr "Please enter your vault password to continue"
 msgid "Please fill all the fields to continue."
 msgstr "Please fill all the fields to continue."
 
-#: src/strings.ts:1556
+#: src/strings.ts:1557
 msgid "Please grant notifications permission to add new reminders."
 msgstr "Please grant notifications permission to add new reminders."
 
-#: src/strings.ts:2677
+#: src/strings.ts:2678
 msgid "Please login to download attachments."
 msgstr "Please login to download attachments."
 
-#: src/strings.ts:873
+#: src/strings.ts:874
 msgid "Please make sure you have saved the recovery key. Tap one more time to confirm."
 msgstr "Please make sure you have saved the recovery key. Tap one more time to confirm."
 
@@ -4805,27 +4811,27 @@ msgstr "Please make sure you have saved the recovery key. Tap one more time to c
 msgid "Please note that we will respond to your issue on the given link. We recommend that you save it."
 msgstr "Please note that we will respond to your issue on the given link. We recommend that you save it."
 
-#: src/strings.ts:1765
+#: src/strings.ts:1766
 msgid "Please refer to the"
 msgstr "Please refer to the"
 
-#: src/strings.ts:1557
+#: src/strings.ts:1558
 msgid "Please select the day to repeat the reminder on"
 msgstr "Please select the day to repeat the reminder on"
 
-#: src/strings.ts:1396
+#: src/strings.ts:1397
 msgid "please send us an email from your registered email address"
 msgstr "please send us an email from your registered email address"
 
-#: src/strings.ts:2402
+#: src/strings.ts:2403
 msgid "Please set a table size"
 msgstr "Please set a table size"
 
-#: src/strings.ts:1558
+#: src/strings.ts:1559
 msgid "Please set title of the reminder"
 msgstr "Please set title of the reminder"
 
-#: src/strings.ts:1987
+#: src/strings.ts:1988
 msgid "Please try again"
 msgstr "Please try again"
 
@@ -4837,16 +4843,16 @@ msgstr "Please verify it's you"
 msgid "Please wait"
 msgstr "Please wait"
 
-#: src/strings.ts:1006
+#: src/strings.ts:1007
 msgid "Please wait before requesting a new code"
 msgstr "Please wait before requesting a new code"
 
-#: src/strings.ts:1399
-#: src/strings.ts:1551
+#: src/strings.ts:1400
+#: src/strings.ts:1552
 msgid "Please wait before requesting another email"
 msgstr "Please wait before requesting another email"
 
-#: src/strings.ts:942
+#: src/strings.ts:943
 msgid "Please wait while we encrypt {name} for upload."
 msgstr "Please wait while we encrypt {name} for upload."
 
@@ -4858,11 +4864,11 @@ msgstr "Please wait while we export your not."
 msgid "Please wait while we export your notes."
 msgstr "Please wait while we export your notes."
 
-#: src/strings.ts:1894
+#: src/strings.ts:1895
 msgid "Please wait while we finalize your account."
 msgstr "Please wait while we finalize your account."
 
-#: src/strings.ts:1065
+#: src/strings.ts:1066
 msgid "Please wait while we load your subscription"
 msgstr "Please wait while we load your subscription"
 
@@ -4870,15 +4876,15 @@ msgstr "Please wait while we load your subscription"
 msgid "Please wait while we log you out."
 msgstr "Please wait while we log you out."
 
-#: src/strings.ts:1915
+#: src/strings.ts:1916
 msgid "Please wait while we reset your account password."
 msgstr "Please wait while we reset your account password."
 
-#: src/strings.ts:1613
+#: src/strings.ts:1614
 msgid "Please wait while we restore your backup..."
 msgstr "Please wait while we restore your backup..."
 
-#: src/strings.ts:1897
+#: src/strings.ts:1898
 msgid "Please wait while we send you recovery instructions"
 msgstr "Please wait while we send you recovery instructions"
 
@@ -4886,24 +4892,24 @@ msgstr "Please wait while we send you recovery instructions"
 msgid "Please wait while we sync all your data."
 msgstr "Please wait while we sync all your data."
 
-#: src/strings.ts:1071
+#: src/strings.ts:1072
 msgid "Please wait while we verify your subscription"
 msgstr "Please wait while we verify your subscription"
 
-#: src/strings.ts:1783
-#: src/strings.ts:1890
+#: src/strings.ts:1784
+#: src/strings.ts:1891
 msgid "Please wait while you are authenticated."
 msgstr "Please wait while you are authenticated."
 
-#: src/strings.ts:1902
+#: src/strings.ts:1903
 msgid "Please wait while your data is downloaded & decrypted."
 msgstr "Please wait while your data is downloaded & decrypted."
 
-#: src/strings.ts:905
+#: src/strings.ts:906
 msgid "Preparing note for share"
 msgstr "Preparing note for share"
 
-#: src/strings.ts:1615
+#: src/strings.ts:1616
 msgid "Preparing to restore backup file..."
 msgstr "Preparing to restore backup file..."
 
@@ -4911,19 +4917,19 @@ msgstr "Preparing to restore backup file..."
 msgid "PRESETS"
 msgstr "PRESETS"
 
-#: src/strings.ts:2129
+#: src/strings.ts:2130
 msgid "Pressing \"—\" will hide the app in your system tray."
 msgstr "Pressing \"—\" will hide the app in your system tray."
 
-#: src/strings.ts:2132
+#: src/strings.ts:2133
 msgid "Pressing \"X\" will hide the app in your system tray."
 msgstr "Pressing \"X\" will hide the app in your system tray."
 
-#: src/strings.ts:2180
+#: src/strings.ts:2181
 msgid "Prevent note title from appearing in tab/window title."
 msgstr "Prevent note title from appearing in tab/window title."
 
-#: src/strings.ts:2323
+#: src/strings.ts:2324
 msgid "Preview attachment"
 msgstr "Preview attachment"
 
@@ -4931,43 +4937,43 @@ msgstr "Preview attachment"
 msgid "Preview not available, content is encrypted."
 msgstr "Preview not available, content is encrypted."
 
-#: src/strings.ts:2390
+#: src/strings.ts:2391
 msgid "Previous match"
 msgstr "Previous match"
 
-#: src/strings.ts:2455
+#: src/strings.ts:2456
 msgid "Previous tab"
 msgstr "Previous tab"
 
-#: src/strings.ts:2034
+#: src/strings.ts:2035
 msgid "Print"
 msgstr "Print"
 
-#: src/strings.ts:2154
+#: src/strings.ts:2155
 msgid "Privacy"
 msgstr "Privacy"
 
-#: src/strings.ts:1161
+#: src/strings.ts:1162
 msgid "Privacy & security"
 msgstr "Privacy & security"
 
-#: src/strings.ts:1655
+#: src/strings.ts:1656
 msgid "Privacy comes first."
 msgstr "Privacy comes first."
 
-#: src/strings.ts:827
+#: src/strings.ts:828
 msgid "Privacy for everyone"
 msgstr "Privacy for everyone"
 
-#: src/strings.ts:1180
+#: src/strings.ts:1181
 msgid "Privacy mode"
 msgstr "Privacy mode"
 
-#: src/strings.ts:2588
+#: src/strings.ts:2589
 msgid "privacy policy"
 msgstr "privacy policy"
 
-#: src/strings.ts:1285
+#: src/strings.ts:1286
 msgid "Privacy policy"
 msgstr "Privacy policy"
 
@@ -4979,43 +4985,43 @@ msgstr "Privacy Policy. "
 msgid "private analytics and bug reports."
 msgstr "private analytics and bug reports."
 
-#: src/strings.ts:821
+#: src/strings.ts:822
 msgid "Private."
 msgstr "Private."
 
-#: src/strings.ts:829
+#: src/strings.ts:830
 msgid "privileged few"
 msgstr "privileged few"
 
-#: src/strings.ts:1721
+#: src/strings.ts:1722
 msgid "Pro"
 msgstr "Pro"
 
-#: src/strings.ts:2480
+#: src/strings.ts:2481
 msgid "Pro plan"
 msgstr "Pro plan"
 
-#: src/strings.ts:2047
+#: src/strings.ts:2048
 msgid "Processing {collection}..."
 msgstr "Processing {collection}..."
 
-#: src/strings.ts:2046
+#: src/strings.ts:2047
 msgid "Processing..."
 msgstr "Processing..."
 
-#: src/strings.ts:1240
+#: src/strings.ts:1241
 msgid "Productivity"
 msgstr "Productivity"
 
-#: src/strings.ts:2143
+#: src/strings.ts:2144
 msgid "Profile"
 msgstr "Profile"
 
-#: src/strings.ts:1955
+#: src/strings.ts:1956
 msgid "Profile updated"
 msgstr "Profile updated"
 
-#: src/strings.ts:1866
+#: src/strings.ts:1867
 msgid "Properties"
 msgstr "Properties"
 
@@ -5023,7 +5029,7 @@ msgstr "Properties"
 msgid "Protect your notes"
 msgstr "Protect your notes"
 
-#: src/strings.ts:2191
+#: src/strings.ts:2192
 msgid "Proxy"
 msgstr "Proxy"
 
@@ -5035,7 +5041,7 @@ msgstr "Publish"
 msgid "Publish note"
 msgstr "Publish note"
 
-#: src/strings.ts:2627
+#: src/strings.ts:2628
 msgid "Publish to the web"
 msgstr "Publish to the web"
 
@@ -5043,7 +5049,7 @@ msgstr "Publish to the web"
 msgid "Publish your note to share it with others. You can set a password to protect it."
 msgstr "Publish your note to share it with others. You can set a password to protect it."
 
-#: src/strings.ts:926
+#: src/strings.ts:927
 msgid "Published"
 msgstr "Published"
 
@@ -5059,39 +5065,39 @@ msgstr "Published note can only be viewed by someone with the password."
 msgid "Published note link will be automatically deleted once it is viewed by someone."
 msgstr "Published note link will be automatically deleted once it is viewed by someone."
 
-#: src/strings.ts:2581
+#: src/strings.ts:2582
 msgid "Purchase"
 msgstr "Purchase"
 
-#: src/strings.ts:1371
+#: src/strings.ts:1372
 msgid "Quick note"
 msgstr "Quick note"
 
-#: src/strings.ts:1241
+#: src/strings.ts:1242
 msgid "Quick note notification"
 msgstr "Quick note notification"
 
-#: src/strings.ts:1692
+#: src/strings.ts:1693
 msgid "Quick note widgets"
 msgstr "Quick note widgets"
 
-#: src/strings.ts:2451
+#: src/strings.ts:2452
 msgid "Quick open"
 msgstr "Quick open"
 
-#: src/strings.ts:1243
+#: src/strings.ts:1244
 msgid "Quickly create a note from the notification"
 msgstr "Quickly create a note from the notification"
 
-#: src/strings.ts:2343
+#: src/strings.ts:2344
 msgid "Quote"
 msgstr "Quote"
 
-#: src/strings.ts:1357
+#: src/strings.ts:1358
 msgid "Rate Notesnook on App Store"
 msgstr "Rate Notesnook on App Store"
 
-#: src/strings.ts:1358
+#: src/strings.ts:1359
 msgid "Rate Notesnook on Play Store"
 msgstr "Rate Notesnook on Play Store"
 
@@ -5103,51 +5109,51 @@ msgstr "Rate now (It takes only a second)"
 msgid "Read full release notes on Github"
 msgstr "Read full release notes on Github"
 
-#: src/strings.ts:912
+#: src/strings.ts:913
 msgid "Read only"
 msgstr "Read only"
 
-#: src/strings.ts:1265
+#: src/strings.ts:1266
 msgid "Read the documentation to learn more about Notesnook"
 msgstr "Read the documentation to learn more about Notesnook"
 
-#: src/strings.ts:1286
+#: src/strings.ts:1287
 msgid "Read the privacy policy"
 msgstr "Read the privacy policy"
 
-#: src/strings.ts:1284
+#: src/strings.ts:1285
 msgid "Read the terms of service"
 msgstr "Read the terms of service"
 
-#: src/strings.ts:1616
+#: src/strings.ts:1617
 msgid "Reading backup file..."
 msgstr "Reading backup file..."
 
-#: src/strings.ts:2555
+#: src/strings.ts:2556
 msgid "Ready to take the next step on your private note taking journey?"
 msgstr "Ready to take the next step on your private note taking journey?"
 
-#: src/strings.ts:2233
+#: src/strings.ts:2234
 msgid "Receipt"
 msgstr "Receipt"
 
-#: src/strings.ts:1611
+#: src/strings.ts:1612
 msgid "RECENT BACKUPS"
 msgstr "RECENT BACKUPS"
 
-#: src/strings.ts:2466
+#: src/strings.ts:2467
 msgid "Recents"
 msgstr "Recents"
 
-#: src/strings.ts:2409
+#: src/strings.ts:2410
 msgid "Recheck all"
 msgstr "Recheck all"
 
-#: src/strings.ts:2001
+#: src/strings.ts:2002
 msgid "Rechecking failed"
 msgstr "Rechecking failed"
 
-#: src/strings.ts:2434
+#: src/strings.ts:2435
 msgid "Recipes"
 msgstr "Recipes"
 
@@ -5155,7 +5161,7 @@ msgstr "Recipes"
 msgid "Recommended"
 msgstr "Recommended"
 
-#: src/strings.ts:2557
+#: src/strings.ts:2558
 msgid "Recommended by Privacy Guides"
 msgstr "Recommended by Privacy Guides"
 
@@ -5163,11 +5169,11 @@ msgstr "Recommended by Privacy Guides"
 msgid "Recover your account"
 msgstr "Recover your account"
 
-#: src/strings.ts:1005
+#: src/strings.ts:1006
 msgid "Recovery codes copied!"
 msgstr "Recovery codes copied!"
 
-#: src/strings.ts:1010
+#: src/strings.ts:1011
 msgid "Recovery codes saved!"
 msgstr "Recovery codes saved!"
 
@@ -5179,35 +5185,35 @@ msgstr "Recovery email has been sent to your email address. Please check your in
 msgid "Recovery email sent!"
 msgstr "Recovery email sent!"
 
-#: src/strings.ts:876
+#: src/strings.ts:877
 msgid "Recovery key copied"
 msgstr "Recovery key copied"
 
-#: src/strings.ts:874
+#: src/strings.ts:875
 msgid "Recovery key QR code saved"
 msgstr "Recovery key QR code saved"
 
-#: src/strings.ts:875
+#: src/strings.ts:876
 msgid "Recovery key text file saved"
 msgstr "Recovery key text file saved"
 
-#: src/strings.ts:1916
+#: src/strings.ts:1917
 msgid "Recovery successful!"
 msgstr "Recovery successful!"
 
-#: src/strings.ts:2446
+#: src/strings.ts:2447
 msgid "Redeem"
 msgstr "Redeem"
 
-#: src/strings.ts:2610
+#: src/strings.ts:2611
 msgid "Redeem code"
 msgstr "Redeem code"
 
-#: src/strings.ts:2443
+#: src/strings.ts:2444
 msgid "Redeem gift code"
 msgstr "Redeem gift code"
 
-#: src/strings.ts:2445
+#: src/strings.ts:2446
 msgid "Redeeming gift code"
 msgstr "Redeeming gift code"
 
@@ -5219,7 +5225,7 @@ msgstr "Redo"
 msgid "Referenced in"
 msgstr "Referenced in"
 
-#: src/strings.ts:935
+#: src/strings.ts:936
 msgid "References"
 msgstr "References"
 
@@ -5227,7 +5233,7 @@ msgstr "References"
 msgid "Regenerate"
 msgstr "Regenerate"
 
-#: src/strings.ts:2097
+#: src/strings.ts:2098
 msgid "Register"
 msgstr "Register"
 
@@ -5235,7 +5241,7 @@ msgstr "Register"
 msgid "Release notes"
 msgstr "Release notes"
 
-#: src/strings.ts:2468
+#: src/strings.ts:2469
 msgid "Release track"
 msgstr "Release track"
 
@@ -5243,19 +5249,19 @@ msgstr "Release track"
 msgid "Relevance"
 msgstr "Relevance"
 
-#: src/strings.ts:1670
+#: src/strings.ts:1671
 msgid "Reload app"
 msgstr "Reload app"
 
-#: src/strings.ts:1828
+#: src/strings.ts:1829
 msgid "Relogin to your account"
 msgstr "Relogin to your account"
 
-#: src/strings.ts:1796
+#: src/strings.ts:1797
 msgid "Remembered your password?"
 msgstr "Remembered your password?"
 
-#: src/strings.ts:925
+#: src/strings.ts:926
 msgid "Remind me"
 msgstr "Remind me"
 
@@ -5263,7 +5269,7 @@ msgstr "Remind me"
 msgid "Remind me in"
 msgstr "Remind me in"
 
-#: src/strings.ts:1506
+#: src/strings.ts:1507
 msgid "Remind me of..."
 msgstr "Remind me of..."
 
@@ -5275,11 +5281,11 @@ msgstr "reminder"
 msgid "Reminder"
 msgstr "Reminder"
 
-#: src/strings.ts:1246
+#: src/strings.ts:1247
 msgid "Reminder notifications"
 msgstr "Reminder notifications"
 
-#: src/strings.ts:1559
+#: src/strings.ts:1560
 msgid "Reminder time cannot be earlier than the current time."
 msgstr "Reminder time cannot be earlier than the current time."
 
@@ -5288,16 +5294,16 @@ msgid "reminders"
 msgstr "reminders"
 
 #: src/strings.ts:318
-#: src/strings.ts:1244
-#: src/strings.ts:1522
+#: src/strings.ts:1245
+#: src/strings.ts:1523
 msgid "Reminders"
 msgstr "Reminders"
 
-#: src/strings.ts:1379
+#: src/strings.ts:1380
 msgid "Reminders cannot be set because notifications have been disabled from app settings. If you want to keep receiving reminder notifications, enable notifications for Notesnook from app settings."
 msgstr "Reminders cannot be set because notifications have been disabled from app settings. If you want to keep receiving reminder notifications, enable notifications for Notesnook from app settings."
 
-#: src/strings.ts:1953
+#: src/strings.ts:1954
 msgid "Reminders will not be active on this device as it does not support notifications."
 msgstr "Reminders will not be active on this device as it does not support notifications."
 
@@ -5305,63 +5311,63 @@ msgstr "Reminders will not be active on this device as it does not support notif
 msgid "Remove"
 msgstr "Remove"
 
-#: src/strings.ts:1175
+#: src/strings.ts:1176
 msgid "Remove all notes from the vault."
 msgstr "Remove all notes from the vault."
 
-#: src/strings.ts:1202
+#: src/strings.ts:1203
 msgid "Remove app lock password"
 msgstr "Remove app lock password"
 
-#: src/strings.ts:1206
+#: src/strings.ts:1207
 msgid "Remove app lock password, app lock will be disabled if no other security method is enabled."
 msgstr "Remove app lock password, app lock will be disabled if no other security method is enabled."
 
-#: src/strings.ts:1201
+#: src/strings.ts:1202
 msgid "Remove app lock pin"
 msgstr "Remove app lock pin"
 
-#: src/strings.ts:1204
+#: src/strings.ts:1205
 msgid "Remove app lock pin, app lock will be disabled if no other security method is enabled."
 msgstr "Remove app lock pin, app lock will be disabled if no other security method is enabled."
 
-#: src/strings.ts:896
+#: src/strings.ts:897
 msgid "Remove as default"
 msgstr "Remove as default"
 
-#: src/strings.ts:2327
+#: src/strings.ts:2328
 msgid "Remove attachment"
 msgstr "Remove attachment"
 
-#: src/strings.ts:931
+#: src/strings.ts:932
 msgid "Remove from all"
 msgstr "Remove from all"
 
-#: src/strings.ts:906
+#: src/strings.ts:907
 msgid "Remove from notebook"
 msgstr "Remove from notebook"
 
-#: src/strings.ts:2467
+#: src/strings.ts:2468
 msgid "Remove from recents"
 msgstr "Remove from recents"
 
-#: src/strings.ts:1044
+#: src/strings.ts:1045
 msgid "Remove full name"
 msgstr "Remove full name"
 
-#: src/strings.ts:2274
+#: src/strings.ts:2275
 msgid "Remove link"
 msgstr "Remove link"
 
-#: src/strings.ts:1040
+#: src/strings.ts:1041
 msgid "Remove profile picture"
 msgstr "Remove profile picture"
 
-#: src/strings.ts:1047
+#: src/strings.ts:1048
 msgid "Remove your full name from profile"
 msgstr "Remove your full name from profile"
 
-#: src/strings.ts:1041
+#: src/strings.ts:1042
 msgid "Remove your profile picture"
 msgstr "Remove your profile picture"
 
@@ -5373,7 +5379,7 @@ msgstr "Rename"
 msgid "Rename file"
 msgstr "Rename file"
 
-#: src/strings.ts:891
+#: src/strings.ts:892
 msgid "Reorder"
 msgstr "Reorder"
 
@@ -5381,19 +5387,19 @@ msgstr "Reorder"
 msgid "Repeats daily at {date}"
 msgstr "Repeats daily at {date}"
 
-#: src/strings.ts:2387
+#: src/strings.ts:2388
 msgid "Replace"
 msgstr "Replace"
 
-#: src/strings.ts:2388
+#: src/strings.ts:2389
 msgid "Replace all"
 msgstr "Replace all"
 
-#: src/strings.ts:2174
+#: src/strings.ts:2175
 msgid "Report"
 msgstr "Report"
 
-#: src/strings.ts:1257
+#: src/strings.ts:1258
 msgid "Report an issue"
 msgstr "Report an issue"
 
@@ -5410,59 +5416,59 @@ msgstr "Resend code in ({seconds})"
 msgid "Resend code{0}"
 msgstr "Resend code{0}"
 
-#: src/strings.ts:1402
+#: src/strings.ts:1403
 msgid "Resend email"
 msgstr "Resend email"
 
-#: src/strings.ts:1820
+#: src/strings.ts:1821
 msgid "Reset"
 msgstr "Reset"
 
-#: src/strings.ts:1912
+#: src/strings.ts:1913
 msgid "Reset account password"
 msgstr "Reset account password"
 
-#: src/strings.ts:2494
+#: src/strings.ts:2495
 msgid "Reset homepage"
 msgstr "Reset homepage"
 
-#: src/strings.ts:1821
+#: src/strings.ts:1822
 msgid "Reset selection"
 msgstr "Reset selection"
 
-#: src/strings.ts:1648
+#: src/strings.ts:1649
 msgid "Reset server urls"
 msgstr "Reset server urls"
 
-#: src/strings.ts:2030
+#: src/strings.ts:2031
 msgid "Reset sidebar"
 msgstr "Reset sidebar"
 
-#: src/strings.ts:1147
+#: src/strings.ts:1148
 msgid "Reset the toolbar to default settings"
 msgstr "Reset the toolbar to default settings"
 
-#: src/strings.ts:1146
+#: src/strings.ts:1147
 msgid "Reset toolbar"
 msgstr "Reset toolbar"
 
-#: src/strings.ts:1914
+#: src/strings.ts:1915
 msgid "Resetting account password ({progress})"
 msgstr "Resetting account password ({progress})"
 
-#: src/strings.ts:1989
+#: src/strings.ts:1990
 msgid "Restart now"
 msgstr "Restart now"
 
-#: src/strings.ts:1647
+#: src/strings.ts:1648
 msgid "Restart the app for changes to take effect."
 msgstr "Restart the app for changes to take effect."
 
-#: src/strings.ts:1318
+#: src/strings.ts:1319
 msgid "Restart the app to apply the changes"
 msgstr "Restart the app to apply the changes"
 
-#: src/strings.ts:1593
+#: src/strings.ts:1594
 msgid "Restart the app."
 msgstr "Restart the app."
 
@@ -5470,31 +5476,31 @@ msgstr "Restart the app."
 msgid "Restore"
 msgstr "Restore"
 
-#: src/strings.ts:1235
+#: src/strings.ts:1236
 msgid "Restore backup"
 msgstr "Restore backup"
 
-#: src/strings.ts:2416
+#: src/strings.ts:2417
 msgid "Restore backup?"
 msgstr "Restore backup?"
 
-#: src/strings.ts:890
+#: src/strings.ts:891
 msgid "Restore failed"
 msgstr "Restore failed"
 
-#: src/strings.ts:1610
+#: src/strings.ts:1611
 msgid "Restore from files"
 msgstr "Restore from files"
 
-#: src/strings.ts:1660
+#: src/strings.ts:1661
 msgid "Restore this version"
 msgstr "Restore this version"
 
-#: src/strings.ts:1236
+#: src/strings.ts:1237
 msgid "Restore your data from a backup"
 msgstr "Restore your data from a backup"
 
-#: src/strings.ts:849
+#: src/strings.ts:850
 msgid "Restored successfully"
 msgstr "Restored successfully"
 
@@ -5506,7 +5512,7 @@ msgstr "Restoring"
 msgid "Restoring {collection}..."
 msgstr "Restoring {collection}..."
 
-#: src/strings.ts:1612
+#: src/strings.ts:1613
 msgid "Restoring backup..."
 msgstr "Restoring backup..."
 
@@ -5522,7 +5528,7 @@ msgstr "Resubscribe to Pro"
 msgid "Reupload"
 msgstr "Reupload"
 
-#: src/strings.ts:2020
+#: src/strings.ts:2021
 msgid "Reveal in list"
 msgstr "Reveal in list"
 
@@ -5530,7 +5536,7 @@ msgstr "Reveal in list"
 msgid "Revoke"
 msgstr "Revoke"
 
-#: src/strings.ts:1179
+#: src/strings.ts:1180
 msgid "Revoke biometric unlocking"
 msgstr "Revoke biometric unlocking"
 
@@ -5538,23 +5544,23 @@ msgstr "Revoke biometric unlocking"
 msgid "Revoke vault fingerprint unlock"
 msgstr "Revoke vault fingerprint unlock"
 
-#: src/strings.ts:1293
+#: src/strings.ts:1294
 msgid "Roadmap"
 msgstr "Roadmap"
 
-#: src/strings.ts:2048
+#: src/strings.ts:2049
 msgid "Root"
 msgstr "Root"
 
-#: src/strings.ts:2027
+#: src/strings.ts:2028
 msgid "Rotate left"
 msgstr "Rotate left"
 
-#: src/strings.ts:2028
+#: src/strings.ts:2029
 msgid "Rotate right"
 msgstr "Rotate right"
 
-#: src/strings.ts:2297
+#: src/strings.ts:2298
 msgid "Row properties"
 msgstr "Row properties"
 
@@ -5562,7 +5568,7 @@ msgstr "Row properties"
 msgid "Run file check"
 msgstr "Run file check"
 
-#: src/strings.ts:2069
+#: src/strings.ts:2070
 msgid "Safe & encrypted notes"
 msgstr "Safe & encrypted notes"
 
@@ -5594,11 +5600,11 @@ msgstr "Save account recovery key"
 msgid "Save and continue"
 msgstr "Save and continue"
 
-#: src/strings.ts:1048
+#: src/strings.ts:1049
 msgid "Save data recovery key"
 msgstr "Save data recovery key"
 
-#: src/strings.ts:953
+#: src/strings.ts:954
 msgid "Save failed. Vault is locked"
 msgstr "Save failed. Vault is locked"
 
@@ -5618,7 +5624,7 @@ msgstr "Save to file"
 msgid "Save to text file"
 msgstr "Save to text file"
 
-#: src/strings.ts:1360
+#: src/strings.ts:1361
 msgid "Save your account recovery key"
 msgstr "Save your account recovery key"
 
@@ -5626,7 +5632,7 @@ msgstr "Save your account recovery key"
 msgid "Save your account recovery key in a safe place. You will need it to recover your account in case you forget your password."
 msgstr "Save your account recovery key in a safe place. You will need it to recover your account in case you forget your password."
 
-#: src/strings.ts:1050
+#: src/strings.ts:1051
 msgid "Save your data recovery key in a safe place. You will need it to recover your data in case you forget your password."
 msgstr "Save your data recovery key in a safe place. You will need it to recover your data in case you forget your password."
 
@@ -5634,15 +5640,15 @@ msgstr "Save your data recovery key in a safe place. You will need it to recover
 msgid "Save your recovery codes in a safe place. You will need them to recover your account in case you lose access to your two-factor authentication methods."
 msgstr "Save your recovery codes in a safe place. You will need them to recover your account in case you lose access to your two-factor authentication methods."
 
-#: src/strings.ts:2406
+#: src/strings.ts:2407
 msgid "Saved"
 msgstr "Saved"
 
-#: src/strings.ts:2407
+#: src/strings.ts:2408
 msgid "Saving"
 msgstr "Saving"
 
-#: src/strings.ts:1588
+#: src/strings.ts:1589
 msgid "Saving this note is taking too long. Copy your changes and restart the app to prevent data loss. If the problem persists, please report it to us at support@streetwriters.co."
 msgstr "Saving this note is taking too long. Copy your changes and restart the app to prevent data loss. If the problem persists, please report it to us at support@streetwriters.co."
 
@@ -5654,40 +5660,40 @@ msgstr "Saving zip file ({progress}%). Please wait..."
 msgid "Saving zip file. Please wait..."
 msgstr "Saving zip file. Please wait..."
 
-#: src/strings.ts:1722
+#: src/strings.ts:1723
 msgid "Scan the QR code with your authenticator app"
 msgstr "Scan the QR code with your authenticator app"
 
-#: src/strings.ts:2432
+#: src/strings.ts:2433
 msgid "School work"
 msgstr "School work"
 
-#: src/strings.ts:2505
+#: src/strings.ts:2506
 msgid "Scroll to bottom"
 msgstr "Scroll to bottom"
 
-#: src/strings.ts:2504
+#: src/strings.ts:2505
 msgid "Scroll to top"
 msgstr "Scroll to top"
 
-#: src/strings.ts:1510
-#: src/strings.ts:1528
+#: src/strings.ts:1511
+#: src/strings.ts:1529
 msgid "Search"
 msgstr "Search"
 
-#: src/strings.ts:1505
+#: src/strings.ts:1506
 msgid "Search a note"
 msgstr "Search a note"
 
-#: src/strings.ts:1503
+#: src/strings.ts:1504
 msgid "Search a note to link to"
 msgstr "Search a note to link to"
 
-#: src/strings.ts:2448
+#: src/strings.ts:2449
 msgid "Search for notes, notebooks, and tags..."
 msgstr "Search for notes, notebooks, and tags..."
 
-#: src/strings.ts:1538
+#: src/strings.ts:1539
 msgid "Search in {routeName}"
 msgstr "Search in {routeName}"
 
@@ -5739,67 +5745,67 @@ msgstr "Search in Tags"
 msgid "Search in Trash"
 msgstr "Search in Trash"
 
-#: src/strings.ts:2369
+#: src/strings.ts:2370
 msgid "Search languages"
 msgstr "Search languages"
 
-#: src/strings.ts:1491
+#: src/strings.ts:1492
 msgid "Search notebooks"
 msgstr "Search notebooks"
 
-#: src/strings.ts:1504
+#: src/strings.ts:1505
 msgid "Search or add a tag"
 msgstr "Search or add a tag"
 
-#: src/strings.ts:1834
+#: src/strings.ts:1835
 msgid "Search themes"
 msgstr "Search themes"
 
-#: src/strings.ts:1508
+#: src/strings.ts:1509
 msgid "Searching for {query}..."
 msgstr "Searching for {query}..."
 
-#: src/strings.ts:878
+#: src/strings.ts:879
 msgid "sec"
 msgstr "sec"
 
-#: src/strings.ts:2153
+#: src/strings.ts:2154
 msgid "Security & privacy"
 msgstr "Security & privacy"
 
-#: src/strings.ts:2093
+#: src/strings.ts:2094
 msgid "Security key"
 msgstr "Security key"
 
-#: src/strings.ts:1988
+#: src/strings.ts:1989
 msgid "Security key successfully registered."
 msgstr "Security key successfully registered."
 
-#: src/strings.ts:1294
+#: src/strings.ts:1295
 msgid "See what the future of Notesnook is going to be like."
 msgstr "See what the future of Notesnook is going to be like."
 
-#: src/strings.ts:1334
+#: src/strings.ts:1335
 msgid "Select"
 msgstr "Select"
 
-#: src/strings.ts:1609
+#: src/strings.ts:1610
 msgid "Select a backup file from your device to restore backup"
 msgstr "Select a backup file from your device to restore backup"
 
-#: src/strings.ts:2499
+#: src/strings.ts:2500
 msgid "Select a notebook to move this notebook into, or unselect to move it to the root level."
 msgstr "Select a notebook to move this notebook into, or unselect to move it to the root level."
 
-#: src/strings.ts:2108
+#: src/strings.ts:2109
 msgid "Select a theme"
 msgstr "Select a theme"
 
-#: src/strings.ts:1226
+#: src/strings.ts:1227
 msgid "Select backup directory"
 msgstr "Select backup directory"
 
-#: src/strings.ts:1855
+#: src/strings.ts:1856
 msgid "Select backup file"
 msgstr "Select backup file"
 
@@ -5815,15 +5821,15 @@ msgstr "Select date"
 msgid "Select day of the week to repeat the reminder."
 msgstr "Select day of the week to repeat the reminder."
 
-#: src/strings.ts:1763
+#: src/strings.ts:1764
 msgid "Select files to import"
 msgstr "Select files to import"
 
-#: src/strings.ts:1606
+#: src/strings.ts:1607
 msgid "Select folder where Notesnook backup files are stored to view and restore them from the app"
 msgstr "Select folder where Notesnook backup files are stored to view and restore them from the app"
 
-#: src/strings.ts:1607
+#: src/strings.ts:1608
 msgid "Select folder with backup files"
 msgstr "Select folder with backup files"
 
@@ -5831,7 +5837,7 @@ msgstr "Select folder with backup files"
 msgid "Select how you would like to recieve the code"
 msgstr "Select how you would like to recieve the code"
 
-#: src/strings.ts:2364
+#: src/strings.ts:2365
 msgid "Select language"
 msgstr "Select language"
 
@@ -5847,7 +5853,7 @@ msgstr "Select notebooks"
 msgid "Select notebooks you want to add note(s) to."
 msgstr "Select notebooks you want to add note(s) to."
 
-#: src/strings.ts:2487
+#: src/strings.ts:2488
 msgid "Select notes to link to \"{title}\""
 msgstr "Select notes to link to \"{title}\""
 
@@ -5855,11 +5861,11 @@ msgstr "Select notes to link to \"{title}\""
 msgid "Select nth day of the month to repeat the reminder."
 msgstr "Select nth day of the month to repeat the reminder."
 
-#: src/strings.ts:1817
+#: src/strings.ts:1818
 msgid "Select profile picture"
 msgstr "Select profile picture"
 
-#: src/strings.ts:2493
+#: src/strings.ts:2494
 msgid "Select the default sidebar tab"
 msgstr "Select the default sidebar tab"
 
@@ -5867,11 +5873,11 @@ msgstr "Select the default sidebar tab"
 msgid "Select the folder that includes your backup files to list them here."
 msgstr "Select the folder that includes your backup files to list them here."
 
-#: src/strings.ts:2140
+#: src/strings.ts:2141
 msgid "Select the languages the spell checker should check in."
 msgstr "Select the languages the spell checker should check in."
 
-#: src/strings.ts:2469
+#: src/strings.ts:2470
 msgid "Select the release track for Notesnook."
 msgstr "Select the release track for Notesnook."
 
@@ -5883,7 +5889,7 @@ msgstr "SELECTED NOTE"
 msgid "Self destruct"
 msgstr "Self destruct"
 
-#: src/strings.ts:2175
+#: src/strings.ts:2176
 msgid "Send"
 msgstr "Send"
 
@@ -5899,47 +5905,47 @@ msgstr "Send code via email"
 msgid "Send code via SMS"
 msgstr "Send code via SMS"
 
-#: src/strings.ts:1859
+#: src/strings.ts:1860
 msgid "Send recovery email"
 msgstr "Send recovery email"
 
-#: src/strings.ts:1895
+#: src/strings.ts:1896
 msgid "Sending recovery email"
 msgstr "Sending recovery email"
 
-#: src/strings.ts:1646
+#: src/strings.ts:1647
 msgid "Server url changed"
 msgstr "Server url changed"
 
-#: src/strings.ts:1649
+#: src/strings.ts:1650
 msgid "Server urls reset"
 msgstr "Server urls reset"
 
-#: src/strings.ts:1627
+#: src/strings.ts:1628
 msgid "Server used for login/sign up and authentication."
 msgstr "Server used for login/sign up and authentication."
 
-#: src/strings.ts:1632
+#: src/strings.ts:1633
 msgid "Server used to host your published notes."
 msgstr "Server used to host your published notes."
 
-#: src/strings.ts:1630
+#: src/strings.ts:1631
 msgid "Server used to receive important notifications & events."
 msgstr "Server used to receive important notifications & events."
 
-#: src/strings.ts:1625
+#: src/strings.ts:1626
 msgid "Server used to sync your notes & other data between devices."
 msgstr "Server used to sync your notes & other data between devices."
 
-#: src/strings.ts:1638
+#: src/strings.ts:1639
 msgid "Server with host {host} not found."
 msgstr "Server with host {host} not found."
 
-#: src/strings.ts:2148
+#: src/strings.ts:2149
 msgid "Servers"
 msgstr "Servers"
 
-#: src/strings.ts:2149
+#: src/strings.ts:2150
 msgid "Servers configuration"
 msgstr "Servers configuration"
 
@@ -5947,11 +5953,11 @@ msgstr "Servers configuration"
 msgid "Session expired"
 msgstr "Session expired"
 
-#: src/strings.ts:2201
+#: src/strings.ts:2202
 msgid "Sessions"
 msgstr "Sessions"
 
-#: src/strings.ts:976
+#: src/strings.ts:977
 msgid "Set a reminder"
 msgstr "Set a reminder"
 
@@ -5959,11 +5965,11 @@ msgstr "Set a reminder"
 msgid "Set as dark theme"
 msgstr "Set as dark theme"
 
-#: src/strings.ts:897
+#: src/strings.ts:898
 msgid "Set as default"
 msgstr "Set as default"
 
-#: src/strings.ts:2491
+#: src/strings.ts:2492
 msgid "Set as homepage"
 msgstr "Set as homepage"
 
@@ -5971,31 +5977,31 @@ msgstr "Set as homepage"
 msgid "Set as light theme"
 msgstr "Set as light theme"
 
-#: src/strings.ts:1333
+#: src/strings.ts:1334
 msgid "Set automatic trash cleanup interval from Settings > Behaviour > Clean trash interval."
 msgstr "Set automatic trash cleanup interval from Settings > Behaviour > Clean trash interval."
 
-#: src/strings.ts:2644
+#: src/strings.ts:2645
 msgid "Set expiry"
 msgstr "Set expiry"
 
-#: src/strings.ts:1310
+#: src/strings.ts:1311
 msgid "Set full name"
 msgstr "Set full name"
 
-#: src/strings.ts:1252
+#: src/strings.ts:1253
 msgid "Set snooze time in minutes"
 msgstr "Set snooze time in minutes"
 
-#: src/strings.ts:1251
+#: src/strings.ts:1252
 msgid "Set the default time to snooze a reminder to when you press the snooze button on a notification."
 msgstr "Set the default time to snooze a reminder to when you press the snooze button on a notification."
 
-#: src/strings.ts:1223
+#: src/strings.ts:1224
 msgid "Set the interval to create a backup (with attachments) automatically."
 msgstr "Set the interval to create a backup (with attachments) automatically."
 
-#: src/strings.ts:1220
+#: src/strings.ts:1221
 msgid "Set the interval to create a partial backup (without attachments) automatically."
 msgstr "Set the interval to create a partial backup (without attachments) automatically."
 
@@ -6004,24 +6010,24 @@ msgid "Set your name"
 msgstr "Set your name"
 
 #: src/strings.ts:387
-#: src/strings.ts:1524
+#: src/strings.ts:1525
 msgid "Settings"
 msgstr "Settings"
 
-#: src/strings.ts:1199
 #: src/strings.ts:1200
+#: src/strings.ts:1201
 msgid "Setup a new password for app lock"
 msgstr "Setup a new password for app lock"
 
-#: src/strings.ts:1196
+#: src/strings.ts:1197
 msgid "Setup a password to lock the app"
 msgstr "Setup a password to lock the app"
 
-#: src/strings.ts:1194
+#: src/strings.ts:1195
 msgid "Setup a pin to lock the app"
 msgstr "Setup a pin to lock the app"
 
-#: src/strings.ts:2193
+#: src/strings.ts:2194
 msgid ""
 "Setup an HTTP/HTTPS/SOCKS proxy.\n"
 "\n"
@@ -6041,11 +6047,11 @@ msgstr ""
 "\n"
 "To remove the proxy, simply erase everything in the input."
 
-#: src/strings.ts:1195
+#: src/strings.ts:1196
 msgid "Setup app lock password"
 msgstr "Setup app lock password"
 
-#: src/strings.ts:1193
+#: src/strings.ts:1194
 msgid "Setup app lock pin"
 msgstr "Setup app lock pin"
 
@@ -6053,15 +6059,15 @@ msgstr "Setup app lock pin"
 msgid "Setup secondary 2FA method"
 msgstr "Setup secondary 2FA method"
 
-#: src/strings.ts:978
+#: src/strings.ts:979
 msgid "Setup using an Authenticator app"
 msgstr "Setup using an Authenticator app"
 
-#: src/strings.ts:985
+#: src/strings.ts:986
 msgid "Setup using email"
 msgstr "Setup using email"
 
-#: src/strings.ts:992
+#: src/strings.ts:993
 msgid "Setup using SMS"
 msgstr "Setup using SMS"
 
@@ -6069,11 +6075,11 @@ msgstr "Setup using SMS"
 msgid "Share"
 msgstr "Share"
 
-#: src/strings.ts:1691
+#: src/strings.ts:1692
 msgid "Share & append to notes from anywhere"
 msgstr "Share & append to notes from anywhere"
 
-#: src/strings.ts:1341
+#: src/strings.ts:1342
 msgid "Share backup"
 msgstr "Share backup"
 
@@ -6081,7 +6087,7 @@ msgstr "Share backup"
 msgid "Share note"
 msgstr "Share note"
 
-#: src/strings.ts:1787
+#: src/strings.ts:1788
 msgid "Share Notesnook with friends!"
 msgstr "Share Notesnook with friends!"
 
@@ -6097,7 +6103,7 @@ msgstr "shortcut"
 msgid "Shortcut"
 msgstr "Shortcut"
 
-#: src/strings.ts:2000
+#: src/strings.ts:2001
 msgid "Shortcut removed"
 msgstr "Shortcut removed"
 
@@ -6113,7 +6119,7 @@ msgstr "Shortcuts"
 msgid "Sign up"
 msgstr "Sign up"
 
-#: src/strings.ts:1030
+#: src/strings.ts:1031
 msgid "Signed up on {date}"
 msgstr "Signed up on {date}"
 
@@ -6125,11 +6131,11 @@ msgstr "Signup failed"
 msgid "Silent"
 msgstr "Silent"
 
-#: src/strings.ts:2338
+#: src/strings.ts:2339
 msgid "Sink list item"
 msgstr "Sink list item"
 
-#: src/strings.ts:2041
+#: src/strings.ts:2042
 msgid "Size"
 msgstr "Size"
 
@@ -6137,7 +6143,7 @@ msgstr "Size"
 msgid "Skip"
 msgstr "Skip"
 
-#: src/strings.ts:1829
+#: src/strings.ts:1830
 msgid "Skip & go directly to the app"
 msgstr "Skip & go directly to the app"
 
@@ -6145,19 +6151,19 @@ msgstr "Skip & go directly to the app"
 msgid "Skip introduction"
 msgstr "Skip introduction"
 
-#: src/strings.ts:1604
+#: src/strings.ts:1605
 msgid "Some exported notes are locked, Unlock to export them"
 msgstr "Some exported notes are locked, Unlock to export them"
 
-#: src/strings.ts:1476
+#: src/strings.ts:1477
 msgid "Some notes are published"
 msgstr "Some notes are published"
 
-#: src/strings.ts:1666
+#: src/strings.ts:1667
 msgid "Something went wrong"
 msgstr "Something went wrong"
 
-#: src/strings.ts:2025
+#: src/strings.ts:2026
 msgid "Sort"
 msgstr "Sort"
 
@@ -6165,55 +6171,55 @@ msgstr "Sort"
 msgid "Sort by"
 msgstr "Sort by"
 
-#: src/strings.ts:2159
+#: src/strings.ts:2160
 msgid "Source code"
 msgstr "Source code"
 
-#: src/strings.ts:2365
+#: src/strings.ts:2366
 msgid "Spaces"
 msgstr "Spaces"
 
-#: src/strings.ts:2603
+#: src/strings.ts:2604
 msgid "Special Offer"
 msgstr "Special Offer"
 
-#: src/strings.ts:2136
+#: src/strings.ts:2137
 msgid "Spell check"
 msgstr "Spell check"
 
-#: src/strings.ts:2304
+#: src/strings.ts:2305
 msgid "Split cells"
 msgstr "Split cells"
 
-#: src/strings.ts:2470
+#: src/strings.ts:2471
 msgid "Stable"
 msgstr "Stable"
 
-#: src/strings.ts:1112
+#: src/strings.ts:1113
 msgid "Start"
 msgstr "Start"
 
-#: src/strings.ts:1830
+#: src/strings.ts:1831
 msgid "Start account recovery"
 msgstr "Start account recovery"
 
-#: src/strings.ts:1825
+#: src/strings.ts:1826
 msgid "Start import"
 msgstr "Start import"
 
-#: src/strings.ts:1822
+#: src/strings.ts:1823
 msgid "Start importing now"
 msgstr "Start importing now"
 
-#: src/strings.ts:2124
+#: src/strings.ts:2125
 msgid "Start minimized"
 msgstr "Start minimized"
 
-#: src/strings.ts:1757
+#: src/strings.ts:1758
 msgid "Start over"
 msgstr "Start over"
 
-#: src/strings.ts:950
+#: src/strings.ts:951
 msgid "Start writing to create a new note"
 msgstr "Start writing to create a new note"
 
@@ -6221,31 +6227,31 @@ msgstr "Start writing to create a new note"
 msgid "Start writing to save your note."
 msgstr "Start writing to save your note."
 
-#: src/strings.ts:1601
+#: src/strings.ts:1602
 msgid "Start writing your note..."
 msgstr "Start writing your note..."
 
-#: src/strings.ts:2232
+#: src/strings.ts:2233
 msgid "Status"
 msgstr "Status"
 
-#: src/strings.ts:2483
+#: src/strings.ts:2484
 msgid "Storage"
 msgstr "Storage"
 
-#: src/strings.ts:1548
+#: src/strings.ts:1549
 msgid "Streaming not supported"
 msgstr "Streaming not supported"
 
-#: src/strings.ts:2270
+#: src/strings.ts:2271
 msgid "Strikethrough"
 msgstr "Strikethrough"
 
-#: src/strings.ts:2234
+#: src/strings.ts:2235
 msgid "Subgroup 1"
 msgstr "Subgroup 1"
 
-#: src/strings.ts:1994
+#: src/strings.ts:1995
 msgid "Subgroup added"
 msgstr "Subgroup added"
 
@@ -6253,15 +6259,15 @@ msgstr "Subgroup added"
 msgid "Submit"
 msgstr "Submit"
 
-#: src/strings.ts:2582
+#: src/strings.ts:2583
 msgid "Subscribe"
 msgstr "Subscribe"
 
-#: src/strings.ts:2583
+#: src/strings.ts:2584
 msgid "Subscribe and start free trial"
 msgstr "Subscribe and start free trial"
 
-#: src/strings.ts:1025
+#: src/strings.ts:1026
 msgid "Subscribe to Pro"
 msgstr "Subscribe to Pro"
 
@@ -6273,7 +6279,7 @@ msgstr "Subscribed on Android"
 msgid "Subscribed on iOS"
 msgstr "Subscribed on iOS"
 
-#: src/strings.ts:1305
+#: src/strings.ts:1306
 msgid "Subscribed on web"
 msgstr "Subscribed on web"
 
@@ -6285,7 +6291,7 @@ msgstr "Subscribed on Web"
 msgid "Subscribed using gift card"
 msgstr "Subscribed using gift card"
 
-#: src/strings.ts:2281
+#: src/strings.ts:2282
 msgid "Subscript"
 msgstr "Subscript"
 
@@ -6293,11 +6299,11 @@ msgstr "Subscript"
 msgid "Subscription awarded from Streetwriters"
 msgstr "Subscription awarded from Streetwriters"
 
-#: src/strings.ts:1029
+#: src/strings.ts:1030
 msgid "Subscription details"
 msgstr "Subscription details"
 
-#: src/strings.ts:1063
+#: src/strings.ts:1064
 msgid "Subscription not activated?"
 msgstr "Subscription not activated?"
 
@@ -6309,15 +6315,15 @@ msgstr "Sun"
 msgid "Sunday"
 msgstr "Sunday"
 
-#: src/strings.ts:2282
+#: src/strings.ts:2283
 msgid "Superscript"
 msgstr "Superscript"
 
-#: src/strings.ts:1469
+#: src/strings.ts:1470
 msgid "Switch to search/replace mode"
 msgstr "Switch to search/replace mode"
 
-#: src/strings.ts:2145
+#: src/strings.ts:2146
 msgid "Sync"
 msgstr "Sync"
 
@@ -6325,7 +6331,7 @@ msgstr "Sync"
 msgid "Sync failed"
 msgstr "Sync failed"
 
-#: src/strings.ts:1363
+#: src/strings.ts:1364
 msgid "Sync is disabled"
 msgstr "Sync is disabled"
 
@@ -6333,19 +6339,19 @@ msgstr "Sync is disabled"
 msgid "Sync now"
 msgstr "Sync now"
 
-#: src/strings.ts:913
+#: src/strings.ts:914
 msgid "Sync off"
 msgstr "Sync off"
 
-#: src/strings.ts:1623
+#: src/strings.ts:1624
 msgid "Sync server"
 msgstr "Sync server"
 
-#: src/strings.ts:1082
+#: src/strings.ts:1083
 msgid "Sync settings"
 msgstr "Sync settings"
 
-#: src/strings.ts:1095
+#: src/strings.ts:1096
 msgid "Sync your notes in the background even when the app is closed. This is an experimental feature. If you face any issues, please turn it off."
 msgstr "Sync your notes in the background even when the app is closed. This is an experimental feature. If you face any issues, please turn it off."
 
@@ -6361,11 +6367,11 @@ msgstr "Syncing"
 msgid "Syncing your data"
 msgstr "Syncing your data"
 
-#: src/strings.ts:1702
+#: src/strings.ts:1703
 msgid "Syncing your notes"
 msgstr "Syncing your notes"
 
-#: src/strings.ts:2350
+#: src/strings.ts:2351
 msgid "Table"
 msgstr "Table"
 
@@ -6373,11 +6379,11 @@ msgstr "Table"
 msgid "Table of contents"
 msgstr "Table of contents"
 
-#: src/strings.ts:2295
+#: src/strings.ts:2296
 msgid "Table settings"
 msgstr "Table settings"
 
-#: src/strings.ts:2544
+#: src/strings.ts:2545
 msgid "tables, outlines, block level note linking"
 msgstr "tables, outlines, block level note linking"
 
@@ -6398,31 +6404,31 @@ msgid "tags"
 msgstr "tags"
 
 #: src/strings.ts:317
-#: src/strings.ts:1525
+#: src/strings.ts:1526
 msgid "Tags"
 msgstr "Tags"
 
-#: src/strings.ts:1543
+#: src/strings.ts:1544
 msgid "Take a backup before logging out"
 msgstr "Take a backup before logging out"
 
-#: src/strings.ts:1215
+#: src/strings.ts:1216
 msgid "Take a full backup of your data with all attachments"
 msgstr "Take a full backup of your data with all attachments"
 
-#: src/strings.ts:1217
+#: src/strings.ts:1218
 msgid "Take a partial backup of your data that does not include attachments"
 msgstr "Take a partial backup of your data that does not include attachments"
 
-#: src/strings.ts:2349
+#: src/strings.ts:2350
 msgid "Take a photo using camera"
 msgstr "Take a photo using camera"
 
-#: src/strings.ts:1373
+#: src/strings.ts:1374
 msgid "Take note"
 msgstr "Take note"
 
-#: src/strings.ts:1656
+#: src/strings.ts:1657
 msgid "Take notes privately."
 msgstr "Take notes privately."
 
@@ -6430,23 +6436,23 @@ msgstr "Take notes privately."
 msgid "Taking too long? Reload editor"
 msgstr "Taking too long? Reload editor"
 
-#: src/strings.ts:1457
+#: src/strings.ts:1458
 msgid "Tap here to change sorting"
 msgstr "Tap here to change sorting"
 
-#: src/strings.ts:1461
+#: src/strings.ts:1462
 msgid "Tap here to jump to a section"
 msgstr "Tap here to jump to a section"
 
-#: src/strings.ts:1369
+#: src/strings.ts:1370
 msgid "Tap here to update to the latest version"
 msgstr "Tap here to update to the latest version"
 
-#: src/strings.ts:1592
+#: src/strings.ts:1593
 msgid "Tap on \"Dismiss\" and copy the contents of your note so they are not lost."
 msgstr "Tap on \"Dismiss\" and copy the contents of your note so they are not lost."
 
-#: src/strings.ts:1372
+#: src/strings.ts:1373
 msgid "Tap on \"Take note\" to add a note."
 msgstr "Tap on \"Take note\" to add a note."
 
@@ -6466,7 +6472,7 @@ msgstr "Tap to deselect"
 msgid "Tap to stop reordering"
 msgstr "Tap to stop reordering"
 
-#: src/strings.ts:1353
+#: src/strings.ts:1354
 msgid "Tap to try again"
 msgstr "Tap to try again"
 
@@ -6474,19 +6480,19 @@ msgstr "Tap to try again"
 msgid "Tap twice to confirm you have saved the recovery key."
 msgstr "Tap twice to confirm you have saved the recovery key."
 
-#: src/strings.ts:2355
+#: src/strings.ts:2356
 msgid "Task list"
 msgstr "Task list"
 
-#: src/strings.ts:2425
+#: src/strings.ts:2426
 msgid "Tasks"
 msgstr "Tasks"
 
-#: src/strings.ts:1162
+#: src/strings.ts:1163
 msgid "Telemetry"
 msgstr "Telemetry"
 
-#: src/strings.ts:1495
+#: src/strings.ts:1496
 msgid ""
 "Tell us more about the issue you are facing.\n"
 "\n"
@@ -6504,11 +6510,11 @@ msgstr ""
 "- Steps to reproduce the issue\n"
 "- Things you have tried etc."
 
-#: src/strings.ts:1494
+#: src/strings.ts:1495
 msgid "Tell us what happened"
 msgstr "Tell us what happened"
 
-#: src/strings.ts:1283
+#: src/strings.ts:1284
 msgid "Terms of service"
 msgstr "Terms of service"
 
@@ -6516,39 +6522,39 @@ msgstr "Terms of service"
 msgid "Terms of Service "
 msgstr "Terms of Service "
 
-#: src/strings.ts:2590
+#: src/strings.ts:2591
 msgid "terms of use."
 msgstr "terms of use."
 
-#: src/strings.ts:1622
+#: src/strings.ts:1623
 msgid "Test connection"
 msgstr "Test connection"
 
-#: src/strings.ts:1645
+#: src/strings.ts:1646
 msgid "Test connection before changing server urls"
 msgstr "Test connection before changing server urls"
 
-#: src/strings.ts:2293
+#: src/strings.ts:2294
 msgid "Text color"
 msgstr "Text color"
 
-#: src/strings.ts:2291
+#: src/strings.ts:2292
 msgid "Text direction"
 msgstr "Text direction"
 
-#: src/strings.ts:1786
+#: src/strings.ts:1787
 msgid "Thank you for choosing end-to-end encrypted note taking. Now you can sync your notes to unlimited devices."
 msgstr "Thank you for choosing end-to-end encrypted note taking. Now you can sync your notes to unlimited devices."
 
-#: src/strings.ts:2050
+#: src/strings.ts:2051
 msgid "Thank you for reporting!"
 msgstr "Thank you for reporting!"
 
-#: src/strings.ts:2561
+#: src/strings.ts:2562
 msgid "Thank you for subscribing"
 msgstr "Thank you for subscribing"
 
-#: src/strings.ts:2598
+#: src/strings.ts:2599
 msgid "Thank you for the purchase"
 msgstr "Thank you for the purchase"
 
@@ -6556,19 +6562,19 @@ msgstr "Thank you for the purchase"
 msgid "Thank you for updating Notesnook! We will be applying some minor changes for a better note taking experience."
 msgstr "Thank you for updating Notesnook! We will be applying some minor changes for a better note taking experience."
 
-#: src/strings.ts:2051
+#: src/strings.ts:2052
 msgid "Thank you for your feedback!"
 msgstr "Thank you for your feedback!"
 
-#: src/strings.ts:2085
+#: src/strings.ts:2086
 msgid "Thank you. You are the proof that privacy always comes first."
 msgstr "Thank you. You are the proof that privacy always comes first."
 
-#: src/strings.ts:1643
+#: src/strings.ts:1644
 msgid "The {title} at {url} is not compatible with this client."
 msgstr "The {title} at {url} is not compatible with this client."
 
-#: src/strings.ts:2643
+#: src/strings.ts:2644
 msgid "The incoming note could not be unlocked with the provided password. Enter the correct password for the incoming note"
 msgstr "The incoming note could not be unlocked with the provided password. Enter the correct password for the incoming note"
 
@@ -6576,11 +6582,11 @@ msgstr "The incoming note could not be unlocked with the provided password. Ente
 msgid "The information above will be publically available at"
 msgstr "The information above will be publically available at"
 
-#: src/strings.ts:2617
+#: src/strings.ts:2618
 msgid "The Notesnook Circle is exclusive to subscribers. Please consider subscribing to gain access to Notesnook Circle and enjoy additional benefits."
 msgstr "The Notesnook Circle is exclusive to subscribers. Please consider subscribing to gain access to Notesnook Circle and enjoy additional benefits."
 
-#: src/strings.ts:2092
+#: src/strings.ts:2093
 msgid "The password/pin for unlocking the app."
 msgstr "The password/pin for unlocking the app."
 
@@ -6592,19 +6598,19 @@ msgstr "The reminder will repeat daily at {date}."
 msgid "The reminder will repeat every year on {date}."
 msgstr "The reminder will repeat every year on {date}."
 
-#: src/strings.ts:1712
+#: src/strings.ts:1713
 msgid "The reminder will start on {date} at {time}."
 msgstr "The reminder will start on {date} at {time}."
 
-#: src/strings.ts:2095
+#: src/strings.ts:2096
 msgid "The security key for unlocking the app. This is the most secure method."
 msgstr "The security key for unlocking the app. This is the most secure method."
 
-#: src/strings.ts:1641
+#: src/strings.ts:1642
 msgid "The URL you have given ({url}) does not point to the {server}."
 msgstr "The URL you have given ({url}) does not point to the {server}."
 
-#: src/strings.ts:1117
+#: src/strings.ts:1118
 msgid "Themes"
 msgstr "Themes"
 
@@ -6612,11 +6618,11 @@ msgstr "Themes"
 msgid "There are no blocks in this note."
 msgstr "There are no blocks in this note."
 
-#: src/strings.ts:2248
+#: src/strings.ts:2249
 msgid "These items will be **kept in your Trash for {interval} days** after which they will be permanently deleted."
 msgstr "These items will be **kept in your Trash for {interval} days** after which they will be permanently deleted."
 
-#: src/strings.ts:1920
+#: src/strings.ts:1921
 msgid "This action is IRREVERSIBLE."
 msgstr "This action is IRREVERSIBLE."
 
@@ -6624,60 +6630,60 @@ msgstr "This action is IRREVERSIBLE."
 msgid "This device"
 msgstr "This device"
 
-#: src/strings.ts:1683
+#: src/strings.ts:1684
 msgid "This error can be fixed by rebuilding the search index. This action won't result in any kind of data loss."
 msgstr "This error can be fixed by rebuilding the search index. This action won't result in any kind of data loss."
 
-#: src/strings.ts:1675
+#: src/strings.ts:1676
 msgid "This error can only be fixed by wiping & reseting the database. Beware that this will wipe all your data inside the database with no way to recover it later on. This WILL NOT change/affect/delete/wipe your data on the server but ONLY on this device."
 msgstr "This error can only be fixed by wiping & reseting the database. Beware that this will wipe all your data inside the database with no way to recover it later on. This WILL NOT change/affect/delete/wipe your data on the server but ONLY on this device."
 
-#: src/strings.ts:1679
+#: src/strings.ts:1680
 msgid "This error can only be fixed by wiping & reseting the Key Store and the database. This WILL NOT change/affect/delete/wipe your data on the server but ONLY on this device."
 msgstr "This error can only be fixed by wiping & reseting the Key Store and the database. This WILL NOT change/affect/delete/wipe your data on the server but ONLY on this device."
 
-#: src/strings.ts:1677
+#: src/strings.ts:1678
 msgid "This error means the at rest encryption key could not be decrypted. This can be due to data corruption or implementation change."
 msgstr "This error means the at rest encryption key could not be decrypted. This can be due to data corruption or implementation change."
 
-#: src/strings.ts:1673
+#: src/strings.ts:1674
 msgid "This error usually means the database file is either corrupt or it could not be decrypted."
 msgstr "This error usually means the database file is either corrupt or it could not be decrypted."
 
-#: src/strings.ts:1681
+#: src/strings.ts:1682
 msgid "This error usually means the search index is corrupted."
 msgstr "This error usually means the search index is corrupted."
 
-#: src/strings.ts:2657
+#: src/strings.ts:2658
 msgid "This feature is not available on this plan."
 msgstr "This feature is not available on this plan."
 
-#: src/strings.ts:1934
+#: src/strings.ts:1935
 msgid "This image cannot be previewed"
 msgstr "This image cannot be previewed"
 
-#: src/strings.ts:2584
+#: src/strings.ts:2585
 msgid "This is a one time purchase, no subscription."
 msgstr "This is a one time purchase, no subscription."
 
-#: src/strings.ts:2045
+#: src/strings.ts:2046
 msgid "This may take a while"
 msgstr "This may take a while"
 
-#: src/strings.ts:1101
-#: src/strings.ts:1110
+#: src/strings.ts:1102
+#: src/strings.ts:1111
 msgid "This must only be used for troubleshooting. Using it regularly for sync is not recommended and will lead to unexpected data loss and other issues. If you are having persistent issues with sync, please report them to us at support@streetwriters.co."
 msgstr "This must only be used for troubleshooting. Using it regularly for sync is not recommended and will lead to unexpected data loss and other issues. If you are having persistent issues with sync, please report them to us at support@streetwriters.co."
 
-#: src/strings.ts:2649
+#: src/strings.ts:2650
 msgid "This note is empty"
 msgstr "This note is empty"
 
-#: src/strings.ts:1594
+#: src/strings.ts:1595
 msgid "This note is locked"
 msgstr "This note is locked"
 
-#: src/strings.ts:952
+#: src/strings.ts:953
 msgid "This note is locked. Unlock note to save changes"
 msgstr "This note is locked. Unlock note to save changes"
 
@@ -6693,11 +6699,11 @@ msgstr "This note is not referenced in other notes."
 msgid "This note will be published to a public URL."
 msgstr "This note will be published to a public URL."
 
-#: src/strings.ts:2101
+#: src/strings.ts:2102
 msgid "This username will be used to distinguish between different credentials in your security key. Make sure it is unique."
 msgstr "This username will be used to distinguish between different credentials in your security key. Make sure it is unique."
 
-#: src/strings.ts:1303
+#: src/strings.ts:1304
 msgid "This version of Notesnook app does not support in-app purchases. Kindly login on the Notesnook web app to make the purchase."
 msgstr "This version of Notesnook app does not support in-app purchases. Kindly login on the Notesnook web app to make the purchase."
 
@@ -6709,11 +6715,11 @@ msgstr "Thu"
 msgid "Thursday"
 msgstr "Thursday"
 
-#: src/strings.ts:1842
+#: src/strings.ts:1843
 msgid "Time"
 msgstr "Time"
 
-#: src/strings.ts:1134
+#: src/strings.ts:1135
 msgid "Time format"
 msgstr "Time format"
 
@@ -6726,76 +6732,76 @@ msgstr "TIP"
 msgid "Title"
 msgstr "Title"
 
-#: src/strings.ts:1157
+#: src/strings.ts:1158
 msgid "Title format"
 msgstr "Title format"
 
-#: src/strings.ts:2668
+#: src/strings.ts:2669
 msgid "Title is required"
 msgstr "Title is required"
 
-#: src/strings.ts:1188
+#: src/strings.ts:1189
 msgid "To use app lock, you must enable biometrics such as Fingerprint lock or Face ID on your phone."
 msgstr "To use app lock, you must enable biometrics such as Fingerprint lock or Face ID on your phone."
 
-#: src/strings.ts:1812
+#: src/strings.ts:1813
 msgid "Toggle dark/light mode"
 msgstr "Toggle dark/light mode"
 
-#: src/strings.ts:2473
+#: src/strings.ts:2474
 msgid "Toggle focus mode"
 msgstr "Toggle focus mode"
 
-#: src/strings.ts:2362
+#: src/strings.ts:2363
 msgid "Toggle indentation mode"
 msgstr "Toggle indentation mode"
 
-#: src/strings.ts:2391
+#: src/strings.ts:2392
 msgid "Toggle replace"
 msgstr "Toggle replace"
 
-#: src/strings.ts:2462
+#: src/strings.ts:2463
 msgid "Toggle theme"
 msgstr "Toggle theme"
 
-#: src/strings.ts:2142
+#: src/strings.ts:2143
 msgid "Toolbar"
 msgstr "Toolbar"
 
-#: src/strings.ts:1148
+#: src/strings.ts:1149
 msgid "Toolbar reset to default preset"
 msgstr "Toolbar reset to default preset"
 
-#: src/strings.ts:1326
-#: src/strings.ts:1523
+#: src/strings.ts:1327
+#: src/strings.ts:1524
 msgid "Trash"
 msgstr "Trash"
 
-#: src/strings.ts:1325
+#: src/strings.ts:1326
 msgid "Trash cleared successfully!"
 msgstr "Trash cleared successfully!"
 
-#: src/strings.ts:1331
+#: src/strings.ts:1332
 msgid "Trash gets automatically cleaned up after {days} days"
 msgstr "Trash gets automatically cleaned up after {days} days"
 
-#: src/strings.ts:1329
+#: src/strings.ts:1330
 msgid "Trash gets automatically cleaned up daily"
 msgstr "Trash gets automatically cleaned up daily"
 
-#: src/strings.ts:2551
+#: src/strings.ts:2552
 msgid "Try {plan} for free"
 msgstr "Try {plan} for free"
 
-#: src/strings.ts:1465
+#: src/strings.ts:1466
 msgid "Try compact mode to fit more items on screen"
 msgstr "Try compact mode to fit more items on screen"
 
-#: src/strings.ts:1824
+#: src/strings.ts:1825
 msgid "Try free for 14 days"
 msgstr "Try free for 14 days"
 
-#: src/strings.ts:2537
+#: src/strings.ts:2538
 msgid "Try it for free"
 msgstr "Try it for free"
 
@@ -6807,19 +6813,19 @@ msgstr "Tue"
 msgid "Tuesday"
 msgstr "Tuesday"
 
-#: src/strings.ts:1086
+#: src/strings.ts:1087
 msgid "Turn off automatic syncing. Changes from this client will be synced only when you run sync manually."
 msgstr "Turn off automatic syncing. Changes from this client will be synced only when you run sync manually."
 
-#: src/strings.ts:892
+#: src/strings.ts:893
 msgid "Turn off reminder"
 msgstr "Turn off reminder"
 
-#: src/strings.ts:893
+#: src/strings.ts:894
 msgid "Turn on reminder"
 msgstr "Turn on reminder"
 
-#: src/strings.ts:1092
+#: src/strings.ts:1093
 msgid "Turns off syncing completely on this device. Any changes made will remain local only and new changes from your other devices won't sync to this device."
 msgstr "Turns off syncing completely on this device. Any changes made will remain local only and new changes from your other devices won't sync to this device."
 
@@ -6835,27 +6841,27 @@ msgstr "Two-factor authentication"
 msgid "Two-factor authentication enabled"
 msgstr "Two-factor authentication enabled"
 
-#: src/strings.ts:1502
+#: src/strings.ts:1503
 msgid "Type # to search for headings"
 msgstr "Type # to search for headings"
 
-#: src/strings.ts:1509
+#: src/strings.ts:1510
 msgid "Type a keyword"
 msgstr "Type a keyword"
 
-#: src/strings.ts:1549
+#: src/strings.ts:1550
 msgid "Unable to resolve download url"
 msgstr "Unable to resolve download url"
 
-#: src/strings.ts:1552
+#: src/strings.ts:1553
 msgid "Unable to send 2FA code"
 msgstr "Unable to send 2FA code"
 
-#: src/strings.ts:2497
+#: src/strings.ts:2498
 msgid "Unarchive"
 msgstr "Unarchive"
 
-#: src/strings.ts:2269
+#: src/strings.ts:2270
 msgid "Underline"
 msgstr "Underline"
 
@@ -6863,19 +6869,19 @@ msgstr "Underline"
 msgid "Undo"
 msgstr "Undo"
 
-#: src/strings.ts:854
+#: src/strings.ts:855
 msgid "Unfavorite"
 msgstr "Unfavorite"
 
-#: src/strings.ts:2594
+#: src/strings.ts:2595
 msgid "Unlimited"
 msgstr "Unlimited"
 
-#: src/strings.ts:930
+#: src/strings.ts:931
 msgid "Unlink from all"
 msgstr "Unlink from all"
 
-#: src/strings.ts:853
+#: src/strings.ts:854
 msgid "Unlink notebook"
 msgstr "Unlink notebook"
 
@@ -6883,11 +6889,11 @@ msgstr "Unlink notebook"
 msgid "Unlock"
 msgstr "Unlock"
 
-#: src/strings.ts:2641
+#: src/strings.ts:2642
 msgid "Unlock incoming note"
 msgstr "Unlock incoming note"
 
-#: src/strings.ts:1383
+#: src/strings.ts:1384
 msgid "Unlock more colors with Notesnook Pro"
 msgstr "Unlock more colors with Notesnook Pro"
 
@@ -6896,19 +6902,19 @@ msgstr "Unlock more colors with Notesnook Pro"
 msgid "Unlock note"
 msgstr "Unlock note"
 
-#: src/strings.ts:888
+#: src/strings.ts:889
 msgid "Unlock note to delete it"
 msgstr "Unlock note to delete it"
 
-#: src/strings.ts:2652
+#: src/strings.ts:2653
 msgid "Unlock note to merge conflicts"
 msgstr "Unlock note to merge conflicts"
 
-#: src/strings.ts:1208
+#: src/strings.ts:1209
 msgid "Unlock the app with biometric authentication. This requires biometrics to be enabled on your device."
 msgstr "Unlock the app with biometric authentication. This requires biometrics to be enabled on your device."
 
-#: src/strings.ts:1932
+#: src/strings.ts:1933
 msgid "Unlock vault"
 msgstr "Unlock vault"
 
@@ -6916,7 +6922,7 @@ msgstr "Unlock vault"
 msgid "Unlock with biometrics"
 msgstr "Unlock with biometrics"
 
-#: src/strings.ts:1827
+#: src/strings.ts:1828
 msgid "Unlock with security key"
 msgstr "Unlock with security key"
 
@@ -6924,19 +6930,19 @@ msgstr "Unlock with security key"
 msgid "Unlock your notes"
 msgstr "Unlock your notes"
 
-#: src/strings.ts:1178
+#: src/strings.ts:1179
 msgid "Unlock your vault with biometric authentication"
 msgstr "Unlock your vault with biometric authentication"
 
-#: src/strings.ts:1710
+#: src/strings.ts:1711
 msgid "Unlocking"
 msgstr "Unlocking"
 
-#: src/strings.ts:899
+#: src/strings.ts:900
 msgid "Unpin"
 msgstr "Unpin"
 
-#: src/strings.ts:927
+#: src/strings.ts:928
 msgid "Unpin notification"
 msgstr "Unpin notification"
 
@@ -6944,20 +6950,20 @@ msgstr "Unpin notification"
 msgid "Unpublish"
 msgstr "Unpublish"
 
-#: src/strings.ts:1477
+#: src/strings.ts:1478
 msgid "Unpublish notes to delete them"
 msgstr "Unpublish notes to delete them"
 
-#: src/strings.ts:2096
+#: src/strings.ts:2097
 msgid "Unregister"
 msgstr "Unregister"
 
-#: src/strings.ts:2645
+#: src/strings.ts:2646
 msgid "Unset expiry"
 msgstr "Unset expiry"
 
 #: src/strings.ts:210
-#: src/strings.ts:2371
+#: src/strings.ts:2372
 msgid "Untitled"
 msgstr "Untitled"
 
@@ -6969,31 +6975,31 @@ msgstr "Update"
 msgid "Update available"
 msgstr "Update available"
 
-#: src/strings.ts:1370
+#: src/strings.ts:1371
 msgid "Update now"
 msgstr "Update now"
 
-#: src/strings.ts:2511
+#: src/strings.ts:2512
 msgid "Upgrade"
 msgstr "Upgrade"
 
-#: src/strings.ts:1918
+#: src/strings.ts:1919
 msgid "Upgrade now"
 msgstr "Upgrade now"
 
-#: src/strings.ts:2510
+#: src/strings.ts:2511
 msgid "Upgrade plan"
 msgstr "Upgrade plan"
 
-#: src/strings.ts:2536
+#: src/strings.ts:2537
 msgid "Upgrade plan to {plan} to use this feature."
 msgstr "Upgrade plan to {plan} to use this feature."
 
-#: src/strings.ts:1939
+#: src/strings.ts:1940
 msgid "Upgrade to Notesnook Pro to add colors."
 msgstr "Upgrade to Notesnook Pro to add colors."
 
-#: src/strings.ts:1940
+#: src/strings.ts:1941
 msgid "Upgrade to Notesnook Pro to create more tags."
 msgstr "Upgrade to Notesnook Pro to create more tags."
 
@@ -7001,7 +7007,7 @@ msgstr "Upgrade to Notesnook Pro to create more tags."
 msgid "Upgrade to Pro"
 msgstr "Upgrade to Pro"
 
-#: src/strings.ts:2609
+#: src/strings.ts:2610
 msgid "Upgrade to redeem"
 msgstr "Upgrade to redeem"
 
@@ -7009,12 +7015,12 @@ msgstr "Upgrade to redeem"
 msgid "Upload"
 msgstr "Upload"
 
-#: src/strings.ts:2348
+#: src/strings.ts:2349
 msgid "Upload from disk"
 msgstr "Upload from disk"
 
 #: src/strings.ts:511
-#: src/strings.ts:1651
+#: src/strings.ts:1652
 msgid "Uploaded"
 msgstr "Uploaded"
 
@@ -7035,11 +7041,11 @@ msgstr "Uploads"
 msgid "Urgent"
 msgstr "Urgent"
 
-#: src/strings.ts:2398
+#: src/strings.ts:2399
 msgid "URL"
 msgstr "URL"
 
-#: src/strings.ts:1789
+#: src/strings.ts:1790
 msgid "Use"
 msgstr "Use"
 
@@ -7047,11 +7053,11 @@ msgstr "Use"
 msgid "Use {keyboardShortcut}+click to select multiple notebooks"
 msgstr "Use {keyboardShortcut}+click to select multiple notebooks"
 
-#: src/strings.ts:1802
+#: src/strings.ts:1803
 msgid "Use a backup file"
 msgstr "Use a backup file"
 
-#: src/strings.ts:1900
+#: src/strings.ts:1901
 msgid "Use a data recovery key to reset your account password."
 msgstr "Use a data recovery key to reset your account password."
 
@@ -7059,43 +7065,43 @@ msgstr "Use a data recovery key to reset your account password."
 msgid "Use account password"
 msgstr "Use account password"
 
-#: src/strings.ts:2543
+#: src/strings.ts:2544
 msgid "Use advanced note taking features like"
 msgstr "Use advanced note taking features like"
 
-#: src/strings.ts:979
+#: src/strings.ts:980
 msgid "Use an authenticator app to generate 2FA codes."
 msgstr "Use an authenticator app to generate 2FA codes."
 
-#: src/strings.ts:2182
+#: src/strings.ts:2183
 msgid "Use custom DNS"
 msgstr "Use custom DNS"
 
-#: src/strings.ts:1123
+#: src/strings.ts:1124
 msgid "Use dark mode for the app"
 msgstr "Use dark mode for the app"
 
-#: src/strings.ts:1621
+#: src/strings.ts:1622
 msgid "Use encryption key"
 msgstr "Use encryption key"
 
-#: src/strings.ts:1160
+#: src/strings.ts:1161
 msgid "Use markdown shortcuts in the editor"
 msgstr "Use markdown shortcuts in the editor"
 
-#: src/strings.ts:2135
+#: src/strings.ts:2136
 msgid "Use native OS titlebar instead of replacing it with a custom one. Requires app restart for changes to take effect."
 msgstr "Use native OS titlebar instead of replacing it with a custom one. Requires app restart for changes to take effect."
 
-#: src/strings.ts:2133
+#: src/strings.ts:2134
 msgid "Use native titlebar"
 msgstr "Use native titlebar"
 
-#: src/strings.ts:1799
+#: src/strings.ts:1800
 msgid "Use recovery key"
 msgstr "Use recovery key"
 
-#: src/strings.ts:1119
+#: src/strings.ts:1120
 msgid "Use system theme"
 msgstr "Use system theme"
 
@@ -7121,43 +7127,43 @@ msgstr ""
 "$headline$: Use starting line of the note as title.\n"
 "$day$: Current day (eg. Monday)"
 
-#: src/strings.ts:1099
+#: src/strings.ts:1100
 msgid "Use this if changes from other devices are not appearing on this device. This will overwrite the data on this device with the latest data from the server."
 msgstr "Use this if changes from other devices are not appearing on this device. This will overwrite the data on this device with the latest data from the server."
 
-#: src/strings.ts:1108
+#: src/strings.ts:1109
 msgid "Use this if changes made on this device are not appearing on other devices. This will overwrite the data on the server with the data from this device."
 msgstr "Use this if changes made on this device are not appearing on other devices. This will overwrite the data on the server with the data from this device."
 
-#: src/strings.ts:2484
+#: src/strings.ts:2485
 msgid "used"
 msgstr "used"
 
-#: src/strings.ts:1018
+#: src/strings.ts:1019
 msgid "User verification failed"
 msgstr "User verification failed"
 
-#: src/strings.ts:2265
+#: src/strings.ts:2266
 msgid "Using {instance} (v{version})"
 msgstr "Using {instance} (v{version})"
 
-#: src/strings.ts:2263
+#: src/strings.ts:2264
 msgid "Using official Notesnook instance"
 msgstr "Using official Notesnook instance"
 
-#: src/strings.ts:1709
+#: src/strings.ts:1710
 msgid "v{version} available"
 msgstr "v{version} available"
 
-#: src/strings.ts:2659
+#: src/strings.ts:2660
 msgid "Value must be between {min} and {max}"
 msgstr "Value must be between {min} and {max}"
 
-#: src/strings.ts:1171
+#: src/strings.ts:1172
 msgid "Vault"
 msgstr "Vault"
 
-#: src/strings.ts:1992
+#: src/strings.ts:1993
 msgid "Vault cleared"
 msgstr "Vault cleared"
 
@@ -7165,7 +7171,7 @@ msgstr "Vault cleared"
 msgid "Vault created"
 msgstr "Vault created"
 
-#: src/strings.ts:1993
+#: src/strings.ts:1994
 msgid "Vault deleted"
 msgstr "Vault deleted"
 
@@ -7173,15 +7179,15 @@ msgstr "Vault deleted"
 msgid "Vault fingerprint unlock"
 msgstr "Vault fingerprint unlock"
 
-#: src/strings.ts:1931
+#: src/strings.ts:1932
 msgid "Vault locked"
 msgstr "Vault locked"
 
-#: src/strings.ts:1930
+#: src/strings.ts:1931
 msgid "Vault unlocked"
 msgstr "Vault unlocked"
 
-#: src/strings.ts:1400
+#: src/strings.ts:1401
 msgid "Verification email sent"
 msgstr "Verification email sent"
 
@@ -7189,19 +7195,19 @@ msgstr "Verification email sent"
 msgid "Verify"
 msgstr "Verify"
 
-#: src/strings.ts:1069
+#: src/strings.ts:1070
 msgid "Verify subscription"
 msgstr "Verify subscription"
 
-#: src/strings.ts:1072
+#: src/strings.ts:1073
 msgid "Verify your subscription to Notesnook Pro"
 msgstr "Verify your subscription to Notesnook Pro"
 
-#: src/strings.ts:1903
+#: src/strings.ts:1904
 msgid "Verifying 2FA code"
 msgstr "Verifying 2FA code"
 
-#: src/strings.ts:1889
+#: src/strings.ts:1890
 msgid "Verifying your email"
 msgstr "Verifying your email"
 
@@ -7221,27 +7227,27 @@ msgstr "Videos"
 msgid "View all linked notebooks"
 msgstr "View all linked notebooks"
 
-#: src/strings.ts:1270
+#: src/strings.ts:1271
 msgid "View and share debug logs"
 msgstr "View and share debug logs"
 
-#: src/strings.ts:1747
+#: src/strings.ts:1748
 msgid "View receipt"
 msgstr "View receipt"
 
-#: src/strings.ts:1060
+#: src/strings.ts:1061
 msgid "View recovery codes"
 msgstr "View recovery codes"
 
-#: src/strings.ts:2162
+#: src/strings.ts:2163
 msgid "View source code"
 msgstr "View source code"
 
-#: src/strings.ts:1062
+#: src/strings.ts:1063
 msgid "View your recovery codes to recover your account in case you lose access to your two-factor authentication methods."
 msgstr "View your recovery codes to recover your account in case you lose access to your two-factor authentication methods."
 
-#: src/strings.ts:2624
+#: src/strings.ts:2625
 msgid "Views"
 msgstr "Views"
 
@@ -7249,15 +7255,15 @@ msgstr "Views"
 msgid "Visit homepage"
 msgstr "Visit homepage"
 
-#: src/strings.ts:1350
+#: src/strings.ts:1351
 msgid "Wait 30 seconds to try again"
 msgstr "Wait 30 seconds to try again"
 
-#: src/strings.ts:1652
+#: src/strings.ts:1653
 msgid "Waiting for upload"
 msgstr "Waiting for upload"
 
-#: src/strings.ts:1911
+#: src/strings.ts:1912
 msgid "We are creating a backup of your data. Please wait..."
 msgstr "We are creating a backup of your data. Please wait..."
 
@@ -7265,35 +7271,35 @@ msgstr "We are creating a backup of your data. Please wait..."
 msgid "We are sorry, it seems that the app crashed due to an error. You can submit a bug report below so we can fix this asap."
 msgstr "We are sorry, it seems that the app crashed due to an error. You can submit a bug report below so we can fix this asap."
 
-#: src/strings.ts:1390
+#: src/strings.ts:1391
 msgid "We have sent you an email confirmation link. Please check your email inbox. If you cannot find the email, check your spam folder."
 msgstr "We have sent you an email confirmation link. Please check your email inbox. If you cannot find the email, check your spam folder."
 
-#: src/strings.ts:2522
+#: src/strings.ts:2523
 msgid "We require credit card details to fight abuse and to make it seamless for you to upgrade. Your credit card is NOT charged until your free trial ends and your subscription starts. You will be notified via email of the upcoming charge before your trial ends."
 msgstr "We require credit card details to fight abuse and to make it seamless for you to upgrade. Your credit card is NOT charged until your free trial ends and your subscription starts. You will be notified via email of the upcoming charge before your trial ends."
 
-#: src/strings.ts:2177
+#: src/strings.ts:2178
 msgid "We send you occasional promotional offers & product updates on your email (once every month)."
 msgstr "We send you occasional promotional offers & product updates on your email (once every month)."
 
-#: src/strings.ts:1167
+#: src/strings.ts:1168
 msgid "We will send you occasional promotional offers & product updates on your email (sent once every month)."
 msgstr "We will send you occasional promotional offers & product updates on your email (sent once every month)."
 
-#: src/strings.ts:1354
+#: src/strings.ts:1355
 msgid "We would love to know what you think!"
 msgstr "We would love to know what you think!"
 
-#: src/strings.ts:2563
+#: src/strings.ts:2564
 msgid "We’re setting up your plan right now. We’ll notify you as soon as everything is ready."
 msgstr "We’re setting up your plan right now. We’ll notify you as soon as everything is ready."
 
-#: src/strings.ts:2333
+#: src/strings.ts:2334
 msgid "Web clip settings"
 msgstr "Web clip settings"
 
-#: src/strings.ts:2029
+#: src/strings.ts:2030
 msgid "Website"
 msgstr "Website"
 
@@ -7309,12 +7315,12 @@ msgstr "Wednesday"
 msgid "Week"
 msgstr "Week"
 
-#: src/strings.ts:2637
+#: src/strings.ts:2638
 msgid "Week format"
 msgstr "Week format"
 
 #: src/strings.ts:168
-#: src/strings.ts:1569
+#: src/strings.ts:1570
 msgid "Weekly"
 msgstr "Weekly"
 
@@ -7322,63 +7328,63 @@ msgstr "Weekly"
 msgid "Welcome back, {email}"
 msgstr "Welcome back, {email}"
 
-#: src/strings.ts:1888
+#: src/strings.ts:1889
 msgid "Welcome back!"
 msgstr "Welcome back!"
 
-#: src/strings.ts:2597
+#: src/strings.ts:2598
 msgid "Welcome to Notesnook {plan}"
 msgstr "Welcome to Notesnook {plan}"
 
-#: src/strings.ts:2083
+#: src/strings.ts:2084
 msgid "Welcome to Notesnook Pro"
 msgstr "Welcome to Notesnook Pro"
 
-#: src/strings.ts:1392
+#: src/strings.ts:1393
 msgid "What do I do if I am not getting the email?"
 msgstr "What do I do if I am not getting the email?"
 
-#: src/strings.ts:2514
+#: src/strings.ts:2515
 msgid "What happens to my data if I switch plans?"
 msgstr "What happens to my data if I switch plans?"
 
-#: src/strings.ts:2530
+#: src/strings.ts:2531
 msgid "What is your refund policy?"
 msgstr "What is your refund policy?"
 
-#: src/strings.ts:1667
+#: src/strings.ts:1668
 msgid "What went wrong?"
 msgstr "What went wrong?"
 
-#: src/strings.ts:2520
+#: src/strings.ts:2521
 msgid "Why do you need my credit card details for a free trial?"
 msgstr "Why do you need my credit card details for a free trial?"
 
-#: src/strings.ts:2394
+#: src/strings.ts:2395
 msgid "Width"
 msgstr "Width"
 
-#: src/strings.ts:2500
+#: src/strings.ts:2501
 msgid "Words"
 msgstr "Words"
 
-#: src/strings.ts:2423
+#: src/strings.ts:2424
 msgid "Work & Office"
 msgstr "Work & Office"
 
-#: src/strings.ts:823
+#: src/strings.ts:824
 msgid "Write notes with freedom, no spying, no tracking."
 msgstr "Write notes with freedom, no spying, no tracking."
 
-#: src/strings.ts:1374
+#: src/strings.ts:1375
 msgid "Write something..."
 msgstr "Write something..."
 
-#: src/strings.ts:1654
+#: src/strings.ts:1655
 msgid "Write with freedom."
 msgstr "Write with freedom."
 
-#: src/strings.ts:2071
+#: src/strings.ts:2072
 msgid "Write with freedom. Never compromise on privacy again."
 msgstr "Write with freedom. Never compromise on privacy again."
 
@@ -7387,7 +7393,7 @@ msgid "Year"
 msgstr "Year"
 
 #: src/strings.ts:170
-#: src/strings.ts:1571
+#: src/strings.ts:1572
 msgid "Yearly"
 msgstr "Yearly"
 
@@ -7395,7 +7401,7 @@ msgstr "Yearly"
 msgid "Yes"
 msgstr "Yes"
 
-#: src/strings.ts:2527
+#: src/strings.ts:2528
 msgid "Yes, you can cancel your trial anytime. No questions asked."
 msgstr "Yes, you can cancel your trial anytime. No questions asked."
 
@@ -7403,27 +7409,27 @@ msgstr "Yes, you can cancel your trial anytime. No questions asked."
 msgid "You also agree to recieve marketing emails from us which you can opt-out of from app settings."
 msgstr "You also agree to recieve marketing emails from us which you can opt-out of from app settings."
 
-#: src/strings.ts:2602
+#: src/strings.ts:2603
 msgid "You are already subscribed to this plan."
 msgstr "You are already subscribed to this plan."
 
-#: src/strings.ts:2250
+#: src/strings.ts:2251
 msgid "You are editing \"{notebookTitle}\"."
 msgstr "You are editing \"{notebookTitle}\"."
 
-#: src/strings.ts:2043
+#: src/strings.ts:2044
 msgid "You are editing #{tag}"
 msgstr "You are editing #{tag}"
 
-#: src/strings.ts:1781
+#: src/strings.ts:1782
 msgid "You are logging into the beta version of Notesnook. Switching between beta &amp; stable versions can cause weird issues including data loss. It is recommended that you do not use both simultaneously."
 msgstr "You are logging into the beta version of Notesnook. Switching between beta &amp; stable versions can cause weird issues including data loss. It is recommended that you do not use both simultaneously."
 
-#: src/strings.ts:1361
+#: src/strings.ts:1362
 msgid "You are not logged in"
 msgstr "You are not logged in"
 
-#: src/strings.ts:886
+#: src/strings.ts:887
 msgid "You are renaming color {color}"
 msgstr "You are renaming color {color}"
 
@@ -7431,39 +7437,39 @@ msgstr "You are renaming color {color}"
 msgid "You can also link a note to multiple Notebooks. Tap and hold any notebook to enable multi-select."
 msgstr "You can also link a note to multiple Notebooks. Tap and hold any notebook to enable multi-select."
 
-#: src/strings.ts:2074
+#: src/strings.ts:2075
 msgid "You can change the theme at any time from Settings or the side menu."
 msgstr "You can change the theme at any time from Settings or the side menu."
 
-#: src/strings.ts:2605
+#: src/strings.ts:2606
 msgid "You can change your subscription plan from the web app"
 msgstr "You can change your subscription plan from the web app"
 
-#: src/strings.ts:2431
+#: src/strings.ts:2432
 msgid "You can create shortcuts of frequently accessed notebooks in the side menu"
 msgstr "You can create shortcuts of frequently accessed notebooks in the side menu"
 
-#: src/strings.ts:2089
+#: src/strings.ts:2090
 msgid "You can import your notes from most other note taking apps."
 msgstr "You can import your notes from most other note taking apps."
 
-#: src/strings.ts:1436
+#: src/strings.ts:1437
 msgid "You can multi-select notes and move them to a notebook at once"
 msgstr "You can multi-select notes and move them to a notebook at once"
 
-#: src/strings.ts:1427
+#: src/strings.ts:1428
 msgid "You can pin frequently used Notebooks to the Side Menu to quickly access them."
 msgstr "You can pin frequently used Notebooks to the Side Menu to quickly access them."
 
-#: src/strings.ts:1170
+#: src/strings.ts:1171
 msgid "You can set a custom proxy URL to increase your privacy."
 msgstr "You can set a custom proxy URL to increase your privacy."
 
-#: src/strings.ts:1408
+#: src/strings.ts:1409
 msgid "You can swipe left anywhere in the app to start a new note."
 msgstr "You can swipe left anywhere in the app to start a new note."
 
-#: src/strings.ts:2056
+#: src/strings.ts:2057
 msgid ""
 "You can track your bug report at [{url}]({url}).\n"
 "\n"
@@ -7477,7 +7483,7 @@ msgstr ""
 "\n"
 "If your issue is critical (e.g. notes not syncing, crashes etc.), please [join our Discord community](https://go.notesnook.com/discord) for one-to-one support."
 
-#: src/strings.ts:2065
+#: src/strings.ts:2066
 msgid ""
 "You can track your feature request at [{url}]({url}).\n"
 "\n"
@@ -7491,67 +7497,67 @@ msgstr ""
 msgid "You can track your issue at "
 msgstr "You can track your issue at "
 
-#: src/strings.ts:1028
+#: src/strings.ts:1029
 msgid "You can use all premium features for free for the next 14 days"
 msgstr "You can use all premium features for free for the next 14 days"
 
-#: src/strings.ts:1058
+#: src/strings.ts:1059
 msgid "You can use fallback 2FA method incase you are unable to login via primary method"
 msgstr "You can use fallback 2FA method incase you are unable to login via primary method"
 
-#: src/strings.ts:1450
+#: src/strings.ts:1451
 msgid "You can view & restore older versions of any note by going to its properties -> History."
 msgstr "You can view & restore older versions of any note by going to its properties -> History."
 
-#: src/strings.ts:1749
+#: src/strings.ts:1750
 msgid "You have {count} custom dictionary words."
 msgstr "You have {count} custom dictionary words."
 
-#: src/strings.ts:2208
+#: src/strings.ts:2209
 msgid "You have been logged out from all other devices."
 msgstr "You have been logged out from all other devices."
 
-#: src/strings.ts:2202
+#: src/strings.ts:2203
 msgid "You have been logged out."
 msgstr "You have been logged out."
 
-#: src/strings.ts:2601
+#: src/strings.ts:2602
 msgid "You have made a one time purchase. To change your plan please contact support."
 msgstr "You have made a one time purchase. To change your plan please contact support."
 
-#: src/strings.ts:964
+#: src/strings.ts:965
 msgid "You have not added any notebooks yet"
 msgstr "You have not added any notebooks yet"
 
-#: src/strings.ts:963
+#: src/strings.ts:964
 msgid "You have not added any tags yet"
 msgstr "You have not added any tags yet"
 
-#: src/strings.ts:962
+#: src/strings.ts:963
 msgid "You have not created any notes yet"
 msgstr "You have not created any notes yet"
 
-#: src/strings.ts:961
+#: src/strings.ts:962
 msgid "You have not favorited any notes yet"
 msgstr "You have not favorited any notes yet"
 
-#: src/strings.ts:966
+#: src/strings.ts:967
 msgid "You have not published any monographs yet"
 msgstr "You have not published any monographs yet"
 
-#: src/strings.ts:965
+#: src/strings.ts:966
 msgid "You have not set any reminders yet"
 msgstr "You have not set any reminders yet"
 
-#: src/strings.ts:1545
+#: src/strings.ts:1546
 msgid "You have unsynced notes. Take a backup or sync your notes to avoid losing your critical data."
 msgstr "You have unsynced notes. Take a backup or sync your notes to avoid losing your critical data."
 
-#: src/strings.ts:1634
+#: src/strings.ts:1635
 msgid "You must log out in order to change/reset server URLs."
 msgstr "You must log out in order to change/reset server URLs."
 
-#: src/strings.ts:2673
+#: src/strings.ts:2674
 msgid ""
 "You need to login to restore attachments from a backup file. [Read more](https://help.notesnook.com/faqs/login-to-restore-attachments-in-backup).\n"
 "  \n"
@@ -7561,11 +7567,11 @@ msgstr ""
 "  \n"
 "Continue without attachments?"
 
-#: src/strings.ts:836
+#: src/strings.ts:837
 msgid "You simply cannot get any better of a note taking app than @notesnook. The UI is clean and slick, it is feature rich, encrypted, reasonably priced (esp. for students & educators) & open source"
 msgstr "You simply cannot get any better of a note taking app than @notesnook. The UI is clean and slick, it is feature rich, encrypted, reasonably priced (esp. for students & educators) & open source"
 
-#: src/strings.ts:1068
+#: src/strings.ts:1069
 msgid "You subscribed to Notesnook Pro on {date}. Verify this subscription?"
 msgstr "You subscribed to Notesnook Pro on {date}. Verify this subscription?"
 
@@ -7593,7 +7599,7 @@ msgstr "You were awarded a subscription to Notesnook Pro by Streetwriters."
 msgid "You will be logged out from all your devices"
 msgstr "You will be logged out from all your devices"
 
-#: src/strings.ts:1851
+#: src/strings.ts:1852
 msgid "You will receive instructions on how to recover your account on this email"
 msgstr "You will receive instructions on how to recover your account on this email"
 
@@ -7601,72 +7607,72 @@ msgstr "You will receive instructions on how to recover your account on this ema
 msgid "Your account email will be changed without affecting your subscription or any other settings."
 msgstr "Your account email will be changed without affecting your subscription or any other settings."
 
-#: src/strings.ts:1917
+#: src/strings.ts:1918
 msgid "Your account has been recovered."
 msgstr "Your account has been recovered."
 
 #: src/strings.ts:502
-#: src/strings.ts:1728
+#: src/strings.ts:1729
 msgid "Your account is now 100% secure against unauthorized logins."
 msgstr "Your account is now 100% secure against unauthorized logins."
 
-#: src/strings.ts:1856
+#: src/strings.ts:1857
 msgid "Your account password must be strong & unique."
 msgstr "Your account password must be strong & unique."
 
-#: src/strings.ts:1034
+#: src/strings.ts:1035
 msgid "Your account will be downgraded in {days} days"
 msgstr "Your account will be downgraded in {days} days"
 
-#: src/strings.ts:1078
+#: src/strings.ts:1079
 msgid "Your account will be permanently deleted along with all your data, login credentials, and subscription information. This action is IRREVERSIBLE. Make sure you have saved a backup of your notes before proceeding."
 msgstr "Your account will be permanently deleted along with all your data, login credentials, and subscription information. This action is IRREVERSIBLE. Make sure you have saved a backup of your notes before proceeding."
 
-#: src/strings.ts:960
+#: src/strings.ts:961
 msgid "Your archive"
 msgstr "Your archive"
 
-#: src/strings.ts:2496
+#: src/strings.ts:2497
 msgid "Your archive is empty"
 msgstr "Your archive is empty"
 
-#: src/strings.ts:1929
+#: src/strings.ts:1930
 msgid "Your backup is ready to download"
 msgstr "Your backup is ready to download"
 
-#: src/strings.ts:1586
+#: src/strings.ts:1587
 msgid "Your changes could not be saved"
 msgstr "Your changes could not be saved"
 
-#: src/strings.ts:1776
+#: src/strings.ts:1777
 msgid "Your changes have been saved and will be reflected after the app has refreshed."
 msgstr "Your changes have been saved and will be reflected after the app has refreshed."
 
-#: src/strings.ts:2109
+#: src/strings.ts:2110
 msgid "Your current 2FA method is {method}"
 msgstr "Your current 2FA method is {method}"
 
-#: src/strings.ts:2608
+#: src/strings.ts:2609
 msgid "Your current subscription does not allow changing plans"
 msgstr "Your current subscription does not allow changing plans"
 
-#: src/strings.ts:1801
+#: src/strings.ts:1802
 msgid "Your data recovery key is basically a hashed version of your password (plus some random salt). It can be used to decrypt your data for re-encryption."
 msgstr "Your data recovery key is basically a hashed version of your password (plus some random salt). It can be used to decrypt your data for re-encryption."
 
-#: src/strings.ts:1854
+#: src/strings.ts:1855
 msgid "Your data recovery key will be used to decrypt your data"
 msgstr "Your data recovery key will be used to decrypt your data"
 
-#: src/strings.ts:2516
+#: src/strings.ts:2517
 msgid "Your data remains 100% accessible regardless of what plan you are on. That includes your notes, notebooks, attachments, and anything else you might have created."
 msgstr "Your data remains 100% accessible regardless of what plan you are on. That includes your notes, notebooks, attachments, and anything else you might have created."
 
-#: src/strings.ts:1784
+#: src/strings.ts:1785
 msgid "Your email has been confirmed."
 msgstr "Your email has been confirmed."
 
-#: src/strings.ts:2507
+#: src/strings.ts:2508
 msgid "Your email has been confirmed. You can now securely sync your encrypted notes across all devices."
 msgstr "Your email has been confirmed. You can now securely sync your encrypted notes across all devices."
 
@@ -7674,39 +7680,39 @@ msgstr "Your email has been confirmed. You can now securely sync your encrypted 
 msgid "Your email is not confirmed. Please confirm your email address to change account password."
 msgstr "Your email is not confirmed. Please confirm your email address to change account password."
 
-#: src/strings.ts:954
+#: src/strings.ts:955
 msgid "Your favorites"
 msgstr "Your favorites"
 
-#: src/strings.ts:1031
+#: src/strings.ts:1032
 msgid "Your free trial ends on {date}"
 msgstr "Your free trial ends on {date}"
 
-#: src/strings.ts:1404
+#: src/strings.ts:1405
 msgid "Your free trial has expired"
 msgstr "Your free trial has expired"
 
-#: src/strings.ts:1026
+#: src/strings.ts:1027
 msgid "Your free trial has started"
 msgstr "Your free trial has started"
 
-#: src/strings.ts:1403
+#: src/strings.ts:1404
 msgid "Your free trial is ending soon"
 msgstr "Your free trial is ending soon"
 
-#: src/strings.ts:2636
+#: src/strings.ts:2637
 msgid "Your free trial is on-going. Your subscription will start on {trialExpiryDate}"
 msgstr "Your free trial is on-going. Your subscription will start on {trialExpiryDate}"
 
-#: src/strings.ts:1778
+#: src/strings.ts:1779
 msgid "Your full name"
 msgstr "Your full name"
 
-#: src/strings.ts:959
+#: src/strings.ts:960
 msgid "Your monographs"
 msgstr "Your monographs"
 
-#: src/strings.ts:1312
+#: src/strings.ts:1313
 msgid "Your name is stored 100% end-to-end encrypted and only visible to you."
 msgstr "Your name is stored 100% end-to-end encrypted and only visible to you."
 
@@ -7714,31 +7720,31 @@ msgstr "Your name is stored 100% end-to-end encrypted and only visible to you."
 msgid "Your note will be unencrypted and removed from the vault."
 msgstr "Your note will be unencrypted and removed from the vault."
 
-#: src/strings.ts:957
+#: src/strings.ts:958
 msgid "Your notebooks"
 msgstr "Your notebooks"
 
-#: src/strings.ts:955
+#: src/strings.ts:956
 msgid "Your notes"
 msgstr "Your notes"
 
-#: src/strings.ts:1892
+#: src/strings.ts:1893
 msgid "Your password is always hashed before leaving this device."
 msgstr "Your password is always hashed before leaving this device."
 
-#: src/strings.ts:832
+#: src/strings.ts:833
 msgid "Your privacy matters to us, no matter who you are. In a world where everyone is trying to spy on you, Notesnook encrypts all your data before it leaves your device. With Notesnook no one can ever sell your data again."
 msgstr "Your privacy matters to us, no matter who you are. In a world where everyone is trying to spy on you, Notesnook encrypts all your data before it leaves your device. With Notesnook no one can ever sell your data again."
 
-#: src/strings.ts:1309
+#: src/strings.ts:1310
 msgid "Your profile pictrure is stored 100% end-to-end encrypted and only visible to you."
 msgstr "Your profile pictrure is stored 100% end-to-end encrypted and only visible to you."
 
-#: src/strings.ts:1997
+#: src/strings.ts:1998
 msgid "Your refund has been issued. Please wait 24 hours before reaching out to us in case you do not receive your funds."
 msgstr "Your refund has been issued. Please wait 24 hours before reaching out to us in case you do not receive your funds."
 
-#: src/strings.ts:958
+#: src/strings.ts:959
 msgid "Your reminders"
 msgstr "Your reminders"
 
@@ -7746,31 +7752,31 @@ msgstr "Your reminders"
 msgid "Your session has expired. Please enter password for {obfuscatedEmail} to continue."
 msgstr "Your session has expired. Please enter password for {obfuscatedEmail} to continue."
 
-#: src/strings.ts:1035
+#: src/strings.ts:1036
 msgid "Your subscription ends on {date}"
 msgstr "Your subscription ends on {date}"
 
-#: src/strings.ts:1995
+#: src/strings.ts:1996
 msgid "Your subscription has been canceled."
 msgstr "Your subscription has been canceled."
 
-#: src/strings.ts:1032
+#: src/strings.ts:1033
 msgid "Your subscription has ended"
 msgstr "Your subscription has ended"
 
-#: src/strings.ts:1036
+#: src/strings.ts:1037
 msgid "Your subscription renews on {date}"
 msgstr "Your subscription renews on {date}"
 
-#: src/strings.ts:2053
+#: src/strings.ts:2054
 msgid "Your support request has been forwarded"
 msgstr "Your support request has been forwarded"
 
-#: src/strings.ts:2062
+#: src/strings.ts:2063
 msgid "Your support request has been forwarded to our support team. We will get back to you via email as soon as possible. If you don't receive an email from us within 24-48 hours, please send us an email directly at support@notesnook.com."
 msgstr "Your support request has been forwarded to our support team. We will get back to you via email as soon as possible. If you don't receive an email from us within 24-48 hours, please send us an email directly at support@notesnook.com."
 
-#: src/strings.ts:956
+#: src/strings.ts:957
 msgid "Your tags"
 msgstr "Your tags"
 
@@ -7786,22 +7792,22 @@ msgstr "Z to A"
 msgid "Zipping"
 msgstr "Zipping"
 
-#: src/strings.ts:2472
+#: src/strings.ts:2473
 msgid "Zoom"
 msgstr "Zoom"
 
-#: src/strings.ts:2103
+#: src/strings.ts:2104
 msgid "Zoom factor"
 msgstr "Zoom factor"
 
-#: src/strings.ts:1700
+#: src/strings.ts:1701
 msgid "Zoom in"
 msgstr "Zoom in"
 
-#: src/strings.ts:2104
+#: src/strings.ts:2105
 msgid "Zoom in or out the app content."
 msgstr "Zoom in or out the app content."
 
-#: src/strings.ts:1699
+#: src/strings.ts:1700
 msgid "Zoom out"
 msgstr "Zoom out"

--- a/packages/intl/locale/en.po
+++ b/packages/intl/locale/en.po
@@ -14,7 +14,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/strings.ts:2422
+#: src/strings.ts:2421
 msgid " \"Notebook > Notes\""
 msgstr " \"Notebook > Notes\""
 
@@ -22,27 +22,27 @@ msgstr " \"Notebook > Notes\""
 msgid " Unlock with password once to enable biometric access."
 msgstr " Unlock with password once to enable biometric access."
 
-#: src/strings.ts:1942
+#: src/strings.ts:1941
 msgid " Upgrade to Notesnook Pro to add more notebooks."
 msgstr " Upgrade to Notesnook Pro to add more notebooks."
 
-#: src/strings.ts:1945
+#: src/strings.ts:1944
 msgid " Upgrade to Notesnook Pro to customize the toolbar."
 msgstr " Upgrade to Notesnook Pro to customize the toolbar."
 
-#: src/strings.ts:1944
+#: src/strings.ts:1943
 msgid " Upgrade to Notesnook Pro to use custom toolbar presets."
 msgstr " Upgrade to Notesnook Pro to use custom toolbar presets."
 
-#: src/strings.ts:1943
+#: src/strings.ts:1942
 msgid " Upgrade to Notesnook Pro to use the notes vault."
 msgstr " Upgrade to Notesnook Pro to use the notes vault."
 
-#: src/strings.ts:1946
+#: src/strings.ts:1945
 msgid " Upgrade to Notesnook Pro to use this feature."
 msgstr " Upgrade to Notesnook Pro to use this feature."
 
-#: src/strings.ts:829
+#: src/strings.ts:828
 msgid "— not just the"
 msgstr "— not just the"
 
@@ -70,19 +70,19 @@ msgid "{0} Highlights 🎉"
 msgstr "{0} Highlights 🎉"
 
 #. placeholder {0}: platform === "ios" ? "Apple" : "Google"
-#: src/strings.ts:2578
+#: src/strings.ts:2577
 msgid "{0} will remind you before your trial ends"
 msgstr "{0} will remind you before your trial ends"
 
-#: src/strings.ts:1754
+#: src/strings.ts:1753
 msgid "{count, plural, one {# error occured} other {# errors occured}}"
 msgstr "{count, plural, one {# error occured} other {# errors occured}}"
 
-#: src/strings.ts:1760
+#: src/strings.ts:1759
 msgid "{count, plural, one {# file ready for import} other {# files ready for import}}"
 msgstr "{count, plural, one {# file ready for import} other {# files ready for import}}"
 
-#: src/strings.ts:1715
+#: src/strings.ts:1714
 msgid "{count, plural, one {# file} other {# files}}"
 msgstr "{count, plural, one {# file} other {# files}}"
 
@@ -90,11 +90,11 @@ msgstr "{count, plural, one {# file} other {# files}}"
 msgid "{count, plural, one {# note} other {# notes}}"
 msgstr "{count, plural, one {# note} other {# notes}}"
 
-#: src/strings.ts:1579
+#: src/strings.ts:1578
 msgid "{count, plural, one {1 hour} other {# hours}}"
 msgstr "{count, plural, one {1 hour} other {# hours}}"
 
-#: src/strings.ts:1574
+#: src/strings.ts:1573
 msgid "{count, plural, one {1 minute} other {# minutes}}"
 msgstr "{count, plural, one {1 minute} other {# minutes}}"
 
@@ -135,7 +135,7 @@ msgstr "{count, plural, one {Are you sure you want to delete this tag?} other {A
 msgid "{count, plural, one {Are you sure you want to download all attachments of this note?} other {Are you sure you want to download all attachments?}}"
 msgstr "{count, plural, one {Are you sure you want to download all attachments of this note?} other {Are you sure you want to download all attachments?}}"
 
-#: src/strings.ts:864
+#: src/strings.ts:863
 msgid "{count, plural, one {Are you sure you want to move this notebook to {selectedNotebookTitle}?} other {Are you sure you want to move these # notebooks {selectedNotebookTitle}?}}"
 msgstr "{count, plural, one {Are you sure you want to move this notebook to {selectedNotebookTitle}?} other {Are you sure you want to move these # notebooks {selectedNotebookTitle}?}}"
 
@@ -294,11 +294,11 @@ msgstr "{count, plural, one {Item restored} other {# items restored}}"
 msgid "{count, plural, one {Item unpublished} other {# items unpublished}}"
 msgstr "{count, plural, one {Item unpublished} other {# items unpublished}}"
 
-#: src/strings.ts:2439
+#: src/strings.ts:2438
 msgid "{count, plural, one {Move all notes in this notebook to trash} other {Move all notes in these notebooks to trash}}"
 msgstr "{count, plural, one {Move all notes in this notebook to trash} other {Move all notes in these notebooks to trash}}"
 
-#: src/strings.ts:862
+#: src/strings.ts:861
 msgid "{count, plural, one {Move notebook} other {Move # notebooks}}"
 msgstr "{count, plural, one {Move notebook} other {Move # notebooks}}"
 
@@ -342,7 +342,7 @@ msgstr "{count, plural, one {Note restored} other {# notes restored}}"
 msgid "{count, plural, one {Note unpublished} other {# notes unpublished}}"
 msgstr "{count, plural, one {Note unpublished} other {# notes unpublished}}"
 
-#: src/strings.ts:921
+#: src/strings.ts:920
 msgid "{count, plural, one {Note will be automatically deleted from all other devices & any future changes won't get synced. Are you sure you want to continue?} other {# notes will be automatically deleted from all other devices & any future changes won't get synced. Are you sure you want to continue?}}"
 msgstr "{count, plural, one {Note will be automatically deleted from all other devices & any future changes won't get synced. Are you sure you want to continue?} other {# notes will be automatically deleted from all other devices & any future changes won't get synced. Are you sure you want to continue?}}"
 
@@ -396,7 +396,7 @@ msgstr "{count, plural, one {Pin note} other {Pin # notes}}"
 msgid "{count, plural, one {Pin notebook} other {Pin # notebooks}}"
 msgstr "{count, plural, one {Pin notebook} other {Pin # notebooks}}"
 
-#: src/strings.ts:916
+#: src/strings.ts:915
 msgid "{count, plural, one {Prevent note from syncing} other {Prevent # notes from syncing}}"
 msgstr "{count, plural, one {Prevent note from syncing} other {Prevent # notes from syncing}}"
 
@@ -497,15 +497,15 @@ msgstr "{count, plural, one {Unpublish item} other {Unpublish # items}}"
 msgid "{count, plural, one {Unpublish note} other {Unpublish # notes}}"
 msgstr "{count, plural, one {Unpublish note} other {Unpublish # notes}}"
 
-#: src/strings.ts:2509
+#: src/strings.ts:2508
 msgid "{count} characters"
 msgstr "{count} characters"
 
-#: src/strings.ts:1565
+#: src/strings.ts:1564
 msgid "{days, plural, one {1 day} other {# days}}"
 msgstr "{days, plural, one {1 day} other {# days}}"
 
-#: src/strings.ts:2569
+#: src/strings.ts:2568
 msgid "{days} days free"
 msgstr "{days} days free"
 
@@ -545,19 +545,19 @@ msgstr "{mode, select, day {Daily} week {Weekly} month {Monthly} year {Yearly} o
 msgid "{mode, select, repeat {Repeat} once {Once} permanent {Permanent} other {Unknown mode}}"
 msgstr "{mode, select, repeat {Repeat} once {Once} permanent {Permanent} other {Unknown mode}}"
 
-#: src/strings.ts:1977
+#: src/strings.ts:1976
 msgid "{n} {added, plural, one {added to 1 notebook} other {added to # notebooks}} and {removed, plural, one {removed from 1 notebook} other {removed from # notebooks}}."
 msgstr "{n} {added, plural, one {added to 1 notebook} other {added to # notebooks}} and {removed, plural, one {removed from 1 notebook} other {removed from # notebooks}}."
 
-#: src/strings.ts:1972
+#: src/strings.ts:1971
 msgid "{n} {added, plural, one {added to 1 notebook} other {added to # notebooks}}."
 msgstr "{n} {added, plural, one {added to 1 notebook} other {added to # notebooks}}."
 
-#: src/strings.ts:1967
+#: src/strings.ts:1966
 msgid "{n} {removed, plural, one {removed from 1 notebook} other {removed from # notebooks}}."
 msgstr "{n} {removed, plural, one {removed from 1 notebook} other {removed from # notebooks}}."
 
-#: src/strings.ts:1962
+#: src/strings.ts:1961
 msgid "{notes, plural, one {1 note} other {# notes}}"
 msgstr "{notes, plural, one {1 note} other {# notes}}"
 
@@ -565,11 +565,11 @@ msgstr "{notes, plural, one {1 note} other {# notes}}"
 msgid "{notes, plural, one {Export note} other {Export # notes}}"
 msgstr "{notes, plural, one {Export note} other {Export # notes}}"
 
-#: src/strings.ts:1707
+#: src/strings.ts:1706
 msgid "{percentage}% updating..."
 msgstr "{percentage}% updating..."
 
-#: src/strings.ts:2553
+#: src/strings.ts:2552
 msgid "{plan} plan"
 msgstr "{plan} plan"
 
@@ -577,11 +577,11 @@ msgstr "{plan} plan"
 msgid "{platform, select, android {{name} saved to selected path} other {{name} saved to File Manager/Notesnook/downloads}}"
 msgstr "{platform, select, android {{name} saved to selected path} other {{name} saved to File Manager/Notesnook/downloads}}"
 
-#: src/strings.ts:1338
+#: src/strings.ts:1337
 msgid "{platform, select, android {Backup file saved in \"Notesnook backups\" folder on your phone.} other {Backup file is saved in File Manager/Notesnook folder}}"
 msgstr "{platform, select, android {Backup file saved in \"Notesnook backups\" folder on your phone.} other {Backup file is saved in File Manager/Notesnook folder}}"
 
-#: src/strings.ts:2369
+#: src/strings.ts:2368
 msgid "{selected} selected"
 msgstr "{selected} selected"
 
@@ -601,43 +601,43 @@ msgstr "{type, select, upload {Uploading} download {Downloading} sync {Syncing} 
 msgid "{type} does not match"
 msgstr "{type} does not match"
 
-#: src/strings.ts:1600
+#: src/strings.ts:1599
 msgid "{words, plural, one {# word} other {# words}}"
 msgstr "{words, plural, one {# word} other {# words}}"
 
-#: src/strings.ts:1663
+#: src/strings.ts:1662
 msgid "{words, plural, other {# selected}}"
 msgstr "{words, plural, other {# selected}}"
 
-#: src/strings.ts:1791
+#: src/strings.ts:1790
 msgid "#notesnook"
 msgstr "#notesnook"
 
-#: src/strings.ts:1584
+#: src/strings.ts:1583
 msgid "12-hour"
 msgstr "12-hour"
 
-#: src/strings.ts:1585
+#: src/strings.ts:1584
 msgid "24-hour"
 msgstr "24-hour"
 
-#: src/strings.ts:1905
+#: src/strings.ts:1904
 msgid "2FA code is required()"
 msgstr "2FA code is required()"
 
-#: src/strings.ts:1009
+#: src/strings.ts:1008
 msgid "2FA code sent via {method}"
 msgstr "2FA code sent via {method}"
 
-#: src/strings.ts:2596
+#: src/strings.ts:2595
 msgid "5 year plan (One time purchase)"
 msgstr "5 year plan (One time purchase)"
 
-#: src/strings.ts:1846
+#: src/strings.ts:1845
 msgid "6 digit code"
 msgstr "6 digit code"
 
-#: src/strings.ts:1432
+#: src/strings.ts:1431
 msgid "A notebook can have unlimited topics with unlimited notes."
 msgstr "A notebook can have unlimited topics with unlimited notes."
 
@@ -653,35 +653,35 @@ msgstr "A vault stores your notes in an encrypted storage."
 msgid "Abc"
 msgstr "Abc"
 
-#: src/strings.ts:1290
+#: src/strings.ts:1289
 msgid "About"
 msgstr "About"
 
-#: src/strings.ts:1025
+#: src/strings.ts:1024
 msgid "Account"
 msgstr "Account"
 
-#: src/strings.ts:1848
+#: src/strings.ts:1847
 msgid "Account password"
 msgstr "Account password"
 
-#: src/strings.ts:2464
+#: src/strings.ts:2463
 msgid "Actions for note: {title}"
 msgstr "Actions for note: {title}"
 
-#: src/strings.ts:2465
+#: src/strings.ts:2464
 msgid "Actions for notebook: {title}"
 msgstr "Actions for notebook: {title}"
 
-#: src/strings.ts:2466
+#: src/strings.ts:2465
 msgid "Actions for tag: {title}"
 msgstr "Actions for tag: {title}"
 
-#: src/strings.ts:2038
+#: src/strings.ts:2037
 msgid "Activate"
 msgstr "Activate"
 
-#: src/strings.ts:1824
+#: src/strings.ts:1823
 msgid "Activating trial"
 msgstr "Activating trial"
 
@@ -689,15 +689,15 @@ msgstr "Activating trial"
 msgid "Add"
 msgstr "Add"
 
-#: src/strings.ts:1057
+#: src/strings.ts:1056
 msgid "Add 2FA fallback method"
 msgstr "Add 2FA fallback method"
 
-#: src/strings.ts:1508
+#: src/strings.ts:1507
 msgid "Add a short note"
 msgstr "Add a short note"
 
-#: src/strings.ts:1601
+#: src/strings.ts:1600
 msgid "Add a tag"
 msgstr "Add a tag"
 
@@ -705,11 +705,11 @@ msgstr "Add a tag"
 msgid "Add color"
 msgstr "Add color"
 
-#: src/strings.ts:896
+#: src/strings.ts:895
 msgid "Add notebook"
 msgstr "Add notebook"
 
-#: src/strings.ts:2491
+#: src/strings.ts:2490
 msgid "Add notes"
 msgstr "Add notes"
 
@@ -717,7 +717,7 @@ msgstr "Add notes"
 msgid "Add notes to {title}"
 msgstr "Add notes to {title}"
 
-#: src/strings.ts:895
+#: src/strings.ts:894
 msgid "Add shortcut"
 msgstr "Add shortcut"
 
@@ -729,55 +729,55 @@ msgstr "Add shortcuts for notebooks and tags here."
 msgid "Add tag"
 msgstr "Add tag"
 
-#: src/strings.ts:934
+#: src/strings.ts:933
 msgid "Add tags"
 msgstr "Add tags"
 
-#: src/strings.ts:935
+#: src/strings.ts:934
 msgid "Add tags to multiple notes at once"
 msgstr "Add tags to multiple notes at once"
 
-#: src/strings.ts:2256
+#: src/strings.ts:2255
 msgid "Add to dictionary"
 msgstr "Add to dictionary"
 
-#: src/strings.ts:2629
+#: src/strings.ts:2628
 msgid "Add to home"
 msgstr "Add to home"
 
-#: src/strings.ts:2489
+#: src/strings.ts:2488
 msgid "Add to notebook"
 msgstr "Add to notebook"
 
-#: src/strings.ts:975
+#: src/strings.ts:974
 msgid "Add your first note"
 msgstr "Add your first note"
 
-#: src/strings.ts:976
+#: src/strings.ts:975
 msgid "Add your first notebook"
 msgstr "Add your first notebook"
 
-#: src/strings.ts:2632
+#: src/strings.ts:2631
 msgid "Adjust the line height of the editor"
 msgstr "Adjust the line height of the editor"
 
-#: src/strings.ts:2182
+#: src/strings.ts:2181
 msgid "Advanced"
 msgstr "Advanced"
 
-#: src/strings.ts:1727
+#: src/strings.ts:1726
 msgid "After scanning the QR code image, the app will display a code that you can enter below."
 msgstr "After scanning the QR code image, the app will display a code that you can enter below."
 
-#: src/strings.ts:2321
+#: src/strings.ts:2320
 msgid "Align left"
 msgstr "Align left"
 
-#: src/strings.ts:2322
+#: src/strings.ts:2321
 msgid "Align right"
 msgstr "Align right"
 
-#: src/strings.ts:2291
+#: src/strings.ts:2290
 msgid "Alignment"
 msgstr "Alignment"
 
@@ -789,7 +789,7 @@ msgstr "All"
 msgid "All attachments are end-to-end encrypted."
 msgstr "All attachments are end-to-end encrypted."
 
-#: src/strings.ts:2416
+#: src/strings.ts:2415
 msgid "All cached attachments have been cleared."
 msgstr "All cached attachments have been cleared."
 
@@ -801,7 +801,7 @@ msgstr "All fields are required"
 msgid "All files"
 msgstr "All files"
 
-#: src/strings.ts:1175
+#: src/strings.ts:1174
 msgid "All locked notes will be re-encrypted with the new password."
 msgstr "All locked notes will be re-encrypted with the new password."
 
@@ -809,15 +809,15 @@ msgstr "All locked notes will be re-encrypted with the new password."
 msgid "All logs are local only and are not sent to any server. You can share the logs from here with us if you face an issue to help us find the root cause."
 msgstr "All logs are local only and are not sent to any server. You can share the logs from here with us if you face an issue to help us find the root cause."
 
-#: src/strings.ts:1638
+#: src/strings.ts:1637
 msgid "All server urls are required."
 msgstr "All server urls are required."
 
-#: src/strings.ts:1907
+#: src/strings.ts:1906
 msgid "All the data in your account will be overwritten with the data in the backup file. There is no way to reverse this action."
 msgstr "All the data in your account will be overwritten with the data in the backup file. There is no way to reverse this action."
 
-#: src/strings.ts:2162
+#: src/strings.ts:2161
 msgid "All the source code for Notesnook is available & open for everyone on GitHub."
 msgstr "All the source code for Notesnook is available & open for everyone on GitHub."
 
@@ -825,15 +825,15 @@ msgstr "All the source code for Notesnook is available & open for everyone on Gi
 msgid "All tools are grouped"
 msgstr "All tools are grouped"
 
-#: src/strings.ts:1322
+#: src/strings.ts:1321
 msgid "All tools in the collapsed section will be removed"
 msgstr "All tools in the collapsed section will be removed"
 
-#: src/strings.ts:1317
+#: src/strings.ts:1316
 msgid "All tools in this group will be removed from the toolbar."
 msgstr "All tools in this group will be removed from the toolbar."
 
-#: src/strings.ts:1347
+#: src/strings.ts:1346
 msgid "All your backups are stored in 'Phone Storage/Notesnook/backups/' folder"
 msgstr "All your backups are stored in 'Phone Storage/Notesnook/backups/' folder"
 
@@ -841,7 +841,7 @@ msgstr "All your backups are stored in 'Phone Storage/Notesnook/backups/' folder
 msgid "Already have an account?"
 msgstr "Already have an account?"
 
-#: src/strings.ts:2232
+#: src/strings.ts:2231
 msgid "Amount"
 msgstr "Amount"
 
@@ -849,7 +849,7 @@ msgstr "Amount"
 msgid "An error occurred while migrating your data. You can logout of your account and try to relogin. However this is not recommended as it may result in some data loss if your data was not synced."
 msgstr "An error occurred while migrating your data. You can logout of your account and try to relogin. However this is not recommended as it may result in some data loss if your data was not synced."
 
-#: src/strings.ts:2590
+#: src/strings.ts:2589
 msgid "and"
 msgstr "and"
 
@@ -857,19 +857,19 @@ msgstr "and"
 msgid "and "
 msgstr "and "
 
-#: src/strings.ts:1792
+#: src/strings.ts:1791
 msgid "and get a chance to win free promo codes."
 msgstr "and get a chance to win free promo codes."
 
-#: src/strings.ts:2546
+#: src/strings.ts:2545
 msgid "and much more."
 msgstr "and much more."
 
-#: src/strings.ts:1398
+#: src/strings.ts:1397
 msgid "and we will manually confirm your account."
 msgstr "and we will manually confirm your account."
 
-#: src/strings.ts:2607
+#: src/strings.ts:2606
 msgid "ANNOUNCEMENT"
 msgstr "ANNOUNCEMENT"
 
@@ -877,29 +877,29 @@ msgstr "ANNOUNCEMENT"
 msgid "App data has been cleared. Kindly relaunch the app to login again."
 msgstr "App data has been cleared. Kindly relaunch the app to login again."
 
-#: src/strings.ts:1184
-#: src/strings.ts:1694
+#: src/strings.ts:1183
+#: src/strings.ts:1693
 msgid "App lock"
 msgstr "App lock"
 
 #: src/strings.ts:781
-#: src/strings.ts:1210
+#: src/strings.ts:1209
 msgid "App lock disabled"
 msgstr "App lock disabled"
 
-#: src/strings.ts:1190
+#: src/strings.ts:1189
 msgid "App lock timeout"
 msgstr "App lock timeout"
 
-#: src/strings.ts:1301
+#: src/strings.ts:1300
 msgid "App version"
 msgstr "App version"
 
-#: src/strings.ts:1775
+#: src/strings.ts:1774
 msgid "App will reload in {sec} seconds"
 msgstr "App will reload in {sec} seconds"
 
-#: src/strings.ts:1115
+#: src/strings.ts:1114
 msgid "Appearance"
 msgstr "Appearance"
 
@@ -915,32 +915,32 @@ msgstr "Applied as light theme"
 msgid "Apply changes"
 msgstr "Apply changes"
 
-#: src/strings.ts:2045
+#: src/strings.ts:2044
 msgid "Applying changes"
 msgstr "Applying changes"
 
-#: src/strings.ts:1531
-#: src/strings.ts:2496
+#: src/strings.ts:1530
+#: src/strings.ts:2495
 msgid "Archive"
 msgstr "Archive"
 
-#: src/strings.ts:1446
+#: src/strings.ts:1445
 msgid "Are you scrolling a lot to find a specific note? Pin it to the top from Note properties."
 msgstr "Are you scrolling a lot to find a specific note? Pin it to the top from Note properties."
 
-#: src/strings.ts:1017
+#: src/strings.ts:1016
 msgid "Are you sure you want to clear all logs from {key}?"
 msgstr "Are you sure you want to clear all logs from {key}?"
 
-#: src/strings.ts:1325
+#: src/strings.ts:1324
 msgid "Are you sure you want to clear trash?"
 msgstr "Are you sure you want to clear trash?"
 
-#: src/strings.ts:2667
+#: src/strings.ts:2666
 msgid "Are you sure you want to delete this attachment?"
 msgstr "Are you sure you want to delete this attachment?"
 
-#: src/strings.ts:1543
+#: src/strings.ts:1542
 msgid "Are you sure you want to logout and clear all data stored on THIS DEVICE?"
 msgstr "Are you sure you want to logout and clear all data stored on THIS DEVICE?"
 
@@ -948,31 +948,31 @@ msgstr "Are you sure you want to logout and clear all data stored on THIS DEVICE
 msgid "Are you sure you want to logout from this device? Any unsynced changes will be lost."
 msgstr "Are you sure you want to logout from this device? Any unsynced changes will be lost."
 
-#: src/strings.ts:2688
+#: src/strings.ts:2687
 msgid "Are you sure you want to open this file: {filePath}?"
 msgstr "Are you sure you want to open this file: {filePath}?"
 
-#: src/strings.ts:1047
+#: src/strings.ts:1046
 msgid "Are you sure you want to remove your name?"
 msgstr "Are you sure you want to remove your name?"
 
-#: src/strings.ts:1044
+#: src/strings.ts:1043
 msgid "Are you sure you want to remove your profile picture?"
 msgstr "Are you sure you want to remove your profile picture?"
 
-#: src/strings.ts:1324
+#: src/strings.ts:1323
 msgid "Are you sure?"
 msgstr "Are you sure?"
 
-#: src/strings.ts:1131
+#: src/strings.ts:1130
 msgid "Ask every time"
 msgstr "Ask every time"
 
-#: src/strings.ts:2034
+#: src/strings.ts:2033
 msgid "Assign color"
 msgstr "Assign color"
 
-#: src/strings.ts:933
+#: src/strings.ts:932
 msgid "Assign to..."
 msgstr "Assign to..."
 
@@ -980,15 +980,15 @@ msgstr "Assign to..."
 msgid "Atleast 8 characters required"
 msgstr "Atleast 8 characters required"
 
-#: src/strings.ts:2358
+#: src/strings.ts:2357
 msgid "Attach image from URL"
 msgstr "Attach image from URL"
 
-#: src/strings.ts:909
+#: src/strings.ts:908
 msgid "Attached files"
 msgstr "Attached files"
 
-#: src/strings.ts:2679
+#: src/strings.ts:2678
 msgid "Attaching files"
 msgstr "Attaching files"
 
@@ -997,27 +997,27 @@ msgid "attachment"
 msgstr "attachment"
 
 #: src/strings.ts:300
-#: src/strings.ts:2355
+#: src/strings.ts:2354
 msgid "Attachment"
 msgstr "Attachment"
 
-#: src/strings.ts:2668
+#: src/strings.ts:2667
 msgid "Attachment deleted"
 msgstr "Attachment deleted"
 
-#: src/strings.ts:2459
+#: src/strings.ts:2458
 msgid "Attachment manager"
 msgstr "Attachment manager"
 
-#: src/strings.ts:1936
+#: src/strings.ts:1935
 msgid "Attachment preview failed"
 msgstr "Attachment preview failed"
 
-#: src/strings.ts:2409
+#: src/strings.ts:2408
 msgid "Attachment recheck cancelled"
 msgstr "Attachment recheck cancelled"
 
-#: src/strings.ts:2326
+#: src/strings.ts:2325
 msgid "Attachment settings"
 msgstr "Attachment settings"
 
@@ -1026,15 +1026,15 @@ msgid "attachments"
 msgstr "attachments"
 
 #: src/strings.ts:320
-#: src/strings.ts:908
+#: src/strings.ts:907
 msgid "Attachments"
 msgstr "Attachments"
 
-#: src/strings.ts:1885
+#: src/strings.ts:1884
 msgid "Attachments cache cleared!"
 msgstr "Attachments cache cleared!"
 
-#: src/strings.ts:2411
+#: src/strings.ts:2410
 msgid "Attachments recheck complete"
 msgstr "Attachments recheck complete"
 
@@ -1042,160 +1042,160 @@ msgstr "Attachments recheck complete"
 msgid "Audios"
 msgstr "Audios"
 
-#: src/strings.ts:1627
+#: src/strings.ts:1626
 msgid "Auth server"
 msgstr "Auth server"
 
-#: src/strings.ts:1796
+#: src/strings.ts:1795
 msgid "Authenticated as {email}"
 msgstr "Authenticated as {email}"
 
-#: src/strings.ts:1899
+#: src/strings.ts:1898
 msgid "Authenticating user"
 msgstr "Authenticating user"
 
-#: src/strings.ts:2145
+#: src/strings.ts:2144
 msgid "Authentication"
 msgstr "Authentication"
 
-#: src/strings.ts:1731
+#: src/strings.ts:1730
 msgid "authentication app"
 msgstr "authentication app"
 
-#: src/strings.ts:1352
+#: src/strings.ts:1351
 msgid "Authentication cancelled by user"
 msgstr "Authentication cancelled by user"
 
-#: src/strings.ts:1353
+#: src/strings.ts:1352
 msgid "Authentication failed"
 msgstr "Authentication failed"
 
-#: src/strings.ts:2108
+#: src/strings.ts:2107
 msgid "Auto"
 msgstr "Auto"
 
-#: src/strings.ts:1662
+#: src/strings.ts:1661
 msgid "Auto save: off"
 msgstr "Auto save: off"
 
-#: src/strings.ts:2122
+#: src/strings.ts:2121
 msgid "Auto start on system startup"
 msgstr "Auto start on system startup"
 
-#: src/strings.ts:1219
-#: src/strings.ts:1690
+#: src/strings.ts:1218
+#: src/strings.ts:1689
 msgid "Automatic backups"
 msgstr "Automatic backups"
 
-#: src/strings.ts:1366
+#: src/strings.ts:1365
 msgid "Automatic backups are off"
 msgstr "Automatic backups are off"
 
-#: src/strings.ts:2006
+#: src/strings.ts:2005
 msgid "Automatic backups disabled"
 msgstr "Automatic backups disabled"
 
-#: src/strings.ts:1222
+#: src/strings.ts:1221
 msgid "Automatic backups with attachments"
 msgstr "Automatic backups with attachments"
 
-#: src/strings.ts:2118
+#: src/strings.ts:2117
 msgid "Automatic updates"
 msgstr "Automatic updates"
 
-#: src/strings.ts:1139
+#: src/strings.ts:1138
 msgid "Automatically clear trash after a certain period of time"
 msgstr "Automatically clear trash after a certain period of time"
 
-#: src/strings.ts:2120
+#: src/strings.ts:2119
 msgid "Automatically download & install updates in the background without prompting first."
 msgstr "Automatically download & install updates in the background without prompting first."
 
-#: src/strings.ts:1192
+#: src/strings.ts:1191
 msgid "Automatically lock the app after a certain period"
 msgstr "Automatically lock the app after a certain period"
 
-#: src/strings.ts:1122
+#: src/strings.ts:1121
 msgid "Automatically switch between light and dark themes based on your system settings"
 msgstr "Automatically switch between light and dark themes based on your system settings"
 
-#: src/strings.ts:2165
+#: src/strings.ts:2164
 msgid "Available on iOS"
 msgstr "Available on iOS"
 
-#: src/strings.ts:2166
+#: src/strings.ts:2165
 msgid "Available on iOS & Android"
 msgstr "Available on iOS & Android"
 
-#: src/strings.ts:2655
+#: src/strings.ts:2654
 msgid "Back"
 msgstr "Back"
 
-#: src/strings.ts:2314
+#: src/strings.ts:2313
 msgid "Background color"
 msgstr "Background color"
 
-#: src/strings.ts:1094
+#: src/strings.ts:1093
 msgid "Background sync (experimental)"
 msgstr "Background sync (experimental)"
 
-#: src/strings.ts:2114
+#: src/strings.ts:2113
 msgid "Backup"
 msgstr "Backup"
 
-#: src/strings.ts:2152
+#: src/strings.ts:2151
 msgid "Backup & export"
 msgstr "Backup & export"
 
-#: src/strings.ts:1211
+#: src/strings.ts:1210
 msgid "Backup & restore"
 msgstr "Backup & restore"
 
-#: src/strings.ts:1336
+#: src/strings.ts:1335
 msgid "Backup complete"
 msgstr "Backup complete"
 
-#: src/strings.ts:1562
+#: src/strings.ts:1561
 msgid "Backup directory not selected"
 msgstr "Backup directory not selected"
 
-#: src/strings.ts:1234
+#: src/strings.ts:1233
 msgid "Backup encryption"
 msgstr "Backup encryption"
 
-#: src/strings.ts:1859
+#: src/strings.ts:1858
 msgid "Backup files have .nnbackup extension"
 msgstr "Backup files have .nnbackup extension"
 
-#: src/strings.ts:883
+#: src/strings.ts:882
 msgid "Backup is encrypted"
 msgstr "Backup is encrypted"
 
-#: src/strings.ts:1615
+#: src/strings.ts:1614
 msgid "Backup is encrypted, decrypting..."
 msgstr "Backup is encrypted, decrypting..."
 
-#: src/strings.ts:1213
+#: src/strings.ts:1212
 msgid "Backup now"
 msgstr "Backup now"
 
-#: src/strings.ts:1214
+#: src/strings.ts:1213
 msgid "Backup now with attachments"
 msgstr "Backup now with attachments"
 
-#: src/strings.ts:890
+#: src/strings.ts:889
 msgid "Backup restored"
 msgstr "Backup restored"
 
-#: src/strings.ts:1920
+#: src/strings.ts:1919
 msgid "Backup saved at {path}"
 msgstr "Backup saved at {path}"
 
-#: src/strings.ts:1348
+#: src/strings.ts:1347
 msgid "Backup successful"
 msgstr "Backup successful"
 
-#: src/strings.ts:2115
+#: src/strings.ts:2114
 msgid "Backup with attachments"
 msgstr "Backup with attachments"
 
@@ -1207,47 +1207,47 @@ msgstr "Backups"
 msgid "Basic"
 msgstr "Basic"
 
-#: src/strings.ts:1794
+#: src/strings.ts:1793
 msgid "Because where's the fun in nookin' alone?"
 msgstr "Because where's the fun in nookin' alone?"
 
-#: src/strings.ts:1125
+#: src/strings.ts:1124
 msgid "Behavior"
 msgstr "Behavior"
 
-#: src/strings.ts:2147
+#: src/strings.ts:2146
 msgid "Behaviour"
 msgstr "Behaviour"
 
-#: src/strings.ts:2483
+#: src/strings.ts:2482
 msgid "Believer plan"
 msgstr "Believer plan"
 
-#: src/strings.ts:2593
+#: src/strings.ts:2592
 msgid "Best value"
 msgstr "Best value"
 
-#: src/strings.ts:2472
+#: src/strings.ts:2471
 msgid "Beta"
 msgstr "Beta"
 
-#: src/strings.ts:2272
+#: src/strings.ts:2271
 msgid "Bi-directional note link"
 msgstr "Bi-directional note link"
 
-#: src/strings.ts:2566
+#: src/strings.ts:2565
 msgid "billed annually at {price}"
 msgstr "billed annually at {price}"
 
-#: src/strings.ts:2567
+#: src/strings.ts:2566
 msgid "billed monthly at {price}"
 msgstr "billed monthly at {price}"
 
-#: src/strings.ts:2213
+#: src/strings.ts:2212
 msgid "Billing history"
 msgstr "Billing history"
 
-#: src/strings.ts:1178
+#: src/strings.ts:1177
 msgid "Biometric unlocking"
 msgstr "Biometric unlocking"
 
@@ -1259,27 +1259,27 @@ msgstr "Biometric unlocking disabled"
 msgid "Biometric unlocking enabled"
 msgstr "Biometric unlocking enabled"
 
-#: src/strings.ts:1350
+#: src/strings.ts:1349
 msgid "Biometrics authentication failed. Please try again."
 msgstr "Biometrics authentication failed. Please try again."
 
-#: src/strings.ts:1187
+#: src/strings.ts:1186
 msgid "Biometrics not enrolled"
 msgstr "Biometrics not enrolled"
 
-#: src/strings.ts:2268
+#: src/strings.ts:2267
 msgid "Bold"
 msgstr "Bold"
 
-#: src/strings.ts:2421
+#: src/strings.ts:2420
 msgid "Boost your productivity with Notebooks and organize your notes."
 msgstr "Boost your productivity with Notebooks and organize your notes."
 
-#: src/strings.ts:1810
+#: src/strings.ts:1809
 msgid "Browse"
 msgstr "Browse"
 
-#: src/strings.ts:2285
+#: src/strings.ts:2284
 msgid "Bullet list"
 msgstr "Bullet list"
 
@@ -1287,7 +1287,7 @@ msgstr "Bullet list"
 msgid "By"
 msgstr "By"
 
-#: src/strings.ts:2588
+#: src/strings.ts:2587
 msgid "By joining you agree to our"
 msgstr "By joining you agree to our"
 
@@ -1295,11 +1295,11 @@ msgstr "By joining you agree to our"
 msgid "By signing up, you agree to our "
 msgstr "By signing up, you agree to our "
 
-#: src/strings.ts:2346
+#: src/strings.ts:2345
 msgid "Callout"
 msgstr "Callout"
 
-#: src/strings.ts:2526
+#: src/strings.ts:2525
 msgid "Can I cancel my free trial anytime?"
 msgstr "Can I cancel my free trial anytime?"
 
@@ -1307,11 +1307,11 @@ msgstr "Can I cancel my free trial anytime?"
 msgid "Cancel"
 msgstr "Cancel"
 
-#: src/strings.ts:2586
+#: src/strings.ts:2585
 msgid "Cancel anytime, subscription auto-renews."
 msgstr "Cancel anytime, subscription auto-renews."
 
-#: src/strings.ts:2548
+#: src/strings.ts:2547
 msgid "Cancel anytime."
 msgstr "Cancel anytime."
 
@@ -1323,7 +1323,7 @@ msgstr "Cancel download"
 msgid "Cancel login"
 msgstr "Cancel login"
 
-#: src/strings.ts:1827
+#: src/strings.ts:1826
 msgid "Cancel subscription"
 msgstr "Cancel subscription"
 
@@ -1331,24 +1331,24 @@ msgstr "Cancel subscription"
 msgid "Cancel upload"
 msgstr "Cancel upload"
 
-#: src/strings.ts:2313
+#: src/strings.ts:2312
 msgid "Cell background color"
 msgstr "Cell background color"
 
-#: src/strings.ts:2315
+#: src/strings.ts:2314
 msgid "Cell border color"
 msgstr "Cell border color"
 
+#: src/strings.ts:2316
 #: src/strings.ts:2317
-#: src/strings.ts:2318
 msgid "Cell border width"
 msgstr "Cell border width"
 
-#: src/strings.ts:2299
+#: src/strings.ts:2298
 msgid "Cell properties"
 msgstr "Cell properties"
 
-#: src/strings.ts:2316
+#: src/strings.ts:2315
 msgid "Cell text color"
 msgstr "Cell text color"
 
@@ -1356,7 +1356,7 @@ msgstr "Cell text color"
 msgid "Change"
 msgstr "Change"
 
-#: src/strings.ts:1060
+#: src/strings.ts:1059
 msgid "Change 2FA fallback method"
 msgstr "Change 2FA fallback method"
 
@@ -1364,15 +1364,15 @@ msgstr "Change 2FA fallback method"
 msgid "Change 2FA method"
 msgstr "Change 2FA method"
 
-#: src/strings.ts:1199
+#: src/strings.ts:1198
 msgid "Change app lock password"
 msgstr "Change app lock password"
 
-#: src/strings.ts:1198
+#: src/strings.ts:1197
 msgid "Change app lock pin"
 msgstr "Change app lock pin"
 
-#: src/strings.ts:1233
+#: src/strings.ts:1232
 msgid "Change backup directory"
 msgstr "Change backup directory"
 
@@ -1380,15 +1380,15 @@ msgstr "Change backup directory"
 msgid "Change email address"
 msgstr "Change email address"
 
-#: src/strings.ts:1126
+#: src/strings.ts:1125
 msgid "Change how the app behaves in different situations"
 msgstr "Change how the app behaves in different situations"
 
-#: src/strings.ts:2364
+#: src/strings.ts:2363
 msgid "Change language"
 msgstr "Change language"
 
-#: src/strings.ts:1254
+#: src/strings.ts:1253
 msgid "Change notification sound"
 msgstr "Change notification sound"
 
@@ -1396,23 +1396,23 @@ msgstr "Change notification sound"
 msgid "Change password"
 msgstr "Change password"
 
-#: src/strings.ts:2600
+#: src/strings.ts:2599
 msgid "Change plan"
 msgstr "Change plan"
 
-#: src/strings.ts:1819
+#: src/strings.ts:1818
 msgid "Change profile picture"
 msgstr "Change profile picture"
 
-#: src/strings.ts:2191
+#: src/strings.ts:2190
 msgid "Change proxy"
 msgstr "Change proxy"
 
-#: src/strings.ts:2212
+#: src/strings.ts:2211
 msgid "Change the payment method you used to purchase this subscription."
 msgstr "Change the payment method you used to purchase this subscription."
 
-#: src/strings.ts:1256
+#: src/strings.ts:1255
 msgid "Change the sound that plays when you receive a notification"
 msgstr "Change the sound that plays when you receive a notification"
 
@@ -1420,15 +1420,15 @@ msgstr "Change the sound that plays when you receive a notification"
 msgid "Change vault password"
 msgstr "Change vault password"
 
-#: src/strings.ts:1054
+#: src/strings.ts:1053
 msgid "Change your account password"
 msgstr "Change your account password"
 
-#: src/strings.ts:1056
+#: src/strings.ts:1055
 msgid "Change your primary two-factor authentication method"
 msgstr "Change your primary two-factor authentication method"
 
-#: src/strings.ts:1090
+#: src/strings.ts:1089
 msgid "Changes from other devices won't be updated in the editor in real-time."
 msgstr "Changes from other devices won't be updated in the editor in real-time."
 
@@ -1436,27 +1436,27 @@ msgstr "Changes from other devices won't be updated in the editor in real-time."
 msgid "Changing password is an irreversible process. You will be logged out from all your devices. Please make sure you do not close the app while your password is changing and have good internet connection."
 msgstr "Changing password is an irreversible process. You will be logged out from all your devices. Please make sure you do not close the app while your password is changing and have good internet connection."
 
-#: src/strings.ts:2502
+#: src/strings.ts:2501
 msgid "Characters"
 msgstr "Characters"
 
-#: src/strings.ts:1297
+#: src/strings.ts:1296
 msgid "Check for new version of Notesnook"
 msgstr "Check for new version of Notesnook"
 
-#: src/strings.ts:1300
+#: src/strings.ts:1299
 msgid "Check for new version of the app available on app launch"
 msgstr "Check for new version of the app available on app launch"
 
-#: src/strings.ts:1296
+#: src/strings.ts:1295
 msgid "Check for updates"
 msgstr "Check for updates"
 
-#: src/strings.ts:1298
+#: src/strings.ts:1297
 msgid "Check for updates automatically"
 msgstr "Check for updates automatically"
 
-#: src/strings.ts:2164
+#: src/strings.ts:2163
 msgid "Check roadmap"
 msgstr "Check roadmap"
 
@@ -1464,7 +1464,7 @@ msgstr "Check roadmap"
 msgid "Check your spam folder if you haven't received an email yet."
 msgstr "Check your spam folder if you haven't received an email yet."
 
-#: src/strings.ts:2413
+#: src/strings.ts:2412
 msgid "Checking all attachments"
 msgstr "Checking all attachments"
 
@@ -1472,51 +1472,51 @@ msgstr "Checking all attachments"
 msgid "Checking for new version"
 msgstr "Checking for new version"
 
-#: src/strings.ts:1706
+#: src/strings.ts:1705
 msgid "Checking for updates"
 msgstr "Checking for updates"
 
-#: src/strings.ts:2412
+#: src/strings.ts:2411
 msgid "Checking note attachments"
 msgstr "Checking note attachments"
 
-#: src/strings.ts:2287
+#: src/strings.ts:2286
 msgid "Checklist"
 msgstr "Checklist"
 
-#: src/strings.ts:2341
+#: src/strings.ts:2340
 msgid "Choose a block to insert"
 msgstr "Choose a block to insert"
 
-#: src/strings.ts:1798
+#: src/strings.ts:1797
 msgid "Choose a recovery method"
 msgstr "Choose a recovery method"
 
-#: src/strings.ts:2113
+#: src/strings.ts:2112
 msgid "Choose backup format"
 msgstr "Choose backup format"
 
-#: src/strings.ts:2377
+#: src/strings.ts:2376
 msgid "Choose custom color"
 msgstr "Choose custom color"
 
-#: src/strings.ts:1119
+#: src/strings.ts:1118
 msgid "Choose from pre-built themes or create your own"
 msgstr "Choose from pre-built themes or create your own"
 
-#: src/strings.ts:1134
+#: src/strings.ts:1133
 msgid "Choose how dates are displayed in the app"
 msgstr "Choose how dates are displayed in the app"
 
-#: src/strings.ts:2635
+#: src/strings.ts:2634
 msgid "Choose how day is displayed in the app"
 msgstr "Choose how day is displayed in the app"
 
-#: src/strings.ts:1159
+#: src/strings.ts:1158
 msgid "Choose how the new note titles are formatted"
 msgstr "Choose how the new note titles are formatted"
 
-#: src/strings.ts:1136
+#: src/strings.ts:1135
 msgid "Choose how time is displayed in the app"
 msgstr "Choose how time is displayed in the app"
 
@@ -1524,67 +1524,67 @@ msgstr "Choose how time is displayed in the app"
 msgid "Choose how you want to secure your notes locally."
 msgstr "Choose how you want to secure your notes locally."
 
-#: src/strings.ts:2640
+#: src/strings.ts:2639
 msgid "Choose what day to display as the first day of the week"
 msgstr "Choose what day to display as the first day of the week"
 
-#: src/strings.ts:1229
+#: src/strings.ts:1228
 msgid "Choose where to save your backups"
 msgstr "Choose where to save your backups"
 
-#: src/strings.ts:2073
+#: src/strings.ts:2072
 msgid "Choose your style"
 msgstr "Choose your style"
 
-#: src/strings.ts:1618
+#: src/strings.ts:1617
 msgid "cleaningUp"
 msgstr "cleaningUp"
 
-#: src/strings.ts:1015
+#: src/strings.ts:1014
 msgid "Clear"
 msgstr "Clear"
 
-#: src/strings.ts:1871
+#: src/strings.ts:1870
 msgid "Clear all cached attachments. Current cache size: {cacheSize}"
 msgstr "Clear all cached attachments. Current cache size: {cacheSize}"
 
-#: src/strings.ts:2281
+#: src/strings.ts:2280
 msgid "Clear all formatting"
 msgstr "Clear all formatting"
 
-#: src/strings.ts:1872
+#: src/strings.ts:1871
 msgid "Clear attachments cache?"
 msgstr "Clear attachments cache?"
 
-#: src/strings.ts:1869
+#: src/strings.ts:1868
 msgid "Clear cache"
 msgstr "Clear cache"
 
-#: src/strings.ts:2375
+#: src/strings.ts:2374
 msgid "Clear completed tasks"
 msgstr "Clear completed tasks"
 
-#: src/strings.ts:1806
+#: src/strings.ts:1805
 msgid "Clear data & reset account"
 msgstr "Clear data & reset account"
 
-#: src/strings.ts:1140
+#: src/strings.ts:1139
 msgid "Clear default notebook"
 msgstr "Clear default notebook"
 
-#: src/strings.ts:1014
+#: src/strings.ts:1013
 msgid "Clear logs"
 msgstr "Clear logs"
 
-#: src/strings.ts:2207
+#: src/strings.ts:2206
 msgid "clear sessions"
 msgstr "clear sessions"
 
-#: src/strings.ts:1323
+#: src/strings.ts:1322
 msgid "Clear trash"
 msgstr "Clear trash"
 
-#: src/strings.ts:1137
+#: src/strings.ts:1136
 msgid "Clear trash interval"
 msgstr "Clear trash interval"
 
@@ -1592,7 +1592,7 @@ msgstr "Clear trash interval"
 msgid "Clear vault"
 msgstr "Clear vault"
 
-#: src/strings.ts:1874
+#: src/strings.ts:1873
 msgid ""
 "Clearing attachments cache will perform the following actions:\n"
 "\n"
@@ -1618,11 +1618,11 @@ msgstr ""
 "\n"
 "**Only use this for troubleshooting purposes. If you are having persistent issues, it is recommended that you reach out to us via support@streetwriters.co so we can help you resolve it permanently.**"
 
-#: src/strings.ts:2240
+#: src/strings.ts:2239
 msgid "Clearing trash will permanently delete all the items in your trash. This action is IRREVERSIBLE."
 msgstr "Clearing trash will permanently delete all the items in your trash. This action is IRREVERSIBLE."
 
-#: src/strings.ts:2622
+#: src/strings.ts:2621
 msgid "Click here to directly claim the promotion."
 msgstr "Click here to directly claim the promotion."
 
@@ -1630,75 +1630,75 @@ msgstr "Click here to directly claim the promotion."
 msgid "Click to deselect"
 msgstr "Click to deselect"
 
-#: src/strings.ts:1868
+#: src/strings.ts:1867
 msgid "Click to preview"
 msgstr "Click to preview"
 
-#: src/strings.ts:1773
+#: src/strings.ts:1772
 msgid "Click to remove"
 msgstr "Click to remove"
 
-#: src/strings.ts:2404
+#: src/strings.ts:2403
 msgid "Click to reset {title}"
 msgstr "Click to reset {title}"
 
-#: src/strings.ts:2630
+#: src/strings.ts:2629
 msgid "Click to save"
 msgstr "Click to save"
 
-#: src/strings.ts:2626
+#: src/strings.ts:2625
 msgid "Click to update"
 msgstr "Click to update"
 
-#: src/strings.ts:1382
+#: src/strings.ts:1381
 msgid "Close"
 msgstr "Close"
 
-#: src/strings.ts:2680
+#: src/strings.ts:2679
 msgid "Close ({seconds})"
 msgstr "Close ({seconds})"
 
-#: src/strings.ts:2020
+#: src/strings.ts:2019
 msgid "Close all"
 msgstr "Close all"
 
-#: src/strings.ts:2462
+#: src/strings.ts:2461
 msgid "Close all tabs"
 msgstr "Close all tabs"
 
-#: src/strings.ts:2461
+#: src/strings.ts:2460
 msgid "Close current tab"
 msgstr "Close current tab"
 
-#: src/strings.ts:2017
+#: src/strings.ts:2016
 msgid "Close others"
 msgstr "Close others"
 
-#: src/strings.ts:2131
+#: src/strings.ts:2130
 msgid "Close to system tray"
 msgstr "Close to system tray"
 
-#: src/strings.ts:2019
+#: src/strings.ts:2018
 msgid "Close to the left"
 msgstr "Close to the left"
 
-#: src/strings.ts:2018
+#: src/strings.ts:2017
 msgid "Close to the right"
 msgstr "Close to the right"
 
-#: src/strings.ts:2540
+#: src/strings.ts:2539
 msgid "cloud storage space for storing images and files."
 msgstr "cloud storage space for storing images and files."
 
-#: src/strings.ts:2279
+#: src/strings.ts:2278
 msgid "Code"
 msgstr "Code"
 
-#: src/strings.ts:2343
+#: src/strings.ts:2342
 msgid "Code block"
 msgstr "Code block"
 
-#: src/strings.ts:2280
+#: src/strings.ts:2279
 msgid "Code remove"
 msgstr "Code remove"
 
@@ -1711,7 +1711,7 @@ msgid "color"
 msgstr "color"
 
 #: src/strings.ts:299
-#: src/strings.ts:1845
+#: src/strings.ts:1844
 msgid "Color"
 msgstr "Color"
 
@@ -1719,11 +1719,11 @@ msgstr "Color"
 msgid "Color #{color} already exists"
 msgstr "Color #{color} already exists"
 
-#: src/strings.ts:2106
+#: src/strings.ts:2105
 msgid "Color scheme"
 msgstr "Color scheme"
 
-#: src/strings.ts:1490
+#: src/strings.ts:1489
 msgid "Color title"
 msgstr "Color title"
 
@@ -1735,19 +1735,19 @@ msgstr "colors"
 msgid "Colors"
 msgstr "Colors"
 
-#: src/strings.ts:2297
+#: src/strings.ts:2296
 msgid "Column properties"
 msgstr "Column properties"
 
-#: src/strings.ts:2453
+#: src/strings.ts:2452
 msgid "Command palette"
 msgstr "Command palette"
 
-#: src/strings.ts:1272
+#: src/strings.ts:1271
 msgid "Community"
 msgstr "Community"
 
-#: src/strings.ts:2560
+#: src/strings.ts:2559
 msgid "Compare plans"
 msgstr "Compare plans"
 
@@ -1759,7 +1759,7 @@ msgstr "Completed"
 msgid "Compress"
 msgstr "Compress"
 
-#: src/strings.ts:1130
+#: src/strings.ts:1129
 msgid "Compress images before uploading"
 msgstr "Compress images before uploading"
 
@@ -1767,19 +1767,19 @@ msgstr "Compress images before uploading"
 msgid "Compressed images are uploaded in Full HD resolution and usually are good enough for most use cases."
 msgstr "Compressed images are uploaded in Full HD resolution and usually are good enough for most use cases."
 
-#: src/strings.ts:2681
+#: src/strings.ts:2680
 msgid "Compressing"
 msgstr "Compressing"
 
-#: src/strings.ts:2685
+#: src/strings.ts:2684
 msgid "Compression failed"
 msgstr "Compression failed"
 
-#: src/strings.ts:2263
+#: src/strings.ts:2262
 msgid "Configure"
 msgstr "Configure"
 
-#: src/strings.ts:2418
+#: src/strings.ts:2417
 msgid "Configure server URLs for Notesnook"
 msgstr "Configure server URLs for Notesnook"
 
@@ -1787,43 +1787,43 @@ msgstr "Configure server URLs for Notesnook"
 msgid "Confirm email"
 msgstr "Confirm email"
 
-#: src/strings.ts:904
+#: src/strings.ts:903
 msgid "Confirm email to publish note"
 msgstr "Confirm email to publish note"
 
-#: src/strings.ts:1489
+#: src/strings.ts:1488
 msgid "Confirm new password"
 msgstr "Confirm new password"
 
-#: src/strings.ts:1484
+#: src/strings.ts:1483
 msgid "Confirm password"
 msgstr "Confirm password"
 
-#: src/strings.ts:2662
+#: src/strings.ts:2661
 msgid "Confirm password required"
 msgstr "Confirm password required"
 
-#: src/strings.ts:1488
+#: src/strings.ts:1487
 msgid "Confirm pin"
 msgstr "Confirm pin"
 
-#: src/strings.ts:2654
+#: src/strings.ts:2653
 msgid "Confirmation email sent"
 msgstr "Confirmation email sent"
 
-#: src/strings.ts:2091
+#: src/strings.ts:2090
 msgid "Congratulations!"
 msgstr "Congratulations!"
 
-#: src/strings.ts:1637
+#: src/strings.ts:1636
 msgid "Connected to all servers sucessfully."
 msgstr "Connected to all servers sucessfully."
 
-#: src/strings.ts:1672
+#: src/strings.ts:1671
 msgid "Contact support"
 msgstr "Contact support"
 
-#: src/strings.ts:1263
+#: src/strings.ts:1262
 msgid "Contact us directly via support@streetwriters.co for any help or support"
 msgstr "Contact us directly via support@streetwriters.co for any help or support"
 
@@ -1831,15 +1831,15 @@ msgstr "Contact us directly via support@streetwriters.co for any help or support
 msgid "Continue"
 msgstr "Continue"
 
-#: src/strings.ts:1165
+#: src/strings.ts:1164
 msgid "Contribute towards a better Notesnook. All tracking information is anonymous."
 msgstr "Contribute towards a better Notesnook. All tracking information is anonymous."
 
-#: src/strings.ts:1249
+#: src/strings.ts:1248
 msgid "Controls whether this device should receive reminder notifications."
 msgstr "Controls whether this device should receive reminder notifications."
 
-#: src/strings.ts:1991
+#: src/strings.ts:1990
 msgid "Copied"
 msgstr "Copied"
 
@@ -1848,7 +1848,7 @@ msgid "Copy"
 msgstr "Copy"
 
 #. placeholder {0}: format ? " " + format : ""
-#: src/strings.ts:2037
+#: src/strings.ts:2036
 msgid "Copy as{0}"
 msgstr "Copy as{0}"
 
@@ -1856,15 +1856,15 @@ msgstr "Copy as{0}"
 msgid "Copy codes"
 msgstr "Copy codes"
 
-#: src/strings.ts:2259
+#: src/strings.ts:2258
 msgid "Copy image"
 msgstr "Copy image"
 
-#: src/strings.ts:911
+#: src/strings.ts:910
 msgid "Copy link"
 msgstr "Copy link"
 
-#: src/strings.ts:2258
+#: src/strings.ts:2257
 msgid "Copy link text"
 msgstr "Copy link text"
 
@@ -1876,27 +1876,27 @@ msgstr "Copy note"
 msgid "Copy to clipboard"
 msgstr "Copy to clipboard"
 
-#: src/strings.ts:1620
+#: src/strings.ts:1619
 msgid "Copying backup files to cache"
 msgstr "Copying backup files to cache"
 
-#: src/strings.ts:1169
+#: src/strings.ts:1168
 msgid "CORS bypass"
 msgstr "CORS bypass"
 
-#: src/strings.ts:1987
+#: src/strings.ts:1986
 msgid "Could not activate trial. Please try again later."
 msgstr "Could not activate trial. Please try again later."
 
-#: src/strings.ts:2005
+#: src/strings.ts:2004
 msgid "Could not clear trash."
 msgstr "Could not clear trash."
 
-#: src/strings.ts:1640
+#: src/strings.ts:1639
 msgid "Could not connect to {server}."
 msgstr "Could not connect to {server}."
 
-#: src/strings.ts:1952
+#: src/strings.ts:1951
 msgid "Could not convert note to {format}."
 msgstr "Could not convert note to {format}."
 
@@ -1916,11 +1916,11 @@ msgstr "Create"
 msgid "Create a group"
 msgstr "Create a group"
 
-#: src/strings.ts:939
+#: src/strings.ts:938
 msgid "Create a new note"
 msgstr "Create a new note"
 
-#: src/strings.ts:952
+#: src/strings.ts:951
 msgid "Create a note first"
 msgstr "Create a note first"
 
@@ -1932,7 +1932,7 @@ msgstr "Create a shortcut"
 msgid "Create a tag to group related notes together."
 msgstr "Create a tag to group related notes together."
 
-#: src/strings.ts:1850
+#: src/strings.ts:1849
 msgid "Create account"
 msgstr "Create account"
 
@@ -1940,19 +1940,19 @@ msgstr "Create account"
 msgid "Create link"
 msgstr "Create link"
 
-#: src/strings.ts:1474
+#: src/strings.ts:1473
 msgid "Create shortcut of this notebook in side menu"
 msgstr "Create shortcut of this notebook in side menu"
 
-#: src/strings.ts:1388
+#: src/strings.ts:1387
 msgid "Create unlimited notebooks with Notesnook Pro"
 msgstr "Create unlimited notebooks with Notesnook Pro"
 
-#: src/strings.ts:1387
+#: src/strings.ts:1386
 msgid "Create unlimited tags with Notesnook Pro"
 msgstr "Create unlimited tags with Notesnook Pro"
 
-#: src/strings.ts:1389
+#: src/strings.ts:1388
 msgid "Create unlimited vaults with Notesnook Pro"
 msgstr "Create unlimited vaults with Notesnook Pro"
 
@@ -1964,12 +1964,12 @@ msgstr "Create vault"
 msgid "Create your account"
 msgstr "Create your account"
 
-#: src/strings.ts:2241
+#: src/strings.ts:2240
 msgid "Created at"
 msgstr "Created at"
 
 #. placeholder {0}: type === "full" ? " full" : ""
-#: src/strings.ts:1345
+#: src/strings.ts:1344
 msgid "Creating a{0} backup"
 msgstr "Creating a{0} backup"
 
@@ -1978,11 +1978,10 @@ msgid "Creation date cannot be after last edited date"
 msgstr "Creation date cannot be after last edited date"
 
 #: src/strings.ts:2049
-#: src/strings.ts:2050
 msgid "Credentials"
 msgstr "Credentials"
 
-#: src/strings.ts:2076
+#: src/strings.ts:2075
 msgid "Cross platform & 100% encrypted"
 msgstr "Cross platform & 100% encrypted"
 
@@ -1990,65 +1989,65 @@ msgstr "Cross platform & 100% encrypted"
 msgid "Curate the toolbar that fits your needs and matches your personality."
 msgstr "Curate the toolbar that fits your needs and matches your personality."
 
-#: src/strings.ts:1837
+#: src/strings.ts:1836
 msgid "Current note"
 msgstr "Current note"
 
-#: src/strings.ts:1480
-#: src/strings.ts:1486
+#: src/strings.ts:1479
+#: src/strings.ts:1485
 msgid "Current password"
 msgstr "Current password"
 
-#: src/strings.ts:2671
+#: src/strings.ts:2670
 msgid "Current password required"
 msgstr "Current password required"
 
-#: src/strings.ts:1230
+#: src/strings.ts:1229
 msgid "Current path: {path}"
 msgstr "Current path: {path}"
 
-#: src/strings.ts:1485
+#: src/strings.ts:1484
 msgid "Current pin"
 msgstr "Current pin"
 
-#: src/strings.ts:1774
+#: src/strings.ts:1773
 msgid "CURRENT PLAN"
 msgstr "CURRENT PLAN"
 
-#: src/strings.ts:2011
+#: src/strings.ts:2010
 msgid "Custom"
 msgstr "Custom"
 
-#: src/strings.ts:2142
+#: src/strings.ts:2141
 msgid "Custom dictionary words"
 msgstr "Custom dictionary words"
 
-#: src/strings.ts:1114
+#: src/strings.ts:1113
 msgid "Customization"
 msgstr "Customization"
 
-#: src/strings.ts:1117
+#: src/strings.ts:1116
 msgid "Customize the appearance of the app with custom themes"
 msgstr "Customize the appearance of the app with custom themes"
 
-#: src/strings.ts:1144
+#: src/strings.ts:1143
 msgid "Customize the note editor"
 msgstr "Customize the note editor"
 
-#: src/strings.ts:1146
+#: src/strings.ts:1145
 msgid "Customize the toolbar in the note editor"
 msgstr "Customize the toolbar in the note editor"
 
-#: src/strings.ts:1145
+#: src/strings.ts:1144
 msgid "Customize toolbar"
 msgstr "Customize toolbar"
 
-#: src/strings.ts:2257
+#: src/strings.ts:2256
 msgid "Cut"
 msgstr "Cut"
 
 #: src/strings.ts:167
-#: src/strings.ts:1569
+#: src/strings.ts:1568
 msgid "Daily"
 msgstr "Daily"
 
@@ -2056,23 +2055,23 @@ msgstr "Daily"
 msgid "Dark"
 msgstr "Dark"
 
-#: src/strings.ts:1123
+#: src/strings.ts:1122
 msgid "Dark mode"
 msgstr "Dark mode"
 
-#: src/strings.ts:2107
+#: src/strings.ts:2106
 msgid "Dark or light, we won't judge."
 msgstr "Dark or light, we won't judge."
 
-#: src/strings.ts:1548
+#: src/strings.ts:1547
 msgid "Database setup failed, could not get database key"
 msgstr "Database setup failed, could not get database key"
 
-#: src/strings.ts:1840
+#: src/strings.ts:1839
 msgid "Date"
 msgstr "Date"
 
-#: src/strings.ts:2116
+#: src/strings.ts:2115
 msgid "Date & time"
 msgstr "Date & time"
 
@@ -2088,7 +2087,7 @@ msgstr "Date deleted"
 msgid "Date edited"
 msgstr "Date edited"
 
-#: src/strings.ts:1133
+#: src/strings.ts:1132
 msgid "Date format"
 msgstr "Date format"
 
@@ -2096,80 +2095,80 @@ msgstr "Date format"
 msgid "Date modified"
 msgstr "Date modified"
 
-#: src/strings.ts:2043
+#: src/strings.ts:2042
 msgid "Date uploaded"
 msgstr "Date uploaded"
 
-#: src/strings.ts:1842
+#: src/strings.ts:1841
 msgid "Day"
 msgstr "Day"
 
-#: src/strings.ts:2634
+#: src/strings.ts:2633
 msgid "Day format"
 msgstr "Day format"
 
-#: src/strings.ts:2039
+#: src/strings.ts:2038
 msgid "Deactivate"
 msgstr "Deactivate"
 
-#: src/strings.ts:1012
+#: src/strings.ts:1011
 msgid "Debug log copied!"
 msgstr "Debug log copied!"
 
-#: src/strings.ts:1270
+#: src/strings.ts:1269
 msgid "Debug logs"
 msgstr "Debug logs"
 
-#: src/strings.ts:1013
+#: src/strings.ts:1012
 msgid "Debug logs downloaded"
 msgstr "Debug logs downloaded"
 
-#: src/strings.ts:1267
+#: src/strings.ts:1266
 msgid "Debugging"
 msgstr "Debugging"
 
-#: src/strings.ts:2406
+#: src/strings.ts:2405
 msgid "Decrease {title}"
 msgstr "Decrease {title}"
 
 #: src/strings.ts:660
-#: src/strings.ts:2009
+#: src/strings.ts:2008
 msgid "Default"
 msgstr "Default"
 
-#: src/strings.ts:1156
+#: src/strings.ts:1155
 msgid "Default font family"
 msgstr "Default font family"
 
-#: src/strings.ts:1157
+#: src/strings.ts:1156
 msgid "Default font family in editor"
 msgstr "Default font family in editor"
 
-#: src/strings.ts:1154
+#: src/strings.ts:1153
 msgid "Default font size"
 msgstr "Default font size"
 
-#: src/strings.ts:1155
+#: src/strings.ts:1154
 msgid "Default font size in editor"
 msgstr "Default font size in editor"
 
-#: src/strings.ts:1142
+#: src/strings.ts:1141
 msgid "Default notebook cleared"
 msgstr "Default notebook cleared"
 
-#: src/strings.ts:1128
+#: src/strings.ts:1127
 msgid "Default screen to open on app launch"
 msgstr "Default screen to open on app launch"
 
-#: src/strings.ts:2493
+#: src/strings.ts:2492
 msgid "Default sidebar tab"
 msgstr "Default sidebar tab"
 
-#: src/strings.ts:1250
+#: src/strings.ts:1249
 msgid "Default snooze time"
 msgstr "Default snooze time"
 
-#: src/strings.ts:1302
+#: src/strings.ts:1301
 msgid "Default sound"
 msgstr "Default sound"
 
@@ -2177,31 +2176,31 @@ msgstr "Default sound"
 msgid "Delete"
 msgstr "Delete"
 
-#: src/strings.ts:1077
+#: src/strings.ts:1076
 msgid "Delete account"
 msgstr "Delete account"
 
-#: src/strings.ts:2665
+#: src/strings.ts:2664
 msgid "Delete attachment"
 msgstr "Delete attachment"
 
-#: src/strings.ts:1320
+#: src/strings.ts:1319
 msgid "Delete collapsed section"
 msgstr "Delete collapsed section"
 
-#: src/strings.ts:2304
+#: src/strings.ts:2303
 msgid "Delete column"
 msgstr "Delete column"
 
-#: src/strings.ts:2651
+#: src/strings.ts:2650
 msgid "Delete data"
 msgstr "Delete data"
 
-#: src/strings.ts:1315
+#: src/strings.ts:1314
 msgid "Delete group"
 msgstr "Delete group"
 
-#: src/strings.ts:2378
+#: src/strings.ts:2377
 msgid "Delete mode"
 msgstr "Delete mode"
 
@@ -2213,11 +2212,11 @@ msgstr "Delete notes in this vault"
 msgid "Delete permanently"
 msgstr "Delete permanently"
 
-#: src/strings.ts:2311
+#: src/strings.ts:2310
 msgid "Delete row"
 msgstr "Delete row"
 
-#: src/strings.ts:2312
+#: src/strings.ts:2311
 msgid "Delete table"
 msgstr "Delete table"
 
@@ -2225,7 +2224,7 @@ msgstr "Delete table"
 msgid "Delete vault"
 msgstr "Delete vault"
 
-#: src/strings.ts:1177
+#: src/strings.ts:1176
 msgid "Delete vault (and optionally remove all notes)."
 msgstr "Delete vault (and optionally remove all notes)."
 
@@ -2233,43 +2232,43 @@ msgstr "Delete vault (and optionally remove all notes)."
 msgid "Deleted on {date}"
 msgstr "Deleted on {date}"
 
-#: src/strings.ts:1929
+#: src/strings.ts:1928
 msgid "Deleting"
 msgstr "Deleting"
 
-#: src/strings.ts:1839
+#: src/strings.ts:1838
 msgid "Description"
 msgstr "Description"
 
-#: src/strings.ts:2117
+#: src/strings.ts:2116
 msgid "Desktop app"
 msgstr "Desktop app"
 
-#: src/strings.ts:2121
+#: src/strings.ts:2120
 msgid "Desktop integration"
 msgstr "Desktop integration"
 
-#: src/strings.ts:872
+#: src/strings.ts:871
 msgid "Did you save recovery key?"
 msgstr "Did you save recovery key?"
 
-#: src/strings.ts:1377
+#: src/strings.ts:1376
 msgid "Disable"
 msgstr "Disable"
 
-#: src/strings.ts:1085
+#: src/strings.ts:1084
 msgid "Disable auto sync"
 msgstr "Disable auto sync"
 
-#: src/strings.ts:2012
+#: src/strings.ts:2011
 msgid "Disable editor margins"
 msgstr "Disable editor margins"
 
-#: src/strings.ts:1088
+#: src/strings.ts:1087
 msgid "Disable realtime sync"
 msgstr "Disable realtime sync"
 
-#: src/strings.ts:1091
+#: src/strings.ts:1090
 msgid "Disable sync"
 msgstr "Disable sync"
 
@@ -2281,11 +2280,11 @@ msgstr "Disabled"
 msgid "Discard"
 msgstr "Discard"
 
-#: src/strings.ts:1598
+#: src/strings.ts:1597
 msgid "Dismiss"
 msgstr "Dismiss"
 
-#: src/strings.ts:1651
+#: src/strings.ts:1650
 msgid "Dismiss announcement"
 msgstr "Dismiss announcement"
 
@@ -2297,7 +2296,7 @@ msgstr "Disputed"
 msgid "Do you enjoy using Notesnook?"
 msgstr "Do you enjoy using Notesnook?"
 
-#: src/strings.ts:1264
+#: src/strings.ts:1263
 msgid "Documentation"
 msgstr "Documentation"
 
@@ -2305,15 +2304,15 @@ msgstr "Documentation"
 msgid "Documents"
 msgstr "Documents"
 
-#: src/strings.ts:985
+#: src/strings.ts:984
 msgid "Don't have access to your authenticator app?"
 msgstr "Don't have access to your authenticator app?"
 
-#: src/strings.ts:992
+#: src/strings.ts:991
 msgid "Don't have access to your email address?"
 msgstr "Don't have access to your email address?"
 
-#: src/strings.ts:1001
+#: src/strings.ts:1000
 msgid "Don't have access to your phone number?"
 msgstr "Don't have access to your phone number?"
 
@@ -2321,23 +2320,23 @@ msgstr "Don't have access to your phone number?"
 msgid "Don't have an account?"
 msgstr "Don't have an account?"
 
-#: src/strings.ts:1833
+#: src/strings.ts:1832
 msgid "Don't have backup file?"
 msgstr "Don't have backup file?"
 
-#: src/strings.ts:1832
+#: src/strings.ts:1831
 msgid "Don't have your account recovery key?"
 msgstr "Don't have your account recovery key?"
 
-#: src/strings.ts:1004
+#: src/strings.ts:1003
 msgid "Don't have your recovery codes?"
 msgstr "Don't have your recovery codes?"
 
-#: src/strings.ts:1811
+#: src/strings.ts:1810
 msgid "Don't show again"
 msgstr "Don't show again"
 
-#: src/strings.ts:1812
+#: src/strings.ts:1811
 msgid "Don't show again on this device?"
 msgstr "Don't show again on this device?"
 
@@ -2345,7 +2344,7 @@ msgstr "Don't show again on this device?"
 msgid "Done"
 msgstr "Done"
 
-#: src/strings.ts:1150
+#: src/strings.ts:1149
 msgid "Double spaced lines"
 msgstr "Double spaced lines"
 
@@ -2353,15 +2352,15 @@ msgstr "Double spaced lines"
 msgid "Download"
 msgstr "Download"
 
-#: src/strings.ts:1817
+#: src/strings.ts:1816
 msgid "Download all attachments"
 msgstr "Download all attachments"
 
-#: src/strings.ts:2327
+#: src/strings.ts:2326
 msgid "Download attachment"
 msgstr "Download attachment"
 
-#: src/strings.ts:1861
+#: src/strings.ts:1860
 msgid "Download backup file"
 msgstr "Download backup file"
 
@@ -2369,11 +2368,11 @@ msgstr "Download backup file"
 msgid "Download cancelled"
 msgstr "Download cancelled"
 
-#: src/strings.ts:2219
+#: src/strings.ts:2218
 msgid "Download everything including attachments on sync"
 msgstr "Download everything including attachments on sync"
 
-#: src/strings.ts:1291
+#: src/strings.ts:1290
 msgid "Download on desktop"
 msgstr "Download on desktop"
 
@@ -2406,23 +2405,23 @@ msgstr "Downloading ({progress})"
 msgid "Downloading attachments"
 msgstr "Downloading attachments"
 
-#: src/strings.ts:1705
+#: src/strings.ts:1704
 msgid "Downloading images"
 msgstr "Downloading images"
 
-#: src/strings.ts:1771
+#: src/strings.ts:1770
 msgid "Drag & drop files here, or click to select files"
 msgstr "Drag & drop files here, or click to select files"
 
-#: src/strings.ts:1770
+#: src/strings.ts:1769
 msgid "Drop the files here"
 msgstr "Drop the files here"
 
-#: src/strings.ts:1664
+#: src/strings.ts:1663
 msgid "Drop your files here to attach"
 msgstr "Drop your files here to attach"
 
-#: src/strings.ts:2570
+#: src/strings.ts:2569
 msgid "Due {date}"
 msgstr "Due {date}"
 
@@ -2430,11 +2429,11 @@ msgstr "Due {date}"
 msgid "Due date"
 msgstr "Due date"
 
-#: src/strings.ts:2568
+#: src/strings.ts:2567
 msgid "Due today"
 msgstr "Due today"
 
-#: src/strings.ts:925
+#: src/strings.ts:924
 msgid "Duplicate"
 msgstr "Duplicate"
 
@@ -2442,15 +2441,15 @@ msgstr "Duplicate"
 msgid "Earliest first"
 msgstr "Earliest first"
 
-#: src/strings.ts:2430
+#: src/strings.ts:2429
 msgid "Easy access"
 msgstr "Easy access"
 
-#: src/strings.ts:1778
+#: src/strings.ts:1777
 msgid "Edit"
 msgstr "Edit"
 
-#: src/strings.ts:2641
+#: src/strings.ts:2640
 msgid "Edit creation date"
 msgstr "Edit creation date"
 
@@ -2458,37 +2457,37 @@ msgstr "Edit creation date"
 msgid "Edit internal link"
 msgstr "Edit internal link"
 
-#: src/strings.ts:2246
-#: src/strings.ts:2274
+#: src/strings.ts:2245
+#: src/strings.ts:2273
 msgid "Edit link"
 msgstr "Edit link"
 
-#: src/strings.ts:2486
+#: src/strings.ts:2485
 msgid "Edit profile"
 msgstr "Edit profile"
 
-#: src/strings.ts:1308
+#: src/strings.ts:1307
 msgid "Edit profile picture"
 msgstr "Edit profile picture"
 
-#: src/strings.ts:1820
+#: src/strings.ts:1819
 msgid "Edit your full name"
 msgstr "Edit your full name"
 
-#: src/strings.ts:1143
-#: src/strings.ts:1527
+#: src/strings.ts:1142
+#: src/strings.ts:1526
 msgid "Editor"
 msgstr "Editor"
 
-#: src/strings.ts:2597
+#: src/strings.ts:2596
 msgid "Education plan"
 msgstr "Education plan"
 
-#: src/strings.ts:1482
+#: src/strings.ts:1481
 msgid "Email"
 msgstr "Email"
 
-#: src/strings.ts:2443
+#: src/strings.ts:2442
 msgid "Email copied"
 msgstr "Email copied"
 
@@ -2500,27 +2499,27 @@ msgstr "Email is required"
 msgid "Email not confirmed"
 msgstr "Email not confirmed"
 
-#: src/strings.ts:1554
+#: src/strings.ts:1553
 msgid "Email or password incorrect"
 msgstr "Email or password incorrect"
 
-#: src/strings.ts:1261
+#: src/strings.ts:1260
 msgid "Email support"
 msgstr "Email support"
 
-#: src/strings.ts:858
+#: src/strings.ts:857
 msgid "Email updated to {email}"
 msgstr "Email updated to {email}"
 
-#: src/strings.ts:2353
+#: src/strings.ts:2352
 msgid "Embed"
 msgstr "Embed"
 
-#: src/strings.ts:2333
+#: src/strings.ts:2332
 msgid "Embed properties"
 msgstr "Embed properties"
 
-#: src/strings.ts:2329
+#: src/strings.ts:2328
 msgid "Embed settings"
 msgstr "Embed settings"
 
@@ -2528,27 +2527,27 @@ msgstr "Embed settings"
 msgid "Enable"
 msgstr "Enable"
 
-#: src/strings.ts:1132
+#: src/strings.ts:1131
 msgid "Enable (Recommended)"
 msgstr "Enable (Recommended)"
 
-#: src/strings.ts:1186
+#: src/strings.ts:1185
 msgid "Enable app lock"
 msgstr "Enable app lock"
 
-#: src/strings.ts:2013
+#: src/strings.ts:2012
 msgid "Enable editor margins"
 msgstr "Enable editor margins"
 
-#: src/strings.ts:2477
+#: src/strings.ts:2476
 msgid "Enable ligatures for common symbols like →, ←, etc"
 msgstr "Enable ligatures for common symbols like →, ←, etc"
 
-#: src/strings.ts:2393
+#: src/strings.ts:2392
 msgid "Enable regex"
 msgstr "Enable regex"
 
-#: src/strings.ts:2138
+#: src/strings.ts:2137
 msgid "Enable spell checker"
 msgstr "Enable spell checker"
 
@@ -2556,7 +2555,7 @@ msgstr "Enable spell checker"
 msgid "Enable two-factor authentication to add an extra layer of security to your account."
 msgstr "Enable two-factor authentication to add an extra layer of security to your account."
 
-#: src/strings.ts:1235
+#: src/strings.ts:1234
 msgid "Encrypt your backups for added security"
 msgstr "Encrypt your backups for added security"
 
@@ -2564,27 +2563,27 @@ msgstr "Encrypt your backups for added security"
 msgid "Encrypted and synced"
 msgstr "Encrypted and synced"
 
-#: src/strings.ts:2253
+#: src/strings.ts:2252
 msgid "Encrypted backup"
 msgstr "Encrypted backup"
 
-#: src/strings.ts:1658
+#: src/strings.ts:1657
 msgid "Encrypted, private, secure."
 msgstr "Encrypted, private, secure."
 
-#: src/strings.ts:2682
+#: src/strings.ts:2681
 msgid "Encrypting"
 msgstr "Encrypting"
 
-#: src/strings.ts:941
+#: src/strings.ts:940
 msgid "Encrypting attachment"
 msgstr "Encrypting attachment"
 
-#: src/strings.ts:1844
+#: src/strings.ts:1843
 msgid "Encryption key"
 msgstr "Encryption key"
 
-#: src/strings.ts:821
+#: src/strings.ts:820
 msgid "End to end encrypted."
 msgstr "End to end encrypted."
 
@@ -2592,23 +2591,23 @@ msgstr "End to end encrypted."
 msgid "Enter 6 digit code"
 msgstr "Enter 6 digit code"
 
-#: src/strings.ts:1080
+#: src/strings.ts:1079
 msgid "Enter account password"
 msgstr "Enter account password"
 
-#: src/strings.ts:1081
+#: src/strings.ts:1080
 msgid "Enter account password to proceed."
 msgstr "Enter account password to proceed."
 
-#: src/strings.ts:1853
+#: src/strings.ts:1852
 msgid "Enter account recovery key"
 msgstr "Enter account recovery key"
 
-#: src/strings.ts:1020
+#: src/strings.ts:1019
 msgid "Enter app lock password"
 msgstr "Enter app lock password"
 
-#: src/strings.ts:1023
+#: src/strings.ts:1022
 msgid "Enter app lock pin"
 msgstr "Enter app lock pin"
 
@@ -2616,27 +2615,27 @@ msgstr "Enter app lock pin"
 msgid "Enter code from authenticator app"
 msgstr "Enter code from authenticator app"
 
-#: src/strings.ts:1512
+#: src/strings.ts:1511
 msgid "Enter email address"
 msgstr "Enter email address"
 
-#: src/strings.ts:2381
+#: src/strings.ts:2380
 msgid "Enter embed source URL"
 msgstr "Enter embed source URL"
 
-#: src/strings.ts:1314
+#: src/strings.ts:1313
 msgid "Enter full name"
 msgstr "Enter full name"
 
-#: src/strings.ts:1702
+#: src/strings.ts:1701
 msgid "Enter fullscreen"
 msgstr "Enter fullscreen"
 
-#: src/strings.ts:1491
+#: src/strings.ts:1490
 msgid "Enter notebook description"
 msgstr "Enter notebook description"
 
-#: src/strings.ts:857
+#: src/strings.ts:856
 msgid "Enter notebook title"
 msgstr "Enter notebook title"
 
@@ -2644,11 +2643,11 @@ msgstr "Enter notebook title"
 msgid "Enter password"
 msgstr "Enter password"
 
-#: src/strings.ts:2099
+#: src/strings.ts:2098
 msgid "Enter pin or password to enable app lock."
 msgstr "Enter pin or password to enable app lock."
 
-#: src/strings.ts:1005
+#: src/strings.ts:1004
 msgid "Enter recovery code"
 msgstr "Enter recovery code"
 
@@ -2664,7 +2663,7 @@ msgstr "Enter the 6 digit code sent to your email to continue logging in"
 msgid "Enter the 6 digit code sent to your phone number to continue logging in"
 msgstr "Enter the 6 digit code sent to your phone number to continue logging in"
 
-#: src/strings.ts:2445
+#: src/strings.ts:2444
 msgid "Enter the gift code to redeem your subscription."
 msgstr "Enter the gift code to redeem your subscription."
 
@@ -2672,27 +2671,27 @@ msgstr "Enter the gift code to redeem your subscription."
 msgid "Enter the recovery code to continue logging in"
 msgstr "Enter the recovery code to continue logging in"
 
-#: src/strings.ts:2633
+#: src/strings.ts:2632
 msgid "Enter title"
 msgstr "Enter title"
 
-#: src/strings.ts:1494
+#: src/strings.ts:1493
 msgid "Enter verification code sent to your new email"
 msgstr "Enter verification code sent to your new email"
 
-#: src/strings.ts:1493
+#: src/strings.ts:1492
 msgid "Enter your new email"
 msgstr "Enter your new email"
 
-#: src/strings.ts:2100
+#: src/strings.ts:2099
 msgid "Enter your username"
 msgstr "Enter your username"
 
-#: src/strings.ts:2437
+#: src/strings.ts:2436
 msgid "Error"
 msgstr "Error"
 
-#: src/strings.ts:1555
+#: src/strings.ts:1554
 msgid "Error applying promo code"
 msgstr "Error applying promo code"
 
@@ -2700,7 +2699,7 @@ msgstr "Error applying promo code"
 msgid "Error downloading file: {message}"
 msgstr "Error downloading file: {message}"
 
-#: src/strings.ts:1515
+#: src/strings.ts:1514
 msgid "Error getting codes"
 msgstr "Error getting codes"
 
@@ -2708,11 +2707,11 @@ msgstr "Error getting codes"
 msgid "Error loading themes"
 msgstr "Error loading themes"
 
-#: src/strings.ts:1076
+#: src/strings.ts:1075
 msgid "Error logging out"
 msgstr "Error logging out"
 
-#: src/strings.ts:1010
+#: src/strings.ts:1009
 msgid "Error sending 2FA code"
 msgstr "Error sending 2FA code"
 
@@ -2720,55 +2719,55 @@ msgstr "Error sending 2FA code"
 msgid "Errors"
 msgstr "Errors"
 
-#: src/strings.ts:1697
+#: src/strings.ts:1696
 msgid "Errors in {count} attachments"
 msgstr "Errors in {count} attachments"
 
-#: src/strings.ts:2482
+#: src/strings.ts:2481
 msgid "Essential plan"
 msgstr "Essential plan"
 
-#: src/strings.ts:1629
+#: src/strings.ts:1628
 msgid "Events server"
 msgstr "Events server"
 
-#: src/strings.ts:2423
+#: src/strings.ts:2422
 msgid "Every Notebook can have notes and sub notebooks."
 msgstr "Every Notebook can have notes and sub notebooks."
 
-#: src/strings.ts:2425
+#: src/strings.ts:2424
 msgid "Everything related to my job in one place."
 msgstr "Everything related to my job in one place."
 
-#: src/strings.ts:2434
+#: src/strings.ts:2433
 msgid "Everything related to my school in one place."
 msgstr "Everything related to my school in one place."
 
-#: src/strings.ts:2451
+#: src/strings.ts:2450
 msgid "Execute"
 msgstr "Execute"
 
-#: src/strings.ts:2450
+#: src/strings.ts:2449
 msgid "Execute a command..."
 msgstr "Execute a command..."
 
-#: src/strings.ts:2014
+#: src/strings.ts:2013
 msgid "Exit fullscreen"
 msgstr "Exit fullscreen"
 
-#: src/strings.ts:2385
+#: src/strings.ts:2384
 msgid "Expand"
 msgstr "Expand"
 
-#: src/strings.ts:2478
+#: src/strings.ts:2477
 msgid "Expand sidebar"
 msgstr "Expand sidebar"
 
-#: src/strings.ts:2083
+#: src/strings.ts:2082
 msgid "Experience the next level of private note taking\""
 msgstr "Experience the next level of private note taking\""
 
-#: src/strings.ts:2647
+#: src/strings.ts:2646
 msgid "Expiry date"
 msgstr "Expiry date"
 
@@ -2785,7 +2784,6 @@ msgid "Expiry date set"
 msgstr "Expiry date set"
 
 #: src/strings.ts:2550
-#: src/strings.ts:2551
 msgid "Explore all plans"
 msgstr "Explore all plans"
 
@@ -2797,24 +2795,24 @@ msgstr "Export"
 msgid "Export again"
 msgstr "Export again"
 
-#: src/strings.ts:1238
+#: src/strings.ts:1237
 msgid "Export all notes"
 msgstr "Export all notes"
 
-#: src/strings.ts:1240
+#: src/strings.ts:1239
 msgid "Export all notes as pdf, markdown, html or text in a single zip file"
 msgstr "Export all notes as pdf, markdown, html or text in a single zip file"
 
 #. placeholder {0}: format ? " " + format : ""
-#: src/strings.ts:2036
+#: src/strings.ts:2035
 msgid "Export as{0}"
 msgstr "Export as{0}"
 
-#: src/strings.ts:2648
+#: src/strings.ts:2647
 msgid "Export CSV"
 msgstr "Export CSV"
 
-#: src/strings.ts:1386
+#: src/strings.ts:1385
 msgid "Export notes as PDF, Markdown and HTML with Notesnook Pro"
 msgstr "Export notes as PDF, Markdown and HTML with Notesnook Pro"
 
@@ -2822,39 +2820,39 @@ msgstr "Export notes as PDF, Markdown and HTML with Notesnook Pro"
 msgid "Exporting \"{title}\""
 msgstr "Exporting \"{title}\""
 
-#: src/strings.ts:1619
+#: src/strings.ts:1618
 msgid "Extracting files..."
 msgstr "Extracting files..."
 
-#: src/strings.ts:1808
+#: src/strings.ts:1807
 msgid "EXTREMELY DANGEROUS! This action is irreversible. All your data including notes, notebooks, attachments & settings will be deleted. This is a full account reset. Proceed with caution."
 msgstr "EXTREMELY DANGEROUS! This action is irreversible. All your data including notes, notebooks, attachments & settings will be deleted. This is a full account reset. Proceed with caution."
 
-#: src/strings.ts:1260
+#: src/strings.ts:1259
 msgid "Faced an issue or have a suggestion? Click here to create a bug report"
 msgstr "Faced an issue or have a suggestion? Click here to create a bug report"
 
-#: src/strings.ts:2415
+#: src/strings.ts:2414
 msgid "Failed"
 msgstr "Failed"
 
-#: src/strings.ts:2652
+#: src/strings.ts:2651
 msgid "Failed to attach file"
 msgstr "Failed to attach file"
 
-#: src/strings.ts:1937
+#: src/strings.ts:1936
 msgid "Failed to copy note"
 msgstr "Failed to copy note"
 
-#: src/strings.ts:1561
+#: src/strings.ts:1560
 msgid "Failed to decrypt backup"
 msgstr "Failed to decrypt backup"
 
-#: src/strings.ts:2003
+#: src/strings.ts:2002
 msgid "Failed to delete"
 msgstr "Failed to delete"
 
-#: src/strings.ts:1082
+#: src/strings.ts:1081
 msgid "Failed to delete account"
 msgstr "Failed to delete account"
 
@@ -2862,19 +2860,19 @@ msgstr "Failed to delete account"
 msgid "Failed to download file"
 msgstr "Failed to download file"
 
-#: src/strings.ts:1999
+#: src/strings.ts:1998
 msgid "Failed to install theme."
 msgstr "Failed to install theme."
 
-#: src/strings.ts:949
+#: src/strings.ts:948
 msgid "Failed to open"
 msgstr "Failed to open"
 
-#: src/strings.ts:868
+#: src/strings.ts:867
 msgid "Failed to publish note"
 msgstr "Failed to publish note"
 
-#: src/strings.ts:2004
+#: src/strings.ts:2003
 msgid "Failed to register task"
 msgstr "Failed to register task"
 
@@ -2886,23 +2884,23 @@ msgstr "Failed to resolve download url"
 msgid "Failed to send recovery email"
 msgstr "Failed to send recovery email"
 
-#: src/strings.ts:1402
+#: src/strings.ts:1401
 msgid "Failed to send verification email"
 msgstr "Failed to send verification email"
 
-#: src/strings.ts:938
+#: src/strings.ts:937
 msgid "Failed to subscribe"
 msgstr "Failed to subscribe"
 
-#: src/strings.ts:2214
+#: src/strings.ts:2213
 msgid "Failed to take backup"
 msgstr "Failed to take backup"
 
-#: src/strings.ts:2216
+#: src/strings.ts:2215
 msgid "Failed to take backup of your data. Do you want to continue logging out?"
 msgstr "Failed to take backup of your data. Do you want to continue logging out?"
 
-#: src/strings.ts:869
+#: src/strings.ts:868
 msgid "Failed to unpublish note"
 msgstr "Failed to unpublish note"
 
@@ -2914,28 +2912,28 @@ msgstr "Failed to zip files"
 msgid "Fallback method for 2FA enabled"
 msgstr "Fallback method for 2FA enabled"
 
-#: src/strings.ts:2561
+#: src/strings.ts:2560
 msgid "FAQs"
 msgstr "FAQs"
 
-#: src/strings.ts:2033
+#: src/strings.ts:2032
 msgid "Favorite"
 msgstr "Favorite"
 
 #: src/strings.ts:321
-#: src/strings.ts:1522
+#: src/strings.ts:1521
 msgid "Favorites"
 msgstr "Favorites"
 
-#: src/strings.ts:2559
+#: src/strings.ts:2558
 msgid "Featured on"
 msgstr "Featured on"
 
-#: src/strings.ts:2427
+#: src/strings.ts:2426
 msgid "February 2022 Week 2"
 msgstr "February 2022 Week 2"
 
-#: src/strings.ts:2428
+#: src/strings.ts:2427
 msgid "February 2022 Week 3"
 msgstr "February 2022 Week 3"
 
@@ -2955,107 +2953,107 @@ msgstr "File length is 0. Please upload this file again from the attachment mana
 msgid "File length mismatch. Expected {expectedSize} but got {currentSize} bytes. Please upload this file again from the attachment manager."
 msgstr "File length mismatch. Expected {expectedSize} but got {currentSize} bytes. Please upload this file again from the attachment manager."
 
-#: src/strings.ts:2690
+#: src/strings.ts:2689
 msgid "File links cannot be opened in browsers. Please use the Notesnook desktop app."
 msgstr "File links cannot be opened in browsers. Please use the Notesnook desktop app."
 
-#: src/strings.ts:950
+#: src/strings.ts:949
 msgid "File mismatch"
 msgstr "File mismatch"
 
-#: src/strings.ts:2684
+#: src/strings.ts:2683
 msgid "File size limit exceeded. Please upgrade your plan."
 msgstr "File size limit exceeded. Please upgrade your plan."
 
-#: src/strings.ts:946
+#: src/strings.ts:945
 msgid "File size should be less than {sizeInMB}"
 msgstr "File size should be less than {sizeInMB}"
 
-#: src/strings.ts:944
+#: src/strings.ts:943
 msgid "File too big"
 msgstr "File too big"
 
-#: src/strings.ts:1479
+#: src/strings.ts:1478
 msgid "Filter attachments by filename, type or hash"
 msgstr "Filter attachments by filename, type or hash"
 
-#: src/strings.ts:1834
+#: src/strings.ts:1833
 msgid "Filter languages"
 msgstr "Filter languages"
 
-#: src/strings.ts:2619
+#: src/strings.ts:2618
 msgid "Finish your purchase in the browser."
 msgstr "Finish your purchase in the browser."
 
-#: src/strings.ts:1670
+#: src/strings.ts:1669
 msgid "Fix it"
 msgstr "Fix it"
 
-#: src/strings.ts:2016
+#: src/strings.ts:2015
 msgid "Focus mode"
 msgstr "Focus mode"
 
-#: src/strings.ts:2174
+#: src/strings.ts:2173
 msgid "Follow"
 msgstr "Follow"
 
-#: src/strings.ts:1276
+#: src/strings.ts:1275
 msgid "Follow us on Mastodon"
 msgstr "Follow us on Mastodon"
 
-#: src/strings.ts:1278
+#: src/strings.ts:1277
 msgid "Follow us on Mastodon for updates and news about Notesnook"
 msgstr "Follow us on Mastodon for updates and news about Notesnook"
 
-#: src/strings.ts:1279
+#: src/strings.ts:1278
 msgid "Follow us on X"
 msgstr "Follow us on X"
 
-#: src/strings.ts:1280
+#: src/strings.ts:1279
 msgid "Follow us on X for updates and news about Notesnook"
 msgstr "Follow us on X for updates and news about Notesnook"
 
-#: src/strings.ts:2288
+#: src/strings.ts:2287
 msgid "Font family"
 msgstr "Font family"
 
-#: src/strings.ts:2475
+#: src/strings.ts:2474
 msgid "Font ligatures"
 msgstr "Font ligatures"
 
-#: src/strings.ts:2289
+#: src/strings.ts:2288
 msgid "Font size"
 msgstr "Font size"
 
-#: src/strings.ts:2533
+#: src/strings.ts:2532
 msgid "For a monthly subscription, you can get a refund within 7 days of purchase. For a yearly subscription, we offer a full refund within 14 days of purchase. For a 5 year subscription, you can request a refund within 30 days of purchase."
 msgstr "For a monthly subscription, you can get a refund within 7 days of purchase. For a yearly subscription, we offer a full refund within 14 days of purchase. For a 5 year subscription, you can request a refund within 30 days of purchase."
 
-#: src/strings.ts:1687
+#: src/strings.ts:1686
 msgid "For a more integrated user experience, try out Notesnook for {platform}"
 msgstr "For a more integrated user experience, try out Notesnook for {platform}"
 
-#: src/strings.ts:1768
+#: src/strings.ts:1767
 msgid "for help regarding how to use the Notesnook Importer."
 msgstr "for help regarding how to use the Notesnook Importer."
 
-#: src/strings.ts:2542
+#: src/strings.ts:2541
 msgid "for locking your notes as soon as app enters background"
 msgstr "for locking your notes as soon as app enters background"
 
-#: src/strings.ts:2206
+#: src/strings.ts:2205
 msgid "Force logout from all your other logged in devices."
 msgstr "Force logout from all your other logged in devices."
 
-#: src/strings.ts:1097
+#: src/strings.ts:1096
 msgid "Force pull changes"
 msgstr "Force pull changes"
 
-#: src/strings.ts:1106
+#: src/strings.ts:1105
 msgid "Force push changes"
 msgstr "Force push changes"
 
-#: src/strings.ts:2223
+#: src/strings.ts:2222
 msgid ""
 "Force push:\n"
 "Use this if changes made on this device are not appearing on other devices. This will overwrite the data on the server with the data from this device.\n"
@@ -3077,11 +3075,11 @@ msgstr ""
 msgid "Forgot password?"
 msgstr "Forgot password?"
 
-#: src/strings.ts:2576
+#: src/strings.ts:2575
 msgid "Free {duration} day trial, cancel any time"
 msgstr "Free {duration} day trial, cancel any time"
 
-#: src/strings.ts:2480
+#: src/strings.ts:2479
 msgid "Free plan"
 msgstr "Free plan"
 
@@ -3093,55 +3091,55 @@ msgstr "Fri"
 msgid "Friday"
 msgstr "Friday"
 
-#: src/strings.ts:2383
+#: src/strings.ts:2382
 msgid "From code"
 msgstr "From code"
 
-#: src/strings.ts:2380
+#: src/strings.ts:2379
 msgid "From URL"
 msgstr "From URL"
 
-#: src/strings.ts:2000
+#: src/strings.ts:1999
 msgid "Full name updated"
 msgstr "Full name updated"
 
-#: src/strings.ts:2217
+#: src/strings.ts:2216
 msgid "Full offline mode"
 msgstr "Full offline mode"
 
-#: src/strings.ts:2335
+#: src/strings.ts:2334
 msgid "Full screen"
 msgstr "Full screen"
 
-#: src/strings.ts:2103
+#: src/strings.ts:2102
 msgid "General"
 msgstr "General"
 
-#: src/strings.ts:1269
+#: src/strings.ts:1268
 msgid "Get helpful debug info about the app to help us find bugs."
 msgstr "Get helpful debug info about the app to help us find bugs."
 
-#: src/strings.ts:1293
+#: src/strings.ts:1292
 msgid "Get Notesnook app on your desktop and access all notes"
 msgstr "Get Notesnook app on your desktop and access all notes"
 
-#: src/strings.ts:2168
+#: src/strings.ts:2167
 msgid "Get Notesnook app on your iPhone and access all your notes on the go."
 msgstr "Get Notesnook app on your iPhone and access all your notes on the go."
 
-#: src/strings.ts:2170
+#: src/strings.ts:2169
 msgid "Get Notesnook app on your iPhone or Android device and access all your notes on the go."
 msgstr "Get Notesnook app on your iPhone or Android device and access all your notes on the go."
 
-#: src/strings.ts:1383
+#: src/strings.ts:1382
 msgid "Get Notesnook Pro"
 msgstr "Get Notesnook Pro"
 
-#: src/strings.ts:1368
+#: src/strings.ts:1367
 msgid "Get Notesnook Pro to enable automatic backups"
 msgstr "Get Notesnook Pro to enable automatic backups"
 
-#: src/strings.ts:2419
+#: src/strings.ts:2418
 msgid "Get Priority support"
 msgstr "Get Priority support"
 
@@ -3153,11 +3151,11 @@ msgstr "Get Pro"
 msgid "Get started"
 msgstr "Get started"
 
-#: src/strings.ts:2539
+#: src/strings.ts:2538
 msgid "Get this and so much more:"
 msgstr "Get this and so much more:"
 
-#: src/strings.ts:1886
+#: src/strings.ts:1885
 msgid "Getting encryption key..."
 msgstr "Getting encryption key..."
 
@@ -3169,55 +3167,55 @@ msgstr "Getting information"
 msgid "Getting recovery codes"
 msgstr "Getting recovery codes"
 
-#: src/strings.ts:2664
+#: src/strings.ts:2663
 msgid "Gift code required"
 msgstr "Gift code required"
 
-#: src/strings.ts:2173
+#: src/strings.ts:2172
 msgid "GNU GENERAL PUBLIC LICENSE Version 3"
 msgstr "GNU GENERAL PUBLIC LICENSE Version 3"
 
-#: src/strings.ts:2620
+#: src/strings.ts:2619
 msgid "Go back"
 msgstr "Go back"
 
-#: src/strings.ts:2458
+#: src/strings.ts:2457
 msgid "Go back in tab"
 msgstr "Go back in tab"
 
-#: src/strings.ts:2236
+#: src/strings.ts:2235
 msgid "Go back to notebooks"
 msgstr "Go back to notebooks"
 
-#: src/strings.ts:2237
+#: src/strings.ts:2236
 msgid "Go back to tags"
 msgstr "Go back to tags"
 
-#: src/strings.ts:2457
+#: src/strings.ts:2456
 msgid "Go forward in tab"
 msgstr "Go forward in tab"
 
-#: src/strings.ts:1814
+#: src/strings.ts:1813
 msgid "Go to"
 msgstr "Go to"
 
-#: src/strings.ts:1815
+#: src/strings.ts:1814
 msgid "Go to #{tag}"
 msgstr "Go to #{tag}"
 
-#: src/strings.ts:1698
+#: src/strings.ts:1697
 msgid "Go to next page"
 msgstr "Go to next page"
 
-#: src/strings.ts:1699
+#: src/strings.ts:1698
 msgid "Go to previous page"
 msgstr "Go to previous page"
 
-#: src/strings.ts:1305
+#: src/strings.ts:1304
 msgid "Go to web app"
 msgstr "Go to web app"
 
-#: src/strings.ts:2550
+#: src/strings.ts:2549
 msgid "Google will remind you 2 days before your trial ends."
 msgstr "Google will remind you 2 days before your trial ends."
 
@@ -3229,7 +3227,7 @@ msgstr "Got it"
 msgid "GROUP"
 msgstr "GROUP"
 
-#: src/strings.ts:1888
+#: src/strings.ts:1887
 msgid "Group added successfully"
 msgstr "Group added successfully"
 
@@ -3241,27 +3239,27 @@ msgstr "Group by"
 msgid "Hash copied"
 msgstr "Hash copied"
 
-#: src/strings.ts:2220
+#: src/strings.ts:2219
 msgid "Having problems with sync?"
 msgstr "Having problems with sync?"
 
-#: src/strings.ts:2565
+#: src/strings.ts:2564
 msgid "hdImages"
 msgstr "hdImages"
 
-#: src/strings.ts:2361
+#: src/strings.ts:2360
 msgid "Heading {level}"
 msgstr "Heading {level}"
 
-#: src/strings.ts:2290
+#: src/strings.ts:2289
 msgid "Headings"
 msgstr "Headings"
 
-#: src/strings.ts:2396
+#: src/strings.ts:2395
 msgid "Height"
 msgstr "Height"
 
-#: src/strings.ts:1257
+#: src/strings.ts:1256
 msgid "Help and support"
 msgstr "Help and support"
 
@@ -3269,55 +3267,55 @@ msgstr "Help and support"
 msgid "Help improve Notesnook by sending completely anonymized"
 msgstr "Help improve Notesnook by sending completely anonymized"
 
-#: src/strings.ts:1376
+#: src/strings.ts:1375
 msgid "Hide"
 msgstr "Hide"
 
-#: src/strings.ts:1183
+#: src/strings.ts:1182
 msgid "Hide app contents when you switch to other apps. This will also disable screenshot taking in the app."
 msgstr "Hide app contents when you switch to other apps. This will also disable screenshot taking in the app."
 
-#: src/strings.ts:2179
+#: src/strings.ts:2178
 msgid "Hide note title"
 msgstr "Hide note title"
 
-#: src/strings.ts:2293
+#: src/strings.ts:2292
 msgid "Highlight"
 msgstr "Highlight"
 
-#: src/strings.ts:910
+#: src/strings.ts:909
 msgid "History"
 msgstr "History"
 
-#: src/strings.ts:1528
+#: src/strings.ts:1527
 msgid "Home"
 msgstr "Home"
 
-#: src/strings.ts:1127
+#: src/strings.ts:1126
 msgid "Homepage"
 msgstr "Homepage"
 
-#: src/strings.ts:1318
+#: src/strings.ts:1317
 msgid "Homepage changed to {name}"
 msgstr "Homepage changed to {name}"
 
-#: src/strings.ts:2342
+#: src/strings.ts:2341
 msgid "Horizontal rule"
 msgstr "Horizontal rule"
 
-#: src/strings.ts:1799
+#: src/strings.ts:1798
 msgid "How do you want to recover your account?"
 msgstr "How do you want to recover your account?"
 
-#: src/strings.ts:1669
+#: src/strings.ts:1668
 msgid "How to fix it?"
 msgstr "How to fix it?"
 
-#: src/strings.ts:881
+#: src/strings.ts:880
 msgid "hr"
 msgstr "hr"
 
-#: src/strings.ts:2510
+#: src/strings.ts:2509
 msgid "I already have an account"
 msgstr "I already have an account"
 
@@ -3341,15 +3339,15 @@ msgstr "I don't have recovery codes"
 msgid "I have a recovery code"
 msgstr "I have a recovery code"
 
-#: src/strings.ts:1887
+#: src/strings.ts:1886
 msgid "I have saved my key"
 msgstr "I have saved my key"
 
-#: src/strings.ts:2436
+#: src/strings.ts:2435
 msgid "I love cooking and collecting recipes."
 msgstr "I love cooking and collecting recipes."
 
-#: src/strings.ts:2221
+#: src/strings.ts:2220
 msgid "I understand"
 msgstr "I understand"
 
@@ -3365,19 +3363,19 @@ msgstr "If the editor fails to load even after reloading. Try restarting the app
 msgid "If this continues to happen, please reach out to us via"
 msgstr "If this continues to happen, please reach out to us via"
 
-#: src/strings.ts:2124
+#: src/strings.ts:2123
 msgid "If true, Notesnook will automatically start up when you turn on & login to your system."
 msgstr "If true, Notesnook will automatically start up when you turn on & login to your system."
 
-#: src/strings.ts:2127
+#: src/strings.ts:2126
 msgid "If true, Notesnook will start minimized to either the system tray or your system taskbar/dock. This setting only works with Auto start on system startup is enabled."
 msgstr "If true, Notesnook will start minimized to either the system tray or your system taskbar/dock. This setting only works with Auto start on system startup is enabled."
 
-#: src/strings.ts:1725
+#: src/strings.ts:1724
 msgid "If you can't scan the QR code above, enter this text instead (spaces don't matter)"
 msgstr "If you can't scan the QR code above, enter this text instead (spaces don't matter)"
 
-#: src/strings.ts:1395
+#: src/strings.ts:1394
 msgid ""
 "If you didn't get an email from us or the confirmation link isn't\n"
 "            working,"
@@ -3385,11 +3383,11 @@ msgstr ""
 "If you didn't get an email from us or the confirmation link isn't\n"
 "            working,"
 
-#: src/strings.ts:1805
+#: src/strings.ts:1804
 msgid "If you don't have a recovery key, you can recover your data by restoring a Notesnook data backup file (.nnbackup)."
 msgstr "If you don't have a recovery key, you can recover your data by restoring a Notesnook data backup file (.nnbackup)."
 
-#: src/strings.ts:2088
+#: src/strings.ts:2087
 msgid "If you face any issue, you can reach out to us anytime."
 msgstr "If you face any issue, you can reach out to us anytime."
 
@@ -3397,23 +3395,23 @@ msgstr "If you face any issue, you can reach out to us anytime."
 msgid "If you want to ask something in general or need some assistance, we would suggest that you"
 msgstr "If you want to ask something in general or need some assistance, we would suggest that you"
 
-#: src/strings.ts:2347
+#: src/strings.ts:2346
 msgid "Image"
 msgstr "Image"
 
-#: src/strings.ts:1129
+#: src/strings.ts:1128
 msgid "Image Compression"
 msgstr "Image Compression"
 
-#: src/strings.ts:2323
+#: src/strings.ts:2322
 msgid "Image properties"
 msgstr "Image properties"
 
-#: src/strings.ts:2319
+#: src/strings.ts:2318
 msgid "Image settings"
 msgstr "Image settings"
 
-#: src/strings.ts:948
+#: src/strings.ts:947
 msgid "Image size should be less than {sizeInMB}"
 msgstr "Image size should be less than {sizeInMB}"
 
@@ -3425,23 +3423,23 @@ msgstr "Images"
 msgid "Images uploaded without compression are slow to load and take more bandwidth. We recommend compressing images unless you need image in original quality."
 msgstr "Images uploaded without compression are slow to load and take more bandwidth. We recommend compressing images unless you need image in original quality."
 
-#: src/strings.ts:1583
+#: src/strings.ts:1582
 msgid "Immediately"
 msgstr "Immediately"
 
-#: src/strings.ts:2151
+#: src/strings.ts:2150
 msgid "Import & export"
 msgstr "Import & export"
 
-#: src/strings.ts:1752
+#: src/strings.ts:1751
 msgid "Import completed"
 msgstr "Import completed"
 
-#: src/strings.ts:2649
+#: src/strings.ts:2648
 msgid "Import CSV"
 msgstr "Import CSV"
 
-#: src/strings.ts:1767
+#: src/strings.ts:1766
 msgid "import guide"
 msgstr "import guide"
 
@@ -3449,7 +3447,7 @@ msgstr "import guide"
 msgid "Incoming"
 msgstr "Incoming"
 
-#: src/strings.ts:1838
+#: src/strings.ts:1837
 msgid "Incoming note"
 msgstr "Incoming note"
 
@@ -3457,59 +3455,59 @@ msgstr "Incoming note"
 msgid "Incorrect {type}"
 msgstr "Incorrect {type}"
 
-#: src/strings.ts:2405
+#: src/strings.ts:2404
 msgid "Increase {title}"
 msgstr "Increase {title}"
 
-#: src/strings.ts:2247
+#: src/strings.ts:2246
 msgid "Insert"
 msgstr "Insert"
 
-#: src/strings.ts:2402
+#: src/strings.ts:2401
 msgid "Insert a {rows}x{columns} table"
 msgstr "Insert a {rows}x{columns} table"
 
-#: src/strings.ts:2352
+#: src/strings.ts:2351
 msgid "Insert a table"
 msgstr "Insert a table"
 
-#: src/strings.ts:2354
+#: src/strings.ts:2353
 msgid "Insert an embed"
 msgstr "Insert an embed"
 
-#: src/strings.ts:2348
+#: src/strings.ts:2347
 msgid "Insert an image"
 msgstr "Insert an image"
 
-#: src/strings.ts:2300
+#: src/strings.ts:2299
 msgid "Insert column left"
 msgstr "Insert column left"
 
-#: src/strings.ts:2301
+#: src/strings.ts:2300
 msgid "Insert column right"
 msgstr "Insert column right"
 
-#: src/strings.ts:2245
+#: src/strings.ts:2244
 msgid "Insert link"
 msgstr "Insert link"
 
-#: src/strings.ts:2307
+#: src/strings.ts:2306
 msgid "Insert row above"
 msgstr "Insert row above"
 
-#: src/strings.ts:2308
+#: src/strings.ts:2307
 msgid "Insert row below"
 msgstr "Insert row below"
 
-#: src/strings.ts:1685
+#: src/strings.ts:1684
 msgid "Install Notesnook"
 msgstr "Install Notesnook"
 
-#: src/strings.ts:2159
+#: src/strings.ts:2158
 msgid "Install update"
 msgstr "Install update"
 
-#: src/strings.ts:1720
+#: src/strings.ts:1719
 msgid "installs"
 msgstr "installs"
 
@@ -3517,15 +3515,15 @@ msgstr "installs"
 msgid "Invalid {type}"
 msgstr "Invalid {type}"
 
-#: src/strings.ts:1992
+#: src/strings.ts:1991
 msgid "Invalid CORS proxy url"
 msgstr "Invalid CORS proxy url"
 
-#: src/strings.ts:1483
+#: src/strings.ts:1482
 msgid "Invalid email"
 msgstr "Invalid email"
 
-#: src/strings.ts:2657
+#: src/strings.ts:2656
 msgid "Invalid recovery key. Make sure to input your account recovery key, not a 2FA recovery code."
 msgstr "Invalid recovery key. Make sure to input your account recovery key, not a 2FA recovery code."
 
@@ -3533,12 +3531,12 @@ msgstr "Invalid recovery key. Make sure to input your account recovery key, not 
 msgid "Issue created"
 msgstr "Issue created"
 
-#: src/strings.ts:991
-#: src/strings.ts:1000
+#: src/strings.ts:990
+#: src/strings.ts:999
 msgid "It may take a minute to receive your code."
 msgstr "It may take a minute to receive your code."
 
-#: src/strings.ts:1591
+#: src/strings.ts:1590
 msgid "It seems that your changes could not be saved. What to do next:"
 msgstr "It seems that your changes could not be saved. What to do next:"
 
@@ -3546,7 +3544,7 @@ msgstr "It seems that your changes could not be saved. What to do next:"
 msgid "It took us a year to bring Notesnook to life. Share your experience and suggestions to help us improve it."
 msgstr "It took us a year to bring Notesnook to life. Share your experience and suggestions to help us improve it."
 
-#: src/strings.ts:2269
+#: src/strings.ts:2268
 msgid "Italic"
 msgstr "Italic"
 
@@ -3559,7 +3557,7 @@ msgid "Item"
 msgstr "Item"
 
 #: src/strings.ts:311
-#: src/strings.ts:1704
+#: src/strings.ts:1703
 msgid "items"
 msgstr "items"
 
@@ -3567,7 +3565,7 @@ msgstr "items"
 msgid "Items"
 msgstr "Items"
 
-#: src/strings.ts:2171
+#: src/strings.ts:2170
 msgid "Join community"
 msgstr "Join community"
 
@@ -3575,27 +3573,27 @@ msgstr "Join community"
 msgid "join our community on Discord."
 msgstr "join our community on Discord."
 
-#: src/strings.ts:1281
+#: src/strings.ts:1280
 msgid "Join our Discord server"
 msgstr "Join our Discord server"
 
-#: src/strings.ts:1283
+#: src/strings.ts:1282
 msgid "Join our Discord server to chat with other users and the team"
 msgstr "Join our Discord server to chat with other users and the team"
 
-#: src/strings.ts:1273
+#: src/strings.ts:1272
 msgid "Join our Telegram group"
 msgstr "Join our Telegram group"
 
-#: src/strings.ts:1275
+#: src/strings.ts:1274
 msgid "Join our Telegram group to chat with other users and the team"
 msgstr "Join our Telegram group to chat with other users and the team"
 
-#: src/strings.ts:2079
+#: src/strings.ts:2078
 msgid "Join the cause"
 msgstr "Join the cause"
 
-#: src/strings.ts:2027
+#: src/strings.ts:2026
 msgid "Jump to group"
 msgstr "Jump to group"
 
@@ -3603,19 +3601,19 @@ msgstr "Jump to group"
 msgid "Keep"
 msgstr "Keep"
 
-#: src/strings.ts:2022
+#: src/strings.ts:2021
 msgid "Keep open"
 msgstr "Keep open"
 
-#: src/strings.ts:1360
+#: src/strings.ts:1359
 msgid "Keep your data safe"
 msgstr "Keep your data safe"
 
-#: src/strings.ts:2139
+#: src/strings.ts:2138
 msgid "Languages"
 msgstr "Languages"
 
-#: src/strings.ts:2242
+#: src/strings.ts:2241
 msgid "Last edited at"
 msgstr "Last edited at"
 
@@ -3635,7 +3633,7 @@ msgstr "Learn how this works."
 msgid "Learn more"
 msgstr "Learn more"
 
-#: src/strings.ts:978
+#: src/strings.ts:977
 msgid "Learn more about Monographs"
 msgstr "Learn more about Monographs"
 
@@ -3647,7 +3645,7 @@ msgstr "Learn more about Notesnook Monograph"
 msgid "Least relevant first"
 msgstr "Least relevant first"
 
-#: src/strings.ts:1563
+#: src/strings.ts:1562
 msgid "Legal"
 msgstr "Legal"
 
@@ -3655,15 +3653,15 @@ msgstr "Legal"
 msgid "Let us know if you have faced any issue/bug while using Notesnook. We will try to fix it as soon as possible."
 msgstr "Let us know if you have faced any issue/bug while using Notesnook. We will try to fix it as soon as possible."
 
-#: src/strings.ts:2172
+#: src/strings.ts:2171
 msgid "License"
 msgstr "License"
 
-#: src/strings.ts:1721
+#: src/strings.ts:1720
 msgid "Licensed under {license}"
 msgstr "Licensed under {license}"
 
-#: src/strings.ts:2338
+#: src/strings.ts:2337
 msgid "Lift list item"
 msgstr "Lift list item"
 
@@ -3671,39 +3669,39 @@ msgstr "Lift list item"
 msgid "Light"
 msgstr "Light"
 
-#: src/strings.ts:2368
+#: src/strings.ts:2367
 msgid "Line {line}, Column {column}"
 msgstr "Line {line}, Column {column}"
 
-#: src/strings.ts:2631
+#: src/strings.ts:2630
 msgid "Line height"
 msgstr "Line height"
 
-#: src/strings.ts:1153
+#: src/strings.ts:1152
 msgid "Line spacing changed"
 msgstr "Line spacing changed"
 
-#: src/strings.ts:2273
+#: src/strings.ts:2272
 msgid "Link"
 msgstr "Link"
 
-#: src/strings.ts:912
+#: src/strings.ts:911
 msgid "Link copied"
 msgstr "Link copied"
 
-#: src/strings.ts:930
+#: src/strings.ts:929
 msgid "Link notebooks"
 msgstr "Link notebooks"
 
-#: src/strings.ts:2487
+#: src/strings.ts:2486
 msgid "Link notes"
 msgstr "Link notes"
 
-#: src/strings.ts:2278
+#: src/strings.ts:2277
 msgid "Link settings"
 msgstr "Link settings"
 
-#: src/strings.ts:2398
+#: src/strings.ts:2397
 msgid "Link text"
 msgstr "Link text"
 
@@ -3715,7 +3713,7 @@ msgstr "LINK TO A SECTION"
 msgid "Link to note"
 msgstr "Link to note"
 
-#: src/strings.ts:852
+#: src/strings.ts:851
 msgid "Link to notebook"
 msgstr "Link to notebook"
 
@@ -3723,7 +3721,7 @@ msgstr "Link to notebook"
 msgid "Linked notes"
 msgstr "Linked notes"
 
-#: src/strings.ts:1597
+#: src/strings.ts:1596
 msgid "Linking to a specific block is not available for locked notes."
 msgstr "Linking to a specific block is not available for locked notes."
 
@@ -3735,7 +3733,7 @@ msgstr "List of"
 msgid "Load from file"
 msgstr "Load from file"
 
-#: src/strings.ts:1696
+#: src/strings.ts:1695
 msgid "Loading"
 msgstr "Loading"
 
@@ -3744,11 +3742,11 @@ msgstr "Loading"
 msgid "Loading {0}, please wait..."
 msgstr "Loading {0}, please wait..."
 
-#: src/strings.ts:1665
+#: src/strings.ts:1664
 msgid "Loading editor. Please wait..."
 msgstr "Loading editor. Please wait..."
 
-#: src/strings.ts:1065
+#: src/strings.ts:1064
 msgid "Loading subscription details"
 msgstr "Loading subscription details"
 
@@ -3756,35 +3754,35 @@ msgstr "Loading subscription details"
 msgid "Loading themes..."
 msgstr "Loading themes..."
 
-#: src/strings.ts:1328
+#: src/strings.ts:1327
 msgid "Loading trash"
 msgstr "Loading trash"
 
-#: src/strings.ts:974
+#: src/strings.ts:973
 msgid "Loading your archive"
 msgstr "Loading your archive"
 
-#: src/strings.ts:968
+#: src/strings.ts:967
 msgid "Loading your favorites"
 msgstr "Loading your favorites"
 
-#: src/strings.ts:973
+#: src/strings.ts:972
 msgid "Loading your monographs"
 msgstr "Loading your monographs"
 
-#: src/strings.ts:971
+#: src/strings.ts:970
 msgid "Loading your notebooks"
 msgstr "Loading your notebooks"
 
-#: src/strings.ts:969
+#: src/strings.ts:968
 msgid "Loading your notes"
 msgstr "Loading your notes"
 
-#: src/strings.ts:972
+#: src/strings.ts:971
 msgid "Loading your reminders"
 msgstr "Loading your reminders"
 
-#: src/strings.ts:970
+#: src/strings.ts:969
 msgid "Loading your tags"
 msgstr "Loading your tags"
 
@@ -3796,19 +3794,19 @@ msgstr "Lock"
 msgid "Lock note"
 msgstr "Lock note"
 
-#: src/strings.ts:1185
+#: src/strings.ts:1184
 msgid "Lock the app with a password or pin"
 msgstr "Lock the app with a password or pin"
 
-#: src/strings.ts:902
+#: src/strings.ts:901
 msgid "Locked notes cannot be pinned"
 msgstr "Locked notes cannot be pinned"
 
-#: src/strings.ts:905
+#: src/strings.ts:904
 msgid "Locked notes cannot be published"
 msgstr "Locked notes cannot be published"
 
-#: src/strings.ts:2204
+#: src/strings.ts:2203
 msgid "Log out from all other devices"
 msgstr "Log out from all other devices"
 
@@ -3816,7 +3814,7 @@ msgstr "Log out from all other devices"
 msgid "Logged in as {email}"
 msgstr "Logged in as {email}"
 
-#: src/strings.ts:1075
+#: src/strings.ts:1074
 msgid "Logging out will clear all data stored on THIS DEVICE. Make sure you have synced all your changes before logging out."
 msgstr "Logging out will clear all data stored on THIS DEVICE. Make sure you have synced all your changes before logging out."
 
@@ -3824,7 +3822,7 @@ msgstr "Logging out will clear all data stored on THIS DEVICE. Make sure you hav
 msgid "Logging out. Please wait..."
 msgstr "Logging out. Please wait..."
 
-#: src/strings.ts:1783
+#: src/strings.ts:1782
 msgid "Logging you in"
 msgstr "Logging you in"
 
@@ -3836,11 +3834,11 @@ msgstr "Login"
 msgid "Login failed"
 msgstr "Login failed"
 
-#: src/strings.ts:903
+#: src/strings.ts:902
 msgid "Login required"
 msgstr "Login required"
 
-#: src/strings.ts:2672
+#: src/strings.ts:2671
 msgid "Login required to restore attachments"
 msgstr "Login required to restore attachments"
 
@@ -3848,11 +3846,11 @@ msgstr "Login required to restore attachments"
 msgid "Login successful"
 msgstr "Login successful"
 
-#: src/strings.ts:1363
+#: src/strings.ts:1362
 msgid "Login to encrypt and sync notes"
 msgstr "Login to encrypt and sync notes"
 
-#: src/strings.ts:2624
+#: src/strings.ts:2623
 msgid "Login to upload attachments. [Read more](https://help.notesnook.com/faqs/login-to-upload-attachments)"
 msgstr "Login to upload attachments. [Read more](https://help.notesnook.com/faqs/login-to-upload-attachments)"
 
@@ -3872,19 +3870,19 @@ msgstr "Logout and clear data"
 msgid "Logout from this device"
 msgstr "Logout from this device"
 
-#: src/strings.ts:1413
+#: src/strings.ts:1412
 msgid "Long press on any item in list to enter multi-select mode."
 msgstr "Long press on any item in list to enter multi-select mode."
 
-#: src/strings.ts:2373
+#: src/strings.ts:2372
 msgid "Make task list readonly"
 msgstr "Make task list readonly"
 
-#: src/strings.ts:1039
+#: src/strings.ts:1038
 msgid "Manage account"
 msgstr "Manage account"
 
-#: src/strings.ts:1052
+#: src/strings.ts:1051
 msgid "Manage attachments"
 msgstr "Manage attachments"
 
@@ -3892,75 +3890,75 @@ msgstr "Manage attachments"
 msgid "Manage subscription on desktop"
 msgstr "Manage subscription on desktop"
 
-#: src/strings.ts:851
+#: src/strings.ts:850
 msgid "Manage tags"
 msgstr "Manage tags"
 
-#: src/strings.ts:1040
+#: src/strings.ts:1039
 msgid "Manage your account related settings here"
 msgstr "Manage your account related settings here"
 
-#: src/strings.ts:1053
+#: src/strings.ts:1052
 msgid "Manage your attachments in one place"
 msgstr "Manage your attachments in one place"
 
-#: src/strings.ts:1212
+#: src/strings.ts:1211
 msgid "Manage your backups and restore data"
 msgstr "Manage your backups and restore data"
 
-#: src/strings.ts:1246
+#: src/strings.ts:1245
 msgid "Manage your reminders"
 msgstr "Manage your reminders"
 
-#: src/strings.ts:1084
+#: src/strings.ts:1083
 msgid "Manage your sync settings here"
 msgstr "Manage your sync settings here"
 
-#: src/strings.ts:1441
+#: src/strings.ts:1440
 msgid "Mark important notes by adding them to favorites."
 msgstr "Mark important notes by adding them to favorites."
 
-#: src/strings.ts:1160
+#: src/strings.ts:1159
 msgid "Markdown shortcuts"
 msgstr "Markdown shortcuts"
 
-#: src/strings.ts:1166
+#: src/strings.ts:1165
 msgid "Marketing emails"
 msgstr "Marketing emails"
 
-#: src/strings.ts:2386
+#: src/strings.ts:2385
 msgid "Match case"
 msgstr "Match case"
 
-#: src/strings.ts:2387
+#: src/strings.ts:2386
 msgid "Match whole word"
 msgstr "Match whole word"
 
-#: src/strings.ts:2295
+#: src/strings.ts:2294
 msgid "Math (inline)"
 msgstr "Math (inline)"
 
-#: src/strings.ts:2345
+#: src/strings.ts:2344
 msgid "Math & formulas"
 msgstr "Math & formulas"
 
-#: src/strings.ts:2041
+#: src/strings.ts:2040
 msgid "Maximize"
 msgstr "Maximize"
 
-#: src/strings.ts:2081
+#: src/strings.ts:2080
 msgid "Meet other privacy-minded people & talk to us directly about your concerns, issues and suggestions."
 msgstr "Meet other privacy-minded people & talk to us directly about your concerns, issues and suggestions."
 
-#: src/strings.ts:2429
+#: src/strings.ts:2428
 msgid "Meetings"
 msgstr "Meetings"
 
-#: src/strings.ts:1780
+#: src/strings.ts:1779
 msgid "Member since {date}"
 msgstr "Member since {date}"
 
-#: src/strings.ts:2306
+#: src/strings.ts:2305
 msgid "Merge cells"
 msgstr "Merge cells"
 
@@ -3974,19 +3972,19 @@ msgstr "Migrating {0} {1}... please wait"
 msgid "Migration failed"
 msgstr "Migration failed"
 
-#: src/strings.ts:880
+#: src/strings.ts:879
 msgid "min"
 msgstr "min"
 
-#: src/strings.ts:2010
+#: src/strings.ts:2009
 msgid "Minimal"
 msgstr "Minimal"
 
-#: src/strings.ts:2040
+#: src/strings.ts:2039
 msgid "Minimize"
 msgstr "Minimize"
 
-#: src/strings.ts:2128
+#: src/strings.ts:2127
 msgid "Minimize to system tray"
 msgstr "Minimize to system tray"
 
@@ -4002,39 +4000,39 @@ msgstr "Mon"
 msgid "Monday"
 msgstr "Monday"
 
-#: src/strings.ts:1632
+#: src/strings.ts:1631
 msgid "Monograph server"
 msgstr "Monograph server"
 
-#: src/strings.ts:871
+#: src/strings.ts:870
 msgid "Monograph URL copied"
 msgstr "Monograph URL copied"
 
 #: src/strings.ts:322
-#: src/strings.ts:940
-#: src/strings.ts:1530
+#: src/strings.ts:939
+#: src/strings.ts:1529
 msgid "Monographs"
 msgstr "Monographs"
 
-#: src/strings.ts:1423
+#: src/strings.ts:1422
 msgid "Monographs can be encrypted with a secret key and shared with anyone."
 msgstr "Monographs can be encrypted with a secret key and shared with anyone."
 
-#: src/strings.ts:1418
+#: src/strings.ts:1417
 msgid "Monographs enable you to share your notes in a secure and private way."
 msgstr "Monographs enable you to share your notes in a secure and private way."
 
 #: src/strings.ts:665
-#: src/strings.ts:1841
+#: src/strings.ts:1840
 msgid "Month"
 msgstr "Month"
 
 #: src/strings.ts:169
-#: src/strings.ts:1571
+#: src/strings.ts:1570
 msgid "Monthly"
 msgstr "Monthly"
 
-#: src/strings.ts:2325
+#: src/strings.ts:2324
 msgid "More"
 msgstr "More"
 
@@ -4042,35 +4040,35 @@ msgstr "More"
 msgid "Most relevant first"
 msgstr "Most relevant first"
 
-#: src/strings.ts:853
+#: src/strings.ts:852
 msgid "Move"
 msgstr "Move"
 
-#: src/strings.ts:2374
+#: src/strings.ts:2373
 msgid "Move all checked tasks to bottom"
 msgstr "Move all checked tasks to bottom"
 
-#: src/strings.ts:2302
+#: src/strings.ts:2301
 msgid "Move column left"
 msgstr "Move column left"
 
-#: src/strings.ts:2303
+#: src/strings.ts:2302
 msgid "Move column right"
 msgstr "Move column right"
 
-#: src/strings.ts:937
+#: src/strings.ts:936
 msgid "Move notebook"
 msgstr "Move notebook"
 
-#: src/strings.ts:899
+#: src/strings.ts:898
 msgid "Move notes"
 msgstr "Move notes"
 
-#: src/strings.ts:2310
+#: src/strings.ts:2309
 msgid "Move row down"
 msgstr "Move row down"
 
-#: src/strings.ts:2309
+#: src/strings.ts:2308
 msgid "Move row up"
 msgstr "Move row up"
 
@@ -4082,27 +4080,27 @@ msgstr "Move selected notes"
 msgid "Move to top"
 msgstr "Move to top"
 
-#: src/strings.ts:856
+#: src/strings.ts:855
 msgid "Move to trash"
 msgstr "Move to trash"
 
-#: src/strings.ts:1173
+#: src/strings.ts:1172
 msgid "Multi-layer encryption to most important notes"
 msgstr "Multi-layer encryption to most important notes"
 
-#: src/strings.ts:888
+#: src/strings.ts:887
 msgid "Name"
 msgstr "Name"
 
-#: src/strings.ts:2670
+#: src/strings.ts:2669
 msgid "Name is required."
 msgstr "Name is required."
 
-#: src/strings.ts:1689
+#: src/strings.ts:1688
 msgid "Native high-performance encryption"
 msgstr "Native high-performance encryption"
 
-#: src/strings.ts:2454
+#: src/strings.ts:2453
 msgid "Navigate"
 msgstr "Navigate"
 
@@ -4110,11 +4108,11 @@ msgstr "Navigate"
 msgid "Never"
 msgstr "Never"
 
-#: src/strings.ts:1343
+#: src/strings.ts:1342
 msgid "Never ask again"
 msgstr "Never ask again"
 
-#: src/strings.ts:1038
+#: src/strings.ts:1037
 msgid "Never hesitate to choose privacy"
 msgstr "Never hesitate to choose privacy"
 
@@ -4130,11 +4128,11 @@ msgstr "New - old"
 msgid "New color"
 msgstr "New color"
 
-#: src/strings.ts:1847
+#: src/strings.ts:1846
 msgid "New Email"
 msgstr "New Email"
 
-#: src/strings.ts:1152
+#: src/strings.ts:1151
 msgid "New lines will be double spaced (old ones won't be affected)."
 msgstr "New lines will be double spaced (old ones won't be affected)."
 
@@ -4146,11 +4144,11 @@ msgstr "New note"
 msgid "New notebook"
 msgstr "New notebook"
 
-#: src/strings.ts:1481
+#: src/strings.ts:1480
 msgid "New password"
 msgstr "New password"
 
-#: src/strings.ts:1487
+#: src/strings.ts:1486
 msgid "New pin"
 msgstr "New pin"
 
@@ -4162,11 +4160,11 @@ msgstr "New reminder"
 msgid "New tab"
 msgstr "New tab"
 
-#: src/strings.ts:2460
+#: src/strings.ts:2459
 msgid "New tag"
 msgstr "New tag"
 
-#: src/strings.ts:1369
+#: src/strings.ts:1368
 msgid "New update available"
 msgstr "New update available"
 
@@ -4174,11 +4172,11 @@ msgstr "New update available"
 msgid "New version"
 msgstr "New version"
 
-#: src/strings.ts:2025
+#: src/strings.ts:2024
 msgid "Newest - oldest"
 msgstr "Newest - oldest"
 
-#: src/strings.ts:1141
+#: src/strings.ts:1140
 msgid "Newly created notes will be uncategorized"
 msgstr "Newly created notes will be uncategorized"
 
@@ -4186,11 +4184,11 @@ msgstr "Newly created notes will be uncategorized"
 msgid "Next"
 msgstr "Next"
 
-#: src/strings.ts:2390
+#: src/strings.ts:2389
 msgid "Next match"
 msgstr "Next match"
 
-#: src/strings.ts:2455
+#: src/strings.ts:2454
 msgid "Next tab"
 msgstr "Next tab"
 
@@ -4198,7 +4196,7 @@ msgstr "Next tab"
 msgid "No"
 msgstr "No"
 
-#: src/strings.ts:860
+#: src/strings.ts:859
 msgid "No application found to open {fileToOpen}"
 msgstr "No application found to open {fileToOpen}"
 
@@ -4218,7 +4216,7 @@ msgstr "No blocks linked"
 msgid "No color selected"
 msgstr "No color selected"
 
-#: src/strings.ts:1232
+#: src/strings.ts:1231
 msgid "No directory selected"
 msgstr "No directory selected"
 
@@ -4226,11 +4224,11 @@ msgstr "No directory selected"
 msgid "No downloads in progress."
 msgstr "No downloads in progress."
 
-#: src/strings.ts:1985
+#: src/strings.ts:1984
 msgid "No encryption key found"
 msgstr "No encryption key found"
 
-#: src/strings.ts:1666
+#: src/strings.ts:1665
 msgid "No headings found"
 msgstr "No headings found"
 
@@ -4246,7 +4244,7 @@ msgstr "No links found"
 msgid "No note history available for this device."
 msgstr "No note history available for this device."
 
-#: src/strings.ts:2504
+#: src/strings.ts:2503
 msgid "No notebooks selected to move"
 msgstr "No notebooks selected to move"
 
@@ -4254,7 +4252,7 @@ msgstr "No notebooks selected to move"
 msgid "No one can view this {type} except you."
 msgstr "No one can view this {type} except you."
 
-#: src/strings.ts:2627
+#: src/strings.ts:2626
 msgid "No password"
 msgstr "No password"
 
@@ -4262,7 +4260,7 @@ msgstr "No password"
 msgid "No references found of this note"
 msgstr "No references found of this note"
 
-#: src/strings.ts:1517
+#: src/strings.ts:1516
 msgid "No results found"
 msgstr "No results found"
 
@@ -4270,7 +4268,7 @@ msgstr "No results found"
 msgid "No results found for \"{query}\""
 msgstr "No results found for \"{query}\""
 
-#: src/strings.ts:1517
+#: src/strings.ts:1516
 msgid "No results found for {query}"
 msgstr "No results found for {query}"
 
@@ -4286,7 +4284,7 @@ msgstr "No updates available"
 msgid "None"
 msgstr "None"
 
-#: src/strings.ts:2015
+#: src/strings.ts:2014
 msgid "Normal mode"
 msgstr "Normal mode"
 
@@ -4307,11 +4305,11 @@ msgstr "Note"
 msgid "Note copied to clipboard"
 msgstr "Note copied to clipboard"
 
-#: src/strings.ts:1950
+#: src/strings.ts:1949
 msgid "Note does not exist"
 msgstr "Note does not exist"
 
-#: src/strings.ts:816
+#: src/strings.ts:2696
 msgid "Note duplicated"
 msgstr "Note duplicated"
 
@@ -4323,11 +4321,11 @@ msgstr "Note history"
 msgid "Note locked"
 msgstr "Note locked"
 
-#: src/strings.ts:846
+#: src/strings.ts:845
 msgid "Note restored from history"
 msgstr "Note restored from history"
 
-#: src/strings.ts:1586
+#: src/strings.ts:1585
 msgid "Note title"
 msgstr "Note title"
 
@@ -4339,7 +4337,7 @@ msgstr "Note unlocked"
 msgid "Note version history is local only."
 msgstr "Note version history is local only."
 
-#: src/strings.ts:1225
+#: src/strings.ts:1224
 msgid "NOTE: Creating a backup with attachments can take a while, and also fail completely. The app will try to resume/restart the backup in case of interruptions."
 msgstr "NOTE: Creating a backup with attachments can take a while, and also fail completely. The app will try to resume/restart the backup in case of interruptions."
 
@@ -4348,11 +4346,11 @@ msgid "notebook"
 msgstr "notebook"
 
 #: src/strings.ts:296
-#: src/strings.ts:1521
+#: src/strings.ts:1520
 msgid "Notebook"
 msgstr "Notebook"
 
-#: src/strings.ts:2490
+#: src/strings.ts:2489
 msgid "Notebook added"
 msgstr "Notebook added"
 
@@ -4362,15 +4360,15 @@ msgstr "notebooks"
 
 #: src/strings.ts:258
 #: src/strings.ts:316
-#: src/strings.ts:1520
+#: src/strings.ts:1519
 msgid "Notebooks"
 msgstr "Notebooks"
 
-#: src/strings.ts:1795
+#: src/strings.ts:1794
 msgid "NOTEBOOKS"
 msgstr "NOTEBOOKS"
 
-#: src/strings.ts:2252
+#: src/strings.ts:2251
 msgid "Notebooks are the best way to organize your notes."
 msgstr "Notebooks are the best way to organize your notes."
 
@@ -4379,7 +4377,7 @@ msgid "notes"
 msgstr "notes"
 
 #: src/strings.ts:315
-#: src/strings.ts:1519
+#: src/strings.ts:1518
 msgid "Notes"
 msgstr "Notes"
 
@@ -4387,35 +4385,35 @@ msgstr "Notes"
 msgid "Notes exported as {path} successfully"
 msgstr "Notes exported as {path} successfully"
 
-#: src/strings.ts:1751
+#: src/strings.ts:1750
 msgid "notes imported"
 msgstr "notes imported"
 
-#: src/strings.ts:2554
+#: src/strings.ts:2553
 msgid "Notesnook"
 msgstr "Notesnook"
 
-#: src/strings.ts:2612
+#: src/strings.ts:2611
 msgid "Notesnook Circle"
 msgstr "Notesnook Circle"
 
-#: src/strings.ts:2614
+#: src/strings.ts:2613
 msgid "Notesnook Circle brings together trusted partners who share our commitment to privacy, transparency, and user freedom."
 msgstr "Notesnook Circle brings together trusted partners who share our commitment to privacy, transparency, and user freedom."
 
-#: src/strings.ts:2078
+#: src/strings.ts:2077
 msgid "Notesnook encrypts everything offline before syncing to your other devices. This means that no one can read your notes except you. Not even us."
 msgstr "Notesnook encrypts everything offline before syncing to your other devices. This means that no one can read your notes except you. Not even us."
 
-#: src/strings.ts:2153
+#: src/strings.ts:2152
 msgid "Notesnook Importer"
 msgstr "Notesnook Importer"
 
-#: src/strings.ts:1067
+#: src/strings.ts:1066
 msgid "Notesnook Pro"
 msgstr "Notesnook Pro"
 
-#: src/strings.ts:2185
+#: src/strings.ts:2184
 msgid ""
 "Notesnook uses the following DNS providers:\n"
 "\n"
@@ -4431,31 +4429,31 @@ msgstr ""
 "\n"
 "This can sometimes bypass local ISP blockages on Notesnook traffic. Disable this if you want the app to use system's DNS settings."
 
-#: src/strings.ts:988
+#: src/strings.ts:987
 msgid "Notesnook will send you a 2FA code on your email when prompted"
 msgstr "Notesnook will send you a 2FA code on your email when prompted"
 
-#: src/strings.ts:995
+#: src/strings.ts:994
 msgid "Notesnook will send you an SMS with a 2FA code when prompted"
 msgstr "Notesnook will send you an SMS with a 2FA code when prompted"
 
-#: src/strings.ts:2148
+#: src/strings.ts:2147
 msgid "Notifications"
 msgstr "Notifications"
 
-#: src/strings.ts:1378
+#: src/strings.ts:1377
 msgid "Notifications disabled"
 msgstr "Notifications disabled"
 
-#: src/strings.ts:2286
+#: src/strings.ts:2285
 msgid "Numbered list"
 msgstr "Numbered list"
 
-#: src/strings.ts:1719
+#: src/strings.ts:1718
 msgid "of"
 msgstr "of"
 
-#: src/strings.ts:1603
+#: src/strings.ts:1602
 msgid "Off"
 msgstr "Off"
 
@@ -4463,7 +4461,7 @@ msgstr "Off"
 msgid "Offline"
 msgstr "Offline"
 
-#: src/strings.ts:2238
+#: src/strings.ts:2237
 msgid "Okay"
 msgstr "Okay"
 
@@ -4471,11 +4469,11 @@ msgstr "Okay"
 msgid "Old - new"
 msgstr "Old - new"
 
-#: src/strings.ts:1836
+#: src/strings.ts:1835
 msgid "Older version"
 msgstr "Older version"
 
-#: src/strings.ts:2024
+#: src/strings.ts:2023
 msgid "Oldest - newest"
 msgstr "Oldest - newest"
 
@@ -4483,11 +4481,11 @@ msgstr "Oldest - newest"
 msgid "Once your password is changed, please make sure to save the new account recovery key"
 msgstr "Once your password is changed, please make sure to save the new account recovery key"
 
-#: src/strings.ts:2572
+#: src/strings.ts:2571
 msgid "One time purchase, no auto-renewal"
 msgstr "One time purchase, no auto-renewal"
 
-#: src/strings.ts:1772
+#: src/strings.ts:1771
 msgid "Only .zip files are supported."
 msgstr "Only .zip files are supported."
 
@@ -4503,11 +4501,11 @@ msgstr "Open file location"
 msgid "Open in browser"
 msgstr "Open in browser"
 
-#: src/strings.ts:1307
+#: src/strings.ts:1306
 msgid "Open in browser to manage subscription"
 msgstr "Open in browser to manage subscription"
 
-#: src/strings.ts:2336
+#: src/strings.ts:2335
 msgid "Open in new tab"
 msgstr "Open in new tab"
 
@@ -4515,43 +4513,43 @@ msgstr "Open in new tab"
 msgid "Open issue"
 msgstr "Open issue"
 
-#: src/strings.ts:2276
+#: src/strings.ts:2275
 msgid "Open link"
 msgstr "Open link"
 
-#: src/strings.ts:1864
+#: src/strings.ts:1863
 msgid "Open note"
 msgstr "Open note"
 
-#: src/strings.ts:1381
+#: src/strings.ts:1380
 msgid "Open settings"
 msgstr "Open settings"
 
-#: src/strings.ts:2337
+#: src/strings.ts:2336
 msgid "Open source"
 msgstr "Open source"
 
-#: src/strings.ts:1289
+#: src/strings.ts:1288
 msgid "Open source libraries used in Notesnook"
 msgstr "Open source libraries used in Notesnook"
 
-#: src/strings.ts:1288
+#: src/strings.ts:1287
 msgid "Open source licenses"
 msgstr "Open source licenses"
 
-#: src/strings.ts:820
+#: src/strings.ts:819
 msgid "Open source."
 msgstr "Open source."
 
-#: src/strings.ts:984
+#: src/strings.ts:983
 msgid "Open the two-factor authentication (TOTP) app to view your authentication code."
 msgstr "Open the two-factor authentication (TOTP) app to view your authentication code."
 
-#: src/strings.ts:2686
+#: src/strings.ts:2685
 msgid "Opening local file"
 msgstr "Opening local file"
 
-#: src/strings.ts:1858
+#: src/strings.ts:1857
 msgid "Optional"
 msgstr "Optional"
 
@@ -4559,11 +4557,11 @@ msgstr "Optional"
 msgid "or email us at"
 msgstr "or email us at"
 
-#: src/strings.ts:2023
+#: src/strings.ts:2022
 msgid "Order by"
 msgstr "Order by"
 
-#: src/strings.ts:2231
+#: src/strings.ts:2230
 msgid "Order ID"
 msgstr "Order ID"
 
@@ -4572,23 +4570,23 @@ msgstr "Order ID"
 msgid "Orphaned"
 msgstr "Orphaned"
 
-#: src/strings.ts:2156
+#: src/strings.ts:2155
 msgid "Other"
 msgstr "Other"
 
-#: src/strings.ts:2357
+#: src/strings.ts:2356
 msgid "Outline list"
 msgstr "Outline list"
 
-#: src/strings.ts:2360
+#: src/strings.ts:2359
 msgid "Paragraph"
 msgstr "Paragraph"
 
-#: src/strings.ts:2503
+#: src/strings.ts:2502
 msgid "Paragraphs"
 msgstr "Paragraphs"
 
-#: src/strings.ts:2112
+#: src/strings.ts:2111
 msgid "Partial backups contain all your data except attachments. They are created from data already available on your device and do not require an Internet connection."
 msgstr "Partial backups contain all your data except attachments. They are created from data already available on your device and do not require an Internet connection."
 
@@ -4596,11 +4594,11 @@ msgstr "Partial backups contain all your data except attachments. They are creat
 msgid "Partially refunded"
 msgstr "Partially refunded"
 
-#: src/strings.ts:2414
+#: src/strings.ts:2413
 msgid "Passed"
 msgstr "Passed"
 
-#: src/strings.ts:884
+#: src/strings.ts:883
 msgid "Password"
 msgstr "Password"
 
@@ -4628,7 +4626,7 @@ msgstr "Password not entered"
 msgid "Password protection"
 msgstr "Password protection"
 
-#: src/strings.ts:2661
+#: src/strings.ts:2660
 msgid "Password required"
 msgstr "Password required"
 
@@ -4636,35 +4634,35 @@ msgstr "Password required"
 msgid "Password updated"
 msgstr "Password updated"
 
-#: src/strings.ts:2092
+#: src/strings.ts:2091
 msgid "Password/pin"
 msgstr "Password/pin"
 
-#: src/strings.ts:2260
+#: src/strings.ts:2259
 msgid "Paste"
 msgstr "Paste"
 
-#: src/strings.ts:2261
+#: src/strings.ts:2260
 msgid "Paste and match style"
 msgstr "Paste and match style"
 
-#: src/strings.ts:2382
+#: src/strings.ts:2381
 msgid "Paste embed code here. Only iframes are supported."
 msgstr "Paste embed code here. Only iframes are supported."
 
-#: src/strings.ts:2397
+#: src/strings.ts:2396
 msgid "Paste image URL here"
 msgstr "Paste image URL here"
 
-#: src/strings.ts:2262
+#: src/strings.ts:2261
 msgid "Paste without formatting"
 msgstr "Paste without formatting"
 
-#: src/strings.ts:2573
+#: src/strings.ts:2572
 msgid "Pay once and use for 5 years"
 msgstr "Pay once and use for 5 years"
 
-#: src/strings.ts:2210
+#: src/strings.ts:2209
 msgid "Payment method"
 msgstr "Payment method"
 
@@ -4672,27 +4670,27 @@ msgstr "Payment method"
 msgid "PDF is password protected"
 msgstr "PDF is password protected"
 
-#: src/strings.ts:1730
+#: src/strings.ts:1729
 msgid "phone number"
 msgstr "phone number"
 
-#: src/strings.ts:1849
+#: src/strings.ts:1848
 msgid "Phone number"
 msgstr "Phone number"
 
-#: src/strings.ts:1008
+#: src/strings.ts:1007
 msgid "Phone number not entered"
 msgstr "Phone number not entered"
 
-#: src/strings.ts:901
+#: src/strings.ts:900
 msgid "Pin"
 msgstr "Pin"
 
-#: src/strings.ts:1691
+#: src/strings.ts:1690
 msgid "Pin notes in notifications drawer"
 msgstr "Pin notes in notifications drawer"
 
-#: src/strings.ts:929
+#: src/strings.ts:928
 msgid "Pin notification"
 msgstr "Pin notification"
 
@@ -4700,66 +4698,66 @@ msgstr "Pin notification"
 msgid "Pinned"
 msgstr "Pinned"
 
-#: src/strings.ts:2594
+#: src/strings.ts:2593
 msgid "Plan limits"
 msgstr "Plan limits"
 
-#: src/strings.ts:2554
+#: src/strings.ts:2553
 msgid "Plans"
 msgstr "Plans"
 
-#: src/strings.ts:1365
+#: src/strings.ts:1364
 msgid "Please confirm your email to sync notes"
 msgstr "Please confirm your email to sync notes"
 
-#: src/strings.ts:1003
+#: src/strings.ts:1002
 msgid "Please confirm your identity by entering a recovery code."
 msgstr "Please confirm your identity by entering a recovery code."
 
-#: src/strings.ts:982
-#: src/strings.ts:2244
+#: src/strings.ts:981
+#: src/strings.ts:2243
 msgid "Please confirm your identity by entering the authentication code from your authenticator app."
 msgstr "Please confirm your identity by entering the authentication code from your authenticator app."
 
 #. placeholder {0}: phoneNumber ? phoneNumber : "your registered phone number."
-#: src/strings.ts:997
+#: src/strings.ts:996
 msgid "Please confirm your identity by entering the authentication code sent to {0}."
 msgstr "Please confirm your identity by entering the authentication code sent to {0}."
 
-#: src/strings.ts:990
+#: src/strings.ts:989
 msgid "Please confirm your identity by entering the authentication code sent to your email address."
 msgstr "Please confirm your identity by entering the authentication code sent to your email address."
 
-#: src/strings.ts:1910
+#: src/strings.ts:1909
 msgid "Please download a backup of your data as your account will be cleared before recovery."
 msgstr "Please download a backup of your data as your account will be cleared before recovery."
 
-#: src/strings.ts:2008
+#: src/strings.ts:2007
 msgid "Please enable automatic backups to avoid losing important data."
 msgstr "Please enable automatic backups to avoid losing important data."
 
-#: src/strings.ts:1513
-#: src/strings.ts:2663
+#: src/strings.ts:1512
+#: src/strings.ts:2662
 msgid "Please enter a valid email address"
 msgstr "Please enter a valid email address"
 
-#: src/strings.ts:1955
+#: src/strings.ts:1954
 msgid "Please enter a valid hex color (e.g. #ffffff)"
 msgstr "Please enter a valid hex color (e.g. #ffffff)"
 
-#: src/strings.ts:1514
+#: src/strings.ts:1513
 msgid "Please enter a valid phone number with country code"
 msgstr "Please enter a valid phone number with country code"
 
-#: src/strings.ts:1636
+#: src/strings.ts:1635
 msgid "Please enter a valid URL"
 msgstr "Please enter a valid URL"
 
-#: src/strings.ts:1621
+#: src/strings.ts:1620
 msgid "Please enter password of this backup file"
 msgstr "Please enter password of this backup file"
 
-#: src/strings.ts:2255
+#: src/strings.ts:2254
 msgid "Please enter the password to decrypt and restore this backup."
 msgstr "Please enter the password to decrypt and restore this backup."
 
@@ -4767,27 +4765,27 @@ msgstr "Please enter the password to decrypt and restore this backup."
 msgid "Please enter the password to unlock the PDF and view the content."
 msgstr "Please enter the password to unlock the PDF and view the content."
 
-#: src/strings.ts:1866
+#: src/strings.ts:1865
 msgid "Please enter the password to unlock this note"
 msgstr "Please enter the password to unlock this note"
 
-#: src/strings.ts:1863
+#: src/strings.ts:1862
 msgid "Please enter the password to view this version"
 msgstr "Please enter the password to view this version"
 
-#: src/strings.ts:1022
+#: src/strings.ts:1021
 msgid "Please enter your app lock password to continue"
 msgstr "Please enter your app lock password to continue"
 
-#: src/strings.ts:1024
+#: src/strings.ts:1023
 msgid "Please enter your app lock pin to continue"
 msgstr "Please enter your app lock pin to continue"
 
-#: src/strings.ts:1018
+#: src/strings.ts:1017
 msgid "Please enter your password to continue"
 msgstr "Please enter your password to continue"
 
-#: src/strings.ts:1934
+#: src/strings.ts:1933
 msgid "Please enter your vault password to continue"
 msgstr "Please enter your vault password to continue"
 
@@ -4795,15 +4793,15 @@ msgstr "Please enter your vault password to continue"
 msgid "Please fill all the fields to continue."
 msgstr "Please fill all the fields to continue."
 
-#: src/strings.ts:1557
+#: src/strings.ts:1556
 msgid "Please grant notifications permission to add new reminders."
 msgstr "Please grant notifications permission to add new reminders."
 
-#: src/strings.ts:2678
+#: src/strings.ts:2677
 msgid "Please login to download attachments."
 msgstr "Please login to download attachments."
 
-#: src/strings.ts:874
+#: src/strings.ts:873
 msgid "Please make sure you have saved the recovery key. Tap one more time to confirm."
 msgstr "Please make sure you have saved the recovery key. Tap one more time to confirm."
 
@@ -4811,27 +4809,27 @@ msgstr "Please make sure you have saved the recovery key. Tap one more time to c
 msgid "Please note that we will respond to your issue on the given link. We recommend that you save it."
 msgstr "Please note that we will respond to your issue on the given link. We recommend that you save it."
 
-#: src/strings.ts:1766
+#: src/strings.ts:1765
 msgid "Please refer to the"
 msgstr "Please refer to the"
 
-#: src/strings.ts:1558
+#: src/strings.ts:1557
 msgid "Please select the day to repeat the reminder on"
 msgstr "Please select the day to repeat the reminder on"
 
-#: src/strings.ts:1397
+#: src/strings.ts:1396
 msgid "please send us an email from your registered email address"
 msgstr "please send us an email from your registered email address"
 
-#: src/strings.ts:2403
+#: src/strings.ts:2402
 msgid "Please set a table size"
 msgstr "Please set a table size"
 
-#: src/strings.ts:1559
+#: src/strings.ts:1558
 msgid "Please set title of the reminder"
 msgstr "Please set title of the reminder"
 
-#: src/strings.ts:1988
+#: src/strings.ts:1987
 msgid "Please try again"
 msgstr "Please try again"
 
@@ -4843,16 +4841,16 @@ msgstr "Please verify it's you"
 msgid "Please wait"
 msgstr "Please wait"
 
-#: src/strings.ts:1007
+#: src/strings.ts:1006
 msgid "Please wait before requesting a new code"
 msgstr "Please wait before requesting a new code"
 
-#: src/strings.ts:1400
-#: src/strings.ts:1552
+#: src/strings.ts:1399
+#: src/strings.ts:1551
 msgid "Please wait before requesting another email"
 msgstr "Please wait before requesting another email"
 
-#: src/strings.ts:943
+#: src/strings.ts:942
 msgid "Please wait while we encrypt {name} for upload."
 msgstr "Please wait while we encrypt {name} for upload."
 
@@ -4864,11 +4862,11 @@ msgstr "Please wait while we export your not."
 msgid "Please wait while we export your notes."
 msgstr "Please wait while we export your notes."
 
-#: src/strings.ts:1895
+#: src/strings.ts:1894
 msgid "Please wait while we finalize your account."
 msgstr "Please wait while we finalize your account."
 
-#: src/strings.ts:1066
+#: src/strings.ts:1065
 msgid "Please wait while we load your subscription"
 msgstr "Please wait while we load your subscription"
 
@@ -4876,15 +4874,15 @@ msgstr "Please wait while we load your subscription"
 msgid "Please wait while we log you out."
 msgstr "Please wait while we log you out."
 
-#: src/strings.ts:1916
+#: src/strings.ts:1915
 msgid "Please wait while we reset your account password."
 msgstr "Please wait while we reset your account password."
 
-#: src/strings.ts:1614
+#: src/strings.ts:1613
 msgid "Please wait while we restore your backup..."
 msgstr "Please wait while we restore your backup..."
 
-#: src/strings.ts:1898
+#: src/strings.ts:1897
 msgid "Please wait while we send you recovery instructions"
 msgstr "Please wait while we send you recovery instructions"
 
@@ -4892,24 +4890,24 @@ msgstr "Please wait while we send you recovery instructions"
 msgid "Please wait while we sync all your data."
 msgstr "Please wait while we sync all your data."
 
-#: src/strings.ts:1072
+#: src/strings.ts:1071
 msgid "Please wait while we verify your subscription"
 msgstr "Please wait while we verify your subscription"
 
-#: src/strings.ts:1784
-#: src/strings.ts:1891
+#: src/strings.ts:1783
+#: src/strings.ts:1890
 msgid "Please wait while you are authenticated."
 msgstr "Please wait while you are authenticated."
 
-#: src/strings.ts:1903
+#: src/strings.ts:1902
 msgid "Please wait while your data is downloaded & decrypted."
 msgstr "Please wait while your data is downloaded & decrypted."
 
-#: src/strings.ts:906
+#: src/strings.ts:905
 msgid "Preparing note for share"
 msgstr "Preparing note for share"
 
-#: src/strings.ts:1616
+#: src/strings.ts:1615
 msgid "Preparing to restore backup file..."
 msgstr "Preparing to restore backup file..."
 
@@ -4917,19 +4915,19 @@ msgstr "Preparing to restore backup file..."
 msgid "PRESETS"
 msgstr "PRESETS"
 
-#: src/strings.ts:2130
+#: src/strings.ts:2129
 msgid "Pressing \"—\" will hide the app in your system tray."
 msgstr "Pressing \"—\" will hide the app in your system tray."
 
-#: src/strings.ts:2133
+#: src/strings.ts:2132
 msgid "Pressing \"X\" will hide the app in your system tray."
 msgstr "Pressing \"X\" will hide the app in your system tray."
 
-#: src/strings.ts:2181
+#: src/strings.ts:2180
 msgid "Prevent note title from appearing in tab/window title."
 msgstr "Prevent note title from appearing in tab/window title."
 
-#: src/strings.ts:2324
+#: src/strings.ts:2323
 msgid "Preview attachment"
 msgstr "Preview attachment"
 
@@ -4937,43 +4935,43 @@ msgstr "Preview attachment"
 msgid "Preview not available, content is encrypted."
 msgstr "Preview not available, content is encrypted."
 
-#: src/strings.ts:2391
+#: src/strings.ts:2390
 msgid "Previous match"
 msgstr "Previous match"
 
-#: src/strings.ts:2456
+#: src/strings.ts:2455
 msgid "Previous tab"
 msgstr "Previous tab"
 
-#: src/strings.ts:2035
+#: src/strings.ts:2034
 msgid "Print"
 msgstr "Print"
 
-#: src/strings.ts:2155
+#: src/strings.ts:2154
 msgid "Privacy"
 msgstr "Privacy"
 
-#: src/strings.ts:1162
+#: src/strings.ts:1161
 msgid "Privacy & security"
 msgstr "Privacy & security"
 
-#: src/strings.ts:1656
+#: src/strings.ts:1655
 msgid "Privacy comes first."
 msgstr "Privacy comes first."
 
-#: src/strings.ts:828
+#: src/strings.ts:827
 msgid "Privacy for everyone"
 msgstr "Privacy for everyone"
 
-#: src/strings.ts:1181
+#: src/strings.ts:1180
 msgid "Privacy mode"
 msgstr "Privacy mode"
 
-#: src/strings.ts:2589
+#: src/strings.ts:2588
 msgid "privacy policy"
 msgstr "privacy policy"
 
-#: src/strings.ts:1286
+#: src/strings.ts:1285
 msgid "Privacy policy"
 msgstr "Privacy policy"
 
@@ -4985,43 +4983,43 @@ msgstr "Privacy Policy. "
 msgid "private analytics and bug reports."
 msgstr "private analytics and bug reports."
 
-#: src/strings.ts:822
+#: src/strings.ts:821
 msgid "Private."
 msgstr "Private."
 
-#: src/strings.ts:830
+#: src/strings.ts:829
 msgid "privileged few"
 msgstr "privileged few"
 
-#: src/strings.ts:1722
+#: src/strings.ts:1721
 msgid "Pro"
 msgstr "Pro"
 
-#: src/strings.ts:2481
+#: src/strings.ts:2480
 msgid "Pro plan"
 msgstr "Pro plan"
 
-#: src/strings.ts:2048
+#: src/strings.ts:2047
 msgid "Processing {collection}..."
 msgstr "Processing {collection}..."
 
-#: src/strings.ts:2047
+#: src/strings.ts:2046
 msgid "Processing..."
 msgstr "Processing..."
 
-#: src/strings.ts:1241
+#: src/strings.ts:1240
 msgid "Productivity"
 msgstr "Productivity"
 
-#: src/strings.ts:2144
+#: src/strings.ts:2143
 msgid "Profile"
 msgstr "Profile"
 
-#: src/strings.ts:1956
+#: src/strings.ts:1955
 msgid "Profile updated"
 msgstr "Profile updated"
 
-#: src/strings.ts:1867
+#: src/strings.ts:1866
 msgid "Properties"
 msgstr "Properties"
 
@@ -5029,7 +5027,7 @@ msgstr "Properties"
 msgid "Protect your notes"
 msgstr "Protect your notes"
 
-#: src/strings.ts:2192
+#: src/strings.ts:2191
 msgid "Proxy"
 msgstr "Proxy"
 
@@ -5041,7 +5039,7 @@ msgstr "Publish"
 msgid "Publish note"
 msgstr "Publish note"
 
-#: src/strings.ts:2628
+#: src/strings.ts:2627
 msgid "Publish to the web"
 msgstr "Publish to the web"
 
@@ -5049,7 +5047,7 @@ msgstr "Publish to the web"
 msgid "Publish your note to share it with others. You can set a password to protect it."
 msgstr "Publish your note to share it with others. You can set a password to protect it."
 
-#: src/strings.ts:927
+#: src/strings.ts:926
 msgid "Published"
 msgstr "Published"
 
@@ -5065,39 +5063,39 @@ msgstr "Published note can only be viewed by someone with the password."
 msgid "Published note link will be automatically deleted once it is viewed by someone."
 msgstr "Published note link will be automatically deleted once it is viewed by someone."
 
-#: src/strings.ts:2582
+#: src/strings.ts:2581
 msgid "Purchase"
 msgstr "Purchase"
 
-#: src/strings.ts:1372
+#: src/strings.ts:1371
 msgid "Quick note"
 msgstr "Quick note"
 
-#: src/strings.ts:1242
+#: src/strings.ts:1241
 msgid "Quick note notification"
 msgstr "Quick note notification"
 
-#: src/strings.ts:1693
+#: src/strings.ts:1692
 msgid "Quick note widgets"
 msgstr "Quick note widgets"
 
-#: src/strings.ts:2452
+#: src/strings.ts:2451
 msgid "Quick open"
 msgstr "Quick open"
 
-#: src/strings.ts:1244
+#: src/strings.ts:1243
 msgid "Quickly create a note from the notification"
 msgstr "Quickly create a note from the notification"
 
-#: src/strings.ts:2344
+#: src/strings.ts:2343
 msgid "Quote"
 msgstr "Quote"
 
-#: src/strings.ts:1358
+#: src/strings.ts:1357
 msgid "Rate Notesnook on App Store"
 msgstr "Rate Notesnook on App Store"
 
-#: src/strings.ts:1359
+#: src/strings.ts:1358
 msgid "Rate Notesnook on Play Store"
 msgstr "Rate Notesnook on Play Store"
 
@@ -5109,51 +5107,51 @@ msgstr "Rate now (It takes only a second)"
 msgid "Read full release notes on Github"
 msgstr "Read full release notes on Github"
 
-#: src/strings.ts:913
+#: src/strings.ts:912
 msgid "Read only"
 msgstr "Read only"
 
-#: src/strings.ts:1266
+#: src/strings.ts:1265
 msgid "Read the documentation to learn more about Notesnook"
 msgstr "Read the documentation to learn more about Notesnook"
 
-#: src/strings.ts:1287
+#: src/strings.ts:1286
 msgid "Read the privacy policy"
 msgstr "Read the privacy policy"
 
-#: src/strings.ts:1285
+#: src/strings.ts:1284
 msgid "Read the terms of service"
 msgstr "Read the terms of service"
 
-#: src/strings.ts:1617
+#: src/strings.ts:1616
 msgid "Reading backup file..."
 msgstr "Reading backup file..."
 
-#: src/strings.ts:2556
+#: src/strings.ts:2555
 msgid "Ready to take the next step on your private note taking journey?"
 msgstr "Ready to take the next step on your private note taking journey?"
 
-#: src/strings.ts:2234
+#: src/strings.ts:2233
 msgid "Receipt"
 msgstr "Receipt"
 
-#: src/strings.ts:1612
+#: src/strings.ts:1611
 msgid "RECENT BACKUPS"
 msgstr "RECENT BACKUPS"
 
-#: src/strings.ts:2467
+#: src/strings.ts:2466
 msgid "Recents"
 msgstr "Recents"
 
-#: src/strings.ts:2410
+#: src/strings.ts:2409
 msgid "Recheck all"
 msgstr "Recheck all"
 
-#: src/strings.ts:2002
+#: src/strings.ts:2001
 msgid "Rechecking failed"
 msgstr "Rechecking failed"
 
-#: src/strings.ts:2435
+#: src/strings.ts:2434
 msgid "Recipes"
 msgstr "Recipes"
 
@@ -5161,7 +5159,7 @@ msgstr "Recipes"
 msgid "Recommended"
 msgstr "Recommended"
 
-#: src/strings.ts:2558
+#: src/strings.ts:2557
 msgid "Recommended by Privacy Guides"
 msgstr "Recommended by Privacy Guides"
 
@@ -5169,11 +5167,11 @@ msgstr "Recommended by Privacy Guides"
 msgid "Recover your account"
 msgstr "Recover your account"
 
-#: src/strings.ts:1006
+#: src/strings.ts:1005
 msgid "Recovery codes copied!"
 msgstr "Recovery codes copied!"
 
-#: src/strings.ts:1011
+#: src/strings.ts:1010
 msgid "Recovery codes saved!"
 msgstr "Recovery codes saved!"
 
@@ -5185,35 +5183,35 @@ msgstr "Recovery email has been sent to your email address. Please check your in
 msgid "Recovery email sent!"
 msgstr "Recovery email sent!"
 
-#: src/strings.ts:877
+#: src/strings.ts:876
 msgid "Recovery key copied"
 msgstr "Recovery key copied"
 
-#: src/strings.ts:875
+#: src/strings.ts:874
 msgid "Recovery key QR code saved"
 msgstr "Recovery key QR code saved"
 
-#: src/strings.ts:876
+#: src/strings.ts:875
 msgid "Recovery key text file saved"
 msgstr "Recovery key text file saved"
 
-#: src/strings.ts:1917
+#: src/strings.ts:1916
 msgid "Recovery successful!"
 msgstr "Recovery successful!"
 
-#: src/strings.ts:2447
+#: src/strings.ts:2446
 msgid "Redeem"
 msgstr "Redeem"
 
-#: src/strings.ts:2611
+#: src/strings.ts:2610
 msgid "Redeem code"
 msgstr "Redeem code"
 
-#: src/strings.ts:2444
+#: src/strings.ts:2443
 msgid "Redeem gift code"
 msgstr "Redeem gift code"
 
-#: src/strings.ts:2446
+#: src/strings.ts:2445
 msgid "Redeeming gift code"
 msgstr "Redeeming gift code"
 
@@ -5225,7 +5223,7 @@ msgstr "Redo"
 msgid "Referenced in"
 msgstr "Referenced in"
 
-#: src/strings.ts:936
+#: src/strings.ts:935
 msgid "References"
 msgstr "References"
 
@@ -5233,7 +5231,7 @@ msgstr "References"
 msgid "Regenerate"
 msgstr "Regenerate"
 
-#: src/strings.ts:2098
+#: src/strings.ts:2097
 msgid "Register"
 msgstr "Register"
 
@@ -5241,7 +5239,7 @@ msgstr "Register"
 msgid "Release notes"
 msgstr "Release notes"
 
-#: src/strings.ts:2469
+#: src/strings.ts:2468
 msgid "Release track"
 msgstr "Release track"
 
@@ -5249,19 +5247,19 @@ msgstr "Release track"
 msgid "Relevance"
 msgstr "Relevance"
 
-#: src/strings.ts:1671
+#: src/strings.ts:1670
 msgid "Reload app"
 msgstr "Reload app"
 
-#: src/strings.ts:1829
+#: src/strings.ts:1828
 msgid "Relogin to your account"
 msgstr "Relogin to your account"
 
-#: src/strings.ts:1797
+#: src/strings.ts:1796
 msgid "Remembered your password?"
 msgstr "Remembered your password?"
 
-#: src/strings.ts:926
+#: src/strings.ts:925
 msgid "Remind me"
 msgstr "Remind me"
 
@@ -5269,7 +5267,7 @@ msgstr "Remind me"
 msgid "Remind me in"
 msgstr "Remind me in"
 
-#: src/strings.ts:1507
+#: src/strings.ts:1506
 msgid "Remind me of..."
 msgstr "Remind me of..."
 
@@ -5281,11 +5279,11 @@ msgstr "reminder"
 msgid "Reminder"
 msgstr "Reminder"
 
-#: src/strings.ts:1247
+#: src/strings.ts:1246
 msgid "Reminder notifications"
 msgstr "Reminder notifications"
 
-#: src/strings.ts:1560
+#: src/strings.ts:1559
 msgid "Reminder time cannot be earlier than the current time."
 msgstr "Reminder time cannot be earlier than the current time."
 
@@ -5294,16 +5292,16 @@ msgid "reminders"
 msgstr "reminders"
 
 #: src/strings.ts:318
-#: src/strings.ts:1245
-#: src/strings.ts:1523
+#: src/strings.ts:1244
+#: src/strings.ts:1522
 msgid "Reminders"
 msgstr "Reminders"
 
-#: src/strings.ts:1380
+#: src/strings.ts:1379
 msgid "Reminders cannot be set because notifications have been disabled from app settings. If you want to keep receiving reminder notifications, enable notifications for Notesnook from app settings."
 msgstr "Reminders cannot be set because notifications have been disabled from app settings. If you want to keep receiving reminder notifications, enable notifications for Notesnook from app settings."
 
-#: src/strings.ts:1954
+#: src/strings.ts:1953
 msgid "Reminders will not be active on this device as it does not support notifications."
 msgstr "Reminders will not be active on this device as it does not support notifications."
 
@@ -5311,63 +5309,63 @@ msgstr "Reminders will not be active on this device as it does not support notif
 msgid "Remove"
 msgstr "Remove"
 
-#: src/strings.ts:1176
+#: src/strings.ts:1175
 msgid "Remove all notes from the vault."
 msgstr "Remove all notes from the vault."
 
-#: src/strings.ts:1203
+#: src/strings.ts:1202
 msgid "Remove app lock password"
 msgstr "Remove app lock password"
 
-#: src/strings.ts:1207
+#: src/strings.ts:1206
 msgid "Remove app lock password, app lock will be disabled if no other security method is enabled."
 msgstr "Remove app lock password, app lock will be disabled if no other security method is enabled."
 
-#: src/strings.ts:1202
+#: src/strings.ts:1201
 msgid "Remove app lock pin"
 msgstr "Remove app lock pin"
 
-#: src/strings.ts:1205
+#: src/strings.ts:1204
 msgid "Remove app lock pin, app lock will be disabled if no other security method is enabled."
 msgstr "Remove app lock pin, app lock will be disabled if no other security method is enabled."
 
-#: src/strings.ts:897
+#: src/strings.ts:896
 msgid "Remove as default"
 msgstr "Remove as default"
 
-#: src/strings.ts:2328
+#: src/strings.ts:2327
 msgid "Remove attachment"
 msgstr "Remove attachment"
 
-#: src/strings.ts:932
+#: src/strings.ts:931
 msgid "Remove from all"
 msgstr "Remove from all"
 
-#: src/strings.ts:907
+#: src/strings.ts:906
 msgid "Remove from notebook"
 msgstr "Remove from notebook"
 
-#: src/strings.ts:2468
+#: src/strings.ts:2467
 msgid "Remove from recents"
 msgstr "Remove from recents"
 
-#: src/strings.ts:1045
+#: src/strings.ts:1044
 msgid "Remove full name"
 msgstr "Remove full name"
 
-#: src/strings.ts:2275
+#: src/strings.ts:2274
 msgid "Remove link"
 msgstr "Remove link"
 
-#: src/strings.ts:1041
+#: src/strings.ts:1040
 msgid "Remove profile picture"
 msgstr "Remove profile picture"
 
-#: src/strings.ts:1048
+#: src/strings.ts:1047
 msgid "Remove your full name from profile"
 msgstr "Remove your full name from profile"
 
-#: src/strings.ts:1042
+#: src/strings.ts:1041
 msgid "Remove your profile picture"
 msgstr "Remove your profile picture"
 
@@ -5379,7 +5377,7 @@ msgstr "Rename"
 msgid "Rename file"
 msgstr "Rename file"
 
-#: src/strings.ts:892
+#: src/strings.ts:891
 msgid "Reorder"
 msgstr "Reorder"
 
@@ -5387,19 +5385,19 @@ msgstr "Reorder"
 msgid "Repeats daily at {date}"
 msgstr "Repeats daily at {date}"
 
-#: src/strings.ts:2388
+#: src/strings.ts:2387
 msgid "Replace"
 msgstr "Replace"
 
-#: src/strings.ts:2389
+#: src/strings.ts:2388
 msgid "Replace all"
 msgstr "Replace all"
 
-#: src/strings.ts:2175
+#: src/strings.ts:2174
 msgid "Report"
 msgstr "Report"
 
-#: src/strings.ts:1258
+#: src/strings.ts:1257
 msgid "Report an issue"
 msgstr "Report an issue"
 
@@ -5416,59 +5414,59 @@ msgstr "Resend code in ({seconds})"
 msgid "Resend code{0}"
 msgstr "Resend code{0}"
 
-#: src/strings.ts:1403
+#: src/strings.ts:1402
 msgid "Resend email"
 msgstr "Resend email"
 
-#: src/strings.ts:1821
+#: src/strings.ts:1820
 msgid "Reset"
 msgstr "Reset"
 
-#: src/strings.ts:1913
+#: src/strings.ts:1912
 msgid "Reset account password"
 msgstr "Reset account password"
 
-#: src/strings.ts:2495
+#: src/strings.ts:2494
 msgid "Reset homepage"
 msgstr "Reset homepage"
 
-#: src/strings.ts:1822
+#: src/strings.ts:1821
 msgid "Reset selection"
 msgstr "Reset selection"
 
-#: src/strings.ts:1649
+#: src/strings.ts:1648
 msgid "Reset server urls"
 msgstr "Reset server urls"
 
-#: src/strings.ts:2031
+#: src/strings.ts:2030
 msgid "Reset sidebar"
 msgstr "Reset sidebar"
 
-#: src/strings.ts:1148
+#: src/strings.ts:1147
 msgid "Reset the toolbar to default settings"
 msgstr "Reset the toolbar to default settings"
 
-#: src/strings.ts:1147
+#: src/strings.ts:1146
 msgid "Reset toolbar"
 msgstr "Reset toolbar"
 
-#: src/strings.ts:1915
+#: src/strings.ts:1914
 msgid "Resetting account password ({progress})"
 msgstr "Resetting account password ({progress})"
 
-#: src/strings.ts:1990
+#: src/strings.ts:1989
 msgid "Restart now"
 msgstr "Restart now"
 
-#: src/strings.ts:1648
+#: src/strings.ts:1647
 msgid "Restart the app for changes to take effect."
 msgstr "Restart the app for changes to take effect."
 
-#: src/strings.ts:1319
+#: src/strings.ts:1318
 msgid "Restart the app to apply the changes"
 msgstr "Restart the app to apply the changes"
 
-#: src/strings.ts:1594
+#: src/strings.ts:1593
 msgid "Restart the app."
 msgstr "Restart the app."
 
@@ -5476,31 +5474,31 @@ msgstr "Restart the app."
 msgid "Restore"
 msgstr "Restore"
 
-#: src/strings.ts:1236
+#: src/strings.ts:1235
 msgid "Restore backup"
 msgstr "Restore backup"
 
-#: src/strings.ts:2417
+#: src/strings.ts:2416
 msgid "Restore backup?"
 msgstr "Restore backup?"
 
-#: src/strings.ts:891
+#: src/strings.ts:890
 msgid "Restore failed"
 msgstr "Restore failed"
 
-#: src/strings.ts:1611
+#: src/strings.ts:1610
 msgid "Restore from files"
 msgstr "Restore from files"
 
-#: src/strings.ts:1661
+#: src/strings.ts:1660
 msgid "Restore this version"
 msgstr "Restore this version"
 
-#: src/strings.ts:1237
+#: src/strings.ts:1236
 msgid "Restore your data from a backup"
 msgstr "Restore your data from a backup"
 
-#: src/strings.ts:850
+#: src/strings.ts:849
 msgid "Restored successfully"
 msgstr "Restored successfully"
 
@@ -5512,7 +5510,7 @@ msgstr "Restoring"
 msgid "Restoring {collection}..."
 msgstr "Restoring {collection}..."
 
-#: src/strings.ts:1613
+#: src/strings.ts:1612
 msgid "Restoring backup..."
 msgstr "Restoring backup..."
 
@@ -5528,7 +5526,7 @@ msgstr "Resubscribe to Pro"
 msgid "Reupload"
 msgstr "Reupload"
 
-#: src/strings.ts:2021
+#: src/strings.ts:2020
 msgid "Reveal in list"
 msgstr "Reveal in list"
 
@@ -5536,7 +5534,7 @@ msgstr "Reveal in list"
 msgid "Revoke"
 msgstr "Revoke"
 
-#: src/strings.ts:1180
+#: src/strings.ts:1179
 msgid "Revoke biometric unlocking"
 msgstr "Revoke biometric unlocking"
 
@@ -5544,23 +5542,23 @@ msgstr "Revoke biometric unlocking"
 msgid "Revoke vault fingerprint unlock"
 msgstr "Revoke vault fingerprint unlock"
 
-#: src/strings.ts:1294
+#: src/strings.ts:1293
 msgid "Roadmap"
 msgstr "Roadmap"
 
-#: src/strings.ts:2049
+#: src/strings.ts:2048
 msgid "Root"
 msgstr "Root"
 
-#: src/strings.ts:2028
+#: src/strings.ts:2027
 msgid "Rotate left"
 msgstr "Rotate left"
 
-#: src/strings.ts:2029
+#: src/strings.ts:2028
 msgid "Rotate right"
 msgstr "Rotate right"
 
-#: src/strings.ts:2298
+#: src/strings.ts:2297
 msgid "Row properties"
 msgstr "Row properties"
 
@@ -5568,7 +5566,7 @@ msgstr "Row properties"
 msgid "Run file check"
 msgstr "Run file check"
 
-#: src/strings.ts:2070
+#: src/strings.ts:2069
 msgid "Safe & encrypted notes"
 msgstr "Safe & encrypted notes"
 
@@ -5600,11 +5598,11 @@ msgstr "Save account recovery key"
 msgid "Save and continue"
 msgstr "Save and continue"
 
-#: src/strings.ts:1049
+#: src/strings.ts:1048
 msgid "Save data recovery key"
 msgstr "Save data recovery key"
 
-#: src/strings.ts:954
+#: src/strings.ts:953
 msgid "Save failed. Vault is locked"
 msgstr "Save failed. Vault is locked"
 
@@ -5624,7 +5622,7 @@ msgstr "Save to file"
 msgid "Save to text file"
 msgstr "Save to text file"
 
-#: src/strings.ts:1361
+#: src/strings.ts:1360
 msgid "Save your account recovery key"
 msgstr "Save your account recovery key"
 
@@ -5632,7 +5630,7 @@ msgstr "Save your account recovery key"
 msgid "Save your account recovery key in a safe place. You will need it to recover your account in case you forget your password."
 msgstr "Save your account recovery key in a safe place. You will need it to recover your account in case you forget your password."
 
-#: src/strings.ts:1051
+#: src/strings.ts:1050
 msgid "Save your data recovery key in a safe place. You will need it to recover your data in case you forget your password."
 msgstr "Save your data recovery key in a safe place. You will need it to recover your data in case you forget your password."
 
@@ -5640,15 +5638,15 @@ msgstr "Save your data recovery key in a safe place. You will need it to recover
 msgid "Save your recovery codes in a safe place. You will need them to recover your account in case you lose access to your two-factor authentication methods."
 msgstr "Save your recovery codes in a safe place. You will need them to recover your account in case you lose access to your two-factor authentication methods."
 
-#: src/strings.ts:2407
+#: src/strings.ts:2406
 msgid "Saved"
 msgstr "Saved"
 
-#: src/strings.ts:2408
+#: src/strings.ts:2407
 msgid "Saving"
 msgstr "Saving"
 
-#: src/strings.ts:1589
+#: src/strings.ts:1588
 msgid "Saving this note is taking too long. Copy your changes and restart the app to prevent data loss. If the problem persists, please report it to us at support@streetwriters.co."
 msgstr "Saving this note is taking too long. Copy your changes and restart the app to prevent data loss. If the problem persists, please report it to us at support@streetwriters.co."
 
@@ -5660,40 +5658,40 @@ msgstr "Saving zip file ({progress}%). Please wait..."
 msgid "Saving zip file. Please wait..."
 msgstr "Saving zip file. Please wait..."
 
-#: src/strings.ts:1723
+#: src/strings.ts:1722
 msgid "Scan the QR code with your authenticator app"
 msgstr "Scan the QR code with your authenticator app"
 
-#: src/strings.ts:2433
+#: src/strings.ts:2432
 msgid "School work"
 msgstr "School work"
 
-#: src/strings.ts:2506
+#: src/strings.ts:2505
 msgid "Scroll to bottom"
 msgstr "Scroll to bottom"
 
-#: src/strings.ts:2505
+#: src/strings.ts:2504
 msgid "Scroll to top"
 msgstr "Scroll to top"
 
-#: src/strings.ts:1511
-#: src/strings.ts:1529
+#: src/strings.ts:1510
+#: src/strings.ts:1528
 msgid "Search"
 msgstr "Search"
 
-#: src/strings.ts:1506
+#: src/strings.ts:1505
 msgid "Search a note"
 msgstr "Search a note"
 
-#: src/strings.ts:1504
+#: src/strings.ts:1503
 msgid "Search a note to link to"
 msgstr "Search a note to link to"
 
-#: src/strings.ts:2449
+#: src/strings.ts:2448
 msgid "Search for notes, notebooks, and tags..."
 msgstr "Search for notes, notebooks, and tags..."
 
-#: src/strings.ts:1539
+#: src/strings.ts:1538
 msgid "Search in {routeName}"
 msgstr "Search in {routeName}"
 
@@ -5745,67 +5743,67 @@ msgstr "Search in Tags"
 msgid "Search in Trash"
 msgstr "Search in Trash"
 
-#: src/strings.ts:2370
+#: src/strings.ts:2369
 msgid "Search languages"
 msgstr "Search languages"
 
-#: src/strings.ts:1492
+#: src/strings.ts:1491
 msgid "Search notebooks"
 msgstr "Search notebooks"
 
-#: src/strings.ts:1505
+#: src/strings.ts:1504
 msgid "Search or add a tag"
 msgstr "Search or add a tag"
 
-#: src/strings.ts:1835
+#: src/strings.ts:1834
 msgid "Search themes"
 msgstr "Search themes"
 
-#: src/strings.ts:1509
+#: src/strings.ts:1508
 msgid "Searching for {query}..."
 msgstr "Searching for {query}..."
 
-#: src/strings.ts:879
+#: src/strings.ts:878
 msgid "sec"
 msgstr "sec"
 
-#: src/strings.ts:2154
+#: src/strings.ts:2153
 msgid "Security & privacy"
 msgstr "Security & privacy"
 
-#: src/strings.ts:2094
+#: src/strings.ts:2093
 msgid "Security key"
 msgstr "Security key"
 
-#: src/strings.ts:1989
+#: src/strings.ts:1988
 msgid "Security key successfully registered."
 msgstr "Security key successfully registered."
 
-#: src/strings.ts:1295
+#: src/strings.ts:1294
 msgid "See what the future of Notesnook is going to be like."
 msgstr "See what the future of Notesnook is going to be like."
 
-#: src/strings.ts:1335
+#: src/strings.ts:1334
 msgid "Select"
 msgstr "Select"
 
-#: src/strings.ts:1610
+#: src/strings.ts:1609
 msgid "Select a backup file from your device to restore backup"
 msgstr "Select a backup file from your device to restore backup"
 
-#: src/strings.ts:2500
+#: src/strings.ts:2499
 msgid "Select a notebook to move this notebook into, or unselect to move it to the root level."
 msgstr "Select a notebook to move this notebook into, or unselect to move it to the root level."
 
-#: src/strings.ts:2109
+#: src/strings.ts:2108
 msgid "Select a theme"
 msgstr "Select a theme"
 
-#: src/strings.ts:1227
+#: src/strings.ts:1226
 msgid "Select backup directory"
 msgstr "Select backup directory"
 
-#: src/strings.ts:1856
+#: src/strings.ts:1855
 msgid "Select backup file"
 msgstr "Select backup file"
 
@@ -5821,15 +5819,15 @@ msgstr "Select date"
 msgid "Select day of the week to repeat the reminder."
 msgstr "Select day of the week to repeat the reminder."
 
-#: src/strings.ts:1764
+#: src/strings.ts:1763
 msgid "Select files to import"
 msgstr "Select files to import"
 
-#: src/strings.ts:1607
+#: src/strings.ts:1606
 msgid "Select folder where Notesnook backup files are stored to view and restore them from the app"
 msgstr "Select folder where Notesnook backup files are stored to view and restore them from the app"
 
-#: src/strings.ts:1608
+#: src/strings.ts:1607
 msgid "Select folder with backup files"
 msgstr "Select folder with backup files"
 
@@ -5837,7 +5835,7 @@ msgstr "Select folder with backup files"
 msgid "Select how you would like to recieve the code"
 msgstr "Select how you would like to recieve the code"
 
-#: src/strings.ts:2365
+#: src/strings.ts:2364
 msgid "Select language"
 msgstr "Select language"
 
@@ -5853,7 +5851,7 @@ msgstr "Select notebooks"
 msgid "Select notebooks you want to add note(s) to."
 msgstr "Select notebooks you want to add note(s) to."
 
-#: src/strings.ts:2488
+#: src/strings.ts:2487
 msgid "Select notes to link to \"{title}\""
 msgstr "Select notes to link to \"{title}\""
 
@@ -5861,11 +5859,11 @@ msgstr "Select notes to link to \"{title}\""
 msgid "Select nth day of the month to repeat the reminder."
 msgstr "Select nth day of the month to repeat the reminder."
 
-#: src/strings.ts:1818
+#: src/strings.ts:1817
 msgid "Select profile picture"
 msgstr "Select profile picture"
 
-#: src/strings.ts:2494
+#: src/strings.ts:2493
 msgid "Select the default sidebar tab"
 msgstr "Select the default sidebar tab"
 
@@ -5873,11 +5871,11 @@ msgstr "Select the default sidebar tab"
 msgid "Select the folder that includes your backup files to list them here."
 msgstr "Select the folder that includes your backup files to list them here."
 
-#: src/strings.ts:2141
+#: src/strings.ts:2140
 msgid "Select the languages the spell checker should check in."
 msgstr "Select the languages the spell checker should check in."
 
-#: src/strings.ts:2470
+#: src/strings.ts:2469
 msgid "Select the release track for Notesnook."
 msgstr "Select the release track for Notesnook."
 
@@ -5889,7 +5887,7 @@ msgstr "SELECTED NOTE"
 msgid "Self destruct"
 msgstr "Self destruct"
 
-#: src/strings.ts:2176
+#: src/strings.ts:2175
 msgid "Send"
 msgstr "Send"
 
@@ -5905,47 +5903,47 @@ msgstr "Send code via email"
 msgid "Send code via SMS"
 msgstr "Send code via SMS"
 
-#: src/strings.ts:1860
+#: src/strings.ts:1859
 msgid "Send recovery email"
 msgstr "Send recovery email"
 
-#: src/strings.ts:1896
+#: src/strings.ts:1895
 msgid "Sending recovery email"
 msgstr "Sending recovery email"
 
-#: src/strings.ts:1647
+#: src/strings.ts:1646
 msgid "Server url changed"
 msgstr "Server url changed"
 
-#: src/strings.ts:1650
+#: src/strings.ts:1649
 msgid "Server urls reset"
 msgstr "Server urls reset"
 
-#: src/strings.ts:1628
+#: src/strings.ts:1627
 msgid "Server used for login/sign up and authentication."
 msgstr "Server used for login/sign up and authentication."
 
-#: src/strings.ts:1633
+#: src/strings.ts:1632
 msgid "Server used to host your published notes."
 msgstr "Server used to host your published notes."
 
-#: src/strings.ts:1631
+#: src/strings.ts:1630
 msgid "Server used to receive important notifications & events."
 msgstr "Server used to receive important notifications & events."
 
-#: src/strings.ts:1626
+#: src/strings.ts:1625
 msgid "Server used to sync your notes & other data between devices."
 msgstr "Server used to sync your notes & other data between devices."
 
-#: src/strings.ts:1639
+#: src/strings.ts:1638
 msgid "Server with host {host} not found."
 msgstr "Server with host {host} not found."
 
-#: src/strings.ts:2149
+#: src/strings.ts:2148
 msgid "Servers"
 msgstr "Servers"
 
-#: src/strings.ts:2150
+#: src/strings.ts:2149
 msgid "Servers configuration"
 msgstr "Servers configuration"
 
@@ -5953,11 +5951,11 @@ msgstr "Servers configuration"
 msgid "Session expired"
 msgstr "Session expired"
 
-#: src/strings.ts:2202
+#: src/strings.ts:2201
 msgid "Sessions"
 msgstr "Sessions"
 
-#: src/strings.ts:977
+#: src/strings.ts:976
 msgid "Set a reminder"
 msgstr "Set a reminder"
 
@@ -5965,11 +5963,11 @@ msgstr "Set a reminder"
 msgid "Set as dark theme"
 msgstr "Set as dark theme"
 
-#: src/strings.ts:898
+#: src/strings.ts:897
 msgid "Set as default"
 msgstr "Set as default"
 
-#: src/strings.ts:2492
+#: src/strings.ts:2491
 msgid "Set as homepage"
 msgstr "Set as homepage"
 
@@ -5977,31 +5975,31 @@ msgstr "Set as homepage"
 msgid "Set as light theme"
 msgstr "Set as light theme"
 
-#: src/strings.ts:1334
+#: src/strings.ts:1333
 msgid "Set automatic trash cleanup interval from Settings > Behaviour > Clean trash interval."
 msgstr "Set automatic trash cleanup interval from Settings > Behaviour > Clean trash interval."
 
-#: src/strings.ts:2645
+#: src/strings.ts:2644
 msgid "Set expiry"
 msgstr "Set expiry"
 
-#: src/strings.ts:1311
+#: src/strings.ts:1310
 msgid "Set full name"
 msgstr "Set full name"
 
-#: src/strings.ts:1253
+#: src/strings.ts:1252
 msgid "Set snooze time in minutes"
 msgstr "Set snooze time in minutes"
 
-#: src/strings.ts:1252
+#: src/strings.ts:1251
 msgid "Set the default time to snooze a reminder to when you press the snooze button on a notification."
 msgstr "Set the default time to snooze a reminder to when you press the snooze button on a notification."
 
-#: src/strings.ts:1224
+#: src/strings.ts:1223
 msgid "Set the interval to create a backup (with attachments) automatically."
 msgstr "Set the interval to create a backup (with attachments) automatically."
 
-#: src/strings.ts:1221
+#: src/strings.ts:1220
 msgid "Set the interval to create a partial backup (without attachments) automatically."
 msgstr "Set the interval to create a partial backup (without attachments) automatically."
 
@@ -6010,24 +6008,24 @@ msgid "Set your name"
 msgstr "Set your name"
 
 #: src/strings.ts:387
-#: src/strings.ts:1525
+#: src/strings.ts:1524
 msgid "Settings"
 msgstr "Settings"
 
+#: src/strings.ts:1199
 #: src/strings.ts:1200
-#: src/strings.ts:1201
 msgid "Setup a new password for app lock"
 msgstr "Setup a new password for app lock"
 
-#: src/strings.ts:1197
+#: src/strings.ts:1196
 msgid "Setup a password to lock the app"
 msgstr "Setup a password to lock the app"
 
-#: src/strings.ts:1195
+#: src/strings.ts:1194
 msgid "Setup a pin to lock the app"
 msgstr "Setup a pin to lock the app"
 
-#: src/strings.ts:2194
+#: src/strings.ts:2193
 msgid ""
 "Setup an HTTP/HTTPS/SOCKS proxy.\n"
 "\n"
@@ -6047,11 +6045,11 @@ msgstr ""
 "\n"
 "To remove the proxy, simply erase everything in the input."
 
-#: src/strings.ts:1196
+#: src/strings.ts:1195
 msgid "Setup app lock password"
 msgstr "Setup app lock password"
 
-#: src/strings.ts:1194
+#: src/strings.ts:1193
 msgid "Setup app lock pin"
 msgstr "Setup app lock pin"
 
@@ -6059,15 +6057,15 @@ msgstr "Setup app lock pin"
 msgid "Setup secondary 2FA method"
 msgstr "Setup secondary 2FA method"
 
-#: src/strings.ts:979
+#: src/strings.ts:978
 msgid "Setup using an Authenticator app"
 msgstr "Setup using an Authenticator app"
 
-#: src/strings.ts:986
+#: src/strings.ts:985
 msgid "Setup using email"
 msgstr "Setup using email"
 
-#: src/strings.ts:993
+#: src/strings.ts:992
 msgid "Setup using SMS"
 msgstr "Setup using SMS"
 
@@ -6075,11 +6073,11 @@ msgstr "Setup using SMS"
 msgid "Share"
 msgstr "Share"
 
-#: src/strings.ts:1692
+#: src/strings.ts:1691
 msgid "Share & append to notes from anywhere"
 msgstr "Share & append to notes from anywhere"
 
-#: src/strings.ts:1342
+#: src/strings.ts:1341
 msgid "Share backup"
 msgstr "Share backup"
 
@@ -6087,7 +6085,7 @@ msgstr "Share backup"
 msgid "Share note"
 msgstr "Share note"
 
-#: src/strings.ts:1788
+#: src/strings.ts:1787
 msgid "Share Notesnook with friends!"
 msgstr "Share Notesnook with friends!"
 
@@ -6103,7 +6101,7 @@ msgstr "shortcut"
 msgid "Shortcut"
 msgstr "Shortcut"
 
-#: src/strings.ts:2001
+#: src/strings.ts:2000
 msgid "Shortcut removed"
 msgstr "Shortcut removed"
 
@@ -6119,7 +6117,7 @@ msgstr "Shortcuts"
 msgid "Sign up"
 msgstr "Sign up"
 
-#: src/strings.ts:1031
+#: src/strings.ts:1030
 msgid "Signed up on {date}"
 msgstr "Signed up on {date}"
 
@@ -6131,11 +6129,11 @@ msgstr "Signup failed"
 msgid "Silent"
 msgstr "Silent"
 
-#: src/strings.ts:2339
+#: src/strings.ts:2338
 msgid "Sink list item"
 msgstr "Sink list item"
 
-#: src/strings.ts:2042
+#: src/strings.ts:2041
 msgid "Size"
 msgstr "Size"
 
@@ -6143,7 +6141,7 @@ msgstr "Size"
 msgid "Skip"
 msgstr "Skip"
 
-#: src/strings.ts:1830
+#: src/strings.ts:1829
 msgid "Skip & go directly to the app"
 msgstr "Skip & go directly to the app"
 
@@ -6151,19 +6149,19 @@ msgstr "Skip & go directly to the app"
 msgid "Skip introduction"
 msgstr "Skip introduction"
 
-#: src/strings.ts:1605
+#: src/strings.ts:1604
 msgid "Some exported notes are locked, Unlock to export them"
 msgstr "Some exported notes are locked, Unlock to export them"
 
-#: src/strings.ts:1477
+#: src/strings.ts:1476
 msgid "Some notes are published"
 msgstr "Some notes are published"
 
-#: src/strings.ts:1667
+#: src/strings.ts:1666
 msgid "Something went wrong"
 msgstr "Something went wrong"
 
-#: src/strings.ts:2026
+#: src/strings.ts:2025
 msgid "Sort"
 msgstr "Sort"
 
@@ -6171,55 +6169,55 @@ msgstr "Sort"
 msgid "Sort by"
 msgstr "Sort by"
 
-#: src/strings.ts:2160
+#: src/strings.ts:2159
 msgid "Source code"
 msgstr "Source code"
 
-#: src/strings.ts:2366
+#: src/strings.ts:2365
 msgid "Spaces"
 msgstr "Spaces"
 
-#: src/strings.ts:2604
+#: src/strings.ts:2603
 msgid "Special Offer"
 msgstr "Special Offer"
 
-#: src/strings.ts:2137
+#: src/strings.ts:2136
 msgid "Spell check"
 msgstr "Spell check"
 
-#: src/strings.ts:2305
+#: src/strings.ts:2304
 msgid "Split cells"
 msgstr "Split cells"
 
-#: src/strings.ts:2471
+#: src/strings.ts:2470
 msgid "Stable"
 msgstr "Stable"
 
-#: src/strings.ts:1113
+#: src/strings.ts:1112
 msgid "Start"
 msgstr "Start"
 
-#: src/strings.ts:1831
+#: src/strings.ts:1830
 msgid "Start account recovery"
 msgstr "Start account recovery"
 
-#: src/strings.ts:1826
+#: src/strings.ts:1825
 msgid "Start import"
 msgstr "Start import"
 
-#: src/strings.ts:1823
+#: src/strings.ts:1822
 msgid "Start importing now"
 msgstr "Start importing now"
 
-#: src/strings.ts:2125
+#: src/strings.ts:2124
 msgid "Start minimized"
 msgstr "Start minimized"
 
-#: src/strings.ts:1758
+#: src/strings.ts:1757
 msgid "Start over"
 msgstr "Start over"
 
-#: src/strings.ts:951
+#: src/strings.ts:950
 msgid "Start writing to create a new note"
 msgstr "Start writing to create a new note"
 
@@ -6227,31 +6225,31 @@ msgstr "Start writing to create a new note"
 msgid "Start writing to save your note."
 msgstr "Start writing to save your note."
 
-#: src/strings.ts:1602
+#: src/strings.ts:1601
 msgid "Start writing your note..."
 msgstr "Start writing your note..."
 
-#: src/strings.ts:2233
+#: src/strings.ts:2232
 msgid "Status"
 msgstr "Status"
 
-#: src/strings.ts:2484
+#: src/strings.ts:2483
 msgid "Storage"
 msgstr "Storage"
 
-#: src/strings.ts:1549
+#: src/strings.ts:1548
 msgid "Streaming not supported"
 msgstr "Streaming not supported"
 
-#: src/strings.ts:2271
+#: src/strings.ts:2270
 msgid "Strikethrough"
 msgstr "Strikethrough"
 
-#: src/strings.ts:2235
+#: src/strings.ts:2234
 msgid "Subgroup 1"
 msgstr "Subgroup 1"
 
-#: src/strings.ts:1995
+#: src/strings.ts:1994
 msgid "Subgroup added"
 msgstr "Subgroup added"
 
@@ -6259,15 +6257,15 @@ msgstr "Subgroup added"
 msgid "Submit"
 msgstr "Submit"
 
-#: src/strings.ts:2583
+#: src/strings.ts:2582
 msgid "Subscribe"
 msgstr "Subscribe"
 
-#: src/strings.ts:2584
+#: src/strings.ts:2583
 msgid "Subscribe and start free trial"
 msgstr "Subscribe and start free trial"
 
-#: src/strings.ts:1026
+#: src/strings.ts:1025
 msgid "Subscribe to Pro"
 msgstr "Subscribe to Pro"
 
@@ -6279,7 +6277,7 @@ msgstr "Subscribed on Android"
 msgid "Subscribed on iOS"
 msgstr "Subscribed on iOS"
 
-#: src/strings.ts:1306
+#: src/strings.ts:1305
 msgid "Subscribed on web"
 msgstr "Subscribed on web"
 
@@ -6291,7 +6289,7 @@ msgstr "Subscribed on Web"
 msgid "Subscribed using gift card"
 msgstr "Subscribed using gift card"
 
-#: src/strings.ts:2282
+#: src/strings.ts:2281
 msgid "Subscript"
 msgstr "Subscript"
 
@@ -6299,11 +6297,11 @@ msgstr "Subscript"
 msgid "Subscription awarded from Streetwriters"
 msgstr "Subscription awarded from Streetwriters"
 
-#: src/strings.ts:1030
+#: src/strings.ts:1029
 msgid "Subscription details"
 msgstr "Subscription details"
 
-#: src/strings.ts:1064
+#: src/strings.ts:1063
 msgid "Subscription not activated?"
 msgstr "Subscription not activated?"
 
@@ -6315,15 +6313,15 @@ msgstr "Sun"
 msgid "Sunday"
 msgstr "Sunday"
 
-#: src/strings.ts:2283
+#: src/strings.ts:2282
 msgid "Superscript"
 msgstr "Superscript"
 
-#: src/strings.ts:1470
+#: src/strings.ts:1469
 msgid "Switch to search/replace mode"
 msgstr "Switch to search/replace mode"
 
-#: src/strings.ts:2146
+#: src/strings.ts:2145
 msgid "Sync"
 msgstr "Sync"
 
@@ -6331,7 +6329,7 @@ msgstr "Sync"
 msgid "Sync failed"
 msgstr "Sync failed"
 
-#: src/strings.ts:1364
+#: src/strings.ts:1363
 msgid "Sync is disabled"
 msgstr "Sync is disabled"
 
@@ -6339,19 +6337,19 @@ msgstr "Sync is disabled"
 msgid "Sync now"
 msgstr "Sync now"
 
-#: src/strings.ts:914
+#: src/strings.ts:913
 msgid "Sync off"
 msgstr "Sync off"
 
-#: src/strings.ts:1624
+#: src/strings.ts:1623
 msgid "Sync server"
 msgstr "Sync server"
 
-#: src/strings.ts:1083
+#: src/strings.ts:1082
 msgid "Sync settings"
 msgstr "Sync settings"
 
-#: src/strings.ts:1096
+#: src/strings.ts:1095
 msgid "Sync your notes in the background even when the app is closed. This is an experimental feature. If you face any issues, please turn it off."
 msgstr "Sync your notes in the background even when the app is closed. This is an experimental feature. If you face any issues, please turn it off."
 
@@ -6367,11 +6365,11 @@ msgstr "Syncing"
 msgid "Syncing your data"
 msgstr "Syncing your data"
 
-#: src/strings.ts:1703
+#: src/strings.ts:1702
 msgid "Syncing your notes"
 msgstr "Syncing your notes"
 
-#: src/strings.ts:2351
+#: src/strings.ts:2350
 msgid "Table"
 msgstr "Table"
 
@@ -6379,11 +6377,11 @@ msgstr "Table"
 msgid "Table of contents"
 msgstr "Table of contents"
 
-#: src/strings.ts:2296
+#: src/strings.ts:2295
 msgid "Table settings"
 msgstr "Table settings"
 
-#: src/strings.ts:2545
+#: src/strings.ts:2544
 msgid "tables, outlines, block level note linking"
 msgstr "tables, outlines, block level note linking"
 
@@ -6404,31 +6402,31 @@ msgid "tags"
 msgstr "tags"
 
 #: src/strings.ts:317
-#: src/strings.ts:1526
+#: src/strings.ts:1525
 msgid "Tags"
 msgstr "Tags"
 
-#: src/strings.ts:1544
+#: src/strings.ts:1543
 msgid "Take a backup before logging out"
 msgstr "Take a backup before logging out"
 
-#: src/strings.ts:1216
+#: src/strings.ts:1215
 msgid "Take a full backup of your data with all attachments"
 msgstr "Take a full backup of your data with all attachments"
 
-#: src/strings.ts:1218
+#: src/strings.ts:1217
 msgid "Take a partial backup of your data that does not include attachments"
 msgstr "Take a partial backup of your data that does not include attachments"
 
-#: src/strings.ts:2350
+#: src/strings.ts:2349
 msgid "Take a photo using camera"
 msgstr "Take a photo using camera"
 
-#: src/strings.ts:1374
+#: src/strings.ts:1373
 msgid "Take note"
 msgstr "Take note"
 
-#: src/strings.ts:1657
+#: src/strings.ts:1656
 msgid "Take notes privately."
 msgstr "Take notes privately."
 
@@ -6436,23 +6434,23 @@ msgstr "Take notes privately."
 msgid "Taking too long? Reload editor"
 msgstr "Taking too long? Reload editor"
 
-#: src/strings.ts:1458
+#: src/strings.ts:1457
 msgid "Tap here to change sorting"
 msgstr "Tap here to change sorting"
 
-#: src/strings.ts:1462
+#: src/strings.ts:1461
 msgid "Tap here to jump to a section"
 msgstr "Tap here to jump to a section"
 
-#: src/strings.ts:1370
+#: src/strings.ts:1369
 msgid "Tap here to update to the latest version"
 msgstr "Tap here to update to the latest version"
 
-#: src/strings.ts:1593
+#: src/strings.ts:1592
 msgid "Tap on \"Dismiss\" and copy the contents of your note so they are not lost."
 msgstr "Tap on \"Dismiss\" and copy the contents of your note so they are not lost."
 
-#: src/strings.ts:1373
+#: src/strings.ts:1372
 msgid "Tap on \"Take note\" to add a note."
 msgstr "Tap on \"Take note\" to add a note."
 
@@ -6472,7 +6470,7 @@ msgstr "Tap to deselect"
 msgid "Tap to stop reordering"
 msgstr "Tap to stop reordering"
 
-#: src/strings.ts:1354
+#: src/strings.ts:1353
 msgid "Tap to try again"
 msgstr "Tap to try again"
 
@@ -6480,19 +6478,19 @@ msgstr "Tap to try again"
 msgid "Tap twice to confirm you have saved the recovery key."
 msgstr "Tap twice to confirm you have saved the recovery key."
 
-#: src/strings.ts:2356
+#: src/strings.ts:2355
 msgid "Task list"
 msgstr "Task list"
 
-#: src/strings.ts:2426
+#: src/strings.ts:2425
 msgid "Tasks"
 msgstr "Tasks"
 
-#: src/strings.ts:1163
+#: src/strings.ts:1162
 msgid "Telemetry"
 msgstr "Telemetry"
 
-#: src/strings.ts:1496
+#: src/strings.ts:1495
 msgid ""
 "Tell us more about the issue you are facing.\n"
 "\n"
@@ -6510,11 +6508,11 @@ msgstr ""
 "- Steps to reproduce the issue\n"
 "- Things you have tried etc."
 
-#: src/strings.ts:1495
+#: src/strings.ts:1494
 msgid "Tell us what happened"
 msgstr "Tell us what happened"
 
-#: src/strings.ts:1284
+#: src/strings.ts:1283
 msgid "Terms of service"
 msgstr "Terms of service"
 
@@ -6522,39 +6520,39 @@ msgstr "Terms of service"
 msgid "Terms of Service "
 msgstr "Terms of Service "
 
-#: src/strings.ts:2591
+#: src/strings.ts:2590
 msgid "terms of use."
 msgstr "terms of use."
 
-#: src/strings.ts:1623
+#: src/strings.ts:1622
 msgid "Test connection"
 msgstr "Test connection"
 
-#: src/strings.ts:1646
+#: src/strings.ts:1645
 msgid "Test connection before changing server urls"
 msgstr "Test connection before changing server urls"
 
-#: src/strings.ts:2294
+#: src/strings.ts:2293
 msgid "Text color"
 msgstr "Text color"
 
-#: src/strings.ts:2292
+#: src/strings.ts:2291
 msgid "Text direction"
 msgstr "Text direction"
 
-#: src/strings.ts:1787
+#: src/strings.ts:1786
 msgid "Thank you for choosing end-to-end encrypted note taking. Now you can sync your notes to unlimited devices."
 msgstr "Thank you for choosing end-to-end encrypted note taking. Now you can sync your notes to unlimited devices."
 
-#: src/strings.ts:2051
+#: src/strings.ts:2050
 msgid "Thank you for reporting!"
 msgstr "Thank you for reporting!"
 
-#: src/strings.ts:2562
+#: src/strings.ts:2561
 msgid "Thank you for subscribing"
 msgstr "Thank you for subscribing"
 
-#: src/strings.ts:2599
+#: src/strings.ts:2598
 msgid "Thank you for the purchase"
 msgstr "Thank you for the purchase"
 
@@ -6562,19 +6560,19 @@ msgstr "Thank you for the purchase"
 msgid "Thank you for updating Notesnook! We will be applying some minor changes for a better note taking experience."
 msgstr "Thank you for updating Notesnook! We will be applying some minor changes for a better note taking experience."
 
-#: src/strings.ts:2052
+#: src/strings.ts:2051
 msgid "Thank you for your feedback!"
 msgstr "Thank you for your feedback!"
 
-#: src/strings.ts:2086
+#: src/strings.ts:2085
 msgid "Thank you. You are the proof that privacy always comes first."
 msgstr "Thank you. You are the proof that privacy always comes first."
 
-#: src/strings.ts:1644
+#: src/strings.ts:1643
 msgid "The {title} at {url} is not compatible with this client."
 msgstr "The {title} at {url} is not compatible with this client."
 
-#: src/strings.ts:2644
+#: src/strings.ts:2643
 msgid "The incoming note could not be unlocked with the provided password. Enter the correct password for the incoming note"
 msgstr "The incoming note could not be unlocked with the provided password. Enter the correct password for the incoming note"
 
@@ -6582,11 +6580,11 @@ msgstr "The incoming note could not be unlocked with the provided password. Ente
 msgid "The information above will be publically available at"
 msgstr "The information above will be publically available at"
 
-#: src/strings.ts:2618
+#: src/strings.ts:2617
 msgid "The Notesnook Circle is exclusive to subscribers. Please consider subscribing to gain access to Notesnook Circle and enjoy additional benefits."
 msgstr "The Notesnook Circle is exclusive to subscribers. Please consider subscribing to gain access to Notesnook Circle and enjoy additional benefits."
 
-#: src/strings.ts:2093
+#: src/strings.ts:2092
 msgid "The password/pin for unlocking the app."
 msgstr "The password/pin for unlocking the app."
 
@@ -6598,19 +6596,19 @@ msgstr "The reminder will repeat daily at {date}."
 msgid "The reminder will repeat every year on {date}."
 msgstr "The reminder will repeat every year on {date}."
 
-#: src/strings.ts:1713
+#: src/strings.ts:1712
 msgid "The reminder will start on {date} at {time}."
 msgstr "The reminder will start on {date} at {time}."
 
-#: src/strings.ts:2096
+#: src/strings.ts:2095
 msgid "The security key for unlocking the app. This is the most secure method."
 msgstr "The security key for unlocking the app. This is the most secure method."
 
-#: src/strings.ts:1642
+#: src/strings.ts:1641
 msgid "The URL you have given ({url}) does not point to the {server}."
 msgstr "The URL you have given ({url}) does not point to the {server}."
 
-#: src/strings.ts:1118
+#: src/strings.ts:1117
 msgid "Themes"
 msgstr "Themes"
 
@@ -6618,11 +6616,11 @@ msgstr "Themes"
 msgid "There are no blocks in this note."
 msgstr "There are no blocks in this note."
 
-#: src/strings.ts:2249
+#: src/strings.ts:2248
 msgid "These items will be **kept in your Trash for {interval} days** after which they will be permanently deleted."
 msgstr "These items will be **kept in your Trash for {interval} days** after which they will be permanently deleted."
 
-#: src/strings.ts:1921
+#: src/strings.ts:1920
 msgid "This action is IRREVERSIBLE."
 msgstr "This action is IRREVERSIBLE."
 
@@ -6630,60 +6628,60 @@ msgstr "This action is IRREVERSIBLE."
 msgid "This device"
 msgstr "This device"
 
-#: src/strings.ts:1684
+#: src/strings.ts:1683
 msgid "This error can be fixed by rebuilding the search index. This action won't result in any kind of data loss."
 msgstr "This error can be fixed by rebuilding the search index. This action won't result in any kind of data loss."
 
-#: src/strings.ts:1676
+#: src/strings.ts:1675
 msgid "This error can only be fixed by wiping & reseting the database. Beware that this will wipe all your data inside the database with no way to recover it later on. This WILL NOT change/affect/delete/wipe your data on the server but ONLY on this device."
 msgstr "This error can only be fixed by wiping & reseting the database. Beware that this will wipe all your data inside the database with no way to recover it later on. This WILL NOT change/affect/delete/wipe your data on the server but ONLY on this device."
 
-#: src/strings.ts:1680
+#: src/strings.ts:1679
 msgid "This error can only be fixed by wiping & reseting the Key Store and the database. This WILL NOT change/affect/delete/wipe your data on the server but ONLY on this device."
 msgstr "This error can only be fixed by wiping & reseting the Key Store and the database. This WILL NOT change/affect/delete/wipe your data on the server but ONLY on this device."
 
-#: src/strings.ts:1678
+#: src/strings.ts:1677
 msgid "This error means the at rest encryption key could not be decrypted. This can be due to data corruption or implementation change."
 msgstr "This error means the at rest encryption key could not be decrypted. This can be due to data corruption or implementation change."
 
-#: src/strings.ts:1674
+#: src/strings.ts:1673
 msgid "This error usually means the database file is either corrupt or it could not be decrypted."
 msgstr "This error usually means the database file is either corrupt or it could not be decrypted."
 
-#: src/strings.ts:1682
+#: src/strings.ts:1681
 msgid "This error usually means the search index is corrupted."
 msgstr "This error usually means the search index is corrupted."
 
-#: src/strings.ts:2658
+#: src/strings.ts:2657
 msgid "This feature is not available on this plan."
 msgstr "This feature is not available on this plan."
 
-#: src/strings.ts:1935
+#: src/strings.ts:1934
 msgid "This image cannot be previewed"
 msgstr "This image cannot be previewed"
 
-#: src/strings.ts:2585
+#: src/strings.ts:2584
 msgid "This is a one time purchase, no subscription."
 msgstr "This is a one time purchase, no subscription."
 
-#: src/strings.ts:2046
+#: src/strings.ts:2045
 msgid "This may take a while"
 msgstr "This may take a while"
 
-#: src/strings.ts:1102
-#: src/strings.ts:1111
+#: src/strings.ts:1101
+#: src/strings.ts:1110
 msgid "This must only be used for troubleshooting. Using it regularly for sync is not recommended and will lead to unexpected data loss and other issues. If you are having persistent issues with sync, please report them to us at support@streetwriters.co."
 msgstr "This must only be used for troubleshooting. Using it regularly for sync is not recommended and will lead to unexpected data loss and other issues. If you are having persistent issues with sync, please report them to us at support@streetwriters.co."
 
-#: src/strings.ts:2650
+#: src/strings.ts:2649
 msgid "This note is empty"
 msgstr "This note is empty"
 
-#: src/strings.ts:1595
+#: src/strings.ts:1594
 msgid "This note is locked"
 msgstr "This note is locked"
 
-#: src/strings.ts:953
+#: src/strings.ts:952
 msgid "This note is locked. Unlock note to save changes"
 msgstr "This note is locked. Unlock note to save changes"
 
@@ -6699,11 +6697,11 @@ msgstr "This note is not referenced in other notes."
 msgid "This note will be published to a public URL."
 msgstr "This note will be published to a public URL."
 
-#: src/strings.ts:2102
+#: src/strings.ts:2101
 msgid "This username will be used to distinguish between different credentials in your security key. Make sure it is unique."
 msgstr "This username will be used to distinguish between different credentials in your security key. Make sure it is unique."
 
-#: src/strings.ts:1304
+#: src/strings.ts:1303
 msgid "This version of Notesnook app does not support in-app purchases. Kindly login on the Notesnook web app to make the purchase."
 msgstr "This version of Notesnook app does not support in-app purchases. Kindly login on the Notesnook web app to make the purchase."
 
@@ -6715,11 +6713,11 @@ msgstr "Thu"
 msgid "Thursday"
 msgstr "Thursday"
 
-#: src/strings.ts:1843
+#: src/strings.ts:1842
 msgid "Time"
 msgstr "Time"
 
-#: src/strings.ts:1135
+#: src/strings.ts:1134
 msgid "Time format"
 msgstr "Time format"
 
@@ -6732,76 +6730,76 @@ msgstr "TIP"
 msgid "Title"
 msgstr "Title"
 
-#: src/strings.ts:1158
+#: src/strings.ts:1157
 msgid "Title format"
 msgstr "Title format"
 
-#: src/strings.ts:2669
+#: src/strings.ts:2668
 msgid "Title is required"
 msgstr "Title is required"
 
-#: src/strings.ts:1189
+#: src/strings.ts:1188
 msgid "To use app lock, you must enable biometrics such as Fingerprint lock or Face ID on your phone."
 msgstr "To use app lock, you must enable biometrics such as Fingerprint lock or Face ID on your phone."
 
-#: src/strings.ts:1813
+#: src/strings.ts:1812
 msgid "Toggle dark/light mode"
 msgstr "Toggle dark/light mode"
 
-#: src/strings.ts:2474
+#: src/strings.ts:2473
 msgid "Toggle focus mode"
 msgstr "Toggle focus mode"
 
-#: src/strings.ts:2363
+#: src/strings.ts:2362
 msgid "Toggle indentation mode"
 msgstr "Toggle indentation mode"
 
-#: src/strings.ts:2392
+#: src/strings.ts:2391
 msgid "Toggle replace"
 msgstr "Toggle replace"
 
-#: src/strings.ts:2463
+#: src/strings.ts:2462
 msgid "Toggle theme"
 msgstr "Toggle theme"
 
-#: src/strings.ts:2143
+#: src/strings.ts:2142
 msgid "Toolbar"
 msgstr "Toolbar"
 
-#: src/strings.ts:1149
+#: src/strings.ts:1148
 msgid "Toolbar reset to default preset"
 msgstr "Toolbar reset to default preset"
 
-#: src/strings.ts:1327
-#: src/strings.ts:1524
+#: src/strings.ts:1326
+#: src/strings.ts:1523
 msgid "Trash"
 msgstr "Trash"
 
-#: src/strings.ts:1326
+#: src/strings.ts:1325
 msgid "Trash cleared successfully!"
 msgstr "Trash cleared successfully!"
 
-#: src/strings.ts:1332
+#: src/strings.ts:1331
 msgid "Trash gets automatically cleaned up after {days} days"
 msgstr "Trash gets automatically cleaned up after {days} days"
 
-#: src/strings.ts:1330
+#: src/strings.ts:1329
 msgid "Trash gets automatically cleaned up daily"
 msgstr "Trash gets automatically cleaned up daily"
 
-#: src/strings.ts:2552
+#: src/strings.ts:2551
 msgid "Try {plan} for free"
 msgstr "Try {plan} for free"
 
-#: src/strings.ts:1466
+#: src/strings.ts:1465
 msgid "Try compact mode to fit more items on screen"
 msgstr "Try compact mode to fit more items on screen"
 
-#: src/strings.ts:1825
+#: src/strings.ts:1824
 msgid "Try free for 14 days"
 msgstr "Try free for 14 days"
 
-#: src/strings.ts:2538
+#: src/strings.ts:2537
 msgid "Try it for free"
 msgstr "Try it for free"
 
@@ -6813,19 +6811,19 @@ msgstr "Tue"
 msgid "Tuesday"
 msgstr "Tuesday"
 
-#: src/strings.ts:1087
+#: src/strings.ts:1086
 msgid "Turn off automatic syncing. Changes from this client will be synced only when you run sync manually."
 msgstr "Turn off automatic syncing. Changes from this client will be synced only when you run sync manually."
 
-#: src/strings.ts:893
+#: src/strings.ts:892
 msgid "Turn off reminder"
 msgstr "Turn off reminder"
 
-#: src/strings.ts:894
+#: src/strings.ts:893
 msgid "Turn on reminder"
 msgstr "Turn on reminder"
 
-#: src/strings.ts:1093
+#: src/strings.ts:1092
 msgid "Turns off syncing completely on this device. Any changes made will remain local only and new changes from your other devices won't sync to this device."
 msgstr "Turns off syncing completely on this device. Any changes made will remain local only and new changes from your other devices won't sync to this device."
 
@@ -6841,27 +6839,27 @@ msgstr "Two-factor authentication"
 msgid "Two-factor authentication enabled"
 msgstr "Two-factor authentication enabled"
 
-#: src/strings.ts:1503
+#: src/strings.ts:1502
 msgid "Type # to search for headings"
 msgstr "Type # to search for headings"
 
-#: src/strings.ts:1510
+#: src/strings.ts:1509
 msgid "Type a keyword"
 msgstr "Type a keyword"
 
-#: src/strings.ts:1550
+#: src/strings.ts:1549
 msgid "Unable to resolve download url"
 msgstr "Unable to resolve download url"
 
-#: src/strings.ts:1553
+#: src/strings.ts:1552
 msgid "Unable to send 2FA code"
 msgstr "Unable to send 2FA code"
 
-#: src/strings.ts:2498
+#: src/strings.ts:2497
 msgid "Unarchive"
 msgstr "Unarchive"
 
-#: src/strings.ts:2270
+#: src/strings.ts:2269
 msgid "Underline"
 msgstr "Underline"
 
@@ -6869,19 +6867,19 @@ msgstr "Underline"
 msgid "Undo"
 msgstr "Undo"
 
-#: src/strings.ts:855
+#: src/strings.ts:854
 msgid "Unfavorite"
 msgstr "Unfavorite"
 
-#: src/strings.ts:2595
+#: src/strings.ts:2594
 msgid "Unlimited"
 msgstr "Unlimited"
 
-#: src/strings.ts:931
+#: src/strings.ts:930
 msgid "Unlink from all"
 msgstr "Unlink from all"
 
-#: src/strings.ts:854
+#: src/strings.ts:853
 msgid "Unlink notebook"
 msgstr "Unlink notebook"
 
@@ -6889,11 +6887,11 @@ msgstr "Unlink notebook"
 msgid "Unlock"
 msgstr "Unlock"
 
-#: src/strings.ts:2642
+#: src/strings.ts:2641
 msgid "Unlock incoming note"
 msgstr "Unlock incoming note"
 
-#: src/strings.ts:1384
+#: src/strings.ts:1383
 msgid "Unlock more colors with Notesnook Pro"
 msgstr "Unlock more colors with Notesnook Pro"
 
@@ -6902,19 +6900,19 @@ msgstr "Unlock more colors with Notesnook Pro"
 msgid "Unlock note"
 msgstr "Unlock note"
 
-#: src/strings.ts:889
+#: src/strings.ts:888
 msgid "Unlock note to delete it"
 msgstr "Unlock note to delete it"
 
-#: src/strings.ts:2653
+#: src/strings.ts:2652
 msgid "Unlock note to merge conflicts"
 msgstr "Unlock note to merge conflicts"
 
-#: src/strings.ts:1209
+#: src/strings.ts:1208
 msgid "Unlock the app with biometric authentication. This requires biometrics to be enabled on your device."
 msgstr "Unlock the app with biometric authentication. This requires biometrics to be enabled on your device."
 
-#: src/strings.ts:1933
+#: src/strings.ts:1932
 msgid "Unlock vault"
 msgstr "Unlock vault"
 
@@ -6922,7 +6920,7 @@ msgstr "Unlock vault"
 msgid "Unlock with biometrics"
 msgstr "Unlock with biometrics"
 
-#: src/strings.ts:1828
+#: src/strings.ts:1827
 msgid "Unlock with security key"
 msgstr "Unlock with security key"
 
@@ -6930,19 +6928,19 @@ msgstr "Unlock with security key"
 msgid "Unlock your notes"
 msgstr "Unlock your notes"
 
-#: src/strings.ts:1179
+#: src/strings.ts:1178
 msgid "Unlock your vault with biometric authentication"
 msgstr "Unlock your vault with biometric authentication"
 
-#: src/strings.ts:1711
+#: src/strings.ts:1710
 msgid "Unlocking"
 msgstr "Unlocking"
 
-#: src/strings.ts:900
+#: src/strings.ts:899
 msgid "Unpin"
 msgstr "Unpin"
 
-#: src/strings.ts:928
+#: src/strings.ts:927
 msgid "Unpin notification"
 msgstr "Unpin notification"
 
@@ -6950,20 +6948,20 @@ msgstr "Unpin notification"
 msgid "Unpublish"
 msgstr "Unpublish"
 
-#: src/strings.ts:1478
+#: src/strings.ts:1477
 msgid "Unpublish notes to delete them"
 msgstr "Unpublish notes to delete them"
 
-#: src/strings.ts:2097
+#: src/strings.ts:2096
 msgid "Unregister"
 msgstr "Unregister"
 
-#: src/strings.ts:2646
+#: src/strings.ts:2645
 msgid "Unset expiry"
 msgstr "Unset expiry"
 
 #: src/strings.ts:210
-#: src/strings.ts:2372
+#: src/strings.ts:2371
 msgid "Untitled"
 msgstr "Untitled"
 
@@ -6975,31 +6973,31 @@ msgstr "Update"
 msgid "Update available"
 msgstr "Update available"
 
-#: src/strings.ts:1371
+#: src/strings.ts:1370
 msgid "Update now"
 msgstr "Update now"
 
-#: src/strings.ts:2512
+#: src/strings.ts:2511
 msgid "Upgrade"
 msgstr "Upgrade"
 
-#: src/strings.ts:1919
+#: src/strings.ts:1918
 msgid "Upgrade now"
 msgstr "Upgrade now"
 
-#: src/strings.ts:2511
+#: src/strings.ts:2510
 msgid "Upgrade plan"
 msgstr "Upgrade plan"
 
-#: src/strings.ts:2537
+#: src/strings.ts:2536
 msgid "Upgrade plan to {plan} to use this feature."
 msgstr "Upgrade plan to {plan} to use this feature."
 
-#: src/strings.ts:1940
+#: src/strings.ts:1939
 msgid "Upgrade to Notesnook Pro to add colors."
 msgstr "Upgrade to Notesnook Pro to add colors."
 
-#: src/strings.ts:1941
+#: src/strings.ts:1940
 msgid "Upgrade to Notesnook Pro to create more tags."
 msgstr "Upgrade to Notesnook Pro to create more tags."
 
@@ -7007,7 +7005,7 @@ msgstr "Upgrade to Notesnook Pro to create more tags."
 msgid "Upgrade to Pro"
 msgstr "Upgrade to Pro"
 
-#: src/strings.ts:2610
+#: src/strings.ts:2609
 msgid "Upgrade to redeem"
 msgstr "Upgrade to redeem"
 
@@ -7015,12 +7013,12 @@ msgstr "Upgrade to redeem"
 msgid "Upload"
 msgstr "Upload"
 
-#: src/strings.ts:2349
+#: src/strings.ts:2348
 msgid "Upload from disk"
 msgstr "Upload from disk"
 
 #: src/strings.ts:511
-#: src/strings.ts:1652
+#: src/strings.ts:1651
 msgid "Uploaded"
 msgstr "Uploaded"
 
@@ -7041,11 +7039,11 @@ msgstr "Uploads"
 msgid "Urgent"
 msgstr "Urgent"
 
-#: src/strings.ts:2399
+#: src/strings.ts:2398
 msgid "URL"
 msgstr "URL"
 
-#: src/strings.ts:1790
+#: src/strings.ts:1789
 msgid "Use"
 msgstr "Use"
 
@@ -7053,11 +7051,11 @@ msgstr "Use"
 msgid "Use {keyboardShortcut}+click to select multiple notebooks"
 msgstr "Use {keyboardShortcut}+click to select multiple notebooks"
 
-#: src/strings.ts:1803
+#: src/strings.ts:1802
 msgid "Use a backup file"
 msgstr "Use a backup file"
 
-#: src/strings.ts:1901
+#: src/strings.ts:1900
 msgid "Use a data recovery key to reset your account password."
 msgstr "Use a data recovery key to reset your account password."
 
@@ -7065,43 +7063,43 @@ msgstr "Use a data recovery key to reset your account password."
 msgid "Use account password"
 msgstr "Use account password"
 
-#: src/strings.ts:2544
+#: src/strings.ts:2543
 msgid "Use advanced note taking features like"
 msgstr "Use advanced note taking features like"
 
-#: src/strings.ts:980
+#: src/strings.ts:979
 msgid "Use an authenticator app to generate 2FA codes."
 msgstr "Use an authenticator app to generate 2FA codes."
 
-#: src/strings.ts:2183
+#: src/strings.ts:2182
 msgid "Use custom DNS"
 msgstr "Use custom DNS"
 
-#: src/strings.ts:1124
+#: src/strings.ts:1123
 msgid "Use dark mode for the app"
 msgstr "Use dark mode for the app"
 
-#: src/strings.ts:1622
+#: src/strings.ts:1621
 msgid "Use encryption key"
 msgstr "Use encryption key"
 
-#: src/strings.ts:1161
+#: src/strings.ts:1160
 msgid "Use markdown shortcuts in the editor"
 msgstr "Use markdown shortcuts in the editor"
 
-#: src/strings.ts:2136
+#: src/strings.ts:2135
 msgid "Use native OS titlebar instead of replacing it with a custom one. Requires app restart for changes to take effect."
 msgstr "Use native OS titlebar instead of replacing it with a custom one. Requires app restart for changes to take effect."
 
-#: src/strings.ts:2134
+#: src/strings.ts:2133
 msgid "Use native titlebar"
 msgstr "Use native titlebar"
 
-#: src/strings.ts:1800
+#: src/strings.ts:1799
 msgid "Use recovery key"
 msgstr "Use recovery key"
 
-#: src/strings.ts:1120
+#: src/strings.ts:1119
 msgid "Use system theme"
 msgstr "Use system theme"
 
@@ -7127,43 +7125,43 @@ msgstr ""
 "$headline$: Use starting line of the note as title.\n"
 "$day$: Current day (eg. Monday)"
 
-#: src/strings.ts:1100
+#: src/strings.ts:1099
 msgid "Use this if changes from other devices are not appearing on this device. This will overwrite the data on this device with the latest data from the server."
 msgstr "Use this if changes from other devices are not appearing on this device. This will overwrite the data on this device with the latest data from the server."
 
-#: src/strings.ts:1109
+#: src/strings.ts:1108
 msgid "Use this if changes made on this device are not appearing on other devices. This will overwrite the data on the server with the data from this device."
 msgstr "Use this if changes made on this device are not appearing on other devices. This will overwrite the data on the server with the data from this device."
 
-#: src/strings.ts:2485
+#: src/strings.ts:2484
 msgid "used"
 msgstr "used"
 
-#: src/strings.ts:1019
+#: src/strings.ts:1018
 msgid "User verification failed"
 msgstr "User verification failed"
 
-#: src/strings.ts:2266
+#: src/strings.ts:2265
 msgid "Using {instance} (v{version})"
 msgstr "Using {instance} (v{version})"
 
-#: src/strings.ts:2264
+#: src/strings.ts:2263
 msgid "Using official Notesnook instance"
 msgstr "Using official Notesnook instance"
 
-#: src/strings.ts:1710
+#: src/strings.ts:1709
 msgid "v{version} available"
 msgstr "v{version} available"
 
-#: src/strings.ts:2660
+#: src/strings.ts:2659
 msgid "Value must be between {min} and {max}"
 msgstr "Value must be between {min} and {max}"
 
-#: src/strings.ts:1172
+#: src/strings.ts:1171
 msgid "Vault"
 msgstr "Vault"
 
-#: src/strings.ts:1993
+#: src/strings.ts:1992
 msgid "Vault cleared"
 msgstr "Vault cleared"
 
@@ -7171,7 +7169,7 @@ msgstr "Vault cleared"
 msgid "Vault created"
 msgstr "Vault created"
 
-#: src/strings.ts:1994
+#: src/strings.ts:1993
 msgid "Vault deleted"
 msgstr "Vault deleted"
 
@@ -7179,15 +7177,15 @@ msgstr "Vault deleted"
 msgid "Vault fingerprint unlock"
 msgstr "Vault fingerprint unlock"
 
-#: src/strings.ts:1932
+#: src/strings.ts:1931
 msgid "Vault locked"
 msgstr "Vault locked"
 
-#: src/strings.ts:1931
+#: src/strings.ts:1930
 msgid "Vault unlocked"
 msgstr "Vault unlocked"
 
-#: src/strings.ts:1401
+#: src/strings.ts:1400
 msgid "Verification email sent"
 msgstr "Verification email sent"
 
@@ -7195,19 +7193,19 @@ msgstr "Verification email sent"
 msgid "Verify"
 msgstr "Verify"
 
-#: src/strings.ts:1070
+#: src/strings.ts:1069
 msgid "Verify subscription"
 msgstr "Verify subscription"
 
-#: src/strings.ts:1073
+#: src/strings.ts:1072
 msgid "Verify your subscription to Notesnook Pro"
 msgstr "Verify your subscription to Notesnook Pro"
 
-#: src/strings.ts:1904
+#: src/strings.ts:1903
 msgid "Verifying 2FA code"
 msgstr "Verifying 2FA code"
 
-#: src/strings.ts:1890
+#: src/strings.ts:1889
 msgid "Verifying your email"
 msgstr "Verifying your email"
 
@@ -7227,27 +7225,27 @@ msgstr "Videos"
 msgid "View all linked notebooks"
 msgstr "View all linked notebooks"
 
-#: src/strings.ts:1271
+#: src/strings.ts:1270
 msgid "View and share debug logs"
 msgstr "View and share debug logs"
 
-#: src/strings.ts:1748
+#: src/strings.ts:1747
 msgid "View receipt"
 msgstr "View receipt"
 
-#: src/strings.ts:1061
+#: src/strings.ts:1060
 msgid "View recovery codes"
 msgstr "View recovery codes"
 
-#: src/strings.ts:2163
+#: src/strings.ts:2162
 msgid "View source code"
 msgstr "View source code"
 
-#: src/strings.ts:1063
+#: src/strings.ts:1062
 msgid "View your recovery codes to recover your account in case you lose access to your two-factor authentication methods."
 msgstr "View your recovery codes to recover your account in case you lose access to your two-factor authentication methods."
 
-#: src/strings.ts:2625
+#: src/strings.ts:2624
 msgid "Views"
 msgstr "Views"
 
@@ -7255,15 +7253,15 @@ msgstr "Views"
 msgid "Visit homepage"
 msgstr "Visit homepage"
 
-#: src/strings.ts:1351
+#: src/strings.ts:1350
 msgid "Wait 30 seconds to try again"
 msgstr "Wait 30 seconds to try again"
 
-#: src/strings.ts:1653
+#: src/strings.ts:1652
 msgid "Waiting for upload"
 msgstr "Waiting for upload"
 
-#: src/strings.ts:1912
+#: src/strings.ts:1911
 msgid "We are creating a backup of your data. Please wait..."
 msgstr "We are creating a backup of your data. Please wait..."
 
@@ -7271,35 +7269,35 @@ msgstr "We are creating a backup of your data. Please wait..."
 msgid "We are sorry, it seems that the app crashed due to an error. You can submit a bug report below so we can fix this asap."
 msgstr "We are sorry, it seems that the app crashed due to an error. You can submit a bug report below so we can fix this asap."
 
-#: src/strings.ts:1391
+#: src/strings.ts:1390
 msgid "We have sent you an email confirmation link. Please check your email inbox. If you cannot find the email, check your spam folder."
 msgstr "We have sent you an email confirmation link. Please check your email inbox. If you cannot find the email, check your spam folder."
 
-#: src/strings.ts:2523
+#: src/strings.ts:2522
 msgid "We require credit card details to fight abuse and to make it seamless for you to upgrade. Your credit card is NOT charged until your free trial ends and your subscription starts. You will be notified via email of the upcoming charge before your trial ends."
 msgstr "We require credit card details to fight abuse and to make it seamless for you to upgrade. Your credit card is NOT charged until your free trial ends and your subscription starts. You will be notified via email of the upcoming charge before your trial ends."
 
-#: src/strings.ts:2178
+#: src/strings.ts:2177
 msgid "We send you occasional promotional offers & product updates on your email (once every month)."
 msgstr "We send you occasional promotional offers & product updates on your email (once every month)."
 
-#: src/strings.ts:1168
+#: src/strings.ts:1167
 msgid "We will send you occasional promotional offers & product updates on your email (sent once every month)."
 msgstr "We will send you occasional promotional offers & product updates on your email (sent once every month)."
 
-#: src/strings.ts:1355
+#: src/strings.ts:1354
 msgid "We would love to know what you think!"
 msgstr "We would love to know what you think!"
 
-#: src/strings.ts:2564
+#: src/strings.ts:2563
 msgid "We’re setting up your plan right now. We’ll notify you as soon as everything is ready."
 msgstr "We’re setting up your plan right now. We’ll notify you as soon as everything is ready."
 
-#: src/strings.ts:2334
+#: src/strings.ts:2333
 msgid "Web clip settings"
 msgstr "Web clip settings"
 
-#: src/strings.ts:2030
+#: src/strings.ts:2029
 msgid "Website"
 msgstr "Website"
 
@@ -7315,12 +7313,12 @@ msgstr "Wednesday"
 msgid "Week"
 msgstr "Week"
 
-#: src/strings.ts:2638
+#: src/strings.ts:2637
 msgid "Week format"
 msgstr "Week format"
 
 #: src/strings.ts:168
-#: src/strings.ts:1570
+#: src/strings.ts:1569
 msgid "Weekly"
 msgstr "Weekly"
 
@@ -7328,63 +7326,63 @@ msgstr "Weekly"
 msgid "Welcome back, {email}"
 msgstr "Welcome back, {email}"
 
-#: src/strings.ts:1889
+#: src/strings.ts:1888
 msgid "Welcome back!"
 msgstr "Welcome back!"
 
-#: src/strings.ts:2598
+#: src/strings.ts:2597
 msgid "Welcome to Notesnook {plan}"
 msgstr "Welcome to Notesnook {plan}"
 
-#: src/strings.ts:2084
+#: src/strings.ts:2083
 msgid "Welcome to Notesnook Pro"
 msgstr "Welcome to Notesnook Pro"
 
-#: src/strings.ts:1393
+#: src/strings.ts:1392
 msgid "What do I do if I am not getting the email?"
 msgstr "What do I do if I am not getting the email?"
 
-#: src/strings.ts:2515
+#: src/strings.ts:2514
 msgid "What happens to my data if I switch plans?"
 msgstr "What happens to my data if I switch plans?"
 
-#: src/strings.ts:2531
+#: src/strings.ts:2530
 msgid "What is your refund policy?"
 msgstr "What is your refund policy?"
 
-#: src/strings.ts:1668
+#: src/strings.ts:1667
 msgid "What went wrong?"
 msgstr "What went wrong?"
 
-#: src/strings.ts:2521
+#: src/strings.ts:2520
 msgid "Why do you need my credit card details for a free trial?"
 msgstr "Why do you need my credit card details for a free trial?"
 
-#: src/strings.ts:2395
+#: src/strings.ts:2394
 msgid "Width"
 msgstr "Width"
 
-#: src/strings.ts:2501
+#: src/strings.ts:2500
 msgid "Words"
 msgstr "Words"
 
-#: src/strings.ts:2424
+#: src/strings.ts:2423
 msgid "Work & Office"
 msgstr "Work & Office"
 
-#: src/strings.ts:824
+#: src/strings.ts:823
 msgid "Write notes with freedom, no spying, no tracking."
 msgstr "Write notes with freedom, no spying, no tracking."
 
-#: src/strings.ts:1375
+#: src/strings.ts:1374
 msgid "Write something..."
 msgstr "Write something..."
 
-#: src/strings.ts:1655
+#: src/strings.ts:1654
 msgid "Write with freedom."
 msgstr "Write with freedom."
 
-#: src/strings.ts:2072
+#: src/strings.ts:2071
 msgid "Write with freedom. Never compromise on privacy again."
 msgstr "Write with freedom. Never compromise on privacy again."
 
@@ -7393,7 +7391,7 @@ msgid "Year"
 msgstr "Year"
 
 #: src/strings.ts:170
-#: src/strings.ts:1572
+#: src/strings.ts:1571
 msgid "Yearly"
 msgstr "Yearly"
 
@@ -7401,7 +7399,7 @@ msgstr "Yearly"
 msgid "Yes"
 msgstr "Yes"
 
-#: src/strings.ts:2528
+#: src/strings.ts:2527
 msgid "Yes, you can cancel your trial anytime. No questions asked."
 msgstr "Yes, you can cancel your trial anytime. No questions asked."
 
@@ -7409,27 +7407,27 @@ msgstr "Yes, you can cancel your trial anytime. No questions asked."
 msgid "You also agree to recieve marketing emails from us which you can opt-out of from app settings."
 msgstr "You also agree to recieve marketing emails from us which you can opt-out of from app settings."
 
-#: src/strings.ts:2603
+#: src/strings.ts:2602
 msgid "You are already subscribed to this plan."
 msgstr "You are already subscribed to this plan."
 
-#: src/strings.ts:2251
+#: src/strings.ts:2250
 msgid "You are editing \"{notebookTitle}\"."
 msgstr "You are editing \"{notebookTitle}\"."
 
-#: src/strings.ts:2044
+#: src/strings.ts:2043
 msgid "You are editing #{tag}"
 msgstr "You are editing #{tag}"
 
-#: src/strings.ts:1782
+#: src/strings.ts:1781
 msgid "You are logging into the beta version of Notesnook. Switching between beta &amp; stable versions can cause weird issues including data loss. It is recommended that you do not use both simultaneously."
 msgstr "You are logging into the beta version of Notesnook. Switching between beta &amp; stable versions can cause weird issues including data loss. It is recommended that you do not use both simultaneously."
 
-#: src/strings.ts:1362
+#: src/strings.ts:1361
 msgid "You are not logged in"
 msgstr "You are not logged in"
 
-#: src/strings.ts:887
+#: src/strings.ts:886
 msgid "You are renaming color {color}"
 msgstr "You are renaming color {color}"
 
@@ -7437,39 +7435,39 @@ msgstr "You are renaming color {color}"
 msgid "You can also link a note to multiple Notebooks. Tap and hold any notebook to enable multi-select."
 msgstr "You can also link a note to multiple Notebooks. Tap and hold any notebook to enable multi-select."
 
-#: src/strings.ts:2075
+#: src/strings.ts:2074
 msgid "You can change the theme at any time from Settings or the side menu."
 msgstr "You can change the theme at any time from Settings or the side menu."
 
-#: src/strings.ts:2606
+#: src/strings.ts:2605
 msgid "You can change your subscription plan from the web app"
 msgstr "You can change your subscription plan from the web app"
 
-#: src/strings.ts:2432
+#: src/strings.ts:2431
 msgid "You can create shortcuts of frequently accessed notebooks in the side menu"
 msgstr "You can create shortcuts of frequently accessed notebooks in the side menu"
 
-#: src/strings.ts:2090
+#: src/strings.ts:2089
 msgid "You can import your notes from most other note taking apps."
 msgstr "You can import your notes from most other note taking apps."
 
-#: src/strings.ts:1437
+#: src/strings.ts:1436
 msgid "You can multi-select notes and move them to a notebook at once"
 msgstr "You can multi-select notes and move them to a notebook at once"
 
-#: src/strings.ts:1428
+#: src/strings.ts:1427
 msgid "You can pin frequently used Notebooks to the Side Menu to quickly access them."
 msgstr "You can pin frequently used Notebooks to the Side Menu to quickly access them."
 
-#: src/strings.ts:1171
+#: src/strings.ts:1170
 msgid "You can set a custom proxy URL to increase your privacy."
 msgstr "You can set a custom proxy URL to increase your privacy."
 
-#: src/strings.ts:1409
+#: src/strings.ts:1408
 msgid "You can swipe left anywhere in the app to start a new note."
 msgstr "You can swipe left anywhere in the app to start a new note."
 
-#: src/strings.ts:2057
+#: src/strings.ts:2056
 msgid ""
 "You can track your bug report at [{url}]({url}).\n"
 "\n"
@@ -7483,7 +7481,7 @@ msgstr ""
 "\n"
 "If your issue is critical (e.g. notes not syncing, crashes etc.), please [join our Discord community](https://go.notesnook.com/discord) for one-to-one support."
 
-#: src/strings.ts:2066
+#: src/strings.ts:2065
 msgid ""
 "You can track your feature request at [{url}]({url}).\n"
 "\n"
@@ -7497,67 +7495,67 @@ msgstr ""
 msgid "You can track your issue at "
 msgstr "You can track your issue at "
 
-#: src/strings.ts:1029
+#: src/strings.ts:1028
 msgid "You can use all premium features for free for the next 14 days"
 msgstr "You can use all premium features for free for the next 14 days"
 
-#: src/strings.ts:1059
+#: src/strings.ts:1058
 msgid "You can use fallback 2FA method incase you are unable to login via primary method"
 msgstr "You can use fallback 2FA method incase you are unable to login via primary method"
 
-#: src/strings.ts:1451
+#: src/strings.ts:1450
 msgid "You can view & restore older versions of any note by going to its properties -> History."
 msgstr "You can view & restore older versions of any note by going to its properties -> History."
 
-#: src/strings.ts:1750
+#: src/strings.ts:1749
 msgid "You have {count} custom dictionary words."
 msgstr "You have {count} custom dictionary words."
 
-#: src/strings.ts:2209
+#: src/strings.ts:2208
 msgid "You have been logged out from all other devices."
 msgstr "You have been logged out from all other devices."
 
-#: src/strings.ts:2203
+#: src/strings.ts:2202
 msgid "You have been logged out."
 msgstr "You have been logged out."
 
-#: src/strings.ts:2602
+#: src/strings.ts:2601
 msgid "You have made a one time purchase. To change your plan please contact support."
 msgstr "You have made a one time purchase. To change your plan please contact support."
 
-#: src/strings.ts:965
+#: src/strings.ts:964
 msgid "You have not added any notebooks yet"
 msgstr "You have not added any notebooks yet"
 
-#: src/strings.ts:964
+#: src/strings.ts:963
 msgid "You have not added any tags yet"
 msgstr "You have not added any tags yet"
 
-#: src/strings.ts:963
+#: src/strings.ts:962
 msgid "You have not created any notes yet"
 msgstr "You have not created any notes yet"
 
-#: src/strings.ts:962
+#: src/strings.ts:961
 msgid "You have not favorited any notes yet"
 msgstr "You have not favorited any notes yet"
 
-#: src/strings.ts:967
+#: src/strings.ts:966
 msgid "You have not published any monographs yet"
 msgstr "You have not published any monographs yet"
 
-#: src/strings.ts:966
+#: src/strings.ts:965
 msgid "You have not set any reminders yet"
 msgstr "You have not set any reminders yet"
 
-#: src/strings.ts:1546
+#: src/strings.ts:1545
 msgid "You have unsynced notes. Take a backup or sync your notes to avoid losing your critical data."
 msgstr "You have unsynced notes. Take a backup or sync your notes to avoid losing your critical data."
 
-#: src/strings.ts:1635
+#: src/strings.ts:1634
 msgid "You must log out in order to change/reset server URLs."
 msgstr "You must log out in order to change/reset server URLs."
 
-#: src/strings.ts:2674
+#: src/strings.ts:2673
 msgid ""
 "You need to login to restore attachments from a backup file. [Read more](https://help.notesnook.com/faqs/login-to-restore-attachments-in-backup).\n"
 "  \n"
@@ -7567,11 +7565,11 @@ msgstr ""
 "  \n"
 "Continue without attachments?"
 
-#: src/strings.ts:837
+#: src/strings.ts:836
 msgid "You simply cannot get any better of a note taking app than @notesnook. The UI is clean and slick, it is feature rich, encrypted, reasonably priced (esp. for students & educators) & open source"
 msgstr "You simply cannot get any better of a note taking app than @notesnook. The UI is clean and slick, it is feature rich, encrypted, reasonably priced (esp. for students & educators) & open source"
 
-#: src/strings.ts:1069
+#: src/strings.ts:1068
 msgid "You subscribed to Notesnook Pro on {date}. Verify this subscription?"
 msgstr "You subscribed to Notesnook Pro on {date}. Verify this subscription?"
 
@@ -7599,7 +7597,7 @@ msgstr "You were awarded a subscription to Notesnook Pro by Streetwriters."
 msgid "You will be logged out from all your devices"
 msgstr "You will be logged out from all your devices"
 
-#: src/strings.ts:1852
+#: src/strings.ts:1851
 msgid "You will receive instructions on how to recover your account on this email"
 msgstr "You will receive instructions on how to recover your account on this email"
 
@@ -7607,72 +7605,72 @@ msgstr "You will receive instructions on how to recover your account on this ema
 msgid "Your account email will be changed without affecting your subscription or any other settings."
 msgstr "Your account email will be changed without affecting your subscription or any other settings."
 
-#: src/strings.ts:1918
+#: src/strings.ts:1917
 msgid "Your account has been recovered."
 msgstr "Your account has been recovered."
 
 #: src/strings.ts:502
-#: src/strings.ts:1729
+#: src/strings.ts:1728
 msgid "Your account is now 100% secure against unauthorized logins."
 msgstr "Your account is now 100% secure against unauthorized logins."
 
-#: src/strings.ts:1857
+#: src/strings.ts:1856
 msgid "Your account password must be strong & unique."
 msgstr "Your account password must be strong & unique."
 
-#: src/strings.ts:1035
+#: src/strings.ts:1034
 msgid "Your account will be downgraded in {days} days"
 msgstr "Your account will be downgraded in {days} days"
 
-#: src/strings.ts:1079
+#: src/strings.ts:1078
 msgid "Your account will be permanently deleted along with all your data, login credentials, and subscription information. This action is IRREVERSIBLE. Make sure you have saved a backup of your notes before proceeding."
 msgstr "Your account will be permanently deleted along with all your data, login credentials, and subscription information. This action is IRREVERSIBLE. Make sure you have saved a backup of your notes before proceeding."
 
-#: src/strings.ts:961
+#: src/strings.ts:960
 msgid "Your archive"
 msgstr "Your archive"
 
-#: src/strings.ts:2497
+#: src/strings.ts:2496
 msgid "Your archive is empty"
 msgstr "Your archive is empty"
 
-#: src/strings.ts:1930
+#: src/strings.ts:1929
 msgid "Your backup is ready to download"
 msgstr "Your backup is ready to download"
 
-#: src/strings.ts:1587
+#: src/strings.ts:1586
 msgid "Your changes could not be saved"
 msgstr "Your changes could not be saved"
 
-#: src/strings.ts:1777
+#: src/strings.ts:1776
 msgid "Your changes have been saved and will be reflected after the app has refreshed."
 msgstr "Your changes have been saved and will be reflected after the app has refreshed."
 
-#: src/strings.ts:2110
+#: src/strings.ts:2109
 msgid "Your current 2FA method is {method}"
 msgstr "Your current 2FA method is {method}"
 
-#: src/strings.ts:2609
+#: src/strings.ts:2608
 msgid "Your current subscription does not allow changing plans"
 msgstr "Your current subscription does not allow changing plans"
 
-#: src/strings.ts:1802
+#: src/strings.ts:1801
 msgid "Your data recovery key is basically a hashed version of your password (plus some random salt). It can be used to decrypt your data for re-encryption."
 msgstr "Your data recovery key is basically a hashed version of your password (plus some random salt). It can be used to decrypt your data for re-encryption."
 
-#: src/strings.ts:1855
+#: src/strings.ts:1854
 msgid "Your data recovery key will be used to decrypt your data"
 msgstr "Your data recovery key will be used to decrypt your data"
 
-#: src/strings.ts:2517
+#: src/strings.ts:2516
 msgid "Your data remains 100% accessible regardless of what plan you are on. That includes your notes, notebooks, attachments, and anything else you might have created."
 msgstr "Your data remains 100% accessible regardless of what plan you are on. That includes your notes, notebooks, attachments, and anything else you might have created."
 
-#: src/strings.ts:1785
+#: src/strings.ts:1784
 msgid "Your email has been confirmed."
 msgstr "Your email has been confirmed."
 
-#: src/strings.ts:2508
+#: src/strings.ts:2507
 msgid "Your email has been confirmed. You can now securely sync your encrypted notes across all devices."
 msgstr "Your email has been confirmed. You can now securely sync your encrypted notes across all devices."
 
@@ -7680,39 +7678,39 @@ msgstr "Your email has been confirmed. You can now securely sync your encrypted 
 msgid "Your email is not confirmed. Please confirm your email address to change account password."
 msgstr "Your email is not confirmed. Please confirm your email address to change account password."
 
-#: src/strings.ts:955
+#: src/strings.ts:954
 msgid "Your favorites"
 msgstr "Your favorites"
 
-#: src/strings.ts:1032
+#: src/strings.ts:1031
 msgid "Your free trial ends on {date}"
 msgstr "Your free trial ends on {date}"
 
-#: src/strings.ts:1405
+#: src/strings.ts:1404
 msgid "Your free trial has expired"
 msgstr "Your free trial has expired"
 
-#: src/strings.ts:1027
+#: src/strings.ts:1026
 msgid "Your free trial has started"
 msgstr "Your free trial has started"
 
-#: src/strings.ts:1404
+#: src/strings.ts:1403
 msgid "Your free trial is ending soon"
 msgstr "Your free trial is ending soon"
 
-#: src/strings.ts:2637
+#: src/strings.ts:2636
 msgid "Your free trial is on-going. Your subscription will start on {trialExpiryDate}"
 msgstr "Your free trial is on-going. Your subscription will start on {trialExpiryDate}"
 
-#: src/strings.ts:1779
+#: src/strings.ts:1778
 msgid "Your full name"
 msgstr "Your full name"
 
-#: src/strings.ts:960
+#: src/strings.ts:959
 msgid "Your monographs"
 msgstr "Your monographs"
 
-#: src/strings.ts:1313
+#: src/strings.ts:1312
 msgid "Your name is stored 100% end-to-end encrypted and only visible to you."
 msgstr "Your name is stored 100% end-to-end encrypted and only visible to you."
 
@@ -7720,31 +7718,31 @@ msgstr "Your name is stored 100% end-to-end encrypted and only visible to you."
 msgid "Your note will be unencrypted and removed from the vault."
 msgstr "Your note will be unencrypted and removed from the vault."
 
-#: src/strings.ts:958
+#: src/strings.ts:957
 msgid "Your notebooks"
 msgstr "Your notebooks"
 
-#: src/strings.ts:956
+#: src/strings.ts:955
 msgid "Your notes"
 msgstr "Your notes"
 
-#: src/strings.ts:1893
+#: src/strings.ts:1892
 msgid "Your password is always hashed before leaving this device."
 msgstr "Your password is always hashed before leaving this device."
 
-#: src/strings.ts:833
+#: src/strings.ts:832
 msgid "Your privacy matters to us, no matter who you are. In a world where everyone is trying to spy on you, Notesnook encrypts all your data before it leaves your device. With Notesnook no one can ever sell your data again."
 msgstr "Your privacy matters to us, no matter who you are. In a world where everyone is trying to spy on you, Notesnook encrypts all your data before it leaves your device. With Notesnook no one can ever sell your data again."
 
-#: src/strings.ts:1310
+#: src/strings.ts:1309
 msgid "Your profile pictrure is stored 100% end-to-end encrypted and only visible to you."
 msgstr "Your profile pictrure is stored 100% end-to-end encrypted and only visible to you."
 
-#: src/strings.ts:1998
+#: src/strings.ts:1997
 msgid "Your refund has been issued. Please wait 24 hours before reaching out to us in case you do not receive your funds."
 msgstr "Your refund has been issued. Please wait 24 hours before reaching out to us in case you do not receive your funds."
 
-#: src/strings.ts:959
+#: src/strings.ts:958
 msgid "Your reminders"
 msgstr "Your reminders"
 
@@ -7752,31 +7750,31 @@ msgstr "Your reminders"
 msgid "Your session has expired. Please enter password for {obfuscatedEmail} to continue."
 msgstr "Your session has expired. Please enter password for {obfuscatedEmail} to continue."
 
-#: src/strings.ts:1036
+#: src/strings.ts:1035
 msgid "Your subscription ends on {date}"
 msgstr "Your subscription ends on {date}"
 
-#: src/strings.ts:1996
+#: src/strings.ts:1995
 msgid "Your subscription has been canceled."
 msgstr "Your subscription has been canceled."
 
-#: src/strings.ts:1033
+#: src/strings.ts:1032
 msgid "Your subscription has ended"
 msgstr "Your subscription has ended"
 
-#: src/strings.ts:1037
+#: src/strings.ts:1036
 msgid "Your subscription renews on {date}"
 msgstr "Your subscription renews on {date}"
 
-#: src/strings.ts:2054
+#: src/strings.ts:2053
 msgid "Your support request has been forwarded"
 msgstr "Your support request has been forwarded"
 
-#: src/strings.ts:2063
+#: src/strings.ts:2062
 msgid "Your support request has been forwarded to our support team. We will get back to you via email as soon as possible. If you don't receive an email from us within 24-48 hours, please send us an email directly at support@notesnook.com."
 msgstr "Your support request has been forwarded to our support team. We will get back to you via email as soon as possible. If you don't receive an email from us within 24-48 hours, please send us an email directly at support@notesnook.com."
 
-#: src/strings.ts:957
+#: src/strings.ts:956
 msgid "Your tags"
 msgstr "Your tags"
 
@@ -7792,22 +7790,22 @@ msgstr "Z to A"
 msgid "Zipping"
 msgstr "Zipping"
 
-#: src/strings.ts:2473
+#: src/strings.ts:2472
 msgid "Zoom"
 msgstr "Zoom"
 
-#: src/strings.ts:2104
+#: src/strings.ts:2103
 msgid "Zoom factor"
 msgstr "Zoom factor"
 
-#: src/strings.ts:1701
+#: src/strings.ts:1700
 msgid "Zoom in"
 msgstr "Zoom in"
 
-#: src/strings.ts:2105
+#: src/strings.ts:2104
 msgid "Zoom in or out the app content."
 msgstr "Zoom in or out the app content."
 
-#: src/strings.ts:1700
+#: src/strings.ts:1699
 msgid "Zoom out"
 msgstr "Zoom out"

--- a/packages/intl/locale/pseudo-LOCALE.po
+++ b/packages/intl/locale/pseudo-LOCALE.po
@@ -14,7 +14,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/strings.ts:2421
+#: src/strings.ts:2422
 msgid " \"Notebook > Notes\""
 msgstr ""
 
@@ -22,27 +22,27 @@ msgstr ""
 msgid " Unlock with password once to enable biometric access."
 msgstr ""
 
-#: src/strings.ts:1941
+#: src/strings.ts:1942
 msgid " Upgrade to Notesnook Pro to add more notebooks."
 msgstr ""
 
-#: src/strings.ts:1944
+#: src/strings.ts:1945
 msgid " Upgrade to Notesnook Pro to customize the toolbar."
 msgstr ""
 
-#: src/strings.ts:1943
+#: src/strings.ts:1944
 msgid " Upgrade to Notesnook Pro to use custom toolbar presets."
 msgstr ""
 
-#: src/strings.ts:1942
+#: src/strings.ts:1943
 msgid " Upgrade to Notesnook Pro to use the notes vault."
 msgstr ""
 
-#: src/strings.ts:1945
+#: src/strings.ts:1946
 msgid " Upgrade to Notesnook Pro to use this feature."
 msgstr ""
 
-#: src/strings.ts:828
+#: src/strings.ts:829
 msgid "— not just the"
 msgstr ""
 
@@ -70,19 +70,19 @@ msgid "{0} Highlights 🎉"
 msgstr ""
 
 #. placeholder {0}: platform === "ios" ? "Apple" : "Google"
-#: src/strings.ts:2577
+#: src/strings.ts:2578
 msgid "{0} will remind you before your trial ends"
 msgstr ""
 
-#: src/strings.ts:1753
+#: src/strings.ts:1754
 msgid "{count, plural, one {# error occured} other {# errors occured}}"
 msgstr ""
 
-#: src/strings.ts:1759
+#: src/strings.ts:1760
 msgid "{count, plural, one {# file ready for import} other {# files ready for import}}"
 msgstr ""
 
-#: src/strings.ts:1714
+#: src/strings.ts:1715
 msgid "{count, plural, one {# file} other {# files}}"
 msgstr ""
 
@@ -90,11 +90,11 @@ msgstr ""
 msgid "{count, plural, one {# note} other {# notes}}"
 msgstr ""
 
-#: src/strings.ts:1578
+#: src/strings.ts:1579
 msgid "{count, plural, one {1 hour} other {# hours}}"
 msgstr ""
 
-#: src/strings.ts:1573
+#: src/strings.ts:1574
 msgid "{count, plural, one {1 minute} other {# minutes}}"
 msgstr ""
 
@@ -135,7 +135,7 @@ msgstr ""
 msgid "{count, plural, one {Are you sure you want to download all attachments of this note?} other {Are you sure you want to download all attachments?}}"
 msgstr ""
 
-#: src/strings.ts:863
+#: src/strings.ts:864
 msgid "{count, plural, one {Are you sure you want to move this notebook to {selectedNotebookTitle}?} other {Are you sure you want to move these # notebooks {selectedNotebookTitle}?}}"
 msgstr ""
 
@@ -294,11 +294,11 @@ msgstr ""
 msgid "{count, plural, one {Item unpublished} other {# items unpublished}}"
 msgstr ""
 
-#: src/strings.ts:2438
+#: src/strings.ts:2439
 msgid "{count, plural, one {Move all notes in this notebook to trash} other {Move all notes in these notebooks to trash}}"
 msgstr ""
 
-#: src/strings.ts:861
+#: src/strings.ts:862
 msgid "{count, plural, one {Move notebook} other {Move # notebooks}}"
 msgstr ""
 
@@ -342,7 +342,7 @@ msgstr ""
 msgid "{count, plural, one {Note unpublished} other {# notes unpublished}}"
 msgstr ""
 
-#: src/strings.ts:920
+#: src/strings.ts:921
 msgid "{count, plural, one {Note will be automatically deleted from all other devices & any future changes won't get synced. Are you sure you want to continue?} other {# notes will be automatically deleted from all other devices & any future changes won't get synced. Are you sure you want to continue?}}"
 msgstr ""
 
@@ -396,7 +396,7 @@ msgstr ""
 msgid "{count, plural, one {Pin notebook} other {Pin # notebooks}}"
 msgstr ""
 
-#: src/strings.ts:915
+#: src/strings.ts:916
 msgid "{count, plural, one {Prevent note from syncing} other {Prevent # notes from syncing}}"
 msgstr ""
 
@@ -497,15 +497,15 @@ msgstr ""
 msgid "{count, plural, one {Unpublish note} other {Unpublish # notes}}"
 msgstr ""
 
-#: src/strings.ts:2508
+#: src/strings.ts:2509
 msgid "{count} characters"
 msgstr ""
 
-#: src/strings.ts:1564
+#: src/strings.ts:1565
 msgid "{days, plural, one {1 day} other {# days}}"
 msgstr ""
 
-#: src/strings.ts:2568
+#: src/strings.ts:2569
 msgid "{days} days free"
 msgstr ""
 
@@ -545,19 +545,19 @@ msgstr ""
 msgid "{mode, select, repeat {Repeat} once {Once} permanent {Permanent} other {Unknown mode}}"
 msgstr ""
 
-#: src/strings.ts:1976
+#: src/strings.ts:1977
 msgid "{n} {added, plural, one {added to 1 notebook} other {added to # notebooks}} and {removed, plural, one {removed from 1 notebook} other {removed from # notebooks}}."
 msgstr ""
 
-#: src/strings.ts:1971
+#: src/strings.ts:1972
 msgid "{n} {added, plural, one {added to 1 notebook} other {added to # notebooks}}."
 msgstr ""
 
-#: src/strings.ts:1966
+#: src/strings.ts:1967
 msgid "{n} {removed, plural, one {removed from 1 notebook} other {removed from # notebooks}}."
 msgstr ""
 
-#: src/strings.ts:1961
+#: src/strings.ts:1962
 msgid "{notes, plural, one {1 note} other {# notes}}"
 msgstr ""
 
@@ -565,11 +565,11 @@ msgstr ""
 msgid "{notes, plural, one {Export note} other {Export # notes}}"
 msgstr ""
 
-#: src/strings.ts:1706
+#: src/strings.ts:1707
 msgid "{percentage}% updating..."
 msgstr ""
 
-#: src/strings.ts:2552
+#: src/strings.ts:2553
 msgid "{plan} plan"
 msgstr ""
 
@@ -577,11 +577,11 @@ msgstr ""
 msgid "{platform, select, android {{name} saved to selected path} other {{name} saved to File Manager/Notesnook/downloads}}"
 msgstr ""
 
-#: src/strings.ts:1337
+#: src/strings.ts:1338
 msgid "{platform, select, android {Backup file saved in \"Notesnook backups\" folder on your phone.} other {Backup file is saved in File Manager/Notesnook folder}}"
 msgstr ""
 
-#: src/strings.ts:2368
+#: src/strings.ts:2369
 msgid "{selected} selected"
 msgstr ""
 
@@ -601,43 +601,43 @@ msgstr ""
 msgid "{type} does not match"
 msgstr ""
 
-#: src/strings.ts:1599
+#: src/strings.ts:1600
 msgid "{words, plural, one {# word} other {# words}}"
 msgstr ""
 
-#: src/strings.ts:1662
+#: src/strings.ts:1663
 msgid "{words, plural, other {# selected}}"
 msgstr ""
 
-#: src/strings.ts:1790
+#: src/strings.ts:1791
 msgid "#notesnook"
 msgstr ""
 
-#: src/strings.ts:1583
+#: src/strings.ts:1584
 msgid "12-hour"
 msgstr ""
 
-#: src/strings.ts:1584
+#: src/strings.ts:1585
 msgid "24-hour"
 msgstr ""
 
-#: src/strings.ts:1904
+#: src/strings.ts:1905
 msgid "2FA code is required()"
 msgstr ""
 
-#: src/strings.ts:1008
+#: src/strings.ts:1009
 msgid "2FA code sent via {method}"
 msgstr ""
 
-#: src/strings.ts:2595
+#: src/strings.ts:2596
 msgid "5 year plan (One time purchase)"
 msgstr ""
 
-#: src/strings.ts:1845
+#: src/strings.ts:1846
 msgid "6 digit code"
 msgstr ""
 
-#: src/strings.ts:1431
+#: src/strings.ts:1432
 msgid "A notebook can have unlimited topics with unlimited notes."
 msgstr ""
 
@@ -653,35 +653,35 @@ msgstr ""
 msgid "Abc"
 msgstr ""
 
-#: src/strings.ts:1289
+#: src/strings.ts:1290
 msgid "About"
 msgstr ""
 
-#: src/strings.ts:1024
+#: src/strings.ts:1025
 msgid "Account"
 msgstr ""
 
-#: src/strings.ts:1847
+#: src/strings.ts:1848
 msgid "Account password"
 msgstr ""
 
-#: src/strings.ts:2463
+#: src/strings.ts:2464
 msgid "Actions for note: {title}"
 msgstr ""
 
-#: src/strings.ts:2464
+#: src/strings.ts:2465
 msgid "Actions for notebook: {title}"
 msgstr ""
 
-#: src/strings.ts:2465
+#: src/strings.ts:2466
 msgid "Actions for tag: {title}"
 msgstr ""
 
-#: src/strings.ts:2037
+#: src/strings.ts:2038
 msgid "Activate"
 msgstr ""
 
-#: src/strings.ts:1823
+#: src/strings.ts:1824
 msgid "Activating trial"
 msgstr ""
 
@@ -689,15 +689,15 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: src/strings.ts:1056
+#: src/strings.ts:1057
 msgid "Add 2FA fallback method"
 msgstr ""
 
-#: src/strings.ts:1507
+#: src/strings.ts:1508
 msgid "Add a short note"
 msgstr ""
 
-#: src/strings.ts:1600
+#: src/strings.ts:1601
 msgid "Add a tag"
 msgstr ""
 
@@ -705,11 +705,11 @@ msgstr ""
 msgid "Add color"
 msgstr ""
 
-#: src/strings.ts:895
+#: src/strings.ts:896
 msgid "Add notebook"
 msgstr ""
 
-#: src/strings.ts:2490
+#: src/strings.ts:2491
 msgid "Add notes"
 msgstr ""
 
@@ -717,7 +717,7 @@ msgstr ""
 msgid "Add notes to {title}"
 msgstr ""
 
-#: src/strings.ts:894
+#: src/strings.ts:895
 msgid "Add shortcut"
 msgstr ""
 
@@ -729,55 +729,55 @@ msgstr ""
 msgid "Add tag"
 msgstr ""
 
-#: src/strings.ts:933
+#: src/strings.ts:934
 msgid "Add tags"
 msgstr ""
 
-#: src/strings.ts:934
+#: src/strings.ts:935
 msgid "Add tags to multiple notes at once"
 msgstr ""
 
-#: src/strings.ts:2255
+#: src/strings.ts:2256
 msgid "Add to dictionary"
 msgstr ""
 
-#: src/strings.ts:2628
+#: src/strings.ts:2629
 msgid "Add to home"
 msgstr ""
 
-#: src/strings.ts:2488
+#: src/strings.ts:2489
 msgid "Add to notebook"
 msgstr ""
 
-#: src/strings.ts:974
+#: src/strings.ts:975
 msgid "Add your first note"
 msgstr ""
 
-#: src/strings.ts:975
+#: src/strings.ts:976
 msgid "Add your first notebook"
 msgstr ""
 
-#: src/strings.ts:2631
+#: src/strings.ts:2632
 msgid "Adjust the line height of the editor"
 msgstr ""
 
-#: src/strings.ts:2181
+#: src/strings.ts:2182
 msgid "Advanced"
 msgstr ""
 
-#: src/strings.ts:1726
+#: src/strings.ts:1727
 msgid "After scanning the QR code image, the app will display a code that you can enter below."
 msgstr ""
 
-#: src/strings.ts:2320
+#: src/strings.ts:2321
 msgid "Align left"
 msgstr ""
 
-#: src/strings.ts:2321
+#: src/strings.ts:2322
 msgid "Align right"
 msgstr ""
 
-#: src/strings.ts:2290
+#: src/strings.ts:2291
 msgid "Alignment"
 msgstr ""
 
@@ -789,7 +789,7 @@ msgstr ""
 msgid "All attachments are end-to-end encrypted."
 msgstr ""
 
-#: src/strings.ts:2415
+#: src/strings.ts:2416
 msgid "All cached attachments have been cleared."
 msgstr ""
 
@@ -801,7 +801,7 @@ msgstr ""
 msgid "All files"
 msgstr ""
 
-#: src/strings.ts:1174
+#: src/strings.ts:1175
 msgid "All locked notes will be re-encrypted with the new password."
 msgstr ""
 
@@ -809,15 +809,15 @@ msgstr ""
 msgid "All logs are local only and are not sent to any server. You can share the logs from here with us if you face an issue to help us find the root cause."
 msgstr ""
 
-#: src/strings.ts:1637
+#: src/strings.ts:1638
 msgid "All server urls are required."
 msgstr ""
 
-#: src/strings.ts:1906
+#: src/strings.ts:1907
 msgid "All the data in your account will be overwritten with the data in the backup file. There is no way to reverse this action."
 msgstr ""
 
-#: src/strings.ts:2161
+#: src/strings.ts:2162
 msgid "All the source code for Notesnook is available & open for everyone on GitHub."
 msgstr ""
 
@@ -825,15 +825,15 @@ msgstr ""
 msgid "All tools are grouped"
 msgstr ""
 
-#: src/strings.ts:1321
+#: src/strings.ts:1322
 msgid "All tools in the collapsed section will be removed"
 msgstr ""
 
-#: src/strings.ts:1316
+#: src/strings.ts:1317
 msgid "All tools in this group will be removed from the toolbar."
 msgstr ""
 
-#: src/strings.ts:1346
+#: src/strings.ts:1347
 msgid "All your backups are stored in 'Phone Storage/Notesnook/backups/' folder"
 msgstr ""
 
@@ -841,7 +841,7 @@ msgstr ""
 msgid "Already have an account?"
 msgstr ""
 
-#: src/strings.ts:2231
+#: src/strings.ts:2232
 msgid "Amount"
 msgstr ""
 
@@ -849,7 +849,7 @@ msgstr ""
 msgid "An error occurred while migrating your data. You can logout of your account and try to relogin. However this is not recommended as it may result in some data loss if your data was not synced."
 msgstr ""
 
-#: src/strings.ts:2589
+#: src/strings.ts:2590
 msgid "and"
 msgstr ""
 
@@ -857,19 +857,19 @@ msgstr ""
 msgid "and "
 msgstr ""
 
-#: src/strings.ts:1791
+#: src/strings.ts:1792
 msgid "and get a chance to win free promo codes."
 msgstr ""
 
-#: src/strings.ts:2545
+#: src/strings.ts:2546
 msgid "and much more."
 msgstr ""
 
-#: src/strings.ts:1397
+#: src/strings.ts:1398
 msgid "and we will manually confirm your account."
 msgstr ""
 
-#: src/strings.ts:2606
+#: src/strings.ts:2607
 msgid "ANNOUNCEMENT"
 msgstr ""
 
@@ -877,29 +877,29 @@ msgstr ""
 msgid "App data has been cleared. Kindly relaunch the app to login again."
 msgstr ""
 
-#: src/strings.ts:1183
-#: src/strings.ts:1693
+#: src/strings.ts:1184
+#: src/strings.ts:1694
 msgid "App lock"
 msgstr ""
 
 #: src/strings.ts:781
-#: src/strings.ts:1209
+#: src/strings.ts:1210
 msgid "App lock disabled"
 msgstr ""
 
-#: src/strings.ts:1189
+#: src/strings.ts:1190
 msgid "App lock timeout"
 msgstr ""
 
-#: src/strings.ts:1300
+#: src/strings.ts:1301
 msgid "App version"
 msgstr ""
 
-#: src/strings.ts:1774
+#: src/strings.ts:1775
 msgid "App will reload in {sec} seconds"
 msgstr ""
 
-#: src/strings.ts:1114
+#: src/strings.ts:1115
 msgid "Appearance"
 msgstr ""
 
@@ -915,32 +915,32 @@ msgstr ""
 msgid "Apply changes"
 msgstr ""
 
-#: src/strings.ts:2044
+#: src/strings.ts:2045
 msgid "Applying changes"
 msgstr ""
 
-#: src/strings.ts:1530
-#: src/strings.ts:2495
+#: src/strings.ts:1531
+#: src/strings.ts:2496
 msgid "Archive"
 msgstr ""
 
-#: src/strings.ts:1445
+#: src/strings.ts:1446
 msgid "Are you scrolling a lot to find a specific note? Pin it to the top from Note properties."
 msgstr ""
 
-#: src/strings.ts:1016
+#: src/strings.ts:1017
 msgid "Are you sure you want to clear all logs from {key}?"
 msgstr ""
 
-#: src/strings.ts:1324
+#: src/strings.ts:1325
 msgid "Are you sure you want to clear trash?"
 msgstr ""
 
-#: src/strings.ts:2666
+#: src/strings.ts:2667
 msgid "Are you sure you want to delete this attachment?"
 msgstr ""
 
-#: src/strings.ts:1542
+#: src/strings.ts:1543
 msgid "Are you sure you want to logout and clear all data stored on THIS DEVICE?"
 msgstr ""
 
@@ -948,31 +948,31 @@ msgstr ""
 msgid "Are you sure you want to logout from this device? Any unsynced changes will be lost."
 msgstr ""
 
-#: src/strings.ts:2687
+#: src/strings.ts:2688
 msgid "Are you sure you want to open this file: {filePath}?"
 msgstr ""
 
-#: src/strings.ts:1046
+#: src/strings.ts:1047
 msgid "Are you sure you want to remove your name?"
 msgstr ""
 
-#: src/strings.ts:1043
+#: src/strings.ts:1044
 msgid "Are you sure you want to remove your profile picture?"
 msgstr ""
 
-#: src/strings.ts:1323
+#: src/strings.ts:1324
 msgid "Are you sure?"
 msgstr ""
 
-#: src/strings.ts:1130
+#: src/strings.ts:1131
 msgid "Ask every time"
 msgstr ""
 
-#: src/strings.ts:2033
+#: src/strings.ts:2034
 msgid "Assign color"
 msgstr ""
 
-#: src/strings.ts:932
+#: src/strings.ts:933
 msgid "Assign to..."
 msgstr ""
 
@@ -980,15 +980,15 @@ msgstr ""
 msgid "Atleast 8 characters required"
 msgstr ""
 
-#: src/strings.ts:2357
+#: src/strings.ts:2358
 msgid "Attach image from URL"
 msgstr ""
 
-#: src/strings.ts:908
+#: src/strings.ts:909
 msgid "Attached files"
 msgstr ""
 
-#: src/strings.ts:2678
+#: src/strings.ts:2679
 msgid "Attaching files"
 msgstr ""
 
@@ -997,27 +997,27 @@ msgid "attachment"
 msgstr ""
 
 #: src/strings.ts:300
-#: src/strings.ts:2354
+#: src/strings.ts:2355
 msgid "Attachment"
 msgstr ""
 
-#: src/strings.ts:2667
+#: src/strings.ts:2668
 msgid "Attachment deleted"
 msgstr ""
 
-#: src/strings.ts:2458
+#: src/strings.ts:2459
 msgid "Attachment manager"
 msgstr ""
 
-#: src/strings.ts:1935
+#: src/strings.ts:1936
 msgid "Attachment preview failed"
 msgstr ""
 
-#: src/strings.ts:2408
+#: src/strings.ts:2409
 msgid "Attachment recheck cancelled"
 msgstr ""
 
-#: src/strings.ts:2325
+#: src/strings.ts:2326
 msgid "Attachment settings"
 msgstr ""
 
@@ -1026,15 +1026,15 @@ msgid "attachments"
 msgstr ""
 
 #: src/strings.ts:320
-#: src/strings.ts:907
+#: src/strings.ts:908
 msgid "Attachments"
 msgstr ""
 
-#: src/strings.ts:1884
+#: src/strings.ts:1885
 msgid "Attachments cache cleared!"
 msgstr ""
 
-#: src/strings.ts:2410
+#: src/strings.ts:2411
 msgid "Attachments recheck complete"
 msgstr ""
 
@@ -1042,160 +1042,160 @@ msgstr ""
 msgid "Audios"
 msgstr ""
 
-#: src/strings.ts:1626
+#: src/strings.ts:1627
 msgid "Auth server"
 msgstr ""
 
-#: src/strings.ts:1795
+#: src/strings.ts:1796
 msgid "Authenticated as {email}"
 msgstr ""
 
-#: src/strings.ts:1898
+#: src/strings.ts:1899
 msgid "Authenticating user"
 msgstr ""
 
-#: src/strings.ts:2144
+#: src/strings.ts:2145
 msgid "Authentication"
 msgstr ""
 
-#: src/strings.ts:1730
+#: src/strings.ts:1731
 msgid "authentication app"
 msgstr ""
 
-#: src/strings.ts:1351
+#: src/strings.ts:1352
 msgid "Authentication cancelled by user"
 msgstr ""
 
-#: src/strings.ts:1352
+#: src/strings.ts:1353
 msgid "Authentication failed"
 msgstr ""
 
-#: src/strings.ts:2107
+#: src/strings.ts:2108
 msgid "Auto"
 msgstr ""
 
-#: src/strings.ts:1661
+#: src/strings.ts:1662
 msgid "Auto save: off"
 msgstr ""
 
-#: src/strings.ts:2121
+#: src/strings.ts:2122
 msgid "Auto start on system startup"
 msgstr ""
 
-#: src/strings.ts:1218
-#: src/strings.ts:1689
+#: src/strings.ts:1219
+#: src/strings.ts:1690
 msgid "Automatic backups"
 msgstr ""
 
-#: src/strings.ts:1365
+#: src/strings.ts:1366
 msgid "Automatic backups are off"
 msgstr ""
 
-#: src/strings.ts:2005
+#: src/strings.ts:2006
 msgid "Automatic backups disabled"
 msgstr ""
 
-#: src/strings.ts:1221
+#: src/strings.ts:1222
 msgid "Automatic backups with attachments"
 msgstr ""
 
-#: src/strings.ts:2117
+#: src/strings.ts:2118
 msgid "Automatic updates"
 msgstr ""
 
-#: src/strings.ts:1138
+#: src/strings.ts:1139
 msgid "Automatically clear trash after a certain period of time"
 msgstr ""
 
-#: src/strings.ts:2119
+#: src/strings.ts:2120
 msgid "Automatically download & install updates in the background without prompting first."
 msgstr ""
 
-#: src/strings.ts:1191
+#: src/strings.ts:1192
 msgid "Automatically lock the app after a certain period"
 msgstr ""
 
-#: src/strings.ts:1121
+#: src/strings.ts:1122
 msgid "Automatically switch between light and dark themes based on your system settings"
 msgstr ""
 
-#: src/strings.ts:2164
+#: src/strings.ts:2165
 msgid "Available on iOS"
 msgstr ""
 
-#: src/strings.ts:2165
+#: src/strings.ts:2166
 msgid "Available on iOS & Android"
 msgstr ""
 
-#: src/strings.ts:2654
+#: src/strings.ts:2655
 msgid "Back"
 msgstr ""
 
-#: src/strings.ts:2313
+#: src/strings.ts:2314
 msgid "Background color"
 msgstr ""
 
-#: src/strings.ts:1093
+#: src/strings.ts:1094
 msgid "Background sync (experimental)"
 msgstr ""
 
-#: src/strings.ts:2113
+#: src/strings.ts:2114
 msgid "Backup"
 msgstr ""
 
-#: src/strings.ts:2151
+#: src/strings.ts:2152
 msgid "Backup & export"
 msgstr ""
 
-#: src/strings.ts:1210
+#: src/strings.ts:1211
 msgid "Backup & restore"
 msgstr ""
 
-#: src/strings.ts:1335
+#: src/strings.ts:1336
 msgid "Backup complete"
 msgstr ""
 
-#: src/strings.ts:1561
+#: src/strings.ts:1562
 msgid "Backup directory not selected"
 msgstr ""
 
-#: src/strings.ts:1233
+#: src/strings.ts:1234
 msgid "Backup encryption"
 msgstr ""
 
-#: src/strings.ts:1858
+#: src/strings.ts:1859
 msgid "Backup files have .nnbackup extension"
 msgstr ""
 
-#: src/strings.ts:882
+#: src/strings.ts:883
 msgid "Backup is encrypted"
 msgstr ""
 
-#: src/strings.ts:1614
+#: src/strings.ts:1615
 msgid "Backup is encrypted, decrypting..."
 msgstr ""
 
-#: src/strings.ts:1212
+#: src/strings.ts:1213
 msgid "Backup now"
 msgstr ""
 
-#: src/strings.ts:1213
+#: src/strings.ts:1214
 msgid "Backup now with attachments"
 msgstr ""
 
-#: src/strings.ts:889
+#: src/strings.ts:890
 msgid "Backup restored"
 msgstr ""
 
-#: src/strings.ts:1919
+#: src/strings.ts:1920
 msgid "Backup saved at {path}"
 msgstr ""
 
-#: src/strings.ts:1347
+#: src/strings.ts:1348
 msgid "Backup successful"
 msgstr ""
 
-#: src/strings.ts:2114
+#: src/strings.ts:2115
 msgid "Backup with attachments"
 msgstr ""
 
@@ -1207,47 +1207,47 @@ msgstr ""
 msgid "Basic"
 msgstr ""
 
-#: src/strings.ts:1793
+#: src/strings.ts:1794
 msgid "Because where's the fun in nookin' alone?"
 msgstr ""
 
-#: src/strings.ts:1124
+#: src/strings.ts:1125
 msgid "Behavior"
 msgstr ""
 
-#: src/strings.ts:2146
+#: src/strings.ts:2147
 msgid "Behaviour"
 msgstr ""
 
-#: src/strings.ts:2482
+#: src/strings.ts:2483
 msgid "Believer plan"
 msgstr ""
 
-#: src/strings.ts:2592
+#: src/strings.ts:2593
 msgid "Best value"
 msgstr ""
 
-#: src/strings.ts:2471
+#: src/strings.ts:2472
 msgid "Beta"
 msgstr ""
 
-#: src/strings.ts:2271
+#: src/strings.ts:2272
 msgid "Bi-directional note link"
 msgstr ""
 
-#: src/strings.ts:2565
+#: src/strings.ts:2566
 msgid "billed annually at {price}"
 msgstr ""
 
-#: src/strings.ts:2566
+#: src/strings.ts:2567
 msgid "billed monthly at {price}"
 msgstr ""
 
-#: src/strings.ts:2212
+#: src/strings.ts:2213
 msgid "Billing history"
 msgstr ""
 
-#: src/strings.ts:1177
+#: src/strings.ts:1178
 msgid "Biometric unlocking"
 msgstr ""
 
@@ -1259,27 +1259,27 @@ msgstr ""
 msgid "Biometric unlocking enabled"
 msgstr ""
 
-#: src/strings.ts:1349
+#: src/strings.ts:1350
 msgid "Biometrics authentication failed. Please try again."
 msgstr ""
 
-#: src/strings.ts:1186
+#: src/strings.ts:1187
 msgid "Biometrics not enrolled"
 msgstr ""
 
-#: src/strings.ts:2267
+#: src/strings.ts:2268
 msgid "Bold"
 msgstr ""
 
-#: src/strings.ts:2420
+#: src/strings.ts:2421
 msgid "Boost your productivity with Notebooks and organize your notes."
 msgstr ""
 
-#: src/strings.ts:1809
+#: src/strings.ts:1810
 msgid "Browse"
 msgstr ""
 
-#: src/strings.ts:2284
+#: src/strings.ts:2285
 msgid "Bullet list"
 msgstr ""
 
@@ -1287,7 +1287,7 @@ msgstr ""
 msgid "By"
 msgstr ""
 
-#: src/strings.ts:2587
+#: src/strings.ts:2588
 msgid "By joining you agree to our"
 msgstr ""
 
@@ -1295,11 +1295,11 @@ msgstr ""
 msgid "By signing up, you agree to our "
 msgstr ""
 
-#: src/strings.ts:2345
+#: src/strings.ts:2346
 msgid "Callout"
 msgstr ""
 
-#: src/strings.ts:2525
+#: src/strings.ts:2526
 msgid "Can I cancel my free trial anytime?"
 msgstr ""
 
@@ -1307,11 +1307,11 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/strings.ts:2585
+#: src/strings.ts:2586
 msgid "Cancel anytime, subscription auto-renews."
 msgstr ""
 
-#: src/strings.ts:2547
+#: src/strings.ts:2548
 msgid "Cancel anytime."
 msgstr ""
 
@@ -1323,7 +1323,7 @@ msgstr ""
 msgid "Cancel login"
 msgstr ""
 
-#: src/strings.ts:1826
+#: src/strings.ts:1827
 msgid "Cancel subscription"
 msgstr ""
 
@@ -1331,24 +1331,24 @@ msgstr ""
 msgid "Cancel upload"
 msgstr ""
 
-#: src/strings.ts:2312
+#: src/strings.ts:2313
 msgid "Cell background color"
 msgstr ""
 
-#: src/strings.ts:2314
+#: src/strings.ts:2315
 msgid "Cell border color"
 msgstr ""
 
-#: src/strings.ts:2316
 #: src/strings.ts:2317
+#: src/strings.ts:2318
 msgid "Cell border width"
 msgstr ""
 
-#: src/strings.ts:2298
+#: src/strings.ts:2299
 msgid "Cell properties"
 msgstr ""
 
-#: src/strings.ts:2315
+#: src/strings.ts:2316
 msgid "Cell text color"
 msgstr ""
 
@@ -1356,7 +1356,7 @@ msgstr ""
 msgid "Change"
 msgstr ""
 
-#: src/strings.ts:1059
+#: src/strings.ts:1060
 msgid "Change 2FA fallback method"
 msgstr ""
 
@@ -1364,15 +1364,15 @@ msgstr ""
 msgid "Change 2FA method"
 msgstr ""
 
-#: src/strings.ts:1198
+#: src/strings.ts:1199
 msgid "Change app lock password"
 msgstr ""
 
-#: src/strings.ts:1197
+#: src/strings.ts:1198
 msgid "Change app lock pin"
 msgstr ""
 
-#: src/strings.ts:1232
+#: src/strings.ts:1233
 msgid "Change backup directory"
 msgstr ""
 
@@ -1380,15 +1380,15 @@ msgstr ""
 msgid "Change email address"
 msgstr ""
 
-#: src/strings.ts:1125
+#: src/strings.ts:1126
 msgid "Change how the app behaves in different situations"
 msgstr ""
 
-#: src/strings.ts:2363
+#: src/strings.ts:2364
 msgid "Change language"
 msgstr ""
 
-#: src/strings.ts:1253
+#: src/strings.ts:1254
 msgid "Change notification sound"
 msgstr ""
 
@@ -1396,23 +1396,23 @@ msgstr ""
 msgid "Change password"
 msgstr ""
 
-#: src/strings.ts:2599
+#: src/strings.ts:2600
 msgid "Change plan"
 msgstr ""
 
-#: src/strings.ts:1818
+#: src/strings.ts:1819
 msgid "Change profile picture"
 msgstr ""
 
-#: src/strings.ts:2190
+#: src/strings.ts:2191
 msgid "Change proxy"
 msgstr ""
 
-#: src/strings.ts:2211
+#: src/strings.ts:2212
 msgid "Change the payment method you used to purchase this subscription."
 msgstr ""
 
-#: src/strings.ts:1255
+#: src/strings.ts:1256
 msgid "Change the sound that plays when you receive a notification"
 msgstr ""
 
@@ -1420,15 +1420,15 @@ msgstr ""
 msgid "Change vault password"
 msgstr ""
 
-#: src/strings.ts:1053
+#: src/strings.ts:1054
 msgid "Change your account password"
 msgstr ""
 
-#: src/strings.ts:1055
+#: src/strings.ts:1056
 msgid "Change your primary two-factor authentication method"
 msgstr ""
 
-#: src/strings.ts:1089
+#: src/strings.ts:1090
 msgid "Changes from other devices won't be updated in the editor in real-time."
 msgstr ""
 
@@ -1436,27 +1436,27 @@ msgstr ""
 msgid "Changing password is an irreversible process. You will be logged out from all your devices. Please make sure you do not close the app while your password is changing and have good internet connection."
 msgstr ""
 
-#: src/strings.ts:2501
+#: src/strings.ts:2502
 msgid "Characters"
 msgstr ""
 
-#: src/strings.ts:1296
+#: src/strings.ts:1297
 msgid "Check for new version of Notesnook"
 msgstr ""
 
-#: src/strings.ts:1299
+#: src/strings.ts:1300
 msgid "Check for new version of the app available on app launch"
 msgstr ""
 
-#: src/strings.ts:1295
+#: src/strings.ts:1296
 msgid "Check for updates"
 msgstr ""
 
-#: src/strings.ts:1297
+#: src/strings.ts:1298
 msgid "Check for updates automatically"
 msgstr ""
 
-#: src/strings.ts:2163
+#: src/strings.ts:2164
 msgid "Check roadmap"
 msgstr ""
 
@@ -1464,7 +1464,7 @@ msgstr ""
 msgid "Check your spam folder if you haven't received an email yet."
 msgstr ""
 
-#: src/strings.ts:2412
+#: src/strings.ts:2413
 msgid "Checking all attachments"
 msgstr ""
 
@@ -1472,51 +1472,51 @@ msgstr ""
 msgid "Checking for new version"
 msgstr ""
 
-#: src/strings.ts:1705
+#: src/strings.ts:1706
 msgid "Checking for updates"
 msgstr ""
 
-#: src/strings.ts:2411
+#: src/strings.ts:2412
 msgid "Checking note attachments"
 msgstr ""
 
-#: src/strings.ts:2286
+#: src/strings.ts:2287
 msgid "Checklist"
 msgstr ""
 
-#: src/strings.ts:2340
+#: src/strings.ts:2341
 msgid "Choose a block to insert"
 msgstr ""
 
-#: src/strings.ts:1797
+#: src/strings.ts:1798
 msgid "Choose a recovery method"
 msgstr ""
 
-#: src/strings.ts:2112
+#: src/strings.ts:2113
 msgid "Choose backup format"
 msgstr ""
 
-#: src/strings.ts:2376
+#: src/strings.ts:2377
 msgid "Choose custom color"
 msgstr ""
 
-#: src/strings.ts:1118
+#: src/strings.ts:1119
 msgid "Choose from pre-built themes or create your own"
 msgstr ""
 
-#: src/strings.ts:1133
+#: src/strings.ts:1134
 msgid "Choose how dates are displayed in the app"
 msgstr ""
 
-#: src/strings.ts:2634
+#: src/strings.ts:2635
 msgid "Choose how day is displayed in the app"
 msgstr ""
 
-#: src/strings.ts:1158
+#: src/strings.ts:1159
 msgid "Choose how the new note titles are formatted"
 msgstr ""
 
-#: src/strings.ts:1135
+#: src/strings.ts:1136
 msgid "Choose how time is displayed in the app"
 msgstr ""
 
@@ -1524,67 +1524,67 @@ msgstr ""
 msgid "Choose how you want to secure your notes locally."
 msgstr ""
 
-#: src/strings.ts:2639
+#: src/strings.ts:2640
 msgid "Choose what day to display as the first day of the week"
 msgstr ""
 
-#: src/strings.ts:1228
+#: src/strings.ts:1229
 msgid "Choose where to save your backups"
 msgstr ""
 
-#: src/strings.ts:2072
+#: src/strings.ts:2073
 msgid "Choose your style"
 msgstr ""
 
-#: src/strings.ts:1617
+#: src/strings.ts:1618
 msgid "cleaningUp"
 msgstr ""
 
-#: src/strings.ts:1014
+#: src/strings.ts:1015
 msgid "Clear"
 msgstr ""
 
-#: src/strings.ts:1870
+#: src/strings.ts:1871
 msgid "Clear all cached attachments. Current cache size: {cacheSize}"
 msgstr ""
 
-#: src/strings.ts:2280
+#: src/strings.ts:2281
 msgid "Clear all formatting"
 msgstr ""
 
-#: src/strings.ts:1871
+#: src/strings.ts:1872
 msgid "Clear attachments cache?"
 msgstr ""
 
-#: src/strings.ts:1868
+#: src/strings.ts:1869
 msgid "Clear cache"
 msgstr ""
 
-#: src/strings.ts:2374
+#: src/strings.ts:2375
 msgid "Clear completed tasks"
 msgstr ""
 
-#: src/strings.ts:1805
+#: src/strings.ts:1806
 msgid "Clear data & reset account"
 msgstr ""
 
-#: src/strings.ts:1139
+#: src/strings.ts:1140
 msgid "Clear default notebook"
 msgstr ""
 
-#: src/strings.ts:1013
+#: src/strings.ts:1014
 msgid "Clear logs"
 msgstr ""
 
-#: src/strings.ts:2206
+#: src/strings.ts:2207
 msgid "clear sessions"
 msgstr ""
 
-#: src/strings.ts:1322
+#: src/strings.ts:1323
 msgid "Clear trash"
 msgstr ""
 
-#: src/strings.ts:1136
+#: src/strings.ts:1137
 msgid "Clear trash interval"
 msgstr ""
 
@@ -1592,7 +1592,7 @@ msgstr ""
 msgid "Clear vault"
 msgstr ""
 
-#: src/strings.ts:1873
+#: src/strings.ts:1874
 msgid ""
 "Clearing attachments cache will perform the following actions:\n"
 "\n"
@@ -1607,11 +1607,11 @@ msgid ""
 "**Only use this for troubleshooting purposes. If you are having persistent issues, it is recommended that you reach out to us via support@streetwriters.co so we can help you resolve it permanently.**"
 msgstr ""
 
-#: src/strings.ts:2239
+#: src/strings.ts:2240
 msgid "Clearing trash will permanently delete all the items in your trash. This action is IRREVERSIBLE."
 msgstr ""
 
-#: src/strings.ts:2621
+#: src/strings.ts:2622
 msgid "Click here to directly claim the promotion."
 msgstr ""
 
@@ -1619,75 +1619,75 @@ msgstr ""
 msgid "Click to deselect"
 msgstr ""
 
-#: src/strings.ts:1867
+#: src/strings.ts:1868
 msgid "Click to preview"
 msgstr ""
 
-#: src/strings.ts:1772
+#: src/strings.ts:1773
 msgid "Click to remove"
 msgstr ""
 
-#: src/strings.ts:2403
+#: src/strings.ts:2404
 msgid "Click to reset {title}"
 msgstr ""
 
-#: src/strings.ts:2629
+#: src/strings.ts:2630
 msgid "Click to save"
 msgstr ""
 
-#: src/strings.ts:2625
+#: src/strings.ts:2626
 msgid "Click to update"
 msgstr ""
 
-#: src/strings.ts:1381
+#: src/strings.ts:1382
 msgid "Close"
 msgstr ""
 
-#: src/strings.ts:2679
+#: src/strings.ts:2680
 msgid "Close ({seconds})"
 msgstr ""
 
-#: src/strings.ts:2019
+#: src/strings.ts:2020
 msgid "Close all"
 msgstr ""
 
-#: src/strings.ts:2461
+#: src/strings.ts:2462
 msgid "Close all tabs"
 msgstr ""
 
-#: src/strings.ts:2460
+#: src/strings.ts:2461
 msgid "Close current tab"
 msgstr ""
 
-#: src/strings.ts:2016
+#: src/strings.ts:2017
 msgid "Close others"
 msgstr ""
 
-#: src/strings.ts:2130
+#: src/strings.ts:2131
 msgid "Close to system tray"
 msgstr ""
 
-#: src/strings.ts:2018
+#: src/strings.ts:2019
 msgid "Close to the left"
 msgstr ""
 
-#: src/strings.ts:2017
+#: src/strings.ts:2018
 msgid "Close to the right"
 msgstr ""
 
-#: src/strings.ts:2539
+#: src/strings.ts:2540
 msgid "cloud storage space for storing images and files."
 msgstr ""
 
-#: src/strings.ts:2278
+#: src/strings.ts:2279
 msgid "Code"
 msgstr ""
 
-#: src/strings.ts:2342
+#: src/strings.ts:2343
 msgid "Code block"
 msgstr ""
 
-#: src/strings.ts:2279
+#: src/strings.ts:2280
 msgid "Code remove"
 msgstr ""
 
@@ -1700,7 +1700,7 @@ msgid "color"
 msgstr ""
 
 #: src/strings.ts:299
-#: src/strings.ts:1844
+#: src/strings.ts:1845
 msgid "Color"
 msgstr ""
 
@@ -1708,11 +1708,11 @@ msgstr ""
 msgid "Color #{color} already exists"
 msgstr ""
 
-#: src/strings.ts:2105
+#: src/strings.ts:2106
 msgid "Color scheme"
 msgstr ""
 
-#: src/strings.ts:1489
+#: src/strings.ts:1490
 msgid "Color title"
 msgstr ""
 
@@ -1724,19 +1724,19 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
-#: src/strings.ts:2296
+#: src/strings.ts:2297
 msgid "Column properties"
 msgstr ""
 
-#: src/strings.ts:2452
+#: src/strings.ts:2453
 msgid "Command palette"
 msgstr ""
 
-#: src/strings.ts:1271
+#: src/strings.ts:1272
 msgid "Community"
 msgstr ""
 
-#: src/strings.ts:2559
+#: src/strings.ts:2560
 msgid "Compare plans"
 msgstr ""
 
@@ -1748,7 +1748,7 @@ msgstr ""
 msgid "Compress"
 msgstr ""
 
-#: src/strings.ts:1129
+#: src/strings.ts:1130
 msgid "Compress images before uploading"
 msgstr ""
 
@@ -1756,19 +1756,19 @@ msgstr ""
 msgid "Compressed images are uploaded in Full HD resolution and usually are good enough for most use cases."
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2680
+#: src/strings.ts:2681
 msgid "Compressing"
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2684
+#: src/strings.ts:2685
 msgid "Compression failed"
 msgstr ""
 
-#: src/strings.ts:2262
+#: src/strings.ts:2263
 msgid "Configure"
 msgstr ""
 
-#: src/strings.ts:2417
+#: src/strings.ts:2418
 msgid "Configure server URLs for Notesnook"
 msgstr ""
 
@@ -1776,43 +1776,43 @@ msgstr ""
 msgid "Confirm email"
 msgstr ""
 
-#: src/strings.ts:903
+#: src/strings.ts:904
 msgid "Confirm email to publish note"
 msgstr ""
 
-#: src/strings.ts:1488
+#: src/strings.ts:1489
 msgid "Confirm new password"
 msgstr ""
 
-#: src/strings.ts:1483
+#: src/strings.ts:1484
 msgid "Confirm password"
 msgstr ""
 
-#: src/strings.ts:2661
+#: src/strings.ts:2662
 msgid "Confirm password required"
 msgstr ""
 
-#: src/strings.ts:1487
+#: src/strings.ts:1488
 msgid "Confirm pin"
 msgstr ""
 
-#: src/strings.ts:2653
+#: src/strings.ts:2654
 msgid "Confirmation email sent"
 msgstr ""
 
-#: src/strings.ts:2090
+#: src/strings.ts:2091
 msgid "Congratulations!"
 msgstr ""
 
-#: src/strings.ts:1636
+#: src/strings.ts:1637
 msgid "Connected to all servers sucessfully."
 msgstr ""
 
-#: src/strings.ts:1671
+#: src/strings.ts:1672
 msgid "Contact support"
 msgstr ""
 
-#: src/strings.ts:1262
+#: src/strings.ts:1263
 msgid "Contact us directly via support@streetwriters.co for any help or support"
 msgstr ""
 
@@ -1820,15 +1820,15 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: src/strings.ts:1164
+#: src/strings.ts:1165
 msgid "Contribute towards a better Notesnook. All tracking information is anonymous."
 msgstr ""
 
-#: src/strings.ts:1248
+#: src/strings.ts:1249
 msgid "Controls whether this device should receive reminder notifications."
 msgstr ""
 
-#: src/strings.ts:1990
+#: src/strings.ts:1991
 msgid "Copied"
 msgstr ""
 
@@ -1837,7 +1837,7 @@ msgid "Copy"
 msgstr ""
 
 #. placeholder {0}: format ? " " + format : ""
-#: src/strings.ts:2036
+#: src/strings.ts:2037
 msgid "Copy as{0}"
 msgstr ""
 
@@ -1845,15 +1845,15 @@ msgstr ""
 msgid "Copy codes"
 msgstr ""
 
-#: src/strings.ts:2258
+#: src/strings.ts:2259
 msgid "Copy image"
 msgstr ""
 
-#: src/strings.ts:910
+#: src/strings.ts:911
 msgid "Copy link"
 msgstr ""
 
-#: src/strings.ts:2257
+#: src/strings.ts:2258
 msgid "Copy link text"
 msgstr ""
 
@@ -1865,27 +1865,27 @@ msgstr ""
 msgid "Copy to clipboard"
 msgstr ""
 
-#: src/strings.ts:1619
+#: src/strings.ts:1620
 msgid "Copying backup files to cache"
 msgstr ""
 
-#: src/strings.ts:1168
+#: src/strings.ts:1169
 msgid "CORS bypass"
 msgstr ""
 
-#: src/strings.ts:1986
+#: src/strings.ts:1987
 msgid "Could not activate trial. Please try again later."
 msgstr ""
 
-#: src/strings.ts:2004
+#: src/strings.ts:2005
 msgid "Could not clear trash."
 msgstr ""
 
-#: src/strings.ts:1639
+#: src/strings.ts:1640
 msgid "Could not connect to {server}."
 msgstr ""
 
-#: src/strings.ts:1951
+#: src/strings.ts:1952
 msgid "Could not convert note to {format}."
 msgstr ""
 
@@ -1905,11 +1905,11 @@ msgstr ""
 msgid "Create a group"
 msgstr ""
 
-#: src/strings.ts:938
+#: src/strings.ts:939
 msgid "Create a new note"
 msgstr ""
 
-#: src/strings.ts:951
+#: src/strings.ts:952
 msgid "Create a note first"
 msgstr ""
 
@@ -1921,7 +1921,7 @@ msgstr ""
 msgid "Create a tag to group related notes together."
 msgstr ""
 
-#: src/strings.ts:1849
+#: src/strings.ts:1850
 msgid "Create account"
 msgstr ""
 
@@ -1929,19 +1929,19 @@ msgstr ""
 msgid "Create link"
 msgstr ""
 
-#: src/strings.ts:1473
+#: src/strings.ts:1474
 msgid "Create shortcut of this notebook in side menu"
 msgstr ""
 
-#: src/strings.ts:1387
+#: src/strings.ts:1388
 msgid "Create unlimited notebooks with Notesnook Pro"
 msgstr ""
 
-#: src/strings.ts:1386
+#: src/strings.ts:1387
 msgid "Create unlimited tags with Notesnook Pro"
 msgstr ""
 
-#: src/strings.ts:1388
+#: src/strings.ts:1389
 msgid "Create unlimited vaults with Notesnook Pro"
 msgstr ""
 
@@ -1953,12 +1953,12 @@ msgstr ""
 msgid "Create your account"
 msgstr ""
 
-#: src/strings.ts:2240
+#: src/strings.ts:2241
 msgid "Created at"
 msgstr ""
 
 #. placeholder {0}: type === "full" ? " full" : ""
-#: src/strings.ts:1344
+#: src/strings.ts:1345
 msgid "Creating a{0} backup"
 msgstr ""
 
@@ -1967,10 +1967,11 @@ msgid "Creation date cannot be after last edited date"
 msgstr ""
 
 #: src/strings.ts:2049
+#: src/strings.ts:2050
 msgid "Credentials"
 msgstr ""
 
-#: src/strings.ts:2075
+#: src/strings.ts:2076
 msgid "Cross platform & 100% encrypted"
 msgstr ""
 
@@ -1978,65 +1979,65 @@ msgstr ""
 msgid "Curate the toolbar that fits your needs and matches your personality."
 msgstr ""
 
-#: src/strings.ts:1836
+#: src/strings.ts:1837
 msgid "Current note"
 msgstr ""
 
-#: src/strings.ts:1479
-#: src/strings.ts:1485
+#: src/strings.ts:1480
+#: src/strings.ts:1486
 msgid "Current password"
 msgstr ""
 
-#: src/strings.ts:2670
+#: src/strings.ts:2671
 msgid "Current password required"
 msgstr ""
 
-#: src/strings.ts:1229
+#: src/strings.ts:1230
 msgid "Current path: {path}"
 msgstr ""
 
-#: src/strings.ts:1484
+#: src/strings.ts:1485
 msgid "Current pin"
 msgstr ""
 
-#: src/strings.ts:1773
+#: src/strings.ts:1774
 msgid "CURRENT PLAN"
 msgstr ""
 
-#: src/strings.ts:2010
+#: src/strings.ts:2011
 msgid "Custom"
 msgstr ""
 
-#: src/strings.ts:2141
+#: src/strings.ts:2142
 msgid "Custom dictionary words"
 msgstr ""
 
-#: src/strings.ts:1113
+#: src/strings.ts:1114
 msgid "Customization"
 msgstr ""
 
-#: src/strings.ts:1116
+#: src/strings.ts:1117
 msgid "Customize the appearance of the app with custom themes"
 msgstr ""
 
-#: src/strings.ts:1143
+#: src/strings.ts:1144
 msgid "Customize the note editor"
 msgstr ""
 
-#: src/strings.ts:1145
+#: src/strings.ts:1146
 msgid "Customize the toolbar in the note editor"
 msgstr ""
 
-#: src/strings.ts:1144
+#: src/strings.ts:1145
 msgid "Customize toolbar"
 msgstr ""
 
-#: src/strings.ts:2256
+#: src/strings.ts:2257
 msgid "Cut"
 msgstr ""
 
 #: src/strings.ts:167
-#: src/strings.ts:1568
+#: src/strings.ts:1569
 msgid "Daily"
 msgstr ""
 
@@ -2044,23 +2045,23 @@ msgstr ""
 msgid "Dark"
 msgstr ""
 
-#: src/strings.ts:1122
+#: src/strings.ts:1123
 msgid "Dark mode"
 msgstr ""
 
-#: src/strings.ts:2106
+#: src/strings.ts:2107
 msgid "Dark or light, we won't judge."
 msgstr ""
 
-#: src/strings.ts:1547
+#: src/strings.ts:1548
 msgid "Database setup failed, could not get database key"
 msgstr ""
 
-#: src/strings.ts:1839
+#: src/strings.ts:1840
 msgid "Date"
 msgstr ""
 
-#: src/strings.ts:2115
+#: src/strings.ts:2116
 msgid "Date & time"
 msgstr ""
 
@@ -2076,7 +2077,7 @@ msgstr ""
 msgid "Date edited"
 msgstr ""
 
-#: src/strings.ts:1132
+#: src/strings.ts:1133
 msgid "Date format"
 msgstr ""
 
@@ -2084,80 +2085,80 @@ msgstr ""
 msgid "Date modified"
 msgstr ""
 
-#: src/strings.ts:2042
+#: src/strings.ts:2043
 msgid "Date uploaded"
 msgstr ""
 
-#: src/strings.ts:1841
+#: src/strings.ts:1842
 msgid "Day"
 msgstr ""
 
-#: src/strings.ts:2633
+#: src/strings.ts:2634
 msgid "Day format"
 msgstr ""
 
-#: src/strings.ts:2038
+#: src/strings.ts:2039
 msgid "Deactivate"
 msgstr ""
 
-#: src/strings.ts:1011
+#: src/strings.ts:1012
 msgid "Debug log copied!"
 msgstr ""
 
-#: src/strings.ts:1269
+#: src/strings.ts:1270
 msgid "Debug logs"
 msgstr ""
 
-#: src/strings.ts:1012
+#: src/strings.ts:1013
 msgid "Debug logs downloaded"
 msgstr ""
 
-#: src/strings.ts:1266
+#: src/strings.ts:1267
 msgid "Debugging"
 msgstr ""
 
-#: src/strings.ts:2405
+#: src/strings.ts:2406
 msgid "Decrease {title}"
 msgstr ""
 
 #: src/strings.ts:660
-#: src/strings.ts:2008
+#: src/strings.ts:2009
 msgid "Default"
 msgstr ""
 
-#: src/strings.ts:1155
+#: src/strings.ts:1156
 msgid "Default font family"
 msgstr ""
 
-#: src/strings.ts:1156
+#: src/strings.ts:1157
 msgid "Default font family in editor"
 msgstr ""
 
-#: src/strings.ts:1153
+#: src/strings.ts:1154
 msgid "Default font size"
 msgstr ""
 
-#: src/strings.ts:1154
+#: src/strings.ts:1155
 msgid "Default font size in editor"
 msgstr ""
 
-#: src/strings.ts:1141
+#: src/strings.ts:1142
 msgid "Default notebook cleared"
 msgstr ""
 
-#: src/strings.ts:1127
+#: src/strings.ts:1128
 msgid "Default screen to open on app launch"
 msgstr ""
 
-#: src/strings.ts:2492
+#: src/strings.ts:2493
 msgid "Default sidebar tab"
 msgstr ""
 
-#: src/strings.ts:1249
+#: src/strings.ts:1250
 msgid "Default snooze time"
 msgstr ""
 
-#: src/strings.ts:1301
+#: src/strings.ts:1302
 msgid "Default sound"
 msgstr ""
 
@@ -2165,31 +2166,31 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: src/strings.ts:1076
+#: src/strings.ts:1077
 msgid "Delete account"
 msgstr ""
 
-#: src/strings.ts:2664
+#: src/strings.ts:2665
 msgid "Delete attachment"
 msgstr ""
 
-#: src/strings.ts:1319
+#: src/strings.ts:1320
 msgid "Delete collapsed section"
 msgstr ""
 
-#: src/strings.ts:2303
+#: src/strings.ts:2304
 msgid "Delete column"
 msgstr ""
 
-#: src/strings.ts:2650
+#: src/strings.ts:2651
 msgid "Delete data"
 msgstr ""
 
-#: src/strings.ts:1314
+#: src/strings.ts:1315
 msgid "Delete group"
 msgstr ""
 
-#: src/strings.ts:2377
+#: src/strings.ts:2378
 msgid "Delete mode"
 msgstr ""
 
@@ -2201,11 +2202,11 @@ msgstr ""
 msgid "Delete permanently"
 msgstr ""
 
-#: src/strings.ts:2310
+#: src/strings.ts:2311
 msgid "Delete row"
 msgstr ""
 
-#: src/strings.ts:2311
+#: src/strings.ts:2312
 msgid "Delete table"
 msgstr ""
 
@@ -2213,7 +2214,7 @@ msgstr ""
 msgid "Delete vault"
 msgstr ""
 
-#: src/strings.ts:1176
+#: src/strings.ts:1177
 msgid "Delete vault (and optionally remove all notes)."
 msgstr ""
 
@@ -2221,43 +2222,43 @@ msgstr ""
 msgid "Deleted on {date}"
 msgstr ""
 
-#: src/strings.ts:1928
+#: src/strings.ts:1929
 msgid "Deleting"
 msgstr ""
 
-#: src/strings.ts:1838
+#: src/strings.ts:1839
 msgid "Description"
 msgstr ""
 
-#: src/strings.ts:2116
+#: src/strings.ts:2117
 msgid "Desktop app"
 msgstr ""
 
-#: src/strings.ts:2120
+#: src/strings.ts:2121
 msgid "Desktop integration"
 msgstr ""
 
-#: src/strings.ts:871
+#: src/strings.ts:872
 msgid "Did you save recovery key?"
 msgstr ""
 
-#: src/strings.ts:1376
+#: src/strings.ts:1377
 msgid "Disable"
 msgstr ""
 
-#: src/strings.ts:1084
+#: src/strings.ts:1085
 msgid "Disable auto sync"
 msgstr ""
 
-#: src/strings.ts:2011
+#: src/strings.ts:2012
 msgid "Disable editor margins"
 msgstr ""
 
-#: src/strings.ts:1087
+#: src/strings.ts:1088
 msgid "Disable realtime sync"
 msgstr ""
 
-#: src/strings.ts:1090
+#: src/strings.ts:1091
 msgid "Disable sync"
 msgstr ""
 
@@ -2269,11 +2270,11 @@ msgstr ""
 msgid "Discard"
 msgstr ""
 
-#: src/strings.ts:1597
+#: src/strings.ts:1598
 msgid "Dismiss"
 msgstr ""
 
-#: src/strings.ts:1650
+#: src/strings.ts:1651
 msgid "Dismiss announcement"
 msgstr ""
 
@@ -2285,7 +2286,7 @@ msgstr ""
 msgid "Do you enjoy using Notesnook?"
 msgstr ""
 
-#: src/strings.ts:1263
+#: src/strings.ts:1264
 msgid "Documentation"
 msgstr ""
 
@@ -2293,15 +2294,15 @@ msgstr ""
 msgid "Documents"
 msgstr ""
 
-#: src/strings.ts:984
+#: src/strings.ts:985
 msgid "Don't have access to your authenticator app?"
 msgstr ""
 
-#: src/strings.ts:991
+#: src/strings.ts:992
 msgid "Don't have access to your email address?"
 msgstr ""
 
-#: src/strings.ts:1000
+#: src/strings.ts:1001
 msgid "Don't have access to your phone number?"
 msgstr ""
 
@@ -2309,23 +2310,23 @@ msgstr ""
 msgid "Don't have an account?"
 msgstr ""
 
-#: src/strings.ts:1832
+#: src/strings.ts:1833
 msgid "Don't have backup file?"
 msgstr ""
 
-#: src/strings.ts:1831
+#: src/strings.ts:1832
 msgid "Don't have your account recovery key?"
 msgstr ""
 
-#: src/strings.ts:1003
+#: src/strings.ts:1004
 msgid "Don't have your recovery codes?"
 msgstr ""
 
-#: src/strings.ts:1810
+#: src/strings.ts:1811
 msgid "Don't show again"
 msgstr ""
 
-#: src/strings.ts:1811
+#: src/strings.ts:1812
 msgid "Don't show again on this device?"
 msgstr ""
 
@@ -2333,7 +2334,7 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: src/strings.ts:1149
+#: src/strings.ts:1150
 msgid "Double spaced lines"
 msgstr ""
 
@@ -2341,15 +2342,15 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: src/strings.ts:1816
+#: src/strings.ts:1817
 msgid "Download all attachments"
 msgstr ""
 
-#: src/strings.ts:2326
+#: src/strings.ts:2327
 msgid "Download attachment"
 msgstr ""
 
-#: src/strings.ts:1860
+#: src/strings.ts:1861
 msgid "Download backup file"
 msgstr ""
 
@@ -2357,11 +2358,11 @@ msgstr ""
 msgid "Download cancelled"
 msgstr ""
 
-#: src/strings.ts:2218
+#: src/strings.ts:2219
 msgid "Download everything including attachments on sync"
 msgstr ""
 
-#: src/strings.ts:1290
+#: src/strings.ts:1291
 msgid "Download on desktop"
 msgstr ""
 
@@ -2394,23 +2395,23 @@ msgstr ""
 msgid "Downloading attachments"
 msgstr ""
 
-#: src/strings.ts:1704
+#: src/strings.ts:1705
 msgid "Downloading images"
 msgstr ""
 
-#: src/strings.ts:1770
+#: src/strings.ts:1771
 msgid "Drag & drop files here, or click to select files"
 msgstr ""
 
-#: src/strings.ts:1769
+#: src/strings.ts:1770
 msgid "Drop the files here"
 msgstr ""
 
-#: src/strings.ts:1663
+#: src/strings.ts:1664
 msgid "Drop your files here to attach"
 msgstr ""
 
-#: src/strings.ts:2569
+#: src/strings.ts:2570
 msgid "Due {date}"
 msgstr ""
 
@@ -2418,11 +2419,11 @@ msgstr ""
 msgid "Due date"
 msgstr ""
 
-#: src/strings.ts:2567
+#: src/strings.ts:2568
 msgid "Due today"
 msgstr ""
 
-#: src/strings.ts:924
+#: src/strings.ts:925
 msgid "Duplicate"
 msgstr ""
 
@@ -2430,15 +2431,15 @@ msgstr ""
 msgid "Earliest first"
 msgstr ""
 
-#: src/strings.ts:2429
+#: src/strings.ts:2430
 msgid "Easy access"
 msgstr ""
 
-#: src/strings.ts:1777
+#: src/strings.ts:1778
 msgid "Edit"
 msgstr ""
 
-#: src/strings.ts:2640
+#: src/strings.ts:2641
 msgid "Edit creation date"
 msgstr ""
 
@@ -2446,37 +2447,37 @@ msgstr ""
 msgid "Edit internal link"
 msgstr ""
 
-#: src/strings.ts:2245
-#: src/strings.ts:2273
+#: src/strings.ts:2246
+#: src/strings.ts:2274
 msgid "Edit link"
 msgstr ""
 
-#: src/strings.ts:2485
+#: src/strings.ts:2486
 msgid "Edit profile"
 msgstr ""
 
-#: src/strings.ts:1307
+#: src/strings.ts:1308
 msgid "Edit profile picture"
 msgstr ""
 
-#: src/strings.ts:1819
+#: src/strings.ts:1820
 msgid "Edit your full name"
 msgstr ""
 
-#: src/strings.ts:1142
-#: src/strings.ts:1526
+#: src/strings.ts:1143
+#: src/strings.ts:1527
 msgid "Editor"
 msgstr ""
 
-#: src/strings.ts:2596
+#: src/strings.ts:2597
 msgid "Education plan"
 msgstr ""
 
-#: src/strings.ts:1481
+#: src/strings.ts:1482
 msgid "Email"
 msgstr ""
 
-#: src/strings.ts:2442
+#: src/strings.ts:2443
 msgid "Email copied"
 msgstr ""
 
@@ -2488,27 +2489,27 @@ msgstr ""
 msgid "Email not confirmed"
 msgstr ""
 
-#: src/strings.ts:1553
+#: src/strings.ts:1554
 msgid "Email or password incorrect"
 msgstr ""
 
-#: src/strings.ts:1260
+#: src/strings.ts:1261
 msgid "Email support"
 msgstr ""
 
-#: src/strings.ts:857
+#: src/strings.ts:858
 msgid "Email updated to {email}"
 msgstr ""
 
-#: src/strings.ts:2352
+#: src/strings.ts:2353
 msgid "Embed"
 msgstr ""
 
-#: src/strings.ts:2332
+#: src/strings.ts:2333
 msgid "Embed properties"
 msgstr ""
 
-#: src/strings.ts:2328
+#: src/strings.ts:2329
 msgid "Embed settings"
 msgstr ""
 
@@ -2516,27 +2517,27 @@ msgstr ""
 msgid "Enable"
 msgstr ""
 
-#: src/strings.ts:1131
+#: src/strings.ts:1132
 msgid "Enable (Recommended)"
 msgstr ""
 
-#: src/strings.ts:1185
+#: src/strings.ts:1186
 msgid "Enable app lock"
 msgstr ""
 
-#: src/strings.ts:2012
+#: src/strings.ts:2013
 msgid "Enable editor margins"
 msgstr ""
 
-#: src/strings.ts:2476
+#: src/strings.ts:2477
 msgid "Enable ligatures for common symbols like →, ←, etc"
 msgstr ""
 
-#: src/strings.ts:2392
+#: src/strings.ts:2393
 msgid "Enable regex"
 msgstr ""
 
-#: src/strings.ts:2137
+#: src/strings.ts:2138
 msgid "Enable spell checker"
 msgstr ""
 
@@ -2544,7 +2545,7 @@ msgstr ""
 msgid "Enable two-factor authentication to add an extra layer of security to your account."
 msgstr ""
 
-#: src/strings.ts:1234
+#: src/strings.ts:1235
 msgid "Encrypt your backups for added security"
 msgstr ""
 
@@ -2552,27 +2553,27 @@ msgstr ""
 msgid "Encrypted and synced"
 msgstr ""
 
-#: src/strings.ts:2252
+#: src/strings.ts:2253
 msgid "Encrypted backup"
 msgstr ""
 
-#: src/strings.ts:1657
+#: src/strings.ts:1658
 msgid "Encrypted, private, secure."
 msgstr ""
 
-#: src/strings.ts:2681
+#: src/strings.ts:2682
 msgid "Encrypting"
 msgstr ""
 
-#: src/strings.ts:940
+#: src/strings.ts:941
 msgid "Encrypting attachment"
 msgstr ""
 
-#: src/strings.ts:1843
+#: src/strings.ts:1844
 msgid "Encryption key"
 msgstr ""
 
-#: src/strings.ts:820
+#: src/strings.ts:821
 msgid "End to end encrypted."
 msgstr ""
 
@@ -2580,23 +2581,23 @@ msgstr ""
 msgid "Enter 6 digit code"
 msgstr ""
 
-#: src/strings.ts:1079
+#: src/strings.ts:1080
 msgid "Enter account password"
 msgstr ""
 
-#: src/strings.ts:1080
+#: src/strings.ts:1081
 msgid "Enter account password to proceed."
 msgstr ""
 
-#: src/strings.ts:1852
+#: src/strings.ts:1853
 msgid "Enter account recovery key"
 msgstr ""
 
-#: src/strings.ts:1019
+#: src/strings.ts:1020
 msgid "Enter app lock password"
 msgstr ""
 
-#: src/strings.ts:1022
+#: src/strings.ts:1023
 msgid "Enter app lock pin"
 msgstr ""
 
@@ -2604,27 +2605,27 @@ msgstr ""
 msgid "Enter code from authenticator app"
 msgstr ""
 
-#: src/strings.ts:1511
+#: src/strings.ts:1512
 msgid "Enter email address"
 msgstr ""
 
-#: src/strings.ts:2380
+#: src/strings.ts:2381
 msgid "Enter embed source URL"
 msgstr ""
 
-#: src/strings.ts:1313
+#: src/strings.ts:1314
 msgid "Enter full name"
 msgstr ""
 
-#: src/strings.ts:1701
+#: src/strings.ts:1702
 msgid "Enter fullscreen"
 msgstr ""
 
-#: src/strings.ts:1490
+#: src/strings.ts:1491
 msgid "Enter notebook description"
 msgstr ""
 
-#: src/strings.ts:856
+#: src/strings.ts:857
 msgid "Enter notebook title"
 msgstr ""
 
@@ -2632,11 +2633,11 @@ msgstr ""
 msgid "Enter password"
 msgstr ""
 
-#: src/strings.ts:2098
+#: src/strings.ts:2099
 msgid "Enter pin or password to enable app lock."
 msgstr ""
 
-#: src/strings.ts:1004
+#: src/strings.ts:1005
 msgid "Enter recovery code"
 msgstr ""
 
@@ -2652,7 +2653,7 @@ msgstr ""
 msgid "Enter the 6 digit code sent to your phone number to continue logging in"
 msgstr ""
 
-#: src/strings.ts:2444
+#: src/strings.ts:2445
 msgid "Enter the gift code to redeem your subscription."
 msgstr ""
 
@@ -2660,27 +2661,27 @@ msgstr ""
 msgid "Enter the recovery code to continue logging in"
 msgstr ""
 
-#: src/strings.ts:2632
+#: src/strings.ts:2633
 msgid "Enter title"
 msgstr ""
 
-#: src/strings.ts:1493
+#: src/strings.ts:1494
 msgid "Enter verification code sent to your new email"
 msgstr ""
 
-#: src/strings.ts:1492
+#: src/strings.ts:1493
 msgid "Enter your new email"
 msgstr ""
 
-#: src/strings.ts:2099
+#: src/strings.ts:2100
 msgid "Enter your username"
 msgstr ""
 
-#: src/strings.ts:2436
+#: src/strings.ts:2437
 msgid "Error"
 msgstr ""
 
-#: src/strings.ts:1554
+#: src/strings.ts:1555
 msgid "Error applying promo code"
 msgstr ""
 
@@ -2688,7 +2689,7 @@ msgstr ""
 msgid "Error downloading file: {message}"
 msgstr ""
 
-#: src/strings.ts:1514
+#: src/strings.ts:1515
 msgid "Error getting codes"
 msgstr ""
 
@@ -2696,11 +2697,11 @@ msgstr ""
 msgid "Error loading themes"
 msgstr ""
 
-#: src/strings.ts:1075
+#: src/strings.ts:1076
 msgid "Error logging out"
 msgstr ""
 
-#: src/strings.ts:1009
+#: src/strings.ts:1010
 msgid "Error sending 2FA code"
 msgstr ""
 
@@ -2708,55 +2709,55 @@ msgstr ""
 msgid "Errors"
 msgstr ""
 
-#: src/strings.ts:1696
+#: src/strings.ts:1697
 msgid "Errors in {count} attachments"
 msgstr ""
 
-#: src/strings.ts:2481
+#: src/strings.ts:2482
 msgid "Essential plan"
 msgstr ""
 
-#: src/strings.ts:1628
+#: src/strings.ts:1629
 msgid "Events server"
 msgstr ""
 
-#: src/strings.ts:2422
+#: src/strings.ts:2423
 msgid "Every Notebook can have notes and sub notebooks."
 msgstr ""
 
-#: src/strings.ts:2424
+#: src/strings.ts:2425
 msgid "Everything related to my job in one place."
 msgstr ""
 
-#: src/strings.ts:2433
+#: src/strings.ts:2434
 msgid "Everything related to my school in one place."
 msgstr ""
 
-#: src/strings.ts:2450
+#: src/strings.ts:2451
 msgid "Execute"
 msgstr ""
 
-#: src/strings.ts:2449
+#: src/strings.ts:2450
 msgid "Execute a command..."
 msgstr ""
 
-#: src/strings.ts:2013
+#: src/strings.ts:2014
 msgid "Exit fullscreen"
 msgstr ""
 
-#: src/strings.ts:2384
+#: src/strings.ts:2385
 msgid "Expand"
 msgstr ""
 
-#: src/strings.ts:2477
+#: src/strings.ts:2478
 msgid "Expand sidebar"
 msgstr ""
 
-#: src/strings.ts:2082
+#: src/strings.ts:2083
 msgid "Experience the next level of private note taking\""
 msgstr ""
 
-#: src/strings.ts:2646
+#: src/strings.ts:2647
 msgid "Expiry date"
 msgstr ""
 
@@ -2773,6 +2774,7 @@ msgid "Expiry date set"
 msgstr ""
 
 #: src/strings.ts:2550
+#: src/strings.ts:2551
 msgid "Explore all plans"
 msgstr ""
 
@@ -2784,24 +2786,24 @@ msgstr ""
 msgid "Export again"
 msgstr ""
 
-#: src/strings.ts:1237
+#: src/strings.ts:1238
 msgid "Export all notes"
 msgstr ""
 
-#: src/strings.ts:1239
+#: src/strings.ts:1240
 msgid "Export all notes as pdf, markdown, html or text in a single zip file"
 msgstr ""
 
 #. placeholder {0}: format ? " " + format : ""
-#: src/strings.ts:2035
+#: src/strings.ts:2036
 msgid "Export as{0}"
 msgstr ""
 
-#: src/strings.ts:2647
+#: src/strings.ts:2648
 msgid "Export CSV"
 msgstr ""
 
-#: src/strings.ts:1385
+#: src/strings.ts:1386
 msgid "Export notes as PDF, Markdown and HTML with Notesnook Pro"
 msgstr ""
 
@@ -2809,39 +2811,39 @@ msgstr ""
 msgid "Exporting \"{title}\""
 msgstr ""
 
-#: src/strings.ts:1618
+#: src/strings.ts:1619
 msgid "Extracting files..."
 msgstr ""
 
-#: src/strings.ts:1807
+#: src/strings.ts:1808
 msgid "EXTREMELY DANGEROUS! This action is irreversible. All your data including notes, notebooks, attachments & settings will be deleted. This is a full account reset. Proceed with caution."
 msgstr ""
 
-#: src/strings.ts:1259
+#: src/strings.ts:1260
 msgid "Faced an issue or have a suggestion? Click here to create a bug report"
 msgstr ""
 
-#: src/strings.ts:2414
+#: src/strings.ts:2415
 msgid "Failed"
 msgstr ""
 
-#: src/strings.ts:2651
+#: src/strings.ts:2652
 msgid "Failed to attach file"
 msgstr ""
 
-#: src/strings.ts:1936
+#: src/strings.ts:1937
 msgid "Failed to copy note"
 msgstr ""
 
-#: src/strings.ts:1560
+#: src/strings.ts:1561
 msgid "Failed to decrypt backup"
 msgstr ""
 
-#: src/strings.ts:2002
+#: src/strings.ts:2003
 msgid "Failed to delete"
 msgstr ""
 
-#: src/strings.ts:1081
+#: src/strings.ts:1082
 msgid "Failed to delete account"
 msgstr ""
 
@@ -2849,19 +2851,19 @@ msgstr ""
 msgid "Failed to download file"
 msgstr ""
 
-#: src/strings.ts:1998
+#: src/strings.ts:1999
 msgid "Failed to install theme."
 msgstr ""
 
-#: src/strings.ts:948
+#: src/strings.ts:949
 msgid "Failed to open"
 msgstr ""
 
-#: src/strings.ts:867
+#: src/strings.ts:868
 msgid "Failed to publish note"
 msgstr ""
 
-#: src/strings.ts:2003
+#: src/strings.ts:2004
 msgid "Failed to register task"
 msgstr ""
 
@@ -2873,23 +2875,23 @@ msgstr ""
 msgid "Failed to send recovery email"
 msgstr ""
 
-#: src/strings.ts:1401
+#: src/strings.ts:1402
 msgid "Failed to send verification email"
 msgstr ""
 
-#: src/strings.ts:937
+#: src/strings.ts:938
 msgid "Failed to subscribe"
 msgstr ""
 
-#: src/strings.ts:2213
+#: src/strings.ts:2214
 msgid "Failed to take backup"
 msgstr ""
 
-#: src/strings.ts:2215
+#: src/strings.ts:2216
 msgid "Failed to take backup of your data. Do you want to continue logging out?"
 msgstr ""
 
-#: src/strings.ts:868
+#: src/strings.ts:869
 msgid "Failed to unpublish note"
 msgstr ""
 
@@ -2901,28 +2903,28 @@ msgstr ""
 msgid "Fallback method for 2FA enabled"
 msgstr ""
 
-#: src/strings.ts:2560
+#: src/strings.ts:2561
 msgid "FAQs"
 msgstr ""
 
-#: src/strings.ts:2032
+#: src/strings.ts:2033
 msgid "Favorite"
 msgstr ""
 
 #: src/strings.ts:321
-#: src/strings.ts:1521
+#: src/strings.ts:1522
 msgid "Favorites"
 msgstr ""
 
-#: src/strings.ts:2558
+#: src/strings.ts:2559
 msgid "Featured on"
 msgstr ""
 
-#: src/strings.ts:2426
+#: src/strings.ts:2427
 msgid "February 2022 Week 2"
 msgstr ""
 
-#: src/strings.ts:2427
+#: src/strings.ts:2428
 msgid "February 2022 Week 3"
 msgstr ""
 
@@ -2942,107 +2944,107 @@ msgstr ""
 msgid "File length mismatch. Expected {expectedSize} but got {currentSize} bytes. Please upload this file again from the attachment manager."
 msgstr ""
 
-#: src/strings.ts:2689
+#: src/strings.ts:2690
 msgid "File links cannot be opened in browsers. Please use the Notesnook desktop app."
 msgstr ""
 
-#: src/strings.ts:949
+#: src/strings.ts:950
 msgid "File mismatch"
 msgstr ""
 
-#: src/strings.ts:2683
+#: src/strings.ts:2684
 msgid "File size limit exceeded. Please upgrade your plan."
 msgstr ""
 
-#: src/strings.ts:945
+#: src/strings.ts:946
 msgid "File size should be less than {sizeInMB}"
 msgstr ""
 
-#: src/strings.ts:943
+#: src/strings.ts:944
 msgid "File too big"
 msgstr ""
 
-#: src/strings.ts:1478
+#: src/strings.ts:1479
 msgid "Filter attachments by filename, type or hash"
 msgstr ""
 
-#: src/strings.ts:1833
+#: src/strings.ts:1834
 msgid "Filter languages"
 msgstr ""
 
-#: src/strings.ts:2618
+#: src/strings.ts:2619
 msgid "Finish your purchase in the browser."
 msgstr ""
 
-#: src/strings.ts:1669
+#: src/strings.ts:1670
 msgid "Fix it"
 msgstr ""
 
-#: src/strings.ts:2015
+#: src/strings.ts:2016
 msgid "Focus mode"
 msgstr ""
 
-#: src/strings.ts:2173
+#: src/strings.ts:2174
 msgid "Follow"
 msgstr ""
 
-#: src/strings.ts:1275
+#: src/strings.ts:1276
 msgid "Follow us on Mastodon"
 msgstr ""
 
-#: src/strings.ts:1277
+#: src/strings.ts:1278
 msgid "Follow us on Mastodon for updates and news about Notesnook"
 msgstr ""
 
-#: src/strings.ts:1278
+#: src/strings.ts:1279
 msgid "Follow us on X"
 msgstr ""
 
-#: src/strings.ts:1279
+#: src/strings.ts:1280
 msgid "Follow us on X for updates and news about Notesnook"
 msgstr ""
 
-#: src/strings.ts:2287
+#: src/strings.ts:2288
 msgid "Font family"
 msgstr ""
 
-#: src/strings.ts:2474
+#: src/strings.ts:2475
 msgid "Font ligatures"
 msgstr ""
 
-#: src/strings.ts:2288
+#: src/strings.ts:2289
 msgid "Font size"
 msgstr ""
 
-#: src/strings.ts:2532
+#: src/strings.ts:2533
 msgid "For a monthly subscription, you can get a refund within 7 days of purchase. For a yearly subscription, we offer a full refund within 14 days of purchase. For a 5 year subscription, you can request a refund within 30 days of purchase."
 msgstr ""
 
-#: src/strings.ts:1686
+#: src/strings.ts:1687
 msgid "For a more integrated user experience, try out Notesnook for {platform}"
 msgstr ""
 
-#: src/strings.ts:1767
+#: src/strings.ts:1768
 msgid "for help regarding how to use the Notesnook Importer."
 msgstr ""
 
-#: src/strings.ts:2541
+#: src/strings.ts:2542
 msgid "for locking your notes as soon as app enters background"
 msgstr ""
 
-#: src/strings.ts:2205
+#: src/strings.ts:2206
 msgid "Force logout from all your other logged in devices."
 msgstr ""
 
-#: src/strings.ts:1096
+#: src/strings.ts:1097
 msgid "Force pull changes"
 msgstr ""
 
-#: src/strings.ts:1105
+#: src/strings.ts:1106
 msgid "Force push changes"
 msgstr ""
 
-#: src/strings.ts:2222
+#: src/strings.ts:2223
 msgid ""
 "Force push:\n"
 "Use this if changes made on this device are not appearing on other devices. This will overwrite the data on the server with the data from this device.\n"
@@ -3057,11 +3059,11 @@ msgstr ""
 msgid "Forgot password?"
 msgstr ""
 
-#: src/strings.ts:2575
+#: src/strings.ts:2576
 msgid "Free {duration} day trial, cancel any time"
 msgstr ""
 
-#: src/strings.ts:2479
+#: src/strings.ts:2480
 msgid "Free plan"
 msgstr ""
 
@@ -3073,55 +3075,55 @@ msgstr ""
 msgid "Friday"
 msgstr ""
 
-#: src/strings.ts:2382
+#: src/strings.ts:2383
 msgid "From code"
 msgstr ""
 
-#: src/strings.ts:2379
+#: src/strings.ts:2380
 msgid "From URL"
 msgstr ""
 
-#: src/strings.ts:1999
+#: src/strings.ts:2000
 msgid "Full name updated"
 msgstr ""
 
-#: src/strings.ts:2216
+#: src/strings.ts:2217
 msgid "Full offline mode"
 msgstr ""
 
-#: src/strings.ts:2334
+#: src/strings.ts:2335
 msgid "Full screen"
 msgstr ""
 
-#: src/strings.ts:2102
+#: src/strings.ts:2103
 msgid "General"
 msgstr ""
 
-#: src/strings.ts:1268
+#: src/strings.ts:1269
 msgid "Get helpful debug info about the app to help us find bugs."
 msgstr ""
 
-#: src/strings.ts:1292
+#: src/strings.ts:1293
 msgid "Get Notesnook app on your desktop and access all notes"
 msgstr ""
 
-#: src/strings.ts:2167
+#: src/strings.ts:2168
 msgid "Get Notesnook app on your iPhone and access all your notes on the go."
 msgstr ""
 
-#: src/strings.ts:2169
+#: src/strings.ts:2170
 msgid "Get Notesnook app on your iPhone or Android device and access all your notes on the go."
 msgstr ""
 
-#: src/strings.ts:1382
+#: src/strings.ts:1383
 msgid "Get Notesnook Pro"
 msgstr ""
 
-#: src/strings.ts:1367
+#: src/strings.ts:1368
 msgid "Get Notesnook Pro to enable automatic backups"
 msgstr ""
 
-#: src/strings.ts:2418
+#: src/strings.ts:2419
 msgid "Get Priority support"
 msgstr ""
 
@@ -3133,11 +3135,11 @@ msgstr ""
 msgid "Get started"
 msgstr ""
 
-#: src/strings.ts:2538
+#: src/strings.ts:2539
 msgid "Get this and so much more:"
 msgstr ""
 
-#: src/strings.ts:1885
+#: src/strings.ts:1886
 msgid "Getting encryption key..."
 msgstr ""
 
@@ -3149,55 +3151,55 @@ msgstr ""
 msgid "Getting recovery codes"
 msgstr ""
 
-#: src/strings.ts:2663
+#: src/strings.ts:2664
 msgid "Gift code required"
 msgstr ""
 
-#: src/strings.ts:2172
+#: src/strings.ts:2173
 msgid "GNU GENERAL PUBLIC LICENSE Version 3"
 msgstr ""
 
-#: src/strings.ts:2619
+#: src/strings.ts:2620
 msgid "Go back"
 msgstr ""
 
-#: src/strings.ts:2457
+#: src/strings.ts:2458
 msgid "Go back in tab"
 msgstr ""
 
-#: src/strings.ts:2235
+#: src/strings.ts:2236
 msgid "Go back to notebooks"
 msgstr ""
 
-#: src/strings.ts:2236
+#: src/strings.ts:2237
 msgid "Go back to tags"
 msgstr ""
 
-#: src/strings.ts:2456
+#: src/strings.ts:2457
 msgid "Go forward in tab"
 msgstr ""
 
-#: src/strings.ts:1813
+#: src/strings.ts:1814
 msgid "Go to"
 msgstr ""
 
-#: src/strings.ts:1814
+#: src/strings.ts:1815
 msgid "Go to #{tag}"
 msgstr ""
 
-#: src/strings.ts:1697
+#: src/strings.ts:1698
 msgid "Go to next page"
 msgstr ""
 
-#: src/strings.ts:1698
+#: src/strings.ts:1699
 msgid "Go to previous page"
 msgstr ""
 
-#: src/strings.ts:1304
+#: src/strings.ts:1305
 msgid "Go to web app"
 msgstr ""
 
-#: src/strings.ts:2549
+#: src/strings.ts:2550
 msgid "Google will remind you 2 days before your trial ends."
 msgstr ""
 
@@ -3209,7 +3211,7 @@ msgstr ""
 msgid "GROUP"
 msgstr ""
 
-#: src/strings.ts:1887
+#: src/strings.ts:1888
 msgid "Group added successfully"
 msgstr ""
 
@@ -3221,27 +3223,27 @@ msgstr ""
 msgid "Hash copied"
 msgstr ""
 
-#: src/strings.ts:2219
+#: src/strings.ts:2220
 msgid "Having problems with sync?"
 msgstr ""
 
-#: src/strings.ts:2564
+#: src/strings.ts:2565
 msgid "hdImages"
 msgstr ""
 
-#: src/strings.ts:2360
+#: src/strings.ts:2361
 msgid "Heading {level}"
 msgstr ""
 
-#: src/strings.ts:2289
+#: src/strings.ts:2290
 msgid "Headings"
 msgstr ""
 
-#: src/strings.ts:2395
+#: src/strings.ts:2396
 msgid "Height"
 msgstr ""
 
-#: src/strings.ts:1256
+#: src/strings.ts:1257
 msgid "Help and support"
 msgstr ""
 
@@ -3249,55 +3251,55 @@ msgstr ""
 msgid "Help improve Notesnook by sending completely anonymized"
 msgstr ""
 
-#: src/strings.ts:1375
+#: src/strings.ts:1376
 msgid "Hide"
 msgstr ""
 
-#: src/strings.ts:1182
+#: src/strings.ts:1183
 msgid "Hide app contents when you switch to other apps. This will also disable screenshot taking in the app."
 msgstr ""
 
-#: src/strings.ts:2178
+#: src/strings.ts:2179
 msgid "Hide note title"
 msgstr ""
 
-#: src/strings.ts:2292
+#: src/strings.ts:2293
 msgid "Highlight"
 msgstr ""
 
-#: src/strings.ts:909
+#: src/strings.ts:910
 msgid "History"
 msgstr ""
 
-#: src/strings.ts:1527
+#: src/strings.ts:1528
 msgid "Home"
 msgstr ""
 
-#: src/strings.ts:1126
+#: src/strings.ts:1127
 msgid "Homepage"
 msgstr ""
 
-#: src/strings.ts:1317
+#: src/strings.ts:1318
 msgid "Homepage changed to {name}"
 msgstr ""
 
-#: src/strings.ts:2341
+#: src/strings.ts:2342
 msgid "Horizontal rule"
 msgstr ""
 
-#: src/strings.ts:1798
+#: src/strings.ts:1799
 msgid "How do you want to recover your account?"
 msgstr ""
 
-#: src/strings.ts:1668
+#: src/strings.ts:1669
 msgid "How to fix it?"
 msgstr ""
 
-#: src/strings.ts:880
+#: src/strings.ts:881
 msgid "hr"
 msgstr ""
 
-#: src/strings.ts:2509
+#: src/strings.ts:2510
 msgid "I already have an account"
 msgstr ""
 
@@ -3321,15 +3323,15 @@ msgstr ""
 msgid "I have a recovery code"
 msgstr ""
 
-#: src/strings.ts:1886
+#: src/strings.ts:1887
 msgid "I have saved my key"
 msgstr ""
 
-#: src/strings.ts:2435
+#: src/strings.ts:2436
 msgid "I love cooking and collecting recipes."
 msgstr ""
 
-#: src/strings.ts:2220
+#: src/strings.ts:2221
 msgid "I understand"
 msgstr ""
 
@@ -3345,29 +3347,29 @@ msgstr ""
 msgid "If this continues to happen, please reach out to us via"
 msgstr ""
 
-#: src/strings.ts:2123
+#: src/strings.ts:2124
 msgid "If true, Notesnook will automatically start up when you turn on & login to your system."
 msgstr ""
 
-#: src/strings.ts:2126
+#: src/strings.ts:2127
 msgid "If true, Notesnook will start minimized to either the system tray or your system taskbar/dock. This setting only works with Auto start on system startup is enabled."
 msgstr ""
 
-#: src/strings.ts:1724
+#: src/strings.ts:1725
 msgid "If you can't scan the QR code above, enter this text instead (spaces don't matter)"
 msgstr ""
 
-#: src/strings.ts:1394
+#: src/strings.ts:1395
 msgid ""
 "If you didn't get an email from us or the confirmation link isn't\n"
 "            working,"
 msgstr ""
 
-#: src/strings.ts:1804
+#: src/strings.ts:1805
 msgid "If you don't have a recovery key, you can recover your data by restoring a Notesnook data backup file (.nnbackup)."
 msgstr ""
 
-#: src/strings.ts:2087
+#: src/strings.ts:2088
 msgid "If you face any issue, you can reach out to us anytime."
 msgstr ""
 
@@ -3375,23 +3377,23 @@ msgstr ""
 msgid "If you want to ask something in general or need some assistance, we would suggest that you"
 msgstr ""
 
-#: src/strings.ts:2346
+#: src/strings.ts:2347
 msgid "Image"
 msgstr ""
 
-#: src/strings.ts:1128
+#: src/strings.ts:1129
 msgid "Image Compression"
 msgstr ""
 
-#: src/strings.ts:2322
+#: src/strings.ts:2323
 msgid "Image properties"
 msgstr ""
 
-#: src/strings.ts:2318
+#: src/strings.ts:2319
 msgid "Image settings"
 msgstr ""
 
-#: src/strings.ts:947
+#: src/strings.ts:948
 msgid "Image size should be less than {sizeInMB}"
 msgstr ""
 
@@ -3403,23 +3405,23 @@ msgstr ""
 msgid "Images uploaded without compression are slow to load and take more bandwidth. We recommend compressing images unless you need image in original quality."
 msgstr ""
 
-#: src/strings.ts:1582
+#: src/strings.ts:1583
 msgid "Immediately"
 msgstr ""
 
-#: src/strings.ts:2150
+#: src/strings.ts:2151
 msgid "Import & export"
 msgstr ""
 
-#: src/strings.ts:1751
+#: src/strings.ts:1752
 msgid "Import completed"
 msgstr ""
 
-#: src/strings.ts:2648
+#: src/strings.ts:2649
 msgid "Import CSV"
 msgstr ""
 
-#: src/strings.ts:1766
+#: src/strings.ts:1767
 msgid "import guide"
 msgstr ""
 
@@ -3427,7 +3429,7 @@ msgstr ""
 msgid "Incoming"
 msgstr ""
 
-#: src/strings.ts:1837
+#: src/strings.ts:1838
 msgid "Incoming note"
 msgstr ""
 
@@ -3435,59 +3437,59 @@ msgstr ""
 msgid "Incorrect {type}"
 msgstr ""
 
-#: src/strings.ts:2404
+#: src/strings.ts:2405
 msgid "Increase {title}"
 msgstr ""
 
-#: src/strings.ts:2246
+#: src/strings.ts:2247
 msgid "Insert"
 msgstr ""
 
-#: src/strings.ts:2401
+#: src/strings.ts:2402
 msgid "Insert a {rows}x{columns} table"
 msgstr ""
 
-#: src/strings.ts:2351
+#: src/strings.ts:2352
 msgid "Insert a table"
 msgstr ""
 
-#: src/strings.ts:2353
+#: src/strings.ts:2354
 msgid "Insert an embed"
 msgstr ""
 
-#: src/strings.ts:2347
+#: src/strings.ts:2348
 msgid "Insert an image"
 msgstr ""
 
-#: src/strings.ts:2299
+#: src/strings.ts:2300
 msgid "Insert column left"
 msgstr ""
 
-#: src/strings.ts:2300
+#: src/strings.ts:2301
 msgid "Insert column right"
 msgstr ""
 
-#: src/strings.ts:2244
+#: src/strings.ts:2245
 msgid "Insert link"
 msgstr ""
 
-#: src/strings.ts:2306
+#: src/strings.ts:2307
 msgid "Insert row above"
 msgstr ""
 
-#: src/strings.ts:2307
+#: src/strings.ts:2308
 msgid "Insert row below"
 msgstr ""
 
-#: src/strings.ts:1684
+#: src/strings.ts:1685
 msgid "Install Notesnook"
 msgstr ""
 
-#: src/strings.ts:2158
+#: src/strings.ts:2159
 msgid "Install update"
 msgstr ""
 
-#: src/strings.ts:1719
+#: src/strings.ts:1720
 msgid "installs"
 msgstr ""
 
@@ -3495,15 +3497,15 @@ msgstr ""
 msgid "Invalid {type}"
 msgstr ""
 
-#: src/strings.ts:1991
+#: src/strings.ts:1992
 msgid "Invalid CORS proxy url"
 msgstr ""
 
-#: src/strings.ts:1482
+#: src/strings.ts:1483
 msgid "Invalid email"
 msgstr ""
 
-#: src/strings.ts:2656
+#: src/strings.ts:2657
 msgid "Invalid recovery key. Make sure to input your account recovery key, not a 2FA recovery code."
 msgstr ""
 
@@ -3511,12 +3513,12 @@ msgstr ""
 msgid "Issue created"
 msgstr ""
 
-#: src/strings.ts:990
-#: src/strings.ts:999
+#: src/strings.ts:991
+#: src/strings.ts:1000
 msgid "It may take a minute to receive your code."
 msgstr ""
 
-#: src/strings.ts:1590
+#: src/strings.ts:1591
 msgid "It seems that your changes could not be saved. What to do next:"
 msgstr ""
 
@@ -3524,7 +3526,7 @@ msgstr ""
 msgid "It took us a year to bring Notesnook to life. Share your experience and suggestions to help us improve it."
 msgstr ""
 
-#: src/strings.ts:2268
+#: src/strings.ts:2269
 msgid "Italic"
 msgstr ""
 
@@ -3537,7 +3539,7 @@ msgid "Item"
 msgstr ""
 
 #: src/strings.ts:311
-#: src/strings.ts:1703
+#: src/strings.ts:1704
 msgid "items"
 msgstr ""
 
@@ -3545,7 +3547,7 @@ msgstr ""
 msgid "Items"
 msgstr ""
 
-#: src/strings.ts:2170
+#: src/strings.ts:2171
 msgid "Join community"
 msgstr ""
 
@@ -3553,27 +3555,27 @@ msgstr ""
 msgid "join our community on Discord."
 msgstr ""
 
-#: src/strings.ts:1280
+#: src/strings.ts:1281
 msgid "Join our Discord server"
 msgstr ""
 
-#: src/strings.ts:1282
+#: src/strings.ts:1283
 msgid "Join our Discord server to chat with other users and the team"
 msgstr ""
 
-#: src/strings.ts:1272
+#: src/strings.ts:1273
 msgid "Join our Telegram group"
 msgstr ""
 
-#: src/strings.ts:1274
+#: src/strings.ts:1275
 msgid "Join our Telegram group to chat with other users and the team"
 msgstr ""
 
-#: src/strings.ts:2078
+#: src/strings.ts:2079
 msgid "Join the cause"
 msgstr ""
 
-#: src/strings.ts:2026
+#: src/strings.ts:2027
 msgid "Jump to group"
 msgstr ""
 
@@ -3581,19 +3583,19 @@ msgstr ""
 msgid "Keep"
 msgstr ""
 
-#: src/strings.ts:2021
+#: src/strings.ts:2022
 msgid "Keep open"
 msgstr ""
 
-#: src/strings.ts:1359
+#: src/strings.ts:1360
 msgid "Keep your data safe"
 msgstr ""
 
-#: src/strings.ts:2138
+#: src/strings.ts:2139
 msgid "Languages"
 msgstr ""
 
-#: src/strings.ts:2241
+#: src/strings.ts:2242
 msgid "Last edited at"
 msgstr ""
 
@@ -3613,7 +3615,7 @@ msgstr ""
 msgid "Learn more"
 msgstr ""
 
-#: src/strings.ts:977
+#: src/strings.ts:978
 msgid "Learn more about Monographs"
 msgstr ""
 
@@ -3625,7 +3627,7 @@ msgstr ""
 msgid "Least relevant first"
 msgstr ""
 
-#: src/strings.ts:1562
+#: src/strings.ts:1563
 msgid "Legal"
 msgstr ""
 
@@ -3633,15 +3635,15 @@ msgstr ""
 msgid "Let us know if you have faced any issue/bug while using Notesnook. We will try to fix it as soon as possible."
 msgstr ""
 
-#: src/strings.ts:2171
+#: src/strings.ts:2172
 msgid "License"
 msgstr ""
 
-#: src/strings.ts:1720
+#: src/strings.ts:1721
 msgid "Licensed under {license}"
 msgstr ""
 
-#: src/strings.ts:2337
+#: src/strings.ts:2338
 msgid "Lift list item"
 msgstr ""
 
@@ -3649,39 +3651,39 @@ msgstr ""
 msgid "Light"
 msgstr ""
 
-#: src/strings.ts:2367
+#: src/strings.ts:2368
 msgid "Line {line}, Column {column}"
 msgstr ""
 
-#: src/strings.ts:2630
+#: src/strings.ts:2631
 msgid "Line height"
 msgstr ""
 
-#: src/strings.ts:1152
+#: src/strings.ts:1153
 msgid "Line spacing changed"
 msgstr ""
 
-#: src/strings.ts:2272
+#: src/strings.ts:2273
 msgid "Link"
 msgstr ""
 
-#: src/strings.ts:911
+#: src/strings.ts:912
 msgid "Link copied"
 msgstr ""
 
-#: src/strings.ts:929
+#: src/strings.ts:930
 msgid "Link notebooks"
 msgstr ""
 
-#: src/strings.ts:2486
+#: src/strings.ts:2487
 msgid "Link notes"
 msgstr ""
 
-#: src/strings.ts:2277
+#: src/strings.ts:2278
 msgid "Link settings"
 msgstr ""
 
-#: src/strings.ts:2397
+#: src/strings.ts:2398
 msgid "Link text"
 msgstr ""
 
@@ -3693,7 +3695,7 @@ msgstr ""
 msgid "Link to note"
 msgstr ""
 
-#: src/strings.ts:851
+#: src/strings.ts:852
 msgid "Link to notebook"
 msgstr ""
 
@@ -3701,7 +3703,7 @@ msgstr ""
 msgid "Linked notes"
 msgstr ""
 
-#: src/strings.ts:1596
+#: src/strings.ts:1597
 msgid "Linking to a specific block is not available for locked notes."
 msgstr ""
 
@@ -3713,7 +3715,7 @@ msgstr ""
 msgid "Load from file"
 msgstr ""
 
-#: src/strings.ts:1695
+#: src/strings.ts:1696
 msgid "Loading"
 msgstr ""
 
@@ -3722,11 +3724,11 @@ msgstr ""
 msgid "Loading {0}, please wait..."
 msgstr ""
 
-#: src/strings.ts:1664
+#: src/strings.ts:1665
 msgid "Loading editor. Please wait..."
 msgstr ""
 
-#: src/strings.ts:1064
+#: src/strings.ts:1065
 msgid "Loading subscription details"
 msgstr ""
 
@@ -3734,35 +3736,35 @@ msgstr ""
 msgid "Loading themes..."
 msgstr ""
 
-#: src/strings.ts:1327
+#: src/strings.ts:1328
 msgid "Loading trash"
 msgstr ""
 
-#: src/strings.ts:973
+#: src/strings.ts:974
 msgid "Loading your archive"
 msgstr ""
 
-#: src/strings.ts:967
+#: src/strings.ts:968
 msgid "Loading your favorites"
 msgstr ""
 
-#: src/strings.ts:972
+#: src/strings.ts:973
 msgid "Loading your monographs"
 msgstr ""
 
-#: src/strings.ts:970
+#: src/strings.ts:971
 msgid "Loading your notebooks"
 msgstr ""
 
-#: src/strings.ts:968
+#: src/strings.ts:969
 msgid "Loading your notes"
 msgstr ""
 
-#: src/strings.ts:971
+#: src/strings.ts:972
 msgid "Loading your reminders"
 msgstr ""
 
-#: src/strings.ts:969
+#: src/strings.ts:970
 msgid "Loading your tags"
 msgstr ""
 
@@ -3774,19 +3776,19 @@ msgstr ""
 msgid "Lock note"
 msgstr ""
 
-#: src/strings.ts:1184
+#: src/strings.ts:1185
 msgid "Lock the app with a password or pin"
 msgstr ""
 
-#: src/strings.ts:901
+#: src/strings.ts:902
 msgid "Locked notes cannot be pinned"
 msgstr ""
 
-#: src/strings.ts:904
+#: src/strings.ts:905
 msgid "Locked notes cannot be published"
 msgstr ""
 
-#: src/strings.ts:2203
+#: src/strings.ts:2204
 msgid "Log out from all other devices"
 msgstr ""
 
@@ -3794,7 +3796,7 @@ msgstr ""
 msgid "Logged in as {email}"
 msgstr ""
 
-#: src/strings.ts:1074
+#: src/strings.ts:1075
 msgid "Logging out will clear all data stored on THIS DEVICE. Make sure you have synced all your changes before logging out."
 msgstr ""
 
@@ -3802,7 +3804,7 @@ msgstr ""
 msgid "Logging out. Please wait..."
 msgstr ""
 
-#: src/strings.ts:1782
+#: src/strings.ts:1783
 msgid "Logging you in"
 msgstr ""
 
@@ -3814,11 +3816,11 @@ msgstr ""
 msgid "Login failed"
 msgstr ""
 
-#: src/strings.ts:902
+#: src/strings.ts:903
 msgid "Login required"
 msgstr ""
 
-#: src/strings.ts:2671
+#: src/strings.ts:2672
 msgid "Login required to restore attachments"
 msgstr ""
 
@@ -3826,11 +3828,11 @@ msgstr ""
 msgid "Login successful"
 msgstr ""
 
-#: src/strings.ts:1362
+#: src/strings.ts:1363
 msgid "Login to encrypt and sync notes"
 msgstr ""
 
-#: src/strings.ts:2623
+#: src/strings.ts:2624
 msgid "Login to upload attachments. [Read more](https://help.notesnook.com/faqs/login-to-upload-attachments)"
 msgstr ""
 
@@ -3850,19 +3852,19 @@ msgstr ""
 msgid "Logout from this device"
 msgstr ""
 
-#: src/strings.ts:1412
+#: src/strings.ts:1413
 msgid "Long press on any item in list to enter multi-select mode."
 msgstr ""
 
-#: src/strings.ts:2372
+#: src/strings.ts:2373
 msgid "Make task list readonly"
 msgstr ""
 
-#: src/strings.ts:1038
+#: src/strings.ts:1039
 msgid "Manage account"
 msgstr ""
 
-#: src/strings.ts:1051
+#: src/strings.ts:1052
 msgid "Manage attachments"
 msgstr ""
 
@@ -3870,75 +3872,75 @@ msgstr ""
 msgid "Manage subscription on desktop"
 msgstr ""
 
-#: src/strings.ts:850
+#: src/strings.ts:851
 msgid "Manage tags"
 msgstr ""
 
-#: src/strings.ts:1039
+#: src/strings.ts:1040
 msgid "Manage your account related settings here"
 msgstr ""
 
-#: src/strings.ts:1052
+#: src/strings.ts:1053
 msgid "Manage your attachments in one place"
 msgstr ""
 
-#: src/strings.ts:1211
+#: src/strings.ts:1212
 msgid "Manage your backups and restore data"
 msgstr ""
 
-#: src/strings.ts:1245
+#: src/strings.ts:1246
 msgid "Manage your reminders"
 msgstr ""
 
-#: src/strings.ts:1083
+#: src/strings.ts:1084
 msgid "Manage your sync settings here"
 msgstr ""
 
-#: src/strings.ts:1440
+#: src/strings.ts:1441
 msgid "Mark important notes by adding them to favorites."
 msgstr ""
 
-#: src/strings.ts:1159
+#: src/strings.ts:1160
 msgid "Markdown shortcuts"
 msgstr ""
 
-#: src/strings.ts:1165
+#: src/strings.ts:1166
 msgid "Marketing emails"
 msgstr ""
 
-#: src/strings.ts:2385
+#: src/strings.ts:2386
 msgid "Match case"
 msgstr ""
 
-#: src/strings.ts:2386
+#: src/strings.ts:2387
 msgid "Match whole word"
 msgstr ""
 
-#: src/strings.ts:2294
+#: src/strings.ts:2295
 msgid "Math (inline)"
 msgstr ""
 
-#: src/strings.ts:2344
+#: src/strings.ts:2345
 msgid "Math & formulas"
 msgstr ""
 
-#: src/strings.ts:2040
+#: src/strings.ts:2041
 msgid "Maximize"
 msgstr ""
 
-#: src/strings.ts:2080
+#: src/strings.ts:2081
 msgid "Meet other privacy-minded people & talk to us directly about your concerns, issues and suggestions."
 msgstr ""
 
-#: src/strings.ts:2428
+#: src/strings.ts:2429
 msgid "Meetings"
 msgstr ""
 
-#: src/strings.ts:1779
+#: src/strings.ts:1780
 msgid "Member since {date}"
 msgstr ""
 
-#: src/strings.ts:2305
+#: src/strings.ts:2306
 msgid "Merge cells"
 msgstr ""
 
@@ -3952,19 +3954,19 @@ msgstr ""
 msgid "Migration failed"
 msgstr ""
 
-#: src/strings.ts:879
+#: src/strings.ts:880
 msgid "min"
 msgstr ""
 
-#: src/strings.ts:2009
+#: src/strings.ts:2010
 msgid "Minimal"
 msgstr ""
 
-#: src/strings.ts:2039
+#: src/strings.ts:2040
 msgid "Minimize"
 msgstr ""
 
-#: src/strings.ts:2127
+#: src/strings.ts:2128
 msgid "Minimize to system tray"
 msgstr ""
 
@@ -3980,39 +3982,39 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
-#: src/strings.ts:1631
+#: src/strings.ts:1632
 msgid "Monograph server"
 msgstr ""
 
-#: src/strings.ts:870
+#: src/strings.ts:871
 msgid "Monograph URL copied"
 msgstr ""
 
 #: src/strings.ts:322
-#: src/strings.ts:939
-#: src/strings.ts:1529
+#: src/strings.ts:940
+#: src/strings.ts:1530
 msgid "Monographs"
 msgstr ""
 
-#: src/strings.ts:1422
+#: src/strings.ts:1423
 msgid "Monographs can be encrypted with a secret key and shared with anyone."
 msgstr ""
 
-#: src/strings.ts:1417
+#: src/strings.ts:1418
 msgid "Monographs enable you to share your notes in a secure and private way."
 msgstr ""
 
 #: src/strings.ts:665
-#: src/strings.ts:1840
+#: src/strings.ts:1841
 msgid "Month"
 msgstr ""
 
 #: src/strings.ts:169
-#: src/strings.ts:1570
+#: src/strings.ts:1571
 msgid "Monthly"
 msgstr ""
 
-#: src/strings.ts:2324
+#: src/strings.ts:2325
 msgid "More"
 msgstr ""
 
@@ -4020,35 +4022,35 @@ msgstr ""
 msgid "Most relevant first"
 msgstr ""
 
-#: src/strings.ts:852
+#: src/strings.ts:853
 msgid "Move"
 msgstr ""
 
-#: src/strings.ts:2373
+#: src/strings.ts:2374
 msgid "Move all checked tasks to bottom"
 msgstr ""
 
-#: src/strings.ts:2301
+#: src/strings.ts:2302
 msgid "Move column left"
 msgstr ""
 
-#: src/strings.ts:2302
+#: src/strings.ts:2303
 msgid "Move column right"
 msgstr ""
 
-#: src/strings.ts:936
+#: src/strings.ts:937
 msgid "Move notebook"
 msgstr ""
 
-#: src/strings.ts:898
+#: src/strings.ts:899
 msgid "Move notes"
 msgstr ""
 
-#: src/strings.ts:2309
+#: src/strings.ts:2310
 msgid "Move row down"
 msgstr ""
 
-#: src/strings.ts:2308
+#: src/strings.ts:2309
 msgid "Move row up"
 msgstr ""
 
@@ -4060,27 +4062,27 @@ msgstr ""
 msgid "Move to top"
 msgstr ""
 
-#: src/strings.ts:855
+#: src/strings.ts:856
 msgid "Move to trash"
 msgstr ""
 
-#: src/strings.ts:1172
+#: src/strings.ts:1173
 msgid "Multi-layer encryption to most important notes"
 msgstr ""
 
-#: src/strings.ts:887
+#: src/strings.ts:888
 msgid "Name"
 msgstr ""
 
-#: src/strings.ts:2669
+#: src/strings.ts:2670
 msgid "Name is required."
 msgstr ""
 
-#: src/strings.ts:1688
+#: src/strings.ts:1689
 msgid "Native high-performance encryption"
 msgstr ""
 
-#: src/strings.ts:2453
+#: src/strings.ts:2454
 msgid "Navigate"
 msgstr ""
 
@@ -4088,11 +4090,11 @@ msgstr ""
 msgid "Never"
 msgstr ""
 
-#: src/strings.ts:1342
+#: src/strings.ts:1343
 msgid "Never ask again"
 msgstr ""
 
-#: src/strings.ts:1037
+#: src/strings.ts:1038
 msgid "Never hesitate to choose privacy"
 msgstr ""
 
@@ -4108,11 +4110,11 @@ msgstr ""
 msgid "New color"
 msgstr ""
 
-#: src/strings.ts:1846
+#: src/strings.ts:1847
 msgid "New Email"
 msgstr ""
 
-#: src/strings.ts:1151
+#: src/strings.ts:1152
 msgid "New lines will be double spaced (old ones won't be affected)."
 msgstr ""
 
@@ -4124,11 +4126,11 @@ msgstr ""
 msgid "New notebook"
 msgstr ""
 
-#: src/strings.ts:1480
+#: src/strings.ts:1481
 msgid "New password"
 msgstr ""
 
-#: src/strings.ts:1486
+#: src/strings.ts:1487
 msgid "New pin"
 msgstr ""
 
@@ -4140,11 +4142,11 @@ msgstr ""
 msgid "New tab"
 msgstr ""
 
-#: src/strings.ts:2459
+#: src/strings.ts:2460
 msgid "New tag"
 msgstr ""
 
-#: src/strings.ts:1368
+#: src/strings.ts:1369
 msgid "New update available"
 msgstr ""
 
@@ -4152,11 +4154,11 @@ msgstr ""
 msgid "New version"
 msgstr ""
 
-#: src/strings.ts:2024
+#: src/strings.ts:2025
 msgid "Newest - oldest"
 msgstr ""
 
-#: src/strings.ts:1140
+#: src/strings.ts:1141
 msgid "Newly created notes will be uncategorized"
 msgstr ""
 
@@ -4164,11 +4166,11 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
-#: src/strings.ts:2389
+#: src/strings.ts:2390
 msgid "Next match"
 msgstr ""
 
-#: src/strings.ts:2454
+#: src/strings.ts:2455
 msgid "Next tab"
 msgstr ""
 
@@ -4176,7 +4178,7 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: src/strings.ts:859
+#: src/strings.ts:860
 msgid "No application found to open {fileToOpen}"
 msgstr ""
 
@@ -4196,7 +4198,7 @@ msgstr ""
 msgid "No color selected"
 msgstr ""
 
-#: src/strings.ts:1231
+#: src/strings.ts:1232
 msgid "No directory selected"
 msgstr ""
 
@@ -4204,11 +4206,11 @@ msgstr ""
 msgid "No downloads in progress."
 msgstr ""
 
-#: src/strings.ts:1984
+#: src/strings.ts:1985
 msgid "No encryption key found"
 msgstr ""
 
-#: src/strings.ts:1665
+#: src/strings.ts:1666
 msgid "No headings found"
 msgstr ""
 
@@ -4224,7 +4226,7 @@ msgstr ""
 msgid "No note history available for this device."
 msgstr ""
 
-#: src/strings.ts:2503
+#: src/strings.ts:2504
 msgid "No notebooks selected to move"
 msgstr ""
 
@@ -4232,7 +4234,7 @@ msgstr ""
 msgid "No one can view this {type} except you."
 msgstr ""
 
-#: src/strings.ts:2626
+#: src/strings.ts:2627
 msgid "No password"
 msgstr ""
 
@@ -4240,7 +4242,7 @@ msgstr ""
 msgid "No references found of this note"
 msgstr ""
 
-#: src/strings.ts:1516
+#: src/strings.ts:1517
 msgid "No results found"
 msgstr ""
 
@@ -4248,7 +4250,7 @@ msgstr ""
 msgid "No results found for \"{query}\""
 msgstr ""
 
-#: src/strings.ts:1516
+#: src/strings.ts:1517
 msgid "No results found for {query}"
 msgstr ""
 
@@ -4264,7 +4266,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: src/strings.ts:2014
+#: src/strings.ts:2015
 msgid "Normal mode"
 msgstr ""
 
@@ -4285,8 +4287,12 @@ msgstr ""
 msgid "Note copied to clipboard"
 msgstr ""
 
-#: src/strings.ts:1949
+#: src/strings.ts:1950
 msgid "Note does not exist"
+msgstr ""
+
+#: src/strings.ts:816
+msgid "Note duplicated"
 msgstr ""
 
 #: src/strings.ts:458
@@ -4297,11 +4303,11 @@ msgstr ""
 msgid "Note locked"
 msgstr ""
 
-#: src/strings.ts:845
+#: src/strings.ts:846
 msgid "Note restored from history"
 msgstr ""
 
-#: src/strings.ts:1585
+#: src/strings.ts:1586
 msgid "Note title"
 msgstr ""
 
@@ -4313,7 +4319,7 @@ msgstr ""
 msgid "Note version history is local only."
 msgstr ""
 
-#: src/strings.ts:1224
+#: src/strings.ts:1225
 msgid "NOTE: Creating a backup with attachments can take a while, and also fail completely. The app will try to resume/restart the backup in case of interruptions."
 msgstr ""
 
@@ -4322,11 +4328,11 @@ msgid "notebook"
 msgstr ""
 
 #: src/strings.ts:296
-#: src/strings.ts:1520
+#: src/strings.ts:1521
 msgid "Notebook"
 msgstr ""
 
-#: src/strings.ts:2489
+#: src/strings.ts:2490
 msgid "Notebook added"
 msgstr ""
 
@@ -4336,15 +4342,15 @@ msgstr ""
 
 #: src/strings.ts:258
 #: src/strings.ts:316
-#: src/strings.ts:1519
+#: src/strings.ts:1520
 msgid "Notebooks"
 msgstr ""
 
-#: src/strings.ts:1794
+#: src/strings.ts:1795
 msgid "NOTEBOOKS"
 msgstr ""
 
-#: src/strings.ts:2251
+#: src/strings.ts:2252
 msgid "Notebooks are the best way to organize your notes."
 msgstr ""
 
@@ -4353,7 +4359,7 @@ msgid "notes"
 msgstr ""
 
 #: src/strings.ts:315
-#: src/strings.ts:1518
+#: src/strings.ts:1519
 msgid "Notes"
 msgstr ""
 
@@ -4361,35 +4367,35 @@ msgstr ""
 msgid "Notes exported as {path} successfully"
 msgstr ""
 
-#: src/strings.ts:1750
+#: src/strings.ts:1751
 msgid "notes imported"
 msgstr ""
 
-#: src/strings.ts:2553
+#: src/strings.ts:2554
 msgid "Notesnook"
 msgstr ""
 
-#: src/strings.ts:2611
+#: src/strings.ts:2612
 msgid "Notesnook Circle"
 msgstr ""
 
-#: src/strings.ts:2613
+#: src/strings.ts:2614
 msgid "Notesnook Circle brings together trusted partners who share our commitment to privacy, transparency, and user freedom."
 msgstr ""
 
-#: src/strings.ts:2077
+#: src/strings.ts:2078
 msgid "Notesnook encrypts everything offline before syncing to your other devices. This means that no one can read your notes except you. Not even us."
 msgstr ""
 
-#: src/strings.ts:2152
+#: src/strings.ts:2153
 msgid "Notesnook Importer"
 msgstr ""
 
-#: src/strings.ts:1066
+#: src/strings.ts:1067
 msgid "Notesnook Pro"
 msgstr ""
 
-#: src/strings.ts:2184
+#: src/strings.ts:2185
 msgid ""
 "Notesnook uses the following DNS providers:\n"
 "\n"
@@ -4399,31 +4405,31 @@ msgid ""
 "This can sometimes bypass local ISP blockages on Notesnook traffic. Disable this if you want the app to use system's DNS settings."
 msgstr ""
 
-#: src/strings.ts:987
+#: src/strings.ts:988
 msgid "Notesnook will send you a 2FA code on your email when prompted"
 msgstr ""
 
-#: src/strings.ts:994
+#: src/strings.ts:995
 msgid "Notesnook will send you an SMS with a 2FA code when prompted"
 msgstr ""
 
-#: src/strings.ts:2147
+#: src/strings.ts:2148
 msgid "Notifications"
 msgstr ""
 
-#: src/strings.ts:1377
+#: src/strings.ts:1378
 msgid "Notifications disabled"
 msgstr ""
 
-#: src/strings.ts:2285
+#: src/strings.ts:2286
 msgid "Numbered list"
 msgstr ""
 
-#: src/strings.ts:1718
+#: src/strings.ts:1719
 msgid "of"
 msgstr ""
 
-#: src/strings.ts:1602
+#: src/strings.ts:1603
 msgid "Off"
 msgstr ""
 
@@ -4431,7 +4437,7 @@ msgstr ""
 msgid "Offline"
 msgstr ""
 
-#: src/strings.ts:2237
+#: src/strings.ts:2238
 msgid "Okay"
 msgstr ""
 
@@ -4439,11 +4445,11 @@ msgstr ""
 msgid "Old - new"
 msgstr ""
 
-#: src/strings.ts:1835
+#: src/strings.ts:1836
 msgid "Older version"
 msgstr ""
 
-#: src/strings.ts:2023
+#: src/strings.ts:2024
 msgid "Oldest - newest"
 msgstr ""
 
@@ -4451,11 +4457,11 @@ msgstr ""
 msgid "Once your password is changed, please make sure to save the new account recovery key"
 msgstr ""
 
-#: src/strings.ts:2571
+#: src/strings.ts:2572
 msgid "One time purchase, no auto-renewal"
 msgstr ""
 
-#: src/strings.ts:1771
+#: src/strings.ts:1772
 msgid "Only .zip files are supported."
 msgstr ""
 
@@ -4471,11 +4477,11 @@ msgstr ""
 msgid "Open in browser"
 msgstr ""
 
-#: src/strings.ts:1306
+#: src/strings.ts:1307
 msgid "Open in browser to manage subscription"
 msgstr ""
 
-#: src/strings.ts:2335
+#: src/strings.ts:2336
 msgid "Open in new tab"
 msgstr ""
 
@@ -4483,43 +4489,43 @@ msgstr ""
 msgid "Open issue"
 msgstr ""
 
-#: src/strings.ts:2275
+#: src/strings.ts:2276
 msgid "Open link"
 msgstr ""
 
-#: src/strings.ts:1863
+#: src/strings.ts:1864
 msgid "Open note"
 msgstr ""
 
-#: src/strings.ts:1380
+#: src/strings.ts:1381
 msgid "Open settings"
 msgstr ""
 
-#: src/strings.ts:2336
+#: src/strings.ts:2337
 msgid "Open source"
 msgstr ""
 
-#: src/strings.ts:1288
+#: src/strings.ts:1289
 msgid "Open source libraries used in Notesnook"
 msgstr ""
 
-#: src/strings.ts:1287
+#: src/strings.ts:1288
 msgid "Open source licenses"
 msgstr ""
 
-#: src/strings.ts:819
+#: src/strings.ts:820
 msgid "Open source."
 msgstr ""
 
-#: src/strings.ts:983
+#: src/strings.ts:984
 msgid "Open the two-factor authentication (TOTP) app to view your authentication code."
 msgstr ""
 
-#: src/strings.ts:2685
+#: src/strings.ts:2686
 msgid "Opening local file"
 msgstr ""
 
-#: src/strings.ts:1857
+#: src/strings.ts:1858
 msgid "Optional"
 msgstr ""
 
@@ -4527,11 +4533,11 @@ msgstr ""
 msgid "or email us at"
 msgstr ""
 
-#: src/strings.ts:2022
+#: src/strings.ts:2023
 msgid "Order by"
 msgstr ""
 
-#: src/strings.ts:2230
+#: src/strings.ts:2231
 msgid "Order ID"
 msgstr ""
 
@@ -4540,23 +4546,23 @@ msgstr ""
 msgid "Orphaned"
 msgstr ""
 
-#: src/strings.ts:2155
+#: src/strings.ts:2156
 msgid "Other"
 msgstr ""
 
-#: src/strings.ts:2356
+#: src/strings.ts:2357
 msgid "Outline list"
 msgstr ""
 
-#: src/strings.ts:2359
+#: src/strings.ts:2360
 msgid "Paragraph"
 msgstr ""
 
-#: src/strings.ts:2502
+#: src/strings.ts:2503
 msgid "Paragraphs"
 msgstr ""
 
-#: src/strings.ts:2111
+#: src/strings.ts:2112
 msgid "Partial backups contain all your data except attachments. They are created from data already available on your device and do not require an Internet connection."
 msgstr ""
 
@@ -4564,11 +4570,11 @@ msgstr ""
 msgid "Partially refunded"
 msgstr ""
 
-#: src/strings.ts:2413
+#: src/strings.ts:2414
 msgid "Passed"
 msgstr ""
 
-#: src/strings.ts:883
+#: src/strings.ts:884
 msgid "Password"
 msgstr ""
 
@@ -4596,7 +4602,7 @@ msgstr ""
 msgid "Password protection"
 msgstr ""
 
-#: src/strings.ts:2660
+#: src/strings.ts:2661
 msgid "Password required"
 msgstr ""
 
@@ -4604,35 +4610,35 @@ msgstr ""
 msgid "Password updated"
 msgstr ""
 
-#: src/strings.ts:2091
+#: src/strings.ts:2092
 msgid "Password/pin"
 msgstr ""
 
-#: src/strings.ts:2259
+#: src/strings.ts:2260
 msgid "Paste"
 msgstr ""
 
-#: src/strings.ts:2260
+#: src/strings.ts:2261
 msgid "Paste and match style"
 msgstr ""
 
-#: src/strings.ts:2381
+#: src/strings.ts:2382
 msgid "Paste embed code here. Only iframes are supported."
 msgstr ""
 
-#: src/strings.ts:2396
+#: src/strings.ts:2397
 msgid "Paste image URL here"
 msgstr ""
 
-#: src/strings.ts:2261
+#: src/strings.ts:2262
 msgid "Paste without formatting"
 msgstr ""
 
-#: src/strings.ts:2572
+#: src/strings.ts:2573
 msgid "Pay once and use for 5 years"
 msgstr ""
 
-#: src/strings.ts:2209
+#: src/strings.ts:2210
 msgid "Payment method"
 msgstr ""
 
@@ -4640,27 +4646,27 @@ msgstr ""
 msgid "PDF is password protected"
 msgstr ""
 
-#: src/strings.ts:1729
+#: src/strings.ts:1730
 msgid "phone number"
 msgstr ""
 
-#: src/strings.ts:1848
+#: src/strings.ts:1849
 msgid "Phone number"
 msgstr ""
 
-#: src/strings.ts:1007
+#: src/strings.ts:1008
 msgid "Phone number not entered"
 msgstr ""
 
-#: src/strings.ts:900
+#: src/strings.ts:901
 msgid "Pin"
 msgstr ""
 
-#: src/strings.ts:1690
+#: src/strings.ts:1691
 msgid "Pin notes in notifications drawer"
 msgstr ""
 
-#: src/strings.ts:928
+#: src/strings.ts:929
 msgid "Pin notification"
 msgstr ""
 
@@ -4668,66 +4674,66 @@ msgstr ""
 msgid "Pinned"
 msgstr ""
 
-#: src/strings.ts:2593
+#: src/strings.ts:2594
 msgid "Plan limits"
 msgstr ""
 
-#: src/strings.ts:2553
+#: src/strings.ts:2554
 msgid "Plans"
 msgstr ""
 
-#: src/strings.ts:1364
+#: src/strings.ts:1365
 msgid "Please confirm your email to sync notes"
 msgstr ""
 
-#: src/strings.ts:1002
+#: src/strings.ts:1003
 msgid "Please confirm your identity by entering a recovery code."
 msgstr ""
 
-#: src/strings.ts:981
-#: src/strings.ts:2243
+#: src/strings.ts:982
+#: src/strings.ts:2244
 msgid "Please confirm your identity by entering the authentication code from your authenticator app."
 msgstr ""
 
 #. placeholder {0}: phoneNumber ? phoneNumber : "your registered phone number."
-#: src/strings.ts:996
+#: src/strings.ts:997
 msgid "Please confirm your identity by entering the authentication code sent to {0}."
 msgstr ""
 
-#: src/strings.ts:989
+#: src/strings.ts:990
 msgid "Please confirm your identity by entering the authentication code sent to your email address."
 msgstr ""
 
-#: src/strings.ts:1909
+#: src/strings.ts:1910
 msgid "Please download a backup of your data as your account will be cleared before recovery."
 msgstr ""
 
-#: src/strings.ts:2007
+#: src/strings.ts:2008
 msgid "Please enable automatic backups to avoid losing important data."
 msgstr ""
 
-#: src/strings.ts:1512
-#: src/strings.ts:2662
+#: src/strings.ts:1513
+#: src/strings.ts:2663
 msgid "Please enter a valid email address"
 msgstr ""
 
-#: src/strings.ts:1954
+#: src/strings.ts:1955
 msgid "Please enter a valid hex color (e.g. #ffffff)"
 msgstr ""
 
-#: src/strings.ts:1513
+#: src/strings.ts:1514
 msgid "Please enter a valid phone number with country code"
 msgstr ""
 
-#: src/strings.ts:1635
+#: src/strings.ts:1636
 msgid "Please enter a valid URL"
 msgstr ""
 
-#: src/strings.ts:1620
+#: src/strings.ts:1621
 msgid "Please enter password of this backup file"
 msgstr ""
 
-#: src/strings.ts:2254
+#: src/strings.ts:2255
 msgid "Please enter the password to decrypt and restore this backup."
 msgstr ""
 
@@ -4735,27 +4741,27 @@ msgstr ""
 msgid "Please enter the password to unlock the PDF and view the content."
 msgstr ""
 
-#: src/strings.ts:1865
+#: src/strings.ts:1866
 msgid "Please enter the password to unlock this note"
 msgstr ""
 
-#: src/strings.ts:1862
+#: src/strings.ts:1863
 msgid "Please enter the password to view this version"
 msgstr ""
 
-#: src/strings.ts:1021
+#: src/strings.ts:1022
 msgid "Please enter your app lock password to continue"
 msgstr ""
 
-#: src/strings.ts:1023
+#: src/strings.ts:1024
 msgid "Please enter your app lock pin to continue"
 msgstr ""
 
-#: src/strings.ts:1017
+#: src/strings.ts:1018
 msgid "Please enter your password to continue"
 msgstr ""
 
-#: src/strings.ts:1933
+#: src/strings.ts:1934
 msgid "Please enter your vault password to continue"
 msgstr ""
 
@@ -4763,15 +4769,15 @@ msgstr ""
 msgid "Please fill all the fields to continue."
 msgstr ""
 
-#: src/strings.ts:1556
+#: src/strings.ts:1557
 msgid "Please grant notifications permission to add new reminders."
 msgstr ""
 
-#: src/strings.ts:2677
+#: src/strings.ts:2678
 msgid "Please login to download attachments."
 msgstr ""
 
-#: src/strings.ts:873
+#: src/strings.ts:874
 msgid "Please make sure you have saved the recovery key. Tap one more time to confirm."
 msgstr ""
 
@@ -4779,27 +4785,27 @@ msgstr ""
 msgid "Please note that we will respond to your issue on the given link. We recommend that you save it."
 msgstr ""
 
-#: src/strings.ts:1765
+#: src/strings.ts:1766
 msgid "Please refer to the"
 msgstr ""
 
-#: src/strings.ts:1557
+#: src/strings.ts:1558
 msgid "Please select the day to repeat the reminder on"
 msgstr ""
 
-#: src/strings.ts:1396
+#: src/strings.ts:1397
 msgid "please send us an email from your registered email address"
 msgstr ""
 
-#: src/strings.ts:2402
+#: src/strings.ts:2403
 msgid "Please set a table size"
 msgstr ""
 
-#: src/strings.ts:1558
+#: src/strings.ts:1559
 msgid "Please set title of the reminder"
 msgstr ""
 
-#: src/strings.ts:1987
+#: src/strings.ts:1988
 msgid "Please try again"
 msgstr ""
 
@@ -4811,16 +4817,16 @@ msgstr ""
 msgid "Please wait"
 msgstr ""
 
-#: src/strings.ts:1006
+#: src/strings.ts:1007
 msgid "Please wait before requesting a new code"
 msgstr ""
 
-#: src/strings.ts:1399
-#: src/strings.ts:1551
+#: src/strings.ts:1400
+#: src/strings.ts:1552
 msgid "Please wait before requesting another email"
 msgstr ""
 
-#: src/strings.ts:942
+#: src/strings.ts:943
 msgid "Please wait while we encrypt {name} for upload."
 msgstr ""
 
@@ -4832,11 +4838,11 @@ msgstr ""
 msgid "Please wait while we export your notes."
 msgstr ""
 
-#: src/strings.ts:1894
+#: src/strings.ts:1895
 msgid "Please wait while we finalize your account."
 msgstr ""
 
-#: src/strings.ts:1065
+#: src/strings.ts:1066
 msgid "Please wait while we load your subscription"
 msgstr ""
 
@@ -4844,15 +4850,15 @@ msgstr ""
 msgid "Please wait while we log you out."
 msgstr ""
 
-#: src/strings.ts:1915
+#: src/strings.ts:1916
 msgid "Please wait while we reset your account password."
 msgstr ""
 
-#: src/strings.ts:1613
+#: src/strings.ts:1614
 msgid "Please wait while we restore your backup..."
 msgstr ""
 
-#: src/strings.ts:1897
+#: src/strings.ts:1898
 msgid "Please wait while we send you recovery instructions"
 msgstr ""
 
@@ -4860,24 +4866,24 @@ msgstr ""
 msgid "Please wait while we sync all your data."
 msgstr ""
 
-#: src/strings.ts:1071
+#: src/strings.ts:1072
 msgid "Please wait while we verify your subscription"
 msgstr ""
 
-#: src/strings.ts:1783
-#: src/strings.ts:1890
+#: src/strings.ts:1784
+#: src/strings.ts:1891
 msgid "Please wait while you are authenticated."
 msgstr ""
 
-#: src/strings.ts:1902
+#: src/strings.ts:1903
 msgid "Please wait while your data is downloaded & decrypted."
 msgstr ""
 
-#: src/strings.ts:905
+#: src/strings.ts:906
 msgid "Preparing note for share"
 msgstr ""
 
-#: src/strings.ts:1615
+#: src/strings.ts:1616
 msgid "Preparing to restore backup file..."
 msgstr ""
 
@@ -4885,19 +4891,19 @@ msgstr ""
 msgid "PRESETS"
 msgstr ""
 
-#: src/strings.ts:2129
+#: src/strings.ts:2130
 msgid "Pressing \"—\" will hide the app in your system tray."
 msgstr ""
 
-#: src/strings.ts:2132
+#: src/strings.ts:2133
 msgid "Pressing \"X\" will hide the app in your system tray."
 msgstr ""
 
-#: src/strings.ts:2180
+#: src/strings.ts:2181
 msgid "Prevent note title from appearing in tab/window title."
 msgstr ""
 
-#: src/strings.ts:2323
+#: src/strings.ts:2324
 msgid "Preview attachment"
 msgstr ""
 
@@ -4905,43 +4911,43 @@ msgstr ""
 msgid "Preview not available, content is encrypted."
 msgstr ""
 
-#: src/strings.ts:2390
+#: src/strings.ts:2391
 msgid "Previous match"
 msgstr ""
 
-#: src/strings.ts:2455
+#: src/strings.ts:2456
 msgid "Previous tab"
 msgstr ""
 
-#: src/strings.ts:2034
+#: src/strings.ts:2035
 msgid "Print"
 msgstr ""
 
-#: src/strings.ts:2154
+#: src/strings.ts:2155
 msgid "Privacy"
 msgstr ""
 
-#: src/strings.ts:1161
+#: src/strings.ts:1162
 msgid "Privacy & security"
 msgstr ""
 
-#: src/strings.ts:1655
+#: src/strings.ts:1656
 msgid "Privacy comes first."
 msgstr ""
 
-#: src/strings.ts:827
+#: src/strings.ts:828
 msgid "Privacy for everyone"
 msgstr ""
 
-#: src/strings.ts:1180
+#: src/strings.ts:1181
 msgid "Privacy mode"
 msgstr ""
 
-#: src/strings.ts:2588
+#: src/strings.ts:2589
 msgid "privacy policy"
 msgstr ""
 
-#: src/strings.ts:1285
+#: src/strings.ts:1286
 msgid "Privacy policy"
 msgstr ""
 
@@ -4953,43 +4959,43 @@ msgstr ""
 msgid "private analytics and bug reports."
 msgstr ""
 
-#: src/strings.ts:821
+#: src/strings.ts:822
 msgid "Private."
 msgstr ""
 
-#: src/strings.ts:829
+#: src/strings.ts:830
 msgid "privileged few"
 msgstr ""
 
-#: src/strings.ts:1721
+#: src/strings.ts:1722
 msgid "Pro"
 msgstr ""
 
-#: src/strings.ts:2480
+#: src/strings.ts:2481
 msgid "Pro plan"
 msgstr ""
 
-#: src/strings.ts:2047
+#: src/strings.ts:2048
 msgid "Processing {collection}..."
 msgstr ""
 
-#: src/strings.ts:2046
+#: src/strings.ts:2047
 msgid "Processing..."
 msgstr ""
 
-#: src/strings.ts:1240
+#: src/strings.ts:1241
 msgid "Productivity"
 msgstr ""
 
-#: src/strings.ts:2143
+#: src/strings.ts:2144
 msgid "Profile"
 msgstr ""
 
-#: src/strings.ts:1955
+#: src/strings.ts:1956
 msgid "Profile updated"
 msgstr ""
 
-#: src/strings.ts:1866
+#: src/strings.ts:1867
 msgid "Properties"
 msgstr ""
 
@@ -4997,7 +5003,7 @@ msgstr ""
 msgid "Protect your notes"
 msgstr ""
 
-#: src/strings.ts:2191
+#: src/strings.ts:2192
 msgid "Proxy"
 msgstr ""
 
@@ -5009,7 +5015,7 @@ msgstr ""
 msgid "Publish note"
 msgstr ""
 
-#: src/strings.ts:2627
+#: src/strings.ts:2628
 msgid "Publish to the web"
 msgstr ""
 
@@ -5017,7 +5023,7 @@ msgstr ""
 msgid "Publish your note to share it with others. You can set a password to protect it."
 msgstr ""
 
-#: src/strings.ts:926
+#: src/strings.ts:927
 msgid "Published"
 msgstr ""
 
@@ -5033,39 +5039,39 @@ msgstr ""
 msgid "Published note link will be automatically deleted once it is viewed by someone."
 msgstr ""
 
-#: src/strings.ts:2581
+#: src/strings.ts:2582
 msgid "Purchase"
 msgstr ""
 
-#: src/strings.ts:1371
+#: src/strings.ts:1372
 msgid "Quick note"
 msgstr ""
 
-#: src/strings.ts:1241
+#: src/strings.ts:1242
 msgid "Quick note notification"
 msgstr ""
 
-#: src/strings.ts:1692
+#: src/strings.ts:1693
 msgid "Quick note widgets"
 msgstr ""
 
-#: src/strings.ts:2451
+#: src/strings.ts:2452
 msgid "Quick open"
 msgstr ""
 
-#: src/strings.ts:1243
+#: src/strings.ts:1244
 msgid "Quickly create a note from the notification"
 msgstr ""
 
-#: src/strings.ts:2343
+#: src/strings.ts:2344
 msgid "Quote"
 msgstr ""
 
-#: src/strings.ts:1357
+#: src/strings.ts:1358
 msgid "Rate Notesnook on App Store"
 msgstr ""
 
-#: src/strings.ts:1358
+#: src/strings.ts:1359
 msgid "Rate Notesnook on Play Store"
 msgstr ""
 
@@ -5077,51 +5083,51 @@ msgstr ""
 msgid "Read full release notes on Github"
 msgstr ""
 
-#: src/strings.ts:912
+#: src/strings.ts:913
 msgid "Read only"
 msgstr ""
 
-#: src/strings.ts:1265
+#: src/strings.ts:1266
 msgid "Read the documentation to learn more about Notesnook"
 msgstr ""
 
-#: src/strings.ts:1286
+#: src/strings.ts:1287
 msgid "Read the privacy policy"
 msgstr ""
 
-#: src/strings.ts:1284
+#: src/strings.ts:1285
 msgid "Read the terms of service"
 msgstr ""
 
-#: src/strings.ts:1616
+#: src/strings.ts:1617
 msgid "Reading backup file..."
 msgstr ""
 
-#: src/strings.ts:2555
+#: src/strings.ts:2556
 msgid "Ready to take the next step on your private note taking journey?"
 msgstr ""
 
-#: src/strings.ts:2233
+#: src/strings.ts:2234
 msgid "Receipt"
 msgstr ""
 
-#: src/strings.ts:1611
+#: src/strings.ts:1612
 msgid "RECENT BACKUPS"
 msgstr ""
 
-#: src/strings.ts:2466
+#: src/strings.ts:2467
 msgid "Recents"
 msgstr ""
 
-#: src/strings.ts:2409
+#: src/strings.ts:2410
 msgid "Recheck all"
 msgstr ""
 
-#: src/strings.ts:2001
+#: src/strings.ts:2002
 msgid "Rechecking failed"
 msgstr ""
 
-#: src/strings.ts:2434
+#: src/strings.ts:2435
 msgid "Recipes"
 msgstr ""
 
@@ -5129,7 +5135,7 @@ msgstr ""
 msgid "Recommended"
 msgstr ""
 
-#: src/strings.ts:2557
+#: src/strings.ts:2558
 msgid "Recommended by Privacy Guides"
 msgstr ""
 
@@ -5137,11 +5143,11 @@ msgstr ""
 msgid "Recover your account"
 msgstr ""
 
-#: src/strings.ts:1005
+#: src/strings.ts:1006
 msgid "Recovery codes copied!"
 msgstr ""
 
-#: src/strings.ts:1010
+#: src/strings.ts:1011
 msgid "Recovery codes saved!"
 msgstr ""
 
@@ -5153,35 +5159,35 @@ msgstr ""
 msgid "Recovery email sent!"
 msgstr ""
 
-#: src/strings.ts:876
+#: src/strings.ts:877
 msgid "Recovery key copied"
 msgstr ""
 
-#: src/strings.ts:874
+#: src/strings.ts:875
 msgid "Recovery key QR code saved"
 msgstr ""
 
-#: src/strings.ts:875
+#: src/strings.ts:876
 msgid "Recovery key text file saved"
 msgstr ""
 
-#: src/strings.ts:1916
+#: src/strings.ts:1917
 msgid "Recovery successful!"
 msgstr ""
 
-#: src/strings.ts:2446
+#: src/strings.ts:2447
 msgid "Redeem"
 msgstr ""
 
-#: src/strings.ts:2610
+#: src/strings.ts:2611
 msgid "Redeem code"
 msgstr ""
 
-#: src/strings.ts:2443
+#: src/strings.ts:2444
 msgid "Redeem gift code"
 msgstr ""
 
-#: src/strings.ts:2445
+#: src/strings.ts:2446
 msgid "Redeeming gift code"
 msgstr ""
 
@@ -5193,7 +5199,7 @@ msgstr ""
 msgid "Referenced in"
 msgstr ""
 
-#: src/strings.ts:935
+#: src/strings.ts:936
 msgid "References"
 msgstr ""
 
@@ -5201,7 +5207,7 @@ msgstr ""
 msgid "Regenerate"
 msgstr ""
 
-#: src/strings.ts:2097
+#: src/strings.ts:2098
 msgid "Register"
 msgstr ""
 
@@ -5209,7 +5215,7 @@ msgstr ""
 msgid "Release notes"
 msgstr ""
 
-#: src/strings.ts:2468
+#: src/strings.ts:2469
 msgid "Release track"
 msgstr ""
 
@@ -5217,19 +5223,19 @@ msgstr ""
 msgid "Relevance"
 msgstr ""
 
-#: src/strings.ts:1670
+#: src/strings.ts:1671
 msgid "Reload app"
 msgstr ""
 
-#: src/strings.ts:1828
+#: src/strings.ts:1829
 msgid "Relogin to your account"
 msgstr ""
 
-#: src/strings.ts:1796
+#: src/strings.ts:1797
 msgid "Remembered your password?"
 msgstr ""
 
-#: src/strings.ts:925
+#: src/strings.ts:926
 msgid "Remind me"
 msgstr ""
 
@@ -5237,7 +5243,7 @@ msgstr ""
 msgid "Remind me in"
 msgstr ""
 
-#: src/strings.ts:1506
+#: src/strings.ts:1507
 msgid "Remind me of..."
 msgstr ""
 
@@ -5249,11 +5255,11 @@ msgstr ""
 msgid "Reminder"
 msgstr ""
 
-#: src/strings.ts:1246
+#: src/strings.ts:1247
 msgid "Reminder notifications"
 msgstr ""
 
-#: src/strings.ts:1559
+#: src/strings.ts:1560
 msgid "Reminder time cannot be earlier than the current time."
 msgstr ""
 
@@ -5262,16 +5268,16 @@ msgid "reminders"
 msgstr ""
 
 #: src/strings.ts:318
-#: src/strings.ts:1244
-#: src/strings.ts:1522
+#: src/strings.ts:1245
+#: src/strings.ts:1523
 msgid "Reminders"
 msgstr ""
 
-#: src/strings.ts:1379
+#: src/strings.ts:1380
 msgid "Reminders cannot be set because notifications have been disabled from app settings. If you want to keep receiving reminder notifications, enable notifications for Notesnook from app settings."
 msgstr ""
 
-#: src/strings.ts:1953
+#: src/strings.ts:1954
 msgid "Reminders will not be active on this device as it does not support notifications."
 msgstr ""
 
@@ -5279,63 +5285,63 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: src/strings.ts:1175
+#: src/strings.ts:1176
 msgid "Remove all notes from the vault."
 msgstr ""
 
-#: src/strings.ts:1202
+#: src/strings.ts:1203
 msgid "Remove app lock password"
 msgstr ""
 
-#: src/strings.ts:1206
+#: src/strings.ts:1207
 msgid "Remove app lock password, app lock will be disabled if no other security method is enabled."
 msgstr ""
 
-#: src/strings.ts:1201
+#: src/strings.ts:1202
 msgid "Remove app lock pin"
 msgstr ""
 
-#: src/strings.ts:1204
+#: src/strings.ts:1205
 msgid "Remove app lock pin, app lock will be disabled if no other security method is enabled."
 msgstr ""
 
-#: src/strings.ts:896
+#: src/strings.ts:897
 msgid "Remove as default"
 msgstr ""
 
-#: src/strings.ts:2327
+#: src/strings.ts:2328
 msgid "Remove attachment"
 msgstr ""
 
-#: src/strings.ts:931
+#: src/strings.ts:932
 msgid "Remove from all"
 msgstr ""
 
-#: src/strings.ts:906
+#: src/strings.ts:907
 msgid "Remove from notebook"
 msgstr ""
 
-#: src/strings.ts:2467
+#: src/strings.ts:2468
 msgid "Remove from recents"
 msgstr ""
 
-#: src/strings.ts:1044
+#: src/strings.ts:1045
 msgid "Remove full name"
 msgstr ""
 
-#: src/strings.ts:2274
+#: src/strings.ts:2275
 msgid "Remove link"
 msgstr ""
 
-#: src/strings.ts:1040
+#: src/strings.ts:1041
 msgid "Remove profile picture"
 msgstr ""
 
-#: src/strings.ts:1047
+#: src/strings.ts:1048
 msgid "Remove your full name from profile"
 msgstr ""
 
-#: src/strings.ts:1041
+#: src/strings.ts:1042
 msgid "Remove your profile picture"
 msgstr ""
 
@@ -5347,7 +5353,7 @@ msgstr ""
 msgid "Rename file"
 msgstr ""
 
-#: src/strings.ts:891
+#: src/strings.ts:892
 msgid "Reorder"
 msgstr ""
 
@@ -5355,19 +5361,19 @@ msgstr ""
 msgid "Repeats daily at {date}"
 msgstr ""
 
-#: src/strings.ts:2387
+#: src/strings.ts:2388
 msgid "Replace"
 msgstr ""
 
-#: src/strings.ts:2388
+#: src/strings.ts:2389
 msgid "Replace all"
 msgstr ""
 
-#: src/strings.ts:2174
+#: src/strings.ts:2175
 msgid "Report"
 msgstr ""
 
-#: src/strings.ts:1257
+#: src/strings.ts:1258
 msgid "Report an issue"
 msgstr ""
 
@@ -5384,59 +5390,59 @@ msgstr ""
 msgid "Resend code{0}"
 msgstr ""
 
-#: src/strings.ts:1402
+#: src/strings.ts:1403
 msgid "Resend email"
 msgstr ""
 
-#: src/strings.ts:1820
+#: src/strings.ts:1821
 msgid "Reset"
 msgstr ""
 
-#: src/strings.ts:1912
+#: src/strings.ts:1913
 msgid "Reset account password"
 msgstr ""
 
-#: src/strings.ts:2494
+#: src/strings.ts:2495
 msgid "Reset homepage"
 msgstr ""
 
-#: src/strings.ts:1821
+#: src/strings.ts:1822
 msgid "Reset selection"
 msgstr ""
 
-#: src/strings.ts:1648
+#: src/strings.ts:1649
 msgid "Reset server urls"
 msgstr ""
 
-#: src/strings.ts:2030
+#: src/strings.ts:2031
 msgid "Reset sidebar"
 msgstr ""
 
-#: src/strings.ts:1147
+#: src/strings.ts:1148
 msgid "Reset the toolbar to default settings"
 msgstr ""
 
-#: src/strings.ts:1146
+#: src/strings.ts:1147
 msgid "Reset toolbar"
 msgstr ""
 
-#: src/strings.ts:1914
+#: src/strings.ts:1915
 msgid "Resetting account password ({progress})"
 msgstr ""
 
-#: src/strings.ts:1989
+#: src/strings.ts:1990
 msgid "Restart now"
 msgstr ""
 
-#: src/strings.ts:1647
+#: src/strings.ts:1648
 msgid "Restart the app for changes to take effect."
 msgstr ""
 
-#: src/strings.ts:1318
+#: src/strings.ts:1319
 msgid "Restart the app to apply the changes"
 msgstr ""
 
-#: src/strings.ts:1593
+#: src/strings.ts:1594
 msgid "Restart the app."
 msgstr ""
 
@@ -5444,31 +5450,31 @@ msgstr ""
 msgid "Restore"
 msgstr ""
 
-#: src/strings.ts:1235
+#: src/strings.ts:1236
 msgid "Restore backup"
 msgstr ""
 
-#: src/strings.ts:2416
+#: src/strings.ts:2417
 msgid "Restore backup?"
 msgstr ""
 
-#: src/strings.ts:890
+#: src/strings.ts:891
 msgid "Restore failed"
 msgstr ""
 
-#: src/strings.ts:1610
+#: src/strings.ts:1611
 msgid "Restore from files"
 msgstr ""
 
-#: src/strings.ts:1660
+#: src/strings.ts:1661
 msgid "Restore this version"
 msgstr ""
 
-#: src/strings.ts:1236
+#: src/strings.ts:1237
 msgid "Restore your data from a backup"
 msgstr ""
 
-#: src/strings.ts:849
+#: src/strings.ts:850
 msgid "Restored successfully"
 msgstr ""
 
@@ -5480,7 +5486,7 @@ msgstr ""
 msgid "Restoring {collection}..."
 msgstr ""
 
-#: src/strings.ts:1612
+#: src/strings.ts:1613
 msgid "Restoring backup..."
 msgstr ""
 
@@ -5496,7 +5502,7 @@ msgstr ""
 msgid "Reupload"
 msgstr ""
 
-#: src/strings.ts:2020
+#: src/strings.ts:2021
 msgid "Reveal in list"
 msgstr ""
 
@@ -5504,7 +5510,7 @@ msgstr ""
 msgid "Revoke"
 msgstr ""
 
-#: src/strings.ts:1179
+#: src/strings.ts:1180
 msgid "Revoke biometric unlocking"
 msgstr ""
 
@@ -5512,23 +5518,23 @@ msgstr ""
 msgid "Revoke vault fingerprint unlock"
 msgstr ""
 
-#: src/strings.ts:1293
+#: src/strings.ts:1294
 msgid "Roadmap"
 msgstr ""
 
-#: src/strings.ts:2048
+#: src/strings.ts:2049
 msgid "Root"
 msgstr ""
 
-#: src/strings.ts:2027
+#: src/strings.ts:2028
 msgid "Rotate left"
 msgstr ""
 
-#: src/strings.ts:2028
+#: src/strings.ts:2029
 msgid "Rotate right"
 msgstr ""
 
-#: src/strings.ts:2297
+#: src/strings.ts:2298
 msgid "Row properties"
 msgstr ""
 
@@ -5536,7 +5542,7 @@ msgstr ""
 msgid "Run file check"
 msgstr ""
 
-#: src/strings.ts:2069
+#: src/strings.ts:2070
 msgid "Safe & encrypted notes"
 msgstr ""
 
@@ -5568,11 +5574,11 @@ msgstr ""
 msgid "Save and continue"
 msgstr ""
 
-#: src/strings.ts:1048
+#: src/strings.ts:1049
 msgid "Save data recovery key"
 msgstr ""
 
-#: src/strings.ts:953
+#: src/strings.ts:954
 msgid "Save failed. Vault is locked"
 msgstr ""
 
@@ -5592,7 +5598,7 @@ msgstr ""
 msgid "Save to text file"
 msgstr ""
 
-#: src/strings.ts:1360
+#: src/strings.ts:1361
 msgid "Save your account recovery key"
 msgstr ""
 
@@ -5600,7 +5606,7 @@ msgstr ""
 msgid "Save your account recovery key in a safe place. You will need it to recover your account in case you forget your password."
 msgstr ""
 
-#: src/strings.ts:1050
+#: src/strings.ts:1051
 msgid "Save your data recovery key in a safe place. You will need it to recover your data in case you forget your password."
 msgstr ""
 
@@ -5608,15 +5614,15 @@ msgstr ""
 msgid "Save your recovery codes in a safe place. You will need them to recover your account in case you lose access to your two-factor authentication methods."
 msgstr ""
 
-#: src/strings.ts:2406
+#: src/strings.ts:2407
 msgid "Saved"
 msgstr ""
 
-#: src/strings.ts:2407
+#: src/strings.ts:2408
 msgid "Saving"
 msgstr ""
 
-#: src/strings.ts:1588
+#: src/strings.ts:1589
 msgid "Saving this note is taking too long. Copy your changes and restart the app to prevent data loss. If the problem persists, please report it to us at support@streetwriters.co."
 msgstr ""
 
@@ -5628,40 +5634,40 @@ msgstr ""
 msgid "Saving zip file. Please wait..."
 msgstr ""
 
-#: src/strings.ts:1722
+#: src/strings.ts:1723
 msgid "Scan the QR code with your authenticator app"
 msgstr ""
 
-#: src/strings.ts:2432
+#: src/strings.ts:2433
 msgid "School work"
 msgstr ""
 
-#: src/strings.ts:2505
+#: src/strings.ts:2506
 msgid "Scroll to bottom"
 msgstr ""
 
-#: src/strings.ts:2504
+#: src/strings.ts:2505
 msgid "Scroll to top"
 msgstr ""
 
-#: src/strings.ts:1510
-#: src/strings.ts:1528
+#: src/strings.ts:1511
+#: src/strings.ts:1529
 msgid "Search"
 msgstr ""
 
-#: src/strings.ts:1505
+#: src/strings.ts:1506
 msgid "Search a note"
 msgstr ""
 
-#: src/strings.ts:1503
+#: src/strings.ts:1504
 msgid "Search a note to link to"
 msgstr ""
 
-#: src/strings.ts:2448
+#: src/strings.ts:2449
 msgid "Search for notes, notebooks, and tags..."
 msgstr ""
 
-#: src/strings.ts:1538
+#: src/strings.ts:1539
 msgid "Search in {routeName}"
 msgstr ""
 
@@ -5713,67 +5719,67 @@ msgstr ""
 msgid "Search in Trash"
 msgstr ""
 
-#: src/strings.ts:2369
+#: src/strings.ts:2370
 msgid "Search languages"
 msgstr ""
 
-#: src/strings.ts:1491
+#: src/strings.ts:1492
 msgid "Search notebooks"
 msgstr ""
 
-#: src/strings.ts:1504
+#: src/strings.ts:1505
 msgid "Search or add a tag"
 msgstr ""
 
-#: src/strings.ts:1834
+#: src/strings.ts:1835
 msgid "Search themes"
 msgstr ""
 
-#: src/strings.ts:1508
+#: src/strings.ts:1509
 msgid "Searching for {query}..."
 msgstr ""
 
-#: src/strings.ts:878
+#: src/strings.ts:879
 msgid "sec"
 msgstr ""
 
-#: src/strings.ts:2153
+#: src/strings.ts:2154
 msgid "Security & privacy"
 msgstr ""
 
-#: src/strings.ts:2093
+#: src/strings.ts:2094
 msgid "Security key"
 msgstr ""
 
-#: src/strings.ts:1988
+#: src/strings.ts:1989
 msgid "Security key successfully registered."
 msgstr ""
 
-#: src/strings.ts:1294
+#: src/strings.ts:1295
 msgid "See what the future of Notesnook is going to be like."
 msgstr ""
 
-#: src/strings.ts:1334
+#: src/strings.ts:1335
 msgid "Select"
 msgstr ""
 
-#: src/strings.ts:1609
+#: src/strings.ts:1610
 msgid "Select a backup file from your device to restore backup"
 msgstr ""
 
-#: src/strings.ts:2499
+#: src/strings.ts:2500
 msgid "Select a notebook to move this notebook into, or unselect to move it to the root level."
 msgstr ""
 
-#: src/strings.ts:2108
+#: src/strings.ts:2109
 msgid "Select a theme"
 msgstr ""
 
-#: src/strings.ts:1226
+#: src/strings.ts:1227
 msgid "Select backup directory"
 msgstr ""
 
-#: src/strings.ts:1855
+#: src/strings.ts:1856
 msgid "Select backup file"
 msgstr ""
 
@@ -5789,15 +5795,15 @@ msgstr ""
 msgid "Select day of the week to repeat the reminder."
 msgstr ""
 
-#: src/strings.ts:1763
+#: src/strings.ts:1764
 msgid "Select files to import"
 msgstr ""
 
-#: src/strings.ts:1606
+#: src/strings.ts:1607
 msgid "Select folder where Notesnook backup files are stored to view and restore them from the app"
 msgstr ""
 
-#: src/strings.ts:1607
+#: src/strings.ts:1608
 msgid "Select folder with backup files"
 msgstr ""
 
@@ -5805,7 +5811,7 @@ msgstr ""
 msgid "Select how you would like to recieve the code"
 msgstr ""
 
-#: src/strings.ts:2364
+#: src/strings.ts:2365
 msgid "Select language"
 msgstr ""
 
@@ -5821,7 +5827,7 @@ msgstr ""
 msgid "Select notebooks you want to add note(s) to."
 msgstr ""
 
-#: src/strings.ts:2487
+#: src/strings.ts:2488
 msgid "Select notes to link to \"{title}\""
 msgstr ""
 
@@ -5829,11 +5835,11 @@ msgstr ""
 msgid "Select nth day of the month to repeat the reminder."
 msgstr ""
 
-#: src/strings.ts:1817
+#: src/strings.ts:1818
 msgid "Select profile picture"
 msgstr ""
 
-#: src/strings.ts:2493
+#: src/strings.ts:2494
 msgid "Select the default sidebar tab"
 msgstr ""
 
@@ -5841,11 +5847,11 @@ msgstr ""
 msgid "Select the folder that includes your backup files to list them here."
 msgstr ""
 
-#: src/strings.ts:2140
+#: src/strings.ts:2141
 msgid "Select the languages the spell checker should check in."
 msgstr ""
 
-#: src/strings.ts:2469
+#: src/strings.ts:2470
 msgid "Select the release track for Notesnook."
 msgstr ""
 
@@ -5857,7 +5863,7 @@ msgstr ""
 msgid "Self destruct"
 msgstr ""
 
-#: src/strings.ts:2175
+#: src/strings.ts:2176
 msgid "Send"
 msgstr ""
 
@@ -5873,47 +5879,47 @@ msgstr ""
 msgid "Send code via SMS"
 msgstr ""
 
-#: src/strings.ts:1859
+#: src/strings.ts:1860
 msgid "Send recovery email"
 msgstr ""
 
-#: src/strings.ts:1895
+#: src/strings.ts:1896
 msgid "Sending recovery email"
 msgstr ""
 
-#: src/strings.ts:1646
+#: src/strings.ts:1647
 msgid "Server url changed"
 msgstr ""
 
-#: src/strings.ts:1649
+#: src/strings.ts:1650
 msgid "Server urls reset"
 msgstr ""
 
-#: src/strings.ts:1627
+#: src/strings.ts:1628
 msgid "Server used for login/sign up and authentication."
 msgstr ""
 
-#: src/strings.ts:1632
+#: src/strings.ts:1633
 msgid "Server used to host your published notes."
 msgstr ""
 
-#: src/strings.ts:1630
+#: src/strings.ts:1631
 msgid "Server used to receive important notifications & events."
 msgstr ""
 
-#: src/strings.ts:1625
+#: src/strings.ts:1626
 msgid "Server used to sync your notes & other data between devices."
 msgstr ""
 
-#: src/strings.ts:1638
+#: src/strings.ts:1639
 msgid "Server with host {host} not found."
 msgstr ""
 
-#: src/strings.ts:2148
+#: src/strings.ts:2149
 msgid "Servers"
 msgstr ""
 
-#: src/strings.ts:2149
+#: src/strings.ts:2150
 msgid "Servers configuration"
 msgstr ""
 
@@ -5921,11 +5927,11 @@ msgstr ""
 msgid "Session expired"
 msgstr ""
 
-#: src/strings.ts:2201
+#: src/strings.ts:2202
 msgid "Sessions"
 msgstr ""
 
-#: src/strings.ts:976
+#: src/strings.ts:977
 msgid "Set a reminder"
 msgstr ""
 
@@ -5933,11 +5939,11 @@ msgstr ""
 msgid "Set as dark theme"
 msgstr ""
 
-#: src/strings.ts:897
+#: src/strings.ts:898
 msgid "Set as default"
 msgstr ""
 
-#: src/strings.ts:2491
+#: src/strings.ts:2492
 msgid "Set as homepage"
 msgstr ""
 
@@ -5945,31 +5951,31 @@ msgstr ""
 msgid "Set as light theme"
 msgstr ""
 
-#: src/strings.ts:1333
+#: src/strings.ts:1334
 msgid "Set automatic trash cleanup interval from Settings > Behaviour > Clean trash interval."
 msgstr ""
 
-#: src/strings.ts:2644
+#: src/strings.ts:2645
 msgid "Set expiry"
 msgstr ""
 
-#: src/strings.ts:1310
+#: src/strings.ts:1311
 msgid "Set full name"
 msgstr ""
 
-#: src/strings.ts:1252
+#: src/strings.ts:1253
 msgid "Set snooze time in minutes"
 msgstr ""
 
-#: src/strings.ts:1251
+#: src/strings.ts:1252
 msgid "Set the default time to snooze a reminder to when you press the snooze button on a notification."
 msgstr ""
 
-#: src/strings.ts:1223
+#: src/strings.ts:1224
 msgid "Set the interval to create a backup (with attachments) automatically."
 msgstr ""
 
-#: src/strings.ts:1220
+#: src/strings.ts:1221
 msgid "Set the interval to create a partial backup (without attachments) automatically."
 msgstr ""
 
@@ -5978,24 +5984,24 @@ msgid "Set your name"
 msgstr ""
 
 #: src/strings.ts:387
-#: src/strings.ts:1524
+#: src/strings.ts:1525
 msgid "Settings"
 msgstr ""
 
-#: src/strings.ts:1199
 #: src/strings.ts:1200
+#: src/strings.ts:1201
 msgid "Setup a new password for app lock"
 msgstr ""
 
-#: src/strings.ts:1196
+#: src/strings.ts:1197
 msgid "Setup a password to lock the app"
 msgstr ""
 
-#: src/strings.ts:1194
+#: src/strings.ts:1195
 msgid "Setup a pin to lock the app"
 msgstr ""
 
-#: src/strings.ts:2193
+#: src/strings.ts:2194
 msgid ""
 "Setup an HTTP/HTTPS/SOCKS proxy.\n"
 "\n"
@@ -6007,11 +6013,11 @@ msgid ""
 "To remove the proxy, simply erase everything in the input."
 msgstr ""
 
-#: src/strings.ts:1195
+#: src/strings.ts:1196
 msgid "Setup app lock password"
 msgstr ""
 
-#: src/strings.ts:1193
+#: src/strings.ts:1194
 msgid "Setup app lock pin"
 msgstr ""
 
@@ -6019,15 +6025,15 @@ msgstr ""
 msgid "Setup secondary 2FA method"
 msgstr ""
 
-#: src/strings.ts:978
+#: src/strings.ts:979
 msgid "Setup using an Authenticator app"
 msgstr ""
 
-#: src/strings.ts:985
+#: src/strings.ts:986
 msgid "Setup using email"
 msgstr ""
 
-#: src/strings.ts:992
+#: src/strings.ts:993
 msgid "Setup using SMS"
 msgstr ""
 
@@ -6035,11 +6041,11 @@ msgstr ""
 msgid "Share"
 msgstr ""
 
-#: src/strings.ts:1691
+#: src/strings.ts:1692
 msgid "Share & append to notes from anywhere"
 msgstr ""
 
-#: src/strings.ts:1341
+#: src/strings.ts:1342
 msgid "Share backup"
 msgstr ""
 
@@ -6047,7 +6053,7 @@ msgstr ""
 msgid "Share note"
 msgstr ""
 
-#: src/strings.ts:1787
+#: src/strings.ts:1788
 msgid "Share Notesnook with friends!"
 msgstr ""
 
@@ -6063,7 +6069,7 @@ msgstr ""
 msgid "Shortcut"
 msgstr ""
 
-#: src/strings.ts:2000
+#: src/strings.ts:2001
 msgid "Shortcut removed"
 msgstr ""
 
@@ -6079,7 +6085,7 @@ msgstr ""
 msgid "Sign up"
 msgstr ""
 
-#: src/strings.ts:1030
+#: src/strings.ts:1031
 msgid "Signed up on {date}"
 msgstr ""
 
@@ -6091,11 +6097,11 @@ msgstr ""
 msgid "Silent"
 msgstr ""
 
-#: src/strings.ts:2338
+#: src/strings.ts:2339
 msgid "Sink list item"
 msgstr ""
 
-#: src/strings.ts:2041
+#: src/strings.ts:2042
 msgid "Size"
 msgstr ""
 
@@ -6103,7 +6109,7 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: src/strings.ts:1829
+#: src/strings.ts:1830
 msgid "Skip & go directly to the app"
 msgstr ""
 
@@ -6111,19 +6117,19 @@ msgstr ""
 msgid "Skip introduction"
 msgstr ""
 
-#: src/strings.ts:1604
+#: src/strings.ts:1605
 msgid "Some exported notes are locked, Unlock to export them"
 msgstr ""
 
-#: src/strings.ts:1476
+#: src/strings.ts:1477
 msgid "Some notes are published"
 msgstr ""
 
-#: src/strings.ts:1666
+#: src/strings.ts:1667
 msgid "Something went wrong"
 msgstr ""
 
-#: src/strings.ts:2025
+#: src/strings.ts:2026
 msgid "Sort"
 msgstr ""
 
@@ -6131,55 +6137,55 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: src/strings.ts:2159
+#: src/strings.ts:2160
 msgid "Source code"
 msgstr ""
 
-#: src/strings.ts:2365
+#: src/strings.ts:2366
 msgid "Spaces"
 msgstr ""
 
-#: src/strings.ts:2603
+#: src/strings.ts:2604
 msgid "Special Offer"
 msgstr ""
 
-#: src/strings.ts:2136
+#: src/strings.ts:2137
 msgid "Spell check"
 msgstr ""
 
-#: src/strings.ts:2304
+#: src/strings.ts:2305
 msgid "Split cells"
 msgstr ""
 
-#: src/strings.ts:2470
+#: src/strings.ts:2471
 msgid "Stable"
 msgstr ""
 
-#: src/strings.ts:1112
+#: src/strings.ts:1113
 msgid "Start"
 msgstr ""
 
-#: src/strings.ts:1830
+#: src/strings.ts:1831
 msgid "Start account recovery"
 msgstr ""
 
-#: src/strings.ts:1825
+#: src/strings.ts:1826
 msgid "Start import"
 msgstr ""
 
-#: src/strings.ts:1822
+#: src/strings.ts:1823
 msgid "Start importing now"
 msgstr ""
 
-#: src/strings.ts:2124
+#: src/strings.ts:2125
 msgid "Start minimized"
 msgstr ""
 
-#: src/strings.ts:1757
+#: src/strings.ts:1758
 msgid "Start over"
 msgstr ""
 
-#: src/strings.ts:950
+#: src/strings.ts:951
 msgid "Start writing to create a new note"
 msgstr ""
 
@@ -6187,31 +6193,31 @@ msgstr ""
 msgid "Start writing to save your note."
 msgstr ""
 
-#: src/strings.ts:1601
+#: src/strings.ts:1602
 msgid "Start writing your note..."
 msgstr ""
 
-#: src/strings.ts:2232
+#: src/strings.ts:2233
 msgid "Status"
 msgstr ""
 
-#: src/strings.ts:2483
+#: src/strings.ts:2484
 msgid "Storage"
 msgstr ""
 
-#: src/strings.ts:1548
+#: src/strings.ts:1549
 msgid "Streaming not supported"
 msgstr ""
 
-#: src/strings.ts:2270
+#: src/strings.ts:2271
 msgid "Strikethrough"
 msgstr ""
 
-#: src/strings.ts:2234
+#: src/strings.ts:2235
 msgid "Subgroup 1"
 msgstr ""
 
-#: src/strings.ts:1994
+#: src/strings.ts:1995
 msgid "Subgroup added"
 msgstr ""
 
@@ -6219,15 +6225,15 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: src/strings.ts:2582
+#: src/strings.ts:2583
 msgid "Subscribe"
 msgstr ""
 
-#: src/strings.ts:2583
+#: src/strings.ts:2584
 msgid "Subscribe and start free trial"
 msgstr ""
 
-#: src/strings.ts:1025
+#: src/strings.ts:1026
 msgid "Subscribe to Pro"
 msgstr ""
 
@@ -6239,7 +6245,7 @@ msgstr ""
 msgid "Subscribed on iOS"
 msgstr ""
 
-#: src/strings.ts:1305
+#: src/strings.ts:1306
 msgid "Subscribed on web"
 msgstr ""
 
@@ -6251,7 +6257,7 @@ msgstr ""
 msgid "Subscribed using gift card"
 msgstr ""
 
-#: src/strings.ts:2281
+#: src/strings.ts:2282
 msgid "Subscript"
 msgstr ""
 
@@ -6259,11 +6265,11 @@ msgstr ""
 msgid "Subscription awarded from Streetwriters"
 msgstr ""
 
-#: src/strings.ts:1029
+#: src/strings.ts:1030
 msgid "Subscription details"
 msgstr ""
 
-#: src/strings.ts:1063
+#: src/strings.ts:1064
 msgid "Subscription not activated?"
 msgstr ""
 
@@ -6275,15 +6281,15 @@ msgstr ""
 msgid "Sunday"
 msgstr ""
 
-#: src/strings.ts:2282
+#: src/strings.ts:2283
 msgid "Superscript"
 msgstr ""
 
-#: src/strings.ts:1469
+#: src/strings.ts:1470
 msgid "Switch to search/replace mode"
 msgstr ""
 
-#: src/strings.ts:2145
+#: src/strings.ts:2146
 msgid "Sync"
 msgstr ""
 
@@ -6291,7 +6297,7 @@ msgstr ""
 msgid "Sync failed"
 msgstr ""
 
-#: src/strings.ts:1363
+#: src/strings.ts:1364
 msgid "Sync is disabled"
 msgstr ""
 
@@ -6299,19 +6305,19 @@ msgstr ""
 msgid "Sync now"
 msgstr ""
 
-#: src/strings.ts:913
+#: src/strings.ts:914
 msgid "Sync off"
 msgstr ""
 
-#: src/strings.ts:1623
+#: src/strings.ts:1624
 msgid "Sync server"
 msgstr ""
 
-#: src/strings.ts:1082
+#: src/strings.ts:1083
 msgid "Sync settings"
 msgstr ""
 
-#: src/strings.ts:1095
+#: src/strings.ts:1096
 msgid "Sync your notes in the background even when the app is closed. This is an experimental feature. If you face any issues, please turn it off."
 msgstr ""
 
@@ -6327,11 +6333,11 @@ msgstr ""
 msgid "Syncing your data"
 msgstr ""
 
-#: src/strings.ts:1702
+#: src/strings.ts:1703
 msgid "Syncing your notes"
 msgstr ""
 
-#: src/strings.ts:2350
+#: src/strings.ts:2351
 msgid "Table"
 msgstr ""
 
@@ -6339,11 +6345,11 @@ msgstr ""
 msgid "Table of contents"
 msgstr ""
 
-#: src/strings.ts:2295
+#: src/strings.ts:2296
 msgid "Table settings"
 msgstr ""
 
-#: src/strings.ts:2544
+#: src/strings.ts:2545
 msgid "tables, outlines, block level note linking"
 msgstr ""
 
@@ -6364,31 +6370,31 @@ msgid "tags"
 msgstr ""
 
 #: src/strings.ts:317
-#: src/strings.ts:1525
+#: src/strings.ts:1526
 msgid "Tags"
 msgstr ""
 
-#: src/strings.ts:1543
+#: src/strings.ts:1544
 msgid "Take a backup before logging out"
 msgstr ""
 
-#: src/strings.ts:1215
+#: src/strings.ts:1216
 msgid "Take a full backup of your data with all attachments"
 msgstr ""
 
-#: src/strings.ts:1217
+#: src/strings.ts:1218
 msgid "Take a partial backup of your data that does not include attachments"
 msgstr ""
 
-#: src/strings.ts:2349
+#: src/strings.ts:2350
 msgid "Take a photo using camera"
 msgstr ""
 
-#: src/strings.ts:1373
+#: src/strings.ts:1374
 msgid "Take note"
 msgstr ""
 
-#: src/strings.ts:1656
+#: src/strings.ts:1657
 msgid "Take notes privately."
 msgstr ""
 
@@ -6396,23 +6402,23 @@ msgstr ""
 msgid "Taking too long? Reload editor"
 msgstr ""
 
-#: src/strings.ts:1457
+#: src/strings.ts:1458
 msgid "Tap here to change sorting"
 msgstr ""
 
-#: src/strings.ts:1461
+#: src/strings.ts:1462
 msgid "Tap here to jump to a section"
 msgstr ""
 
-#: src/strings.ts:1369
+#: src/strings.ts:1370
 msgid "Tap here to update to the latest version"
 msgstr ""
 
-#: src/strings.ts:1592
+#: src/strings.ts:1593
 msgid "Tap on \"Dismiss\" and copy the contents of your note so they are not lost."
 msgstr ""
 
-#: src/strings.ts:1372
+#: src/strings.ts:1373
 msgid "Tap on \"Take note\" to add a note."
 msgstr ""
 
@@ -6432,7 +6438,7 @@ msgstr ""
 msgid "Tap to stop reordering"
 msgstr ""
 
-#: src/strings.ts:1353
+#: src/strings.ts:1354
 msgid "Tap to try again"
 msgstr ""
 
@@ -6440,19 +6446,19 @@ msgstr ""
 msgid "Tap twice to confirm you have saved the recovery key."
 msgstr ""
 
-#: src/strings.ts:2355
+#: src/strings.ts:2356
 msgid "Task list"
 msgstr ""
 
-#: src/strings.ts:2425
+#: src/strings.ts:2426
 msgid "Tasks"
 msgstr ""
 
-#: src/strings.ts:1162
+#: src/strings.ts:1163
 msgid "Telemetry"
 msgstr ""
 
-#: src/strings.ts:1495
+#: src/strings.ts:1496
 msgid ""
 "Tell us more about the issue you are facing.\n"
 "\n"
@@ -6463,11 +6469,11 @@ msgid ""
 "- Things you have tried etc."
 msgstr ""
 
-#: src/strings.ts:1494
+#: src/strings.ts:1495
 msgid "Tell us what happened"
 msgstr ""
 
-#: src/strings.ts:1283
+#: src/strings.ts:1284
 msgid "Terms of service"
 msgstr ""
 
@@ -6475,39 +6481,39 @@ msgstr ""
 msgid "Terms of Service "
 msgstr ""
 
-#: src/strings.ts:2590
+#: src/strings.ts:2591
 msgid "terms of use."
 msgstr ""
 
-#: src/strings.ts:1622
+#: src/strings.ts:1623
 msgid "Test connection"
 msgstr ""
 
-#: src/strings.ts:1645
+#: src/strings.ts:1646
 msgid "Test connection before changing server urls"
 msgstr ""
 
-#: src/strings.ts:2293
+#: src/strings.ts:2294
 msgid "Text color"
 msgstr ""
 
-#: src/strings.ts:2291
+#: src/strings.ts:2292
 msgid "Text direction"
 msgstr ""
 
-#: src/strings.ts:1786
+#: src/strings.ts:1787
 msgid "Thank you for choosing end-to-end encrypted note taking. Now you can sync your notes to unlimited devices."
 msgstr ""
 
-#: src/strings.ts:2050
+#: src/strings.ts:2051
 msgid "Thank you for reporting!"
 msgstr ""
 
-#: src/strings.ts:2561
+#: src/strings.ts:2562
 msgid "Thank you for subscribing"
 msgstr ""
 
-#: src/strings.ts:2598
+#: src/strings.ts:2599
 msgid "Thank you for the purchase"
 msgstr ""
 
@@ -6515,19 +6521,19 @@ msgstr ""
 msgid "Thank you for updating Notesnook! We will be applying some minor changes for a better note taking experience."
 msgstr ""
 
-#: src/strings.ts:2051
+#: src/strings.ts:2052
 msgid "Thank you for your feedback!"
 msgstr ""
 
-#: src/strings.ts:2085
+#: src/strings.ts:2086
 msgid "Thank you. You are the proof that privacy always comes first."
 msgstr ""
 
-#: src/strings.ts:1643
+#: src/strings.ts:1644
 msgid "The {title} at {url} is not compatible with this client."
 msgstr ""
 
-#: src/strings.ts:2643
+#: src/strings.ts:2644
 msgid "The incoming note could not be unlocked with the provided password. Enter the correct password for the incoming note"
 msgstr ""
 
@@ -6535,11 +6541,11 @@ msgstr ""
 msgid "The information above will be publically available at"
 msgstr ""
 
-#: src/strings.ts:2617
+#: src/strings.ts:2618
 msgid "The Notesnook Circle is exclusive to subscribers. Please consider subscribing to gain access to Notesnook Circle and enjoy additional benefits."
 msgstr ""
 
-#: src/strings.ts:2092
+#: src/strings.ts:2093
 msgid "The password/pin for unlocking the app."
 msgstr ""
 
@@ -6551,19 +6557,19 @@ msgstr ""
 msgid "The reminder will repeat every year on {date}."
 msgstr ""
 
-#: src/strings.ts:1712
+#: src/strings.ts:1713
 msgid "The reminder will start on {date} at {time}."
 msgstr ""
 
-#: src/strings.ts:2095
+#: src/strings.ts:2096
 msgid "The security key for unlocking the app. This is the most secure method."
 msgstr ""
 
-#: src/strings.ts:1641
+#: src/strings.ts:1642
 msgid "The URL you have given ({url}) does not point to the {server}."
 msgstr ""
 
-#: src/strings.ts:1117
+#: src/strings.ts:1118
 msgid "Themes"
 msgstr ""
 
@@ -6571,11 +6577,11 @@ msgstr ""
 msgid "There are no blocks in this note."
 msgstr ""
 
-#: src/strings.ts:2248
+#: src/strings.ts:2249
 msgid "These items will be **kept in your Trash for {interval} days** after which they will be permanently deleted."
 msgstr ""
 
-#: src/strings.ts:1920
+#: src/strings.ts:1921
 msgid "This action is IRREVERSIBLE."
 msgstr ""
 
@@ -6583,60 +6589,60 @@ msgstr ""
 msgid "This device"
 msgstr ""
 
-#: src/strings.ts:1683
+#: src/strings.ts:1684
 msgid "This error can be fixed by rebuilding the search index. This action won't result in any kind of data loss."
 msgstr ""
 
-#: src/strings.ts:1675
+#: src/strings.ts:1676
 msgid "This error can only be fixed by wiping & reseting the database. Beware that this will wipe all your data inside the database with no way to recover it later on. This WILL NOT change/affect/delete/wipe your data on the server but ONLY on this device."
 msgstr ""
 
-#: src/strings.ts:1679
+#: src/strings.ts:1680
 msgid "This error can only be fixed by wiping & reseting the Key Store and the database. This WILL NOT change/affect/delete/wipe your data on the server but ONLY on this device."
 msgstr ""
 
-#: src/strings.ts:1677
+#: src/strings.ts:1678
 msgid "This error means the at rest encryption key could not be decrypted. This can be due to data corruption or implementation change."
 msgstr ""
 
-#: src/strings.ts:1673
+#: src/strings.ts:1674
 msgid "This error usually means the database file is either corrupt or it could not be decrypted."
 msgstr ""
 
-#: src/strings.ts:1681
+#: src/strings.ts:1682
 msgid "This error usually means the search index is corrupted."
 msgstr ""
 
-#: src/strings.ts:2657
+#: src/strings.ts:2658
 msgid "This feature is not available on this plan."
 msgstr ""
 
-#: src/strings.ts:1934
+#: src/strings.ts:1935
 msgid "This image cannot be previewed"
 msgstr ""
 
-#: src/strings.ts:2584
+#: src/strings.ts:2585
 msgid "This is a one time purchase, no subscription."
 msgstr ""
 
-#: src/strings.ts:2045
+#: src/strings.ts:2046
 msgid "This may take a while"
 msgstr ""
 
-#: src/strings.ts:1101
-#: src/strings.ts:1110
+#: src/strings.ts:1102
+#: src/strings.ts:1111
 msgid "This must only be used for troubleshooting. Using it regularly for sync is not recommended and will lead to unexpected data loss and other issues. If you are having persistent issues with sync, please report them to us at support@streetwriters.co."
 msgstr ""
 
-#: src/strings.ts:2649
+#: src/strings.ts:2650
 msgid "This note is empty"
 msgstr ""
 
-#: src/strings.ts:1594
+#: src/strings.ts:1595
 msgid "This note is locked"
 msgstr ""
 
-#: src/strings.ts:952
+#: src/strings.ts:953
 msgid "This note is locked. Unlock note to save changes"
 msgstr ""
 
@@ -6652,11 +6658,11 @@ msgstr ""
 msgid "This note will be published to a public URL."
 msgstr ""
 
-#: src/strings.ts:2101
+#: src/strings.ts:2102
 msgid "This username will be used to distinguish between different credentials in your security key. Make sure it is unique."
 msgstr ""
 
-#: src/strings.ts:1303
+#: src/strings.ts:1304
 msgid "This version of Notesnook app does not support in-app purchases. Kindly login on the Notesnook web app to make the purchase."
 msgstr ""
 
@@ -6668,11 +6674,11 @@ msgstr ""
 msgid "Thursday"
 msgstr ""
 
-#: src/strings.ts:1842
+#: src/strings.ts:1843
 msgid "Time"
 msgstr ""
 
-#: src/strings.ts:1134
+#: src/strings.ts:1135
 msgid "Time format"
 msgstr ""
 
@@ -6685,76 +6691,76 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: src/strings.ts:1157
+#: src/strings.ts:1158
 msgid "Title format"
 msgstr ""
 
-#: src/strings.ts:2668
+#: src/strings.ts:2669
 msgid "Title is required"
 msgstr ""
 
-#: src/strings.ts:1188
+#: src/strings.ts:1189
 msgid "To use app lock, you must enable biometrics such as Fingerprint lock or Face ID on your phone."
 msgstr ""
 
-#: src/strings.ts:1812
+#: src/strings.ts:1813
 msgid "Toggle dark/light mode"
 msgstr ""
 
-#: src/strings.ts:2473
+#: src/strings.ts:2474
 msgid "Toggle focus mode"
 msgstr ""
 
-#: src/strings.ts:2362
+#: src/strings.ts:2363
 msgid "Toggle indentation mode"
 msgstr ""
 
-#: src/strings.ts:2391
+#: src/strings.ts:2392
 msgid "Toggle replace"
 msgstr ""
 
-#: src/strings.ts:2462
+#: src/strings.ts:2463
 msgid "Toggle theme"
 msgstr ""
 
-#: src/strings.ts:2142
+#: src/strings.ts:2143
 msgid "Toolbar"
 msgstr ""
 
-#: src/strings.ts:1148
+#: src/strings.ts:1149
 msgid "Toolbar reset to default preset"
 msgstr ""
 
-#: src/strings.ts:1326
-#: src/strings.ts:1523
+#: src/strings.ts:1327
+#: src/strings.ts:1524
 msgid "Trash"
 msgstr ""
 
-#: src/strings.ts:1325
+#: src/strings.ts:1326
 msgid "Trash cleared successfully!"
 msgstr ""
 
-#: src/strings.ts:1331
+#: src/strings.ts:1332
 msgid "Trash gets automatically cleaned up after {days} days"
 msgstr ""
 
-#: src/strings.ts:1329
+#: src/strings.ts:1330
 msgid "Trash gets automatically cleaned up daily"
 msgstr ""
 
-#: src/strings.ts:2551
+#: src/strings.ts:2552
 msgid "Try {plan} for free"
 msgstr ""
 
-#: src/strings.ts:1465
+#: src/strings.ts:1466
 msgid "Try compact mode to fit more items on screen"
 msgstr ""
 
-#: src/strings.ts:1824
+#: src/strings.ts:1825
 msgid "Try free for 14 days"
 msgstr ""
 
-#: src/strings.ts:2537
+#: src/strings.ts:2538
 msgid "Try it for free"
 msgstr ""
 
@@ -6766,19 +6772,19 @@ msgstr ""
 msgid "Tuesday"
 msgstr ""
 
-#: src/strings.ts:1086
+#: src/strings.ts:1087
 msgid "Turn off automatic syncing. Changes from this client will be synced only when you run sync manually."
 msgstr ""
 
-#: src/strings.ts:892
+#: src/strings.ts:893
 msgid "Turn off reminder"
 msgstr ""
 
-#: src/strings.ts:893
+#: src/strings.ts:894
 msgid "Turn on reminder"
 msgstr ""
 
-#: src/strings.ts:1092
+#: src/strings.ts:1093
 msgid "Turns off syncing completely on this device. Any changes made will remain local only and new changes from your other devices won't sync to this device."
 msgstr ""
 
@@ -6794,27 +6800,27 @@ msgstr ""
 msgid "Two-factor authentication enabled"
 msgstr ""
 
-#: src/strings.ts:1502
+#: src/strings.ts:1503
 msgid "Type # to search for headings"
 msgstr ""
 
-#: src/strings.ts:1509
+#: src/strings.ts:1510
 msgid "Type a keyword"
 msgstr ""
 
-#: src/strings.ts:1549
+#: src/strings.ts:1550
 msgid "Unable to resolve download url"
 msgstr ""
 
-#: src/strings.ts:1552
+#: src/strings.ts:1553
 msgid "Unable to send 2FA code"
 msgstr ""
 
-#: src/strings.ts:2497
+#: src/strings.ts:2498
 msgid "Unarchive"
 msgstr ""
 
-#: src/strings.ts:2269
+#: src/strings.ts:2270
 msgid "Underline"
 msgstr ""
 
@@ -6822,19 +6828,19 @@ msgstr ""
 msgid "Undo"
 msgstr ""
 
-#: src/strings.ts:854
+#: src/strings.ts:855
 msgid "Unfavorite"
 msgstr ""
 
-#: src/strings.ts:2594
+#: src/strings.ts:2595
 msgid "Unlimited"
 msgstr ""
 
-#: src/strings.ts:930
+#: src/strings.ts:931
 msgid "Unlink from all"
 msgstr ""
 
-#: src/strings.ts:853
+#: src/strings.ts:854
 msgid "Unlink notebook"
 msgstr ""
 
@@ -6842,11 +6848,11 @@ msgstr ""
 msgid "Unlock"
 msgstr ""
 
-#: src/strings.ts:2641
+#: src/strings.ts:2642
 msgid "Unlock incoming note"
 msgstr ""
 
-#: src/strings.ts:1383
+#: src/strings.ts:1384
 msgid "Unlock more colors with Notesnook Pro"
 msgstr ""
 
@@ -6855,19 +6861,19 @@ msgstr ""
 msgid "Unlock note"
 msgstr ""
 
-#: src/strings.ts:888
+#: src/strings.ts:889
 msgid "Unlock note to delete it"
 msgstr ""
 
-#: src/strings.ts:2652
+#: src/strings.ts:2653
 msgid "Unlock note to merge conflicts"
 msgstr ""
 
-#: src/strings.ts:1208
+#: src/strings.ts:1209
 msgid "Unlock the app with biometric authentication. This requires biometrics to be enabled on your device."
 msgstr ""
 
-#: src/strings.ts:1932
+#: src/strings.ts:1933
 msgid "Unlock vault"
 msgstr ""
 
@@ -6875,7 +6881,7 @@ msgstr ""
 msgid "Unlock with biometrics"
 msgstr ""
 
-#: src/strings.ts:1827
+#: src/strings.ts:1828
 msgid "Unlock with security key"
 msgstr ""
 
@@ -6883,19 +6889,19 @@ msgstr ""
 msgid "Unlock your notes"
 msgstr ""
 
-#: src/strings.ts:1178
+#: src/strings.ts:1179
 msgid "Unlock your vault with biometric authentication"
 msgstr ""
 
-#: src/strings.ts:1710
+#: src/strings.ts:1711
 msgid "Unlocking"
 msgstr ""
 
-#: src/strings.ts:899
+#: src/strings.ts:900
 msgid "Unpin"
 msgstr ""
 
-#: src/strings.ts:927
+#: src/strings.ts:928
 msgid "Unpin notification"
 msgstr ""
 
@@ -6903,20 +6909,20 @@ msgstr ""
 msgid "Unpublish"
 msgstr ""
 
-#: src/strings.ts:1477
+#: src/strings.ts:1478
 msgid "Unpublish notes to delete them"
 msgstr ""
 
-#: src/strings.ts:2096
+#: src/strings.ts:2097
 msgid "Unregister"
 msgstr ""
 
-#: src/strings.ts:2645
+#: src/strings.ts:2646
 msgid "Unset expiry"
 msgstr ""
 
 #: src/strings.ts:210
-#: src/strings.ts:2371
+#: src/strings.ts:2372
 msgid "Untitled"
 msgstr ""
 
@@ -6928,31 +6934,31 @@ msgstr ""
 msgid "Update available"
 msgstr ""
 
-#: src/strings.ts:1370
+#: src/strings.ts:1371
 msgid "Update now"
 msgstr ""
 
-#: src/strings.ts:2511
+#: src/strings.ts:2512
 msgid "Upgrade"
 msgstr ""
 
-#: src/strings.ts:1918
+#: src/strings.ts:1919
 msgid "Upgrade now"
 msgstr ""
 
-#: src/strings.ts:2510
+#: src/strings.ts:2511
 msgid "Upgrade plan"
 msgstr ""
 
-#: src/strings.ts:2536
+#: src/strings.ts:2537
 msgid "Upgrade plan to {plan} to use this feature."
 msgstr ""
 
-#: src/strings.ts:1939
+#: src/strings.ts:1940
 msgid "Upgrade to Notesnook Pro to add colors."
 msgstr ""
 
-#: src/strings.ts:1940
+#: src/strings.ts:1941
 msgid "Upgrade to Notesnook Pro to create more tags."
 msgstr ""
 
@@ -6960,7 +6966,7 @@ msgstr ""
 msgid "Upgrade to Pro"
 msgstr ""
 
-#: src/strings.ts:2609
+#: src/strings.ts:2610
 msgid "Upgrade to redeem"
 msgstr ""
 
@@ -6968,12 +6974,12 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: src/strings.ts:2348
+#: src/strings.ts:2349
 msgid "Upload from disk"
 msgstr ""
 
 #: src/strings.ts:511
-#: src/strings.ts:1651
+#: src/strings.ts:1652
 msgid "Uploaded"
 msgstr ""
 
@@ -6994,11 +7000,11 @@ msgstr ""
 msgid "Urgent"
 msgstr ""
 
-#: src/strings.ts:2398
+#: src/strings.ts:2399
 msgid "URL"
 msgstr ""
 
-#: src/strings.ts:1789
+#: src/strings.ts:1790
 msgid "Use"
 msgstr ""
 
@@ -7006,11 +7012,11 @@ msgstr ""
 msgid "Use {keyboardShortcut}+click to select multiple notebooks"
 msgstr ""
 
-#: src/strings.ts:1802
+#: src/strings.ts:1803
 msgid "Use a backup file"
 msgstr ""
 
-#: src/strings.ts:1900
+#: src/strings.ts:1901
 msgid "Use a data recovery key to reset your account password."
 msgstr ""
 
@@ -7018,43 +7024,43 @@ msgstr ""
 msgid "Use account password"
 msgstr ""
 
-#: src/strings.ts:2543
+#: src/strings.ts:2544
 msgid "Use advanced note taking features like"
 msgstr ""
 
-#: src/strings.ts:979
+#: src/strings.ts:980
 msgid "Use an authenticator app to generate 2FA codes."
 msgstr ""
 
-#: src/strings.ts:2182
+#: src/strings.ts:2183
 msgid "Use custom DNS"
 msgstr ""
 
-#: src/strings.ts:1123
+#: src/strings.ts:1124
 msgid "Use dark mode for the app"
 msgstr ""
 
-#: src/strings.ts:1621
+#: src/strings.ts:1622
 msgid "Use encryption key"
 msgstr ""
 
-#: src/strings.ts:1160
+#: src/strings.ts:1161
 msgid "Use markdown shortcuts in the editor"
 msgstr ""
 
-#: src/strings.ts:2135
+#: src/strings.ts:2136
 msgid "Use native OS titlebar instead of replacing it with a custom one. Requires app restart for changes to take effect."
 msgstr ""
 
-#: src/strings.ts:2133
+#: src/strings.ts:2134
 msgid "Use native titlebar"
 msgstr ""
 
-#: src/strings.ts:1799
+#: src/strings.ts:1800
 msgid "Use recovery key"
 msgstr ""
 
-#: src/strings.ts:1119
+#: src/strings.ts:1120
 msgid "Use system theme"
 msgstr ""
 
@@ -7071,43 +7077,43 @@ msgid ""
 "$day$: Current day (eg. Monday)"
 msgstr ""
 
-#: src/strings.ts:1099
+#: src/strings.ts:1100
 msgid "Use this if changes from other devices are not appearing on this device. This will overwrite the data on this device with the latest data from the server."
 msgstr ""
 
-#: src/strings.ts:1108
+#: src/strings.ts:1109
 msgid "Use this if changes made on this device are not appearing on other devices. This will overwrite the data on the server with the data from this device."
 msgstr ""
 
-#: src/strings.ts:2484
+#: src/strings.ts:2485
 msgid "used"
 msgstr ""
 
-#: src/strings.ts:1018
+#: src/strings.ts:1019
 msgid "User verification failed"
 msgstr ""
 
-#: src/strings.ts:2265
+#: src/strings.ts:2266
 msgid "Using {instance} (v{version})"
 msgstr ""
 
-#: src/strings.ts:2263
+#: src/strings.ts:2264
 msgid "Using official Notesnook instance"
 msgstr ""
 
-#: src/strings.ts:1709
+#: src/strings.ts:1710
 msgid "v{version} available"
 msgstr ""
 
-#: src/strings.ts:2659
+#: src/strings.ts:2660
 msgid "Value must be between {min} and {max}"
 msgstr ""
 
-#: src/strings.ts:1171
+#: src/strings.ts:1172
 msgid "Vault"
 msgstr ""
 
-#: src/strings.ts:1992
+#: src/strings.ts:1993
 msgid "Vault cleared"
 msgstr ""
 
@@ -7115,7 +7121,7 @@ msgstr ""
 msgid "Vault created"
 msgstr ""
 
-#: src/strings.ts:1993
+#: src/strings.ts:1994
 msgid "Vault deleted"
 msgstr ""
 
@@ -7123,15 +7129,15 @@ msgstr ""
 msgid "Vault fingerprint unlock"
 msgstr ""
 
-#: src/strings.ts:1931
+#: src/strings.ts:1932
 msgid "Vault locked"
 msgstr ""
 
-#: src/strings.ts:1930
+#: src/strings.ts:1931
 msgid "Vault unlocked"
 msgstr ""
 
-#: src/strings.ts:1400
+#: src/strings.ts:1401
 msgid "Verification email sent"
 msgstr ""
 
@@ -7139,19 +7145,19 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: src/strings.ts:1069
+#: src/strings.ts:1070
 msgid "Verify subscription"
 msgstr ""
 
-#: src/strings.ts:1072
+#: src/strings.ts:1073
 msgid "Verify your subscription to Notesnook Pro"
 msgstr ""
 
-#: src/strings.ts:1903
+#: src/strings.ts:1904
 msgid "Verifying 2FA code"
 msgstr ""
 
-#: src/strings.ts:1889
+#: src/strings.ts:1890
 msgid "Verifying your email"
 msgstr ""
 
@@ -7171,27 +7177,27 @@ msgstr ""
 msgid "View all linked notebooks"
 msgstr ""
 
-#: src/strings.ts:1270
+#: src/strings.ts:1271
 msgid "View and share debug logs"
 msgstr ""
 
-#: src/strings.ts:1747
+#: src/strings.ts:1748
 msgid "View receipt"
 msgstr ""
 
-#: src/strings.ts:1060
+#: src/strings.ts:1061
 msgid "View recovery codes"
 msgstr ""
 
-#: src/strings.ts:2162
+#: src/strings.ts:2163
 msgid "View source code"
 msgstr ""
 
-#: src/strings.ts:1062
+#: src/strings.ts:1063
 msgid "View your recovery codes to recover your account in case you lose access to your two-factor authentication methods."
 msgstr ""
 
-#: src/strings.ts:2624
+#: src/strings.ts:2625
 msgid "Views"
 msgstr ""
 
@@ -7199,15 +7205,15 @@ msgstr ""
 msgid "Visit homepage"
 msgstr ""
 
-#: src/strings.ts:1350
+#: src/strings.ts:1351
 msgid "Wait 30 seconds to try again"
 msgstr ""
 
-#: src/strings.ts:1652
+#: src/strings.ts:1653
 msgid "Waiting for upload"
 msgstr ""
 
-#: src/strings.ts:1911
+#: src/strings.ts:1912
 msgid "We are creating a backup of your data. Please wait..."
 msgstr ""
 
@@ -7215,35 +7221,35 @@ msgstr ""
 msgid "We are sorry, it seems that the app crashed due to an error. You can submit a bug report below so we can fix this asap."
 msgstr ""
 
-#: src/strings.ts:1390
+#: src/strings.ts:1391
 msgid "We have sent you an email confirmation link. Please check your email inbox. If you cannot find the email, check your spam folder."
 msgstr ""
 
-#: src/strings.ts:2522
+#: src/strings.ts:2523
 msgid "We require credit card details to fight abuse and to make it seamless for you to upgrade. Your credit card is NOT charged until your free trial ends and your subscription starts. You will be notified via email of the upcoming charge before your trial ends."
 msgstr ""
 
-#: src/strings.ts:2177
+#: src/strings.ts:2178
 msgid "We send you occasional promotional offers & product updates on your email (once every month)."
 msgstr ""
 
-#: src/strings.ts:1167
+#: src/strings.ts:1168
 msgid "We will send you occasional promotional offers & product updates on your email (sent once every month)."
 msgstr ""
 
-#: src/strings.ts:1354
+#: src/strings.ts:1355
 msgid "We would love to know what you think!"
 msgstr ""
 
-#: src/strings.ts:2563
+#: src/strings.ts:2564
 msgid "We’re setting up your plan right now. We’ll notify you as soon as everything is ready."
 msgstr ""
 
-#: src/strings.ts:2333
+#: src/strings.ts:2334
 msgid "Web clip settings"
 msgstr ""
 
-#: src/strings.ts:2029
+#: src/strings.ts:2030
 msgid "Website"
 msgstr ""
 
@@ -7259,12 +7265,12 @@ msgstr ""
 msgid "Week"
 msgstr ""
 
-#: src/strings.ts:2637
+#: src/strings.ts:2638
 msgid "Week format"
 msgstr ""
 
 #: src/strings.ts:168
-#: src/strings.ts:1569
+#: src/strings.ts:1570
 msgid "Weekly"
 msgstr ""
 
@@ -7272,63 +7278,63 @@ msgstr ""
 msgid "Welcome back, {email}"
 msgstr ""
 
-#: src/strings.ts:1888
+#: src/strings.ts:1889
 msgid "Welcome back!"
 msgstr ""
 
-#: src/strings.ts:2597
+#: src/strings.ts:2598
 msgid "Welcome to Notesnook {plan}"
 msgstr ""
 
-#: src/strings.ts:2083
+#: src/strings.ts:2084
 msgid "Welcome to Notesnook Pro"
 msgstr ""
 
-#: src/strings.ts:1392
+#: src/strings.ts:1393
 msgid "What do I do if I am not getting the email?"
 msgstr ""
 
-#: src/strings.ts:2514
+#: src/strings.ts:2515
 msgid "What happens to my data if I switch plans?"
 msgstr ""
 
-#: src/strings.ts:2530
+#: src/strings.ts:2531
 msgid "What is your refund policy?"
 msgstr ""
 
-#: src/strings.ts:1667
+#: src/strings.ts:1668
 msgid "What went wrong?"
 msgstr ""
 
-#: src/strings.ts:2520
+#: src/strings.ts:2521
 msgid "Why do you need my credit card details for a free trial?"
 msgstr ""
 
-#: src/strings.ts:2394
+#: src/strings.ts:2395
 msgid "Width"
 msgstr ""
 
-#: src/strings.ts:2500
+#: src/strings.ts:2501
 msgid "Words"
 msgstr ""
 
-#: src/strings.ts:2423
+#: src/strings.ts:2424
 msgid "Work & Office"
 msgstr ""
 
-#: src/strings.ts:823
+#: src/strings.ts:824
 msgid "Write notes with freedom, no spying, no tracking."
 msgstr ""
 
-#: src/strings.ts:1374
+#: src/strings.ts:1375
 msgid "Write something..."
 msgstr ""
 
-#: src/strings.ts:1654
+#: src/strings.ts:1655
 msgid "Write with freedom."
 msgstr ""
 
-#: src/strings.ts:2071
+#: src/strings.ts:2072
 msgid "Write with freedom. Never compromise on privacy again."
 msgstr ""
 
@@ -7337,7 +7343,7 @@ msgid "Year"
 msgstr ""
 
 #: src/strings.ts:170
-#: src/strings.ts:1571
+#: src/strings.ts:1572
 msgid "Yearly"
 msgstr ""
 
@@ -7345,7 +7351,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: src/strings.ts:2527
+#: src/strings.ts:2528
 msgid "Yes, you can cancel your trial anytime. No questions asked."
 msgstr ""
 
@@ -7353,27 +7359,27 @@ msgstr ""
 msgid "You also agree to recieve marketing emails from us which you can opt-out of from app settings."
 msgstr ""
 
-#: src/strings.ts:2602
+#: src/strings.ts:2603
 msgid "You are already subscribed to this plan."
 msgstr ""
 
-#: src/strings.ts:2250
+#: src/strings.ts:2251
 msgid "You are editing \"{notebookTitle}\"."
 msgstr ""
 
-#: src/strings.ts:2043
+#: src/strings.ts:2044
 msgid "You are editing #{tag}"
 msgstr ""
 
-#: src/strings.ts:1781
+#: src/strings.ts:1782
 msgid "You are logging into the beta version of Notesnook. Switching between beta &amp; stable versions can cause weird issues including data loss. It is recommended that you do not use both simultaneously."
 msgstr ""
 
-#: src/strings.ts:1361
+#: src/strings.ts:1362
 msgid "You are not logged in"
 msgstr ""
 
-#: src/strings.ts:886
+#: src/strings.ts:887
 msgid "You are renaming color {color}"
 msgstr ""
 
@@ -7381,39 +7387,39 @@ msgstr ""
 msgid "You can also link a note to multiple Notebooks. Tap and hold any notebook to enable multi-select."
 msgstr ""
 
-#: src/strings.ts:2074
+#: src/strings.ts:2075
 msgid "You can change the theme at any time from Settings or the side menu."
 msgstr ""
 
-#: src/strings.ts:2605
+#: src/strings.ts:2606
 msgid "You can change your subscription plan from the web app"
 msgstr ""
 
-#: src/strings.ts:2431
+#: src/strings.ts:2432
 msgid "You can create shortcuts of frequently accessed notebooks in the side menu"
 msgstr ""
 
-#: src/strings.ts:2089
+#: src/strings.ts:2090
 msgid "You can import your notes from most other note taking apps."
 msgstr ""
 
-#: src/strings.ts:1436
+#: src/strings.ts:1437
 msgid "You can multi-select notes and move them to a notebook at once"
 msgstr ""
 
-#: src/strings.ts:1427
+#: src/strings.ts:1428
 msgid "You can pin frequently used Notebooks to the Side Menu to quickly access them."
 msgstr ""
 
-#: src/strings.ts:1170
+#: src/strings.ts:1171
 msgid "You can set a custom proxy URL to increase your privacy."
 msgstr ""
 
-#: src/strings.ts:1408
+#: src/strings.ts:1409
 msgid "You can swipe left anywhere in the app to start a new note."
 msgstr ""
 
-#: src/strings.ts:2056
+#: src/strings.ts:2057
 msgid ""
 "You can track your bug report at [{url}]({url}).\n"
 "\n"
@@ -7422,7 +7428,7 @@ msgid ""
 "If your issue is critical (e.g. notes not syncing, crashes etc.), please [join our Discord community](https://go.notesnook.com/discord) for one-to-one support."
 msgstr ""
 
-#: src/strings.ts:2065
+#: src/strings.ts:2066
 msgid ""
 "You can track your feature request at [{url}]({url}).\n"
 "\n"
@@ -7433,78 +7439,78 @@ msgstr ""
 msgid "You can track your issue at "
 msgstr ""
 
-#: src/strings.ts:1028
+#: src/strings.ts:1029
 msgid "You can use all premium features for free for the next 14 days"
 msgstr ""
 
-#: src/strings.ts:1058
+#: src/strings.ts:1059
 msgid "You can use fallback 2FA method incase you are unable to login via primary method"
 msgstr ""
 
-#: src/strings.ts:1450
+#: src/strings.ts:1451
 msgid "You can view & restore older versions of any note by going to its properties -> History."
 msgstr ""
 
-#: src/strings.ts:1749
+#: src/strings.ts:1750
 msgid "You have {count} custom dictionary words."
 msgstr ""
 
-#: src/strings.ts:2208
+#: src/strings.ts:2209
 msgid "You have been logged out from all other devices."
 msgstr ""
 
-#: src/strings.ts:2202
+#: src/strings.ts:2203
 msgid "You have been logged out."
 msgstr ""
 
-#: src/strings.ts:2601
+#: src/strings.ts:2602
 msgid "You have made a one time purchase. To change your plan please contact support."
 msgstr ""
 
-#: src/strings.ts:964
+#: src/strings.ts:965
 msgid "You have not added any notebooks yet"
 msgstr ""
 
-#: src/strings.ts:963
+#: src/strings.ts:964
 msgid "You have not added any tags yet"
 msgstr ""
 
-#: src/strings.ts:962
+#: src/strings.ts:963
 msgid "You have not created any notes yet"
 msgstr ""
 
-#: src/strings.ts:961
+#: src/strings.ts:962
 msgid "You have not favorited any notes yet"
 msgstr ""
 
-#: src/strings.ts:966
+#: src/strings.ts:967
 msgid "You have not published any monographs yet"
 msgstr ""
 
-#: src/strings.ts:965
+#: src/strings.ts:966
 msgid "You have not set any reminders yet"
 msgstr ""
 
-#: src/strings.ts:1545
+#: src/strings.ts:1546
 msgid "You have unsynced notes. Take a backup or sync your notes to avoid losing your critical data."
 msgstr ""
 
-#: src/strings.ts:1634
+#: src/strings.ts:1635
 msgid "You must log out in order to change/reset server URLs."
 msgstr ""
 
-#: src/strings.ts:2673
+#: src/strings.ts:2674
 msgid ""
 "You need to login to restore attachments from a backup file. [Read more](https://help.notesnook.com/faqs/login-to-restore-attachments-in-backup).\n"
 "  \n"
 "Continue without attachments?"
 msgstr ""
 
-#: src/strings.ts:836
+#: src/strings.ts:837
 msgid "You simply cannot get any better of a note taking app than @notesnook. The UI is clean and slick, it is feature rich, encrypted, reasonably priced (esp. for students & educators) & open source"
 msgstr ""
 
-#: src/strings.ts:1068
+#: src/strings.ts:1069
 msgid "You subscribed to Notesnook Pro on {date}. Verify this subscription?"
 msgstr ""
 
@@ -7532,7 +7538,7 @@ msgstr ""
 msgid "You will be logged out from all your devices"
 msgstr ""
 
-#: src/strings.ts:1851
+#: src/strings.ts:1852
 msgid "You will receive instructions on how to recover your account on this email"
 msgstr ""
 
@@ -7540,72 +7546,72 @@ msgstr ""
 msgid "Your account email will be changed without affecting your subscription or any other settings."
 msgstr ""
 
-#: src/strings.ts:1917
+#: src/strings.ts:1918
 msgid "Your account has been recovered."
 msgstr ""
 
 #: src/strings.ts:502
-#: src/strings.ts:1728
+#: src/strings.ts:1729
 msgid "Your account is now 100% secure against unauthorized logins."
 msgstr ""
 
-#: src/strings.ts:1856
+#: src/strings.ts:1857
 msgid "Your account password must be strong & unique."
 msgstr ""
 
-#: src/strings.ts:1034
+#: src/strings.ts:1035
 msgid "Your account will be downgraded in {days} days"
 msgstr ""
 
-#: src/strings.ts:1078
+#: src/strings.ts:1079
 msgid "Your account will be permanently deleted along with all your data, login credentials, and subscription information. This action is IRREVERSIBLE. Make sure you have saved a backup of your notes before proceeding."
 msgstr ""
 
-#: src/strings.ts:960
+#: src/strings.ts:961
 msgid "Your archive"
 msgstr ""
 
-#: src/strings.ts:2496
+#: src/strings.ts:2497
 msgid "Your archive is empty"
 msgstr ""
 
-#: src/strings.ts:1929
+#: src/strings.ts:1930
 msgid "Your backup is ready to download"
 msgstr ""
 
-#: src/strings.ts:1586
+#: src/strings.ts:1587
 msgid "Your changes could not be saved"
 msgstr ""
 
-#: src/strings.ts:1776
+#: src/strings.ts:1777
 msgid "Your changes have been saved and will be reflected after the app has refreshed."
 msgstr ""
 
-#: src/strings.ts:2109
+#: src/strings.ts:2110
 msgid "Your current 2FA method is {method}"
 msgstr ""
 
-#: src/strings.ts:2608
+#: src/strings.ts:2609
 msgid "Your current subscription does not allow changing plans"
 msgstr ""
 
-#: src/strings.ts:1801
+#: src/strings.ts:1802
 msgid "Your data recovery key is basically a hashed version of your password (plus some random salt). It can be used to decrypt your data for re-encryption."
 msgstr ""
 
-#: src/strings.ts:1854
+#: src/strings.ts:1855
 msgid "Your data recovery key will be used to decrypt your data"
 msgstr ""
 
-#: src/strings.ts:2516
+#: src/strings.ts:2517
 msgid "Your data remains 100% accessible regardless of what plan you are on. That includes your notes, notebooks, attachments, and anything else you might have created."
 msgstr ""
 
-#: src/strings.ts:1784
+#: src/strings.ts:1785
 msgid "Your email has been confirmed."
 msgstr ""
 
-#: src/strings.ts:2507
+#: src/strings.ts:2508
 msgid "Your email has been confirmed. You can now securely sync your encrypted notes across all devices."
 msgstr ""
 
@@ -7613,39 +7619,39 @@ msgstr ""
 msgid "Your email is not confirmed. Please confirm your email address to change account password."
 msgstr ""
 
-#: src/strings.ts:954
+#: src/strings.ts:955
 msgid "Your favorites"
 msgstr ""
 
-#: src/strings.ts:1031
+#: src/strings.ts:1032
 msgid "Your free trial ends on {date}"
 msgstr ""
 
-#: src/strings.ts:1404
+#: src/strings.ts:1405
 msgid "Your free trial has expired"
 msgstr ""
 
-#: src/strings.ts:1026
+#: src/strings.ts:1027
 msgid "Your free trial has started"
 msgstr ""
 
-#: src/strings.ts:1403
+#: src/strings.ts:1404
 msgid "Your free trial is ending soon"
 msgstr ""
 
-#: src/strings.ts:2636
+#: src/strings.ts:2637
 msgid "Your free trial is on-going. Your subscription will start on {trialExpiryDate}"
 msgstr ""
 
-#: src/strings.ts:1778
+#: src/strings.ts:1779
 msgid "Your full name"
 msgstr ""
 
-#: src/strings.ts:959
+#: src/strings.ts:960
 msgid "Your monographs"
 msgstr ""
 
-#: src/strings.ts:1312
+#: src/strings.ts:1313
 msgid "Your name is stored 100% end-to-end encrypted and only visible to you."
 msgstr ""
 
@@ -7653,31 +7659,31 @@ msgstr ""
 msgid "Your note will be unencrypted and removed from the vault."
 msgstr ""
 
-#: src/strings.ts:957
+#: src/strings.ts:958
 msgid "Your notebooks"
 msgstr ""
 
-#: src/strings.ts:955
+#: src/strings.ts:956
 msgid "Your notes"
 msgstr ""
 
-#: src/strings.ts:1892
+#: src/strings.ts:1893
 msgid "Your password is always hashed before leaving this device."
 msgstr ""
 
-#: src/strings.ts:832
+#: src/strings.ts:833
 msgid "Your privacy matters to us, no matter who you are. In a world where everyone is trying to spy on you, Notesnook encrypts all your data before it leaves your device. With Notesnook no one can ever sell your data again."
 msgstr ""
 
-#: src/strings.ts:1309
+#: src/strings.ts:1310
 msgid "Your profile pictrure is stored 100% end-to-end encrypted and only visible to you."
 msgstr ""
 
-#: src/strings.ts:1997
+#: src/strings.ts:1998
 msgid "Your refund has been issued. Please wait 24 hours before reaching out to us in case you do not receive your funds."
 msgstr ""
 
-#: src/strings.ts:958
+#: src/strings.ts:959
 msgid "Your reminders"
 msgstr ""
 
@@ -7685,31 +7691,31 @@ msgstr ""
 msgid "Your session has expired. Please enter password for {obfuscatedEmail} to continue."
 msgstr ""
 
-#: src/strings.ts:1035
+#: src/strings.ts:1036
 msgid "Your subscription ends on {date}"
 msgstr ""
 
-#: src/strings.ts:1995
+#: src/strings.ts:1996
 msgid "Your subscription has been canceled."
 msgstr ""
 
-#: src/strings.ts:1032
+#: src/strings.ts:1033
 msgid "Your subscription has ended"
 msgstr ""
 
-#: src/strings.ts:1036
+#: src/strings.ts:1037
 msgid "Your subscription renews on {date}"
 msgstr ""
 
-#: src/strings.ts:2053
+#: src/strings.ts:2054
 msgid "Your support request has been forwarded"
 msgstr ""
 
-#: src/strings.ts:2062
+#: src/strings.ts:2063
 msgid "Your support request has been forwarded to our support team. We will get back to you via email as soon as possible. If you don't receive an email from us within 24-48 hours, please send us an email directly at support@notesnook.com."
 msgstr ""
 
-#: src/strings.ts:956
+#: src/strings.ts:957
 msgid "Your tags"
 msgstr ""
 
@@ -7725,22 +7731,22 @@ msgstr ""
 msgid "Zipping"
 msgstr ""
 
-#: src/strings.ts:2472
+#: src/strings.ts:2473
 msgid "Zoom"
 msgstr ""
 
-#: src/strings.ts:2103
+#: src/strings.ts:2104
 msgid "Zoom factor"
 msgstr ""
 
-#: src/strings.ts:1700
+#: src/strings.ts:1701
 msgid "Zoom in"
 msgstr ""
 
-#: src/strings.ts:2104
+#: src/strings.ts:2105
 msgid "Zoom in or out the app content."
 msgstr ""
 
-#: src/strings.ts:1699
+#: src/strings.ts:1700
 msgid "Zoom out"
 msgstr ""

--- a/packages/intl/locale/pseudo-LOCALE.po
+++ b/packages/intl/locale/pseudo-LOCALE.po
@@ -14,7 +14,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/strings.ts:2422
+#: src/strings.ts:2421
 msgid " \"Notebook > Notes\""
 msgstr ""
 
@@ -22,27 +22,27 @@ msgstr ""
 msgid " Unlock with password once to enable biometric access."
 msgstr ""
 
-#: src/strings.ts:1942
+#: src/strings.ts:1941
 msgid " Upgrade to Notesnook Pro to add more notebooks."
 msgstr ""
 
-#: src/strings.ts:1945
+#: src/strings.ts:1944
 msgid " Upgrade to Notesnook Pro to customize the toolbar."
 msgstr ""
 
-#: src/strings.ts:1944
+#: src/strings.ts:1943
 msgid " Upgrade to Notesnook Pro to use custom toolbar presets."
 msgstr ""
 
-#: src/strings.ts:1943
+#: src/strings.ts:1942
 msgid " Upgrade to Notesnook Pro to use the notes vault."
 msgstr ""
 
-#: src/strings.ts:1946
+#: src/strings.ts:1945
 msgid " Upgrade to Notesnook Pro to use this feature."
 msgstr ""
 
-#: src/strings.ts:829
+#: src/strings.ts:828
 msgid "— not just the"
 msgstr ""
 
@@ -70,19 +70,19 @@ msgid "{0} Highlights 🎉"
 msgstr ""
 
 #. placeholder {0}: platform === "ios" ? "Apple" : "Google"
-#: src/strings.ts:2578
+#: src/strings.ts:2577
 msgid "{0} will remind you before your trial ends"
 msgstr ""
 
-#: src/strings.ts:1754
+#: src/strings.ts:1753
 msgid "{count, plural, one {# error occured} other {# errors occured}}"
 msgstr ""
 
-#: src/strings.ts:1760
+#: src/strings.ts:1759
 msgid "{count, plural, one {# file ready for import} other {# files ready for import}}"
 msgstr ""
 
-#: src/strings.ts:1715
+#: src/strings.ts:1714
 msgid "{count, plural, one {# file} other {# files}}"
 msgstr ""
 
@@ -90,11 +90,11 @@ msgstr ""
 msgid "{count, plural, one {# note} other {# notes}}"
 msgstr ""
 
-#: src/strings.ts:1579
+#: src/strings.ts:1578
 msgid "{count, plural, one {1 hour} other {# hours}}"
 msgstr ""
 
-#: src/strings.ts:1574
+#: src/strings.ts:1573
 msgid "{count, plural, one {1 minute} other {# minutes}}"
 msgstr ""
 
@@ -135,7 +135,7 @@ msgstr ""
 msgid "{count, plural, one {Are you sure you want to download all attachments of this note?} other {Are you sure you want to download all attachments?}}"
 msgstr ""
 
-#: src/strings.ts:864
+#: src/strings.ts:863
 msgid "{count, plural, one {Are you sure you want to move this notebook to {selectedNotebookTitle}?} other {Are you sure you want to move these # notebooks {selectedNotebookTitle}?}}"
 msgstr ""
 
@@ -294,11 +294,11 @@ msgstr ""
 msgid "{count, plural, one {Item unpublished} other {# items unpublished}}"
 msgstr ""
 
-#: src/strings.ts:2439
+#: src/strings.ts:2438
 msgid "{count, plural, one {Move all notes in this notebook to trash} other {Move all notes in these notebooks to trash}}"
 msgstr ""
 
-#: src/strings.ts:862
+#: src/strings.ts:861
 msgid "{count, plural, one {Move notebook} other {Move # notebooks}}"
 msgstr ""
 
@@ -342,7 +342,7 @@ msgstr ""
 msgid "{count, plural, one {Note unpublished} other {# notes unpublished}}"
 msgstr ""
 
-#: src/strings.ts:921
+#: src/strings.ts:920
 msgid "{count, plural, one {Note will be automatically deleted from all other devices & any future changes won't get synced. Are you sure you want to continue?} other {# notes will be automatically deleted from all other devices & any future changes won't get synced. Are you sure you want to continue?}}"
 msgstr ""
 
@@ -396,7 +396,7 @@ msgstr ""
 msgid "{count, plural, one {Pin notebook} other {Pin # notebooks}}"
 msgstr ""
 
-#: src/strings.ts:916
+#: src/strings.ts:915
 msgid "{count, plural, one {Prevent note from syncing} other {Prevent # notes from syncing}}"
 msgstr ""
 
@@ -497,15 +497,15 @@ msgstr ""
 msgid "{count, plural, one {Unpublish note} other {Unpublish # notes}}"
 msgstr ""
 
-#: src/strings.ts:2509
+#: src/strings.ts:2508
 msgid "{count} characters"
 msgstr ""
 
-#: src/strings.ts:1565
+#: src/strings.ts:1564
 msgid "{days, plural, one {1 day} other {# days}}"
 msgstr ""
 
-#: src/strings.ts:2569
+#: src/strings.ts:2568
 msgid "{days} days free"
 msgstr ""
 
@@ -545,19 +545,19 @@ msgstr ""
 msgid "{mode, select, repeat {Repeat} once {Once} permanent {Permanent} other {Unknown mode}}"
 msgstr ""
 
-#: src/strings.ts:1977
+#: src/strings.ts:1976
 msgid "{n} {added, plural, one {added to 1 notebook} other {added to # notebooks}} and {removed, plural, one {removed from 1 notebook} other {removed from # notebooks}}."
 msgstr ""
 
-#: src/strings.ts:1972
+#: src/strings.ts:1971
 msgid "{n} {added, plural, one {added to 1 notebook} other {added to # notebooks}}."
 msgstr ""
 
-#: src/strings.ts:1967
+#: src/strings.ts:1966
 msgid "{n} {removed, plural, one {removed from 1 notebook} other {removed from # notebooks}}."
 msgstr ""
 
-#: src/strings.ts:1962
+#: src/strings.ts:1961
 msgid "{notes, plural, one {1 note} other {# notes}}"
 msgstr ""
 
@@ -565,11 +565,11 @@ msgstr ""
 msgid "{notes, plural, one {Export note} other {Export # notes}}"
 msgstr ""
 
-#: src/strings.ts:1707
+#: src/strings.ts:1706
 msgid "{percentage}% updating..."
 msgstr ""
 
-#: src/strings.ts:2553
+#: src/strings.ts:2552
 msgid "{plan} plan"
 msgstr ""
 
@@ -577,11 +577,11 @@ msgstr ""
 msgid "{platform, select, android {{name} saved to selected path} other {{name} saved to File Manager/Notesnook/downloads}}"
 msgstr ""
 
-#: src/strings.ts:1338
+#: src/strings.ts:1337
 msgid "{platform, select, android {Backup file saved in \"Notesnook backups\" folder on your phone.} other {Backup file is saved in File Manager/Notesnook folder}}"
 msgstr ""
 
-#: src/strings.ts:2369
+#: src/strings.ts:2368
 msgid "{selected} selected"
 msgstr ""
 
@@ -601,43 +601,43 @@ msgstr ""
 msgid "{type} does not match"
 msgstr ""
 
-#: src/strings.ts:1600
+#: src/strings.ts:1599
 msgid "{words, plural, one {# word} other {# words}}"
 msgstr ""
 
-#: src/strings.ts:1663
+#: src/strings.ts:1662
 msgid "{words, plural, other {# selected}}"
 msgstr ""
 
-#: src/strings.ts:1791
+#: src/strings.ts:1790
 msgid "#notesnook"
 msgstr ""
 
-#: src/strings.ts:1584
+#: src/strings.ts:1583
 msgid "12-hour"
 msgstr ""
 
-#: src/strings.ts:1585
+#: src/strings.ts:1584
 msgid "24-hour"
 msgstr ""
 
-#: src/strings.ts:1905
+#: src/strings.ts:1904
 msgid "2FA code is required()"
 msgstr ""
 
-#: src/strings.ts:1009
+#: src/strings.ts:1008
 msgid "2FA code sent via {method}"
 msgstr ""
 
-#: src/strings.ts:2596
+#: src/strings.ts:2595
 msgid "5 year plan (One time purchase)"
 msgstr ""
 
-#: src/strings.ts:1846
+#: src/strings.ts:1845
 msgid "6 digit code"
 msgstr ""
 
-#: src/strings.ts:1432
+#: src/strings.ts:1431
 msgid "A notebook can have unlimited topics with unlimited notes."
 msgstr ""
 
@@ -653,35 +653,35 @@ msgstr ""
 msgid "Abc"
 msgstr ""
 
-#: src/strings.ts:1290
+#: src/strings.ts:1289
 msgid "About"
 msgstr ""
 
-#: src/strings.ts:1025
+#: src/strings.ts:1024
 msgid "Account"
 msgstr ""
 
-#: src/strings.ts:1848
+#: src/strings.ts:1847
 msgid "Account password"
 msgstr ""
 
-#: src/strings.ts:2464
+#: src/strings.ts:2463
 msgid "Actions for note: {title}"
 msgstr ""
 
-#: src/strings.ts:2465
+#: src/strings.ts:2464
 msgid "Actions for notebook: {title}"
 msgstr ""
 
-#: src/strings.ts:2466
+#: src/strings.ts:2465
 msgid "Actions for tag: {title}"
 msgstr ""
 
-#: src/strings.ts:2038
+#: src/strings.ts:2037
 msgid "Activate"
 msgstr ""
 
-#: src/strings.ts:1824
+#: src/strings.ts:1823
 msgid "Activating trial"
 msgstr ""
 
@@ -689,15 +689,15 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: src/strings.ts:1057
+#: src/strings.ts:1056
 msgid "Add 2FA fallback method"
 msgstr ""
 
-#: src/strings.ts:1508
+#: src/strings.ts:1507
 msgid "Add a short note"
 msgstr ""
 
-#: src/strings.ts:1601
+#: src/strings.ts:1600
 msgid "Add a tag"
 msgstr ""
 
@@ -705,11 +705,11 @@ msgstr ""
 msgid "Add color"
 msgstr ""
 
-#: src/strings.ts:896
+#: src/strings.ts:895
 msgid "Add notebook"
 msgstr ""
 
-#: src/strings.ts:2491
+#: src/strings.ts:2490
 msgid "Add notes"
 msgstr ""
 
@@ -717,7 +717,7 @@ msgstr ""
 msgid "Add notes to {title}"
 msgstr ""
 
-#: src/strings.ts:895
+#: src/strings.ts:894
 msgid "Add shortcut"
 msgstr ""
 
@@ -729,55 +729,55 @@ msgstr ""
 msgid "Add tag"
 msgstr ""
 
-#: src/strings.ts:934
+#: src/strings.ts:933
 msgid "Add tags"
 msgstr ""
 
-#: src/strings.ts:935
+#: src/strings.ts:934
 msgid "Add tags to multiple notes at once"
 msgstr ""
 
-#: src/strings.ts:2256
+#: src/strings.ts:2255
 msgid "Add to dictionary"
 msgstr ""
 
-#: src/strings.ts:2629
+#: src/strings.ts:2628
 msgid "Add to home"
 msgstr ""
 
-#: src/strings.ts:2489
+#: src/strings.ts:2488
 msgid "Add to notebook"
 msgstr ""
 
-#: src/strings.ts:975
+#: src/strings.ts:974
 msgid "Add your first note"
 msgstr ""
 
-#: src/strings.ts:976
+#: src/strings.ts:975
 msgid "Add your first notebook"
 msgstr ""
 
-#: src/strings.ts:2632
+#: src/strings.ts:2631
 msgid "Adjust the line height of the editor"
 msgstr ""
 
-#: src/strings.ts:2182
+#: src/strings.ts:2181
 msgid "Advanced"
 msgstr ""
 
-#: src/strings.ts:1727
+#: src/strings.ts:1726
 msgid "After scanning the QR code image, the app will display a code that you can enter below."
 msgstr ""
 
-#: src/strings.ts:2321
+#: src/strings.ts:2320
 msgid "Align left"
 msgstr ""
 
-#: src/strings.ts:2322
+#: src/strings.ts:2321
 msgid "Align right"
 msgstr ""
 
-#: src/strings.ts:2291
+#: src/strings.ts:2290
 msgid "Alignment"
 msgstr ""
 
@@ -789,7 +789,7 @@ msgstr ""
 msgid "All attachments are end-to-end encrypted."
 msgstr ""
 
-#: src/strings.ts:2416
+#: src/strings.ts:2415
 msgid "All cached attachments have been cleared."
 msgstr ""
 
@@ -801,7 +801,7 @@ msgstr ""
 msgid "All files"
 msgstr ""
 
-#: src/strings.ts:1175
+#: src/strings.ts:1174
 msgid "All locked notes will be re-encrypted with the new password."
 msgstr ""
 
@@ -809,15 +809,15 @@ msgstr ""
 msgid "All logs are local only and are not sent to any server. You can share the logs from here with us if you face an issue to help us find the root cause."
 msgstr ""
 
-#: src/strings.ts:1638
+#: src/strings.ts:1637
 msgid "All server urls are required."
 msgstr ""
 
-#: src/strings.ts:1907
+#: src/strings.ts:1906
 msgid "All the data in your account will be overwritten with the data in the backup file. There is no way to reverse this action."
 msgstr ""
 
-#: src/strings.ts:2162
+#: src/strings.ts:2161
 msgid "All the source code for Notesnook is available & open for everyone on GitHub."
 msgstr ""
 
@@ -825,15 +825,15 @@ msgstr ""
 msgid "All tools are grouped"
 msgstr ""
 
-#: src/strings.ts:1322
+#: src/strings.ts:1321
 msgid "All tools in the collapsed section will be removed"
 msgstr ""
 
-#: src/strings.ts:1317
+#: src/strings.ts:1316
 msgid "All tools in this group will be removed from the toolbar."
 msgstr ""
 
-#: src/strings.ts:1347
+#: src/strings.ts:1346
 msgid "All your backups are stored in 'Phone Storage/Notesnook/backups/' folder"
 msgstr ""
 
@@ -841,7 +841,7 @@ msgstr ""
 msgid "Already have an account?"
 msgstr ""
 
-#: src/strings.ts:2232
+#: src/strings.ts:2231
 msgid "Amount"
 msgstr ""
 
@@ -849,7 +849,7 @@ msgstr ""
 msgid "An error occurred while migrating your data. You can logout of your account and try to relogin. However this is not recommended as it may result in some data loss if your data was not synced."
 msgstr ""
 
-#: src/strings.ts:2590
+#: src/strings.ts:2589
 msgid "and"
 msgstr ""
 
@@ -857,19 +857,19 @@ msgstr ""
 msgid "and "
 msgstr ""
 
-#: src/strings.ts:1792
+#: src/strings.ts:1791
 msgid "and get a chance to win free promo codes."
 msgstr ""
 
-#: src/strings.ts:2546
+#: src/strings.ts:2545
 msgid "and much more."
 msgstr ""
 
-#: src/strings.ts:1398
+#: src/strings.ts:1397
 msgid "and we will manually confirm your account."
 msgstr ""
 
-#: src/strings.ts:2607
+#: src/strings.ts:2606
 msgid "ANNOUNCEMENT"
 msgstr ""
 
@@ -877,29 +877,29 @@ msgstr ""
 msgid "App data has been cleared. Kindly relaunch the app to login again."
 msgstr ""
 
-#: src/strings.ts:1184
-#: src/strings.ts:1694
+#: src/strings.ts:1183
+#: src/strings.ts:1693
 msgid "App lock"
 msgstr ""
 
 #: src/strings.ts:781
-#: src/strings.ts:1210
+#: src/strings.ts:1209
 msgid "App lock disabled"
 msgstr ""
 
-#: src/strings.ts:1190
+#: src/strings.ts:1189
 msgid "App lock timeout"
 msgstr ""
 
-#: src/strings.ts:1301
+#: src/strings.ts:1300
 msgid "App version"
 msgstr ""
 
-#: src/strings.ts:1775
+#: src/strings.ts:1774
 msgid "App will reload in {sec} seconds"
 msgstr ""
 
-#: src/strings.ts:1115
+#: src/strings.ts:1114
 msgid "Appearance"
 msgstr ""
 
@@ -915,32 +915,32 @@ msgstr ""
 msgid "Apply changes"
 msgstr ""
 
-#: src/strings.ts:2045
+#: src/strings.ts:2044
 msgid "Applying changes"
 msgstr ""
 
-#: src/strings.ts:1531
-#: src/strings.ts:2496
+#: src/strings.ts:1530
+#: src/strings.ts:2495
 msgid "Archive"
 msgstr ""
 
-#: src/strings.ts:1446
+#: src/strings.ts:1445
 msgid "Are you scrolling a lot to find a specific note? Pin it to the top from Note properties."
 msgstr ""
 
-#: src/strings.ts:1017
+#: src/strings.ts:1016
 msgid "Are you sure you want to clear all logs from {key}?"
 msgstr ""
 
-#: src/strings.ts:1325
+#: src/strings.ts:1324
 msgid "Are you sure you want to clear trash?"
 msgstr ""
 
-#: src/strings.ts:2667
+#: src/strings.ts:2666
 msgid "Are you sure you want to delete this attachment?"
 msgstr ""
 
-#: src/strings.ts:1543
+#: src/strings.ts:1542
 msgid "Are you sure you want to logout and clear all data stored on THIS DEVICE?"
 msgstr ""
 
@@ -948,31 +948,31 @@ msgstr ""
 msgid "Are you sure you want to logout from this device? Any unsynced changes will be lost."
 msgstr ""
 
-#: src/strings.ts:2688
+#: src/strings.ts:2687
 msgid "Are you sure you want to open this file: {filePath}?"
 msgstr ""
 
-#: src/strings.ts:1047
+#: src/strings.ts:1046
 msgid "Are you sure you want to remove your name?"
 msgstr ""
 
-#: src/strings.ts:1044
+#: src/strings.ts:1043
 msgid "Are you sure you want to remove your profile picture?"
 msgstr ""
 
-#: src/strings.ts:1324
+#: src/strings.ts:1323
 msgid "Are you sure?"
 msgstr ""
 
-#: src/strings.ts:1131
+#: src/strings.ts:1130
 msgid "Ask every time"
 msgstr ""
 
-#: src/strings.ts:2034
+#: src/strings.ts:2033
 msgid "Assign color"
 msgstr ""
 
-#: src/strings.ts:933
+#: src/strings.ts:932
 msgid "Assign to..."
 msgstr ""
 
@@ -980,15 +980,15 @@ msgstr ""
 msgid "Atleast 8 characters required"
 msgstr ""
 
-#: src/strings.ts:2358
+#: src/strings.ts:2357
 msgid "Attach image from URL"
 msgstr ""
 
-#: src/strings.ts:909
+#: src/strings.ts:908
 msgid "Attached files"
 msgstr ""
 
-#: src/strings.ts:2679
+#: src/strings.ts:2678
 msgid "Attaching files"
 msgstr ""
 
@@ -997,27 +997,27 @@ msgid "attachment"
 msgstr ""
 
 #: src/strings.ts:300
-#: src/strings.ts:2355
+#: src/strings.ts:2354
 msgid "Attachment"
 msgstr ""
 
-#: src/strings.ts:2668
+#: src/strings.ts:2667
 msgid "Attachment deleted"
 msgstr ""
 
-#: src/strings.ts:2459
+#: src/strings.ts:2458
 msgid "Attachment manager"
 msgstr ""
 
-#: src/strings.ts:1936
+#: src/strings.ts:1935
 msgid "Attachment preview failed"
 msgstr ""
 
-#: src/strings.ts:2409
+#: src/strings.ts:2408
 msgid "Attachment recheck cancelled"
 msgstr ""
 
-#: src/strings.ts:2326
+#: src/strings.ts:2325
 msgid "Attachment settings"
 msgstr ""
 
@@ -1026,15 +1026,15 @@ msgid "attachments"
 msgstr ""
 
 #: src/strings.ts:320
-#: src/strings.ts:908
+#: src/strings.ts:907
 msgid "Attachments"
 msgstr ""
 
-#: src/strings.ts:1885
+#: src/strings.ts:1884
 msgid "Attachments cache cleared!"
 msgstr ""
 
-#: src/strings.ts:2411
+#: src/strings.ts:2410
 msgid "Attachments recheck complete"
 msgstr ""
 
@@ -1042,160 +1042,160 @@ msgstr ""
 msgid "Audios"
 msgstr ""
 
-#: src/strings.ts:1627
+#: src/strings.ts:1626
 msgid "Auth server"
 msgstr ""
 
-#: src/strings.ts:1796
+#: src/strings.ts:1795
 msgid "Authenticated as {email}"
 msgstr ""
 
-#: src/strings.ts:1899
+#: src/strings.ts:1898
 msgid "Authenticating user"
 msgstr ""
 
-#: src/strings.ts:2145
+#: src/strings.ts:2144
 msgid "Authentication"
 msgstr ""
 
-#: src/strings.ts:1731
+#: src/strings.ts:1730
 msgid "authentication app"
 msgstr ""
 
-#: src/strings.ts:1352
+#: src/strings.ts:1351
 msgid "Authentication cancelled by user"
 msgstr ""
 
-#: src/strings.ts:1353
+#: src/strings.ts:1352
 msgid "Authentication failed"
 msgstr ""
 
-#: src/strings.ts:2108
+#: src/strings.ts:2107
 msgid "Auto"
 msgstr ""
 
-#: src/strings.ts:1662
+#: src/strings.ts:1661
 msgid "Auto save: off"
 msgstr ""
 
-#: src/strings.ts:2122
+#: src/strings.ts:2121
 msgid "Auto start on system startup"
 msgstr ""
 
-#: src/strings.ts:1219
-#: src/strings.ts:1690
+#: src/strings.ts:1218
+#: src/strings.ts:1689
 msgid "Automatic backups"
 msgstr ""
 
-#: src/strings.ts:1366
+#: src/strings.ts:1365
 msgid "Automatic backups are off"
 msgstr ""
 
-#: src/strings.ts:2006
+#: src/strings.ts:2005
 msgid "Automatic backups disabled"
 msgstr ""
 
-#: src/strings.ts:1222
+#: src/strings.ts:1221
 msgid "Automatic backups with attachments"
 msgstr ""
 
-#: src/strings.ts:2118
+#: src/strings.ts:2117
 msgid "Automatic updates"
 msgstr ""
 
-#: src/strings.ts:1139
+#: src/strings.ts:1138
 msgid "Automatically clear trash after a certain period of time"
 msgstr ""
 
-#: src/strings.ts:2120
+#: src/strings.ts:2119
 msgid "Automatically download & install updates in the background without prompting first."
 msgstr ""
 
-#: src/strings.ts:1192
+#: src/strings.ts:1191
 msgid "Automatically lock the app after a certain period"
 msgstr ""
 
-#: src/strings.ts:1122
+#: src/strings.ts:1121
 msgid "Automatically switch between light and dark themes based on your system settings"
 msgstr ""
 
-#: src/strings.ts:2165
+#: src/strings.ts:2164
 msgid "Available on iOS"
 msgstr ""
 
-#: src/strings.ts:2166
+#: src/strings.ts:2165
 msgid "Available on iOS & Android"
 msgstr ""
 
-#: src/strings.ts:2655
+#: src/strings.ts:2654
 msgid "Back"
 msgstr ""
 
-#: src/strings.ts:2314
+#: src/strings.ts:2313
 msgid "Background color"
 msgstr ""
 
-#: src/strings.ts:1094
+#: src/strings.ts:1093
 msgid "Background sync (experimental)"
 msgstr ""
 
-#: src/strings.ts:2114
+#: src/strings.ts:2113
 msgid "Backup"
 msgstr ""
 
-#: src/strings.ts:2152
+#: src/strings.ts:2151
 msgid "Backup & export"
 msgstr ""
 
-#: src/strings.ts:1211
+#: src/strings.ts:1210
 msgid "Backup & restore"
 msgstr ""
 
-#: src/strings.ts:1336
+#: src/strings.ts:1335
 msgid "Backup complete"
 msgstr ""
 
-#: src/strings.ts:1562
+#: src/strings.ts:1561
 msgid "Backup directory not selected"
 msgstr ""
 
-#: src/strings.ts:1234
+#: src/strings.ts:1233
 msgid "Backup encryption"
 msgstr ""
 
-#: src/strings.ts:1859
+#: src/strings.ts:1858
 msgid "Backup files have .nnbackup extension"
 msgstr ""
 
-#: src/strings.ts:883
+#: src/strings.ts:882
 msgid "Backup is encrypted"
 msgstr ""
 
-#: src/strings.ts:1615
+#: src/strings.ts:1614
 msgid "Backup is encrypted, decrypting..."
 msgstr ""
 
-#: src/strings.ts:1213
+#: src/strings.ts:1212
 msgid "Backup now"
 msgstr ""
 
-#: src/strings.ts:1214
+#: src/strings.ts:1213
 msgid "Backup now with attachments"
 msgstr ""
 
-#: src/strings.ts:890
+#: src/strings.ts:889
 msgid "Backup restored"
 msgstr ""
 
-#: src/strings.ts:1920
+#: src/strings.ts:1919
 msgid "Backup saved at {path}"
 msgstr ""
 
-#: src/strings.ts:1348
+#: src/strings.ts:1347
 msgid "Backup successful"
 msgstr ""
 
-#: src/strings.ts:2115
+#: src/strings.ts:2114
 msgid "Backup with attachments"
 msgstr ""
 
@@ -1207,47 +1207,47 @@ msgstr ""
 msgid "Basic"
 msgstr ""
 
-#: src/strings.ts:1794
+#: src/strings.ts:1793
 msgid "Because where's the fun in nookin' alone?"
 msgstr ""
 
-#: src/strings.ts:1125
+#: src/strings.ts:1124
 msgid "Behavior"
 msgstr ""
 
-#: src/strings.ts:2147
+#: src/strings.ts:2146
 msgid "Behaviour"
 msgstr ""
 
-#: src/strings.ts:2483
+#: src/strings.ts:2482
 msgid "Believer plan"
 msgstr ""
 
-#: src/strings.ts:2593
+#: src/strings.ts:2592
 msgid "Best value"
 msgstr ""
 
-#: src/strings.ts:2472
+#: src/strings.ts:2471
 msgid "Beta"
 msgstr ""
 
-#: src/strings.ts:2272
+#: src/strings.ts:2271
 msgid "Bi-directional note link"
 msgstr ""
 
-#: src/strings.ts:2566
+#: src/strings.ts:2565
 msgid "billed annually at {price}"
 msgstr ""
 
-#: src/strings.ts:2567
+#: src/strings.ts:2566
 msgid "billed monthly at {price}"
 msgstr ""
 
-#: src/strings.ts:2213
+#: src/strings.ts:2212
 msgid "Billing history"
 msgstr ""
 
-#: src/strings.ts:1178
+#: src/strings.ts:1177
 msgid "Biometric unlocking"
 msgstr ""
 
@@ -1259,27 +1259,27 @@ msgstr ""
 msgid "Biometric unlocking enabled"
 msgstr ""
 
-#: src/strings.ts:1350
+#: src/strings.ts:1349
 msgid "Biometrics authentication failed. Please try again."
 msgstr ""
 
-#: src/strings.ts:1187
+#: src/strings.ts:1186
 msgid "Biometrics not enrolled"
 msgstr ""
 
-#: src/strings.ts:2268
+#: src/strings.ts:2267
 msgid "Bold"
 msgstr ""
 
-#: src/strings.ts:2421
+#: src/strings.ts:2420
 msgid "Boost your productivity with Notebooks and organize your notes."
 msgstr ""
 
-#: src/strings.ts:1810
+#: src/strings.ts:1809
 msgid "Browse"
 msgstr ""
 
-#: src/strings.ts:2285
+#: src/strings.ts:2284
 msgid "Bullet list"
 msgstr ""
 
@@ -1287,7 +1287,7 @@ msgstr ""
 msgid "By"
 msgstr ""
 
-#: src/strings.ts:2588
+#: src/strings.ts:2587
 msgid "By joining you agree to our"
 msgstr ""
 
@@ -1295,11 +1295,11 @@ msgstr ""
 msgid "By signing up, you agree to our "
 msgstr ""
 
-#: src/strings.ts:2346
+#: src/strings.ts:2345
 msgid "Callout"
 msgstr ""
 
-#: src/strings.ts:2526
+#: src/strings.ts:2525
 msgid "Can I cancel my free trial anytime?"
 msgstr ""
 
@@ -1307,11 +1307,11 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/strings.ts:2586
+#: src/strings.ts:2585
 msgid "Cancel anytime, subscription auto-renews."
 msgstr ""
 
-#: src/strings.ts:2548
+#: src/strings.ts:2547
 msgid "Cancel anytime."
 msgstr ""
 
@@ -1323,7 +1323,7 @@ msgstr ""
 msgid "Cancel login"
 msgstr ""
 
-#: src/strings.ts:1827
+#: src/strings.ts:1826
 msgid "Cancel subscription"
 msgstr ""
 
@@ -1331,24 +1331,24 @@ msgstr ""
 msgid "Cancel upload"
 msgstr ""
 
-#: src/strings.ts:2313
+#: src/strings.ts:2312
 msgid "Cell background color"
 msgstr ""
 
-#: src/strings.ts:2315
+#: src/strings.ts:2314
 msgid "Cell border color"
 msgstr ""
 
+#: src/strings.ts:2316
 #: src/strings.ts:2317
-#: src/strings.ts:2318
 msgid "Cell border width"
 msgstr ""
 
-#: src/strings.ts:2299
+#: src/strings.ts:2298
 msgid "Cell properties"
 msgstr ""
 
-#: src/strings.ts:2316
+#: src/strings.ts:2315
 msgid "Cell text color"
 msgstr ""
 
@@ -1356,7 +1356,7 @@ msgstr ""
 msgid "Change"
 msgstr ""
 
-#: src/strings.ts:1060
+#: src/strings.ts:1059
 msgid "Change 2FA fallback method"
 msgstr ""
 
@@ -1364,15 +1364,15 @@ msgstr ""
 msgid "Change 2FA method"
 msgstr ""
 
-#: src/strings.ts:1199
+#: src/strings.ts:1198
 msgid "Change app lock password"
 msgstr ""
 
-#: src/strings.ts:1198
+#: src/strings.ts:1197
 msgid "Change app lock pin"
 msgstr ""
 
-#: src/strings.ts:1233
+#: src/strings.ts:1232
 msgid "Change backup directory"
 msgstr ""
 
@@ -1380,15 +1380,15 @@ msgstr ""
 msgid "Change email address"
 msgstr ""
 
-#: src/strings.ts:1126
+#: src/strings.ts:1125
 msgid "Change how the app behaves in different situations"
 msgstr ""
 
-#: src/strings.ts:2364
+#: src/strings.ts:2363
 msgid "Change language"
 msgstr ""
 
-#: src/strings.ts:1254
+#: src/strings.ts:1253
 msgid "Change notification sound"
 msgstr ""
 
@@ -1396,23 +1396,23 @@ msgstr ""
 msgid "Change password"
 msgstr ""
 
-#: src/strings.ts:2600
+#: src/strings.ts:2599
 msgid "Change plan"
 msgstr ""
 
-#: src/strings.ts:1819
+#: src/strings.ts:1818
 msgid "Change profile picture"
 msgstr ""
 
-#: src/strings.ts:2191
+#: src/strings.ts:2190
 msgid "Change proxy"
 msgstr ""
 
-#: src/strings.ts:2212
+#: src/strings.ts:2211
 msgid "Change the payment method you used to purchase this subscription."
 msgstr ""
 
-#: src/strings.ts:1256
+#: src/strings.ts:1255
 msgid "Change the sound that plays when you receive a notification"
 msgstr ""
 
@@ -1420,15 +1420,15 @@ msgstr ""
 msgid "Change vault password"
 msgstr ""
 
-#: src/strings.ts:1054
+#: src/strings.ts:1053
 msgid "Change your account password"
 msgstr ""
 
-#: src/strings.ts:1056
+#: src/strings.ts:1055
 msgid "Change your primary two-factor authentication method"
 msgstr ""
 
-#: src/strings.ts:1090
+#: src/strings.ts:1089
 msgid "Changes from other devices won't be updated in the editor in real-time."
 msgstr ""
 
@@ -1436,27 +1436,27 @@ msgstr ""
 msgid "Changing password is an irreversible process. You will be logged out from all your devices. Please make sure you do not close the app while your password is changing and have good internet connection."
 msgstr ""
 
-#: src/strings.ts:2502
+#: src/strings.ts:2501
 msgid "Characters"
 msgstr ""
 
-#: src/strings.ts:1297
+#: src/strings.ts:1296
 msgid "Check for new version of Notesnook"
 msgstr ""
 
-#: src/strings.ts:1300
+#: src/strings.ts:1299
 msgid "Check for new version of the app available on app launch"
 msgstr ""
 
-#: src/strings.ts:1296
+#: src/strings.ts:1295
 msgid "Check for updates"
 msgstr ""
 
-#: src/strings.ts:1298
+#: src/strings.ts:1297
 msgid "Check for updates automatically"
 msgstr ""
 
-#: src/strings.ts:2164
+#: src/strings.ts:2163
 msgid "Check roadmap"
 msgstr ""
 
@@ -1464,7 +1464,7 @@ msgstr ""
 msgid "Check your spam folder if you haven't received an email yet."
 msgstr ""
 
-#: src/strings.ts:2413
+#: src/strings.ts:2412
 msgid "Checking all attachments"
 msgstr ""
 
@@ -1472,51 +1472,51 @@ msgstr ""
 msgid "Checking for new version"
 msgstr ""
 
-#: src/strings.ts:1706
+#: src/strings.ts:1705
 msgid "Checking for updates"
 msgstr ""
 
-#: src/strings.ts:2412
+#: src/strings.ts:2411
 msgid "Checking note attachments"
 msgstr ""
 
-#: src/strings.ts:2287
+#: src/strings.ts:2286
 msgid "Checklist"
 msgstr ""
 
-#: src/strings.ts:2341
+#: src/strings.ts:2340
 msgid "Choose a block to insert"
 msgstr ""
 
-#: src/strings.ts:1798
+#: src/strings.ts:1797
 msgid "Choose a recovery method"
 msgstr ""
 
-#: src/strings.ts:2113
+#: src/strings.ts:2112
 msgid "Choose backup format"
 msgstr ""
 
-#: src/strings.ts:2377
+#: src/strings.ts:2376
 msgid "Choose custom color"
 msgstr ""
 
-#: src/strings.ts:1119
+#: src/strings.ts:1118
 msgid "Choose from pre-built themes or create your own"
 msgstr ""
 
-#: src/strings.ts:1134
+#: src/strings.ts:1133
 msgid "Choose how dates are displayed in the app"
 msgstr ""
 
-#: src/strings.ts:2635
+#: src/strings.ts:2634
 msgid "Choose how day is displayed in the app"
 msgstr ""
 
-#: src/strings.ts:1159
+#: src/strings.ts:1158
 msgid "Choose how the new note titles are formatted"
 msgstr ""
 
-#: src/strings.ts:1136
+#: src/strings.ts:1135
 msgid "Choose how time is displayed in the app"
 msgstr ""
 
@@ -1524,67 +1524,67 @@ msgstr ""
 msgid "Choose how you want to secure your notes locally."
 msgstr ""
 
-#: src/strings.ts:2640
+#: src/strings.ts:2639
 msgid "Choose what day to display as the first day of the week"
 msgstr ""
 
-#: src/strings.ts:1229
+#: src/strings.ts:1228
 msgid "Choose where to save your backups"
 msgstr ""
 
-#: src/strings.ts:2073
+#: src/strings.ts:2072
 msgid "Choose your style"
 msgstr ""
 
-#: src/strings.ts:1618
+#: src/strings.ts:1617
 msgid "cleaningUp"
 msgstr ""
 
-#: src/strings.ts:1015
+#: src/strings.ts:1014
 msgid "Clear"
 msgstr ""
 
-#: src/strings.ts:1871
+#: src/strings.ts:1870
 msgid "Clear all cached attachments. Current cache size: {cacheSize}"
 msgstr ""
 
-#: src/strings.ts:2281
+#: src/strings.ts:2280
 msgid "Clear all formatting"
 msgstr ""
 
-#: src/strings.ts:1872
+#: src/strings.ts:1871
 msgid "Clear attachments cache?"
 msgstr ""
 
-#: src/strings.ts:1869
+#: src/strings.ts:1868
 msgid "Clear cache"
 msgstr ""
 
-#: src/strings.ts:2375
+#: src/strings.ts:2374
 msgid "Clear completed tasks"
 msgstr ""
 
-#: src/strings.ts:1806
+#: src/strings.ts:1805
 msgid "Clear data & reset account"
 msgstr ""
 
-#: src/strings.ts:1140
+#: src/strings.ts:1139
 msgid "Clear default notebook"
 msgstr ""
 
-#: src/strings.ts:1014
+#: src/strings.ts:1013
 msgid "Clear logs"
 msgstr ""
 
-#: src/strings.ts:2207
+#: src/strings.ts:2206
 msgid "clear sessions"
 msgstr ""
 
-#: src/strings.ts:1323
+#: src/strings.ts:1322
 msgid "Clear trash"
 msgstr ""
 
-#: src/strings.ts:1137
+#: src/strings.ts:1136
 msgid "Clear trash interval"
 msgstr ""
 
@@ -1592,7 +1592,7 @@ msgstr ""
 msgid "Clear vault"
 msgstr ""
 
-#: src/strings.ts:1874
+#: src/strings.ts:1873
 msgid ""
 "Clearing attachments cache will perform the following actions:\n"
 "\n"
@@ -1607,11 +1607,11 @@ msgid ""
 "**Only use this for troubleshooting purposes. If you are having persistent issues, it is recommended that you reach out to us via support@streetwriters.co so we can help you resolve it permanently.**"
 msgstr ""
 
-#: src/strings.ts:2240
+#: src/strings.ts:2239
 msgid "Clearing trash will permanently delete all the items in your trash. This action is IRREVERSIBLE."
 msgstr ""
 
-#: src/strings.ts:2622
+#: src/strings.ts:2621
 msgid "Click here to directly claim the promotion."
 msgstr ""
 
@@ -1619,75 +1619,75 @@ msgstr ""
 msgid "Click to deselect"
 msgstr ""
 
-#: src/strings.ts:1868
+#: src/strings.ts:1867
 msgid "Click to preview"
 msgstr ""
 
-#: src/strings.ts:1773
+#: src/strings.ts:1772
 msgid "Click to remove"
 msgstr ""
 
-#: src/strings.ts:2404
+#: src/strings.ts:2403
 msgid "Click to reset {title}"
 msgstr ""
 
-#: src/strings.ts:2630
+#: src/strings.ts:2629
 msgid "Click to save"
 msgstr ""
 
-#: src/strings.ts:2626
+#: src/strings.ts:2625
 msgid "Click to update"
 msgstr ""
 
-#: src/strings.ts:1382
+#: src/strings.ts:1381
 msgid "Close"
 msgstr ""
 
-#: src/strings.ts:2680
+#: src/strings.ts:2679
 msgid "Close ({seconds})"
 msgstr ""
 
-#: src/strings.ts:2020
+#: src/strings.ts:2019
 msgid "Close all"
 msgstr ""
 
-#: src/strings.ts:2462
+#: src/strings.ts:2461
 msgid "Close all tabs"
 msgstr ""
 
-#: src/strings.ts:2461
+#: src/strings.ts:2460
 msgid "Close current tab"
 msgstr ""
 
-#: src/strings.ts:2017
+#: src/strings.ts:2016
 msgid "Close others"
 msgstr ""
 
-#: src/strings.ts:2131
+#: src/strings.ts:2130
 msgid "Close to system tray"
 msgstr ""
 
-#: src/strings.ts:2019
+#: src/strings.ts:2018
 msgid "Close to the left"
 msgstr ""
 
-#: src/strings.ts:2018
+#: src/strings.ts:2017
 msgid "Close to the right"
 msgstr ""
 
-#: src/strings.ts:2540
+#: src/strings.ts:2539
 msgid "cloud storage space for storing images and files."
 msgstr ""
 
-#: src/strings.ts:2279
+#: src/strings.ts:2278
 msgid "Code"
 msgstr ""
 
-#: src/strings.ts:2343
+#: src/strings.ts:2342
 msgid "Code block"
 msgstr ""
 
-#: src/strings.ts:2280
+#: src/strings.ts:2279
 msgid "Code remove"
 msgstr ""
 
@@ -1700,7 +1700,7 @@ msgid "color"
 msgstr ""
 
 #: src/strings.ts:299
-#: src/strings.ts:1845
+#: src/strings.ts:1844
 msgid "Color"
 msgstr ""
 
@@ -1708,11 +1708,11 @@ msgstr ""
 msgid "Color #{color} already exists"
 msgstr ""
 
-#: src/strings.ts:2106
+#: src/strings.ts:2105
 msgid "Color scheme"
 msgstr ""
 
-#: src/strings.ts:1490
+#: src/strings.ts:1489
 msgid "Color title"
 msgstr ""
 
@@ -1724,19 +1724,19 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
-#: src/strings.ts:2297
+#: src/strings.ts:2296
 msgid "Column properties"
 msgstr ""
 
-#: src/strings.ts:2453
+#: src/strings.ts:2452
 msgid "Command palette"
 msgstr ""
 
-#: src/strings.ts:1272
+#: src/strings.ts:1271
 msgid "Community"
 msgstr ""
 
-#: src/strings.ts:2560
+#: src/strings.ts:2559
 msgid "Compare plans"
 msgstr ""
 
@@ -1748,7 +1748,7 @@ msgstr ""
 msgid "Compress"
 msgstr ""
 
-#: src/strings.ts:1130
+#: src/strings.ts:1129
 msgid "Compress images before uploading"
 msgstr ""
 
@@ -1756,19 +1756,19 @@ msgstr ""
 msgid "Compressed images are uploaded in Full HD resolution and usually are good enough for most use cases."
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2681
+#: src/strings.ts:2680
 msgid "Compressing"
 msgstr "<<<<<<< HEAD"
 
-#: src/strings.ts:2685
+#: src/strings.ts:2684
 msgid "Compression failed"
 msgstr ""
 
-#: src/strings.ts:2263
+#: src/strings.ts:2262
 msgid "Configure"
 msgstr ""
 
-#: src/strings.ts:2418
+#: src/strings.ts:2417
 msgid "Configure server URLs for Notesnook"
 msgstr ""
 
@@ -1776,43 +1776,43 @@ msgstr ""
 msgid "Confirm email"
 msgstr ""
 
-#: src/strings.ts:904
+#: src/strings.ts:903
 msgid "Confirm email to publish note"
 msgstr ""
 
-#: src/strings.ts:1489
+#: src/strings.ts:1488
 msgid "Confirm new password"
 msgstr ""
 
-#: src/strings.ts:1484
+#: src/strings.ts:1483
 msgid "Confirm password"
 msgstr ""
 
-#: src/strings.ts:2662
+#: src/strings.ts:2661
 msgid "Confirm password required"
 msgstr ""
 
-#: src/strings.ts:1488
+#: src/strings.ts:1487
 msgid "Confirm pin"
 msgstr ""
 
-#: src/strings.ts:2654
+#: src/strings.ts:2653
 msgid "Confirmation email sent"
 msgstr ""
 
-#: src/strings.ts:2091
+#: src/strings.ts:2090
 msgid "Congratulations!"
 msgstr ""
 
-#: src/strings.ts:1637
+#: src/strings.ts:1636
 msgid "Connected to all servers sucessfully."
 msgstr ""
 
-#: src/strings.ts:1672
+#: src/strings.ts:1671
 msgid "Contact support"
 msgstr ""
 
-#: src/strings.ts:1263
+#: src/strings.ts:1262
 msgid "Contact us directly via support@streetwriters.co for any help or support"
 msgstr ""
 
@@ -1820,15 +1820,15 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: src/strings.ts:1165
+#: src/strings.ts:1164
 msgid "Contribute towards a better Notesnook. All tracking information is anonymous."
 msgstr ""
 
-#: src/strings.ts:1249
+#: src/strings.ts:1248
 msgid "Controls whether this device should receive reminder notifications."
 msgstr ""
 
-#: src/strings.ts:1991
+#: src/strings.ts:1990
 msgid "Copied"
 msgstr ""
 
@@ -1837,7 +1837,7 @@ msgid "Copy"
 msgstr ""
 
 #. placeholder {0}: format ? " " + format : ""
-#: src/strings.ts:2037
+#: src/strings.ts:2036
 msgid "Copy as{0}"
 msgstr ""
 
@@ -1845,15 +1845,15 @@ msgstr ""
 msgid "Copy codes"
 msgstr ""
 
-#: src/strings.ts:2259
+#: src/strings.ts:2258
 msgid "Copy image"
 msgstr ""
 
-#: src/strings.ts:911
+#: src/strings.ts:910
 msgid "Copy link"
 msgstr ""
 
-#: src/strings.ts:2258
+#: src/strings.ts:2257
 msgid "Copy link text"
 msgstr ""
 
@@ -1865,27 +1865,27 @@ msgstr ""
 msgid "Copy to clipboard"
 msgstr ""
 
-#: src/strings.ts:1620
+#: src/strings.ts:1619
 msgid "Copying backup files to cache"
 msgstr ""
 
-#: src/strings.ts:1169
+#: src/strings.ts:1168
 msgid "CORS bypass"
 msgstr ""
 
-#: src/strings.ts:1987
+#: src/strings.ts:1986
 msgid "Could not activate trial. Please try again later."
 msgstr ""
 
-#: src/strings.ts:2005
+#: src/strings.ts:2004
 msgid "Could not clear trash."
 msgstr ""
 
-#: src/strings.ts:1640
+#: src/strings.ts:1639
 msgid "Could not connect to {server}."
 msgstr ""
 
-#: src/strings.ts:1952
+#: src/strings.ts:1951
 msgid "Could not convert note to {format}."
 msgstr ""
 
@@ -1905,11 +1905,11 @@ msgstr ""
 msgid "Create a group"
 msgstr ""
 
-#: src/strings.ts:939
+#: src/strings.ts:938
 msgid "Create a new note"
 msgstr ""
 
-#: src/strings.ts:952
+#: src/strings.ts:951
 msgid "Create a note first"
 msgstr ""
 
@@ -1921,7 +1921,7 @@ msgstr ""
 msgid "Create a tag to group related notes together."
 msgstr ""
 
-#: src/strings.ts:1850
+#: src/strings.ts:1849
 msgid "Create account"
 msgstr ""
 
@@ -1929,19 +1929,19 @@ msgstr ""
 msgid "Create link"
 msgstr ""
 
-#: src/strings.ts:1474
+#: src/strings.ts:1473
 msgid "Create shortcut of this notebook in side menu"
 msgstr ""
 
-#: src/strings.ts:1388
+#: src/strings.ts:1387
 msgid "Create unlimited notebooks with Notesnook Pro"
 msgstr ""
 
-#: src/strings.ts:1387
+#: src/strings.ts:1386
 msgid "Create unlimited tags with Notesnook Pro"
 msgstr ""
 
-#: src/strings.ts:1389
+#: src/strings.ts:1388
 msgid "Create unlimited vaults with Notesnook Pro"
 msgstr ""
 
@@ -1953,12 +1953,12 @@ msgstr ""
 msgid "Create your account"
 msgstr ""
 
-#: src/strings.ts:2241
+#: src/strings.ts:2240
 msgid "Created at"
 msgstr ""
 
 #. placeholder {0}: type === "full" ? " full" : ""
-#: src/strings.ts:1345
+#: src/strings.ts:1344
 msgid "Creating a{0} backup"
 msgstr ""
 
@@ -1967,11 +1967,10 @@ msgid "Creation date cannot be after last edited date"
 msgstr ""
 
 #: src/strings.ts:2049
-#: src/strings.ts:2050
 msgid "Credentials"
 msgstr ""
 
-#: src/strings.ts:2076
+#: src/strings.ts:2075
 msgid "Cross platform & 100% encrypted"
 msgstr ""
 
@@ -1979,65 +1978,65 @@ msgstr ""
 msgid "Curate the toolbar that fits your needs and matches your personality."
 msgstr ""
 
-#: src/strings.ts:1837
+#: src/strings.ts:1836
 msgid "Current note"
 msgstr ""
 
-#: src/strings.ts:1480
-#: src/strings.ts:1486
+#: src/strings.ts:1479
+#: src/strings.ts:1485
 msgid "Current password"
 msgstr ""
 
-#: src/strings.ts:2671
+#: src/strings.ts:2670
 msgid "Current password required"
 msgstr ""
 
-#: src/strings.ts:1230
+#: src/strings.ts:1229
 msgid "Current path: {path}"
 msgstr ""
 
-#: src/strings.ts:1485
+#: src/strings.ts:1484
 msgid "Current pin"
 msgstr ""
 
-#: src/strings.ts:1774
+#: src/strings.ts:1773
 msgid "CURRENT PLAN"
 msgstr ""
 
-#: src/strings.ts:2011
+#: src/strings.ts:2010
 msgid "Custom"
 msgstr ""
 
-#: src/strings.ts:2142
+#: src/strings.ts:2141
 msgid "Custom dictionary words"
 msgstr ""
 
-#: src/strings.ts:1114
+#: src/strings.ts:1113
 msgid "Customization"
 msgstr ""
 
-#: src/strings.ts:1117
+#: src/strings.ts:1116
 msgid "Customize the appearance of the app with custom themes"
 msgstr ""
 
-#: src/strings.ts:1144
+#: src/strings.ts:1143
 msgid "Customize the note editor"
 msgstr ""
 
-#: src/strings.ts:1146
+#: src/strings.ts:1145
 msgid "Customize the toolbar in the note editor"
 msgstr ""
 
-#: src/strings.ts:1145
+#: src/strings.ts:1144
 msgid "Customize toolbar"
 msgstr ""
 
-#: src/strings.ts:2257
+#: src/strings.ts:2256
 msgid "Cut"
 msgstr ""
 
 #: src/strings.ts:167
-#: src/strings.ts:1569
+#: src/strings.ts:1568
 msgid "Daily"
 msgstr ""
 
@@ -2045,23 +2044,23 @@ msgstr ""
 msgid "Dark"
 msgstr ""
 
-#: src/strings.ts:1123
+#: src/strings.ts:1122
 msgid "Dark mode"
 msgstr ""
 
-#: src/strings.ts:2107
+#: src/strings.ts:2106
 msgid "Dark or light, we won't judge."
 msgstr ""
 
-#: src/strings.ts:1548
+#: src/strings.ts:1547
 msgid "Database setup failed, could not get database key"
 msgstr ""
 
-#: src/strings.ts:1840
+#: src/strings.ts:1839
 msgid "Date"
 msgstr ""
 
-#: src/strings.ts:2116
+#: src/strings.ts:2115
 msgid "Date & time"
 msgstr ""
 
@@ -2077,7 +2076,7 @@ msgstr ""
 msgid "Date edited"
 msgstr ""
 
-#: src/strings.ts:1133
+#: src/strings.ts:1132
 msgid "Date format"
 msgstr ""
 
@@ -2085,80 +2084,80 @@ msgstr ""
 msgid "Date modified"
 msgstr ""
 
-#: src/strings.ts:2043
+#: src/strings.ts:2042
 msgid "Date uploaded"
 msgstr ""
 
-#: src/strings.ts:1842
+#: src/strings.ts:1841
 msgid "Day"
 msgstr ""
 
-#: src/strings.ts:2634
+#: src/strings.ts:2633
 msgid "Day format"
 msgstr ""
 
-#: src/strings.ts:2039
+#: src/strings.ts:2038
 msgid "Deactivate"
 msgstr ""
 
-#: src/strings.ts:1012
+#: src/strings.ts:1011
 msgid "Debug log copied!"
 msgstr ""
 
-#: src/strings.ts:1270
+#: src/strings.ts:1269
 msgid "Debug logs"
 msgstr ""
 
-#: src/strings.ts:1013
+#: src/strings.ts:1012
 msgid "Debug logs downloaded"
 msgstr ""
 
-#: src/strings.ts:1267
+#: src/strings.ts:1266
 msgid "Debugging"
 msgstr ""
 
-#: src/strings.ts:2406
+#: src/strings.ts:2405
 msgid "Decrease {title}"
 msgstr ""
 
 #: src/strings.ts:660
-#: src/strings.ts:2009
+#: src/strings.ts:2008
 msgid "Default"
 msgstr ""
 
-#: src/strings.ts:1156
+#: src/strings.ts:1155
 msgid "Default font family"
 msgstr ""
 
-#: src/strings.ts:1157
+#: src/strings.ts:1156
 msgid "Default font family in editor"
 msgstr ""
 
-#: src/strings.ts:1154
+#: src/strings.ts:1153
 msgid "Default font size"
 msgstr ""
 
-#: src/strings.ts:1155
+#: src/strings.ts:1154
 msgid "Default font size in editor"
 msgstr ""
 
-#: src/strings.ts:1142
+#: src/strings.ts:1141
 msgid "Default notebook cleared"
 msgstr ""
 
-#: src/strings.ts:1128
+#: src/strings.ts:1127
 msgid "Default screen to open on app launch"
 msgstr ""
 
-#: src/strings.ts:2493
+#: src/strings.ts:2492
 msgid "Default sidebar tab"
 msgstr ""
 
-#: src/strings.ts:1250
+#: src/strings.ts:1249
 msgid "Default snooze time"
 msgstr ""
 
-#: src/strings.ts:1302
+#: src/strings.ts:1301
 msgid "Default sound"
 msgstr ""
 
@@ -2166,31 +2165,31 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: src/strings.ts:1077
+#: src/strings.ts:1076
 msgid "Delete account"
 msgstr ""
 
-#: src/strings.ts:2665
+#: src/strings.ts:2664
 msgid "Delete attachment"
 msgstr ""
 
-#: src/strings.ts:1320
+#: src/strings.ts:1319
 msgid "Delete collapsed section"
 msgstr ""
 
-#: src/strings.ts:2304
+#: src/strings.ts:2303
 msgid "Delete column"
 msgstr ""
 
-#: src/strings.ts:2651
+#: src/strings.ts:2650
 msgid "Delete data"
 msgstr ""
 
-#: src/strings.ts:1315
+#: src/strings.ts:1314
 msgid "Delete group"
 msgstr ""
 
-#: src/strings.ts:2378
+#: src/strings.ts:2377
 msgid "Delete mode"
 msgstr ""
 
@@ -2202,11 +2201,11 @@ msgstr ""
 msgid "Delete permanently"
 msgstr ""
 
-#: src/strings.ts:2311
+#: src/strings.ts:2310
 msgid "Delete row"
 msgstr ""
 
-#: src/strings.ts:2312
+#: src/strings.ts:2311
 msgid "Delete table"
 msgstr ""
 
@@ -2214,7 +2213,7 @@ msgstr ""
 msgid "Delete vault"
 msgstr ""
 
-#: src/strings.ts:1177
+#: src/strings.ts:1176
 msgid "Delete vault (and optionally remove all notes)."
 msgstr ""
 
@@ -2222,43 +2221,43 @@ msgstr ""
 msgid "Deleted on {date}"
 msgstr ""
 
-#: src/strings.ts:1929
+#: src/strings.ts:1928
 msgid "Deleting"
 msgstr ""
 
-#: src/strings.ts:1839
+#: src/strings.ts:1838
 msgid "Description"
 msgstr ""
 
-#: src/strings.ts:2117
+#: src/strings.ts:2116
 msgid "Desktop app"
 msgstr ""
 
-#: src/strings.ts:2121
+#: src/strings.ts:2120
 msgid "Desktop integration"
 msgstr ""
 
-#: src/strings.ts:872
+#: src/strings.ts:871
 msgid "Did you save recovery key?"
 msgstr ""
 
-#: src/strings.ts:1377
+#: src/strings.ts:1376
 msgid "Disable"
 msgstr ""
 
-#: src/strings.ts:1085
+#: src/strings.ts:1084
 msgid "Disable auto sync"
 msgstr ""
 
-#: src/strings.ts:2012
+#: src/strings.ts:2011
 msgid "Disable editor margins"
 msgstr ""
 
-#: src/strings.ts:1088
+#: src/strings.ts:1087
 msgid "Disable realtime sync"
 msgstr ""
 
-#: src/strings.ts:1091
+#: src/strings.ts:1090
 msgid "Disable sync"
 msgstr ""
 
@@ -2270,11 +2269,11 @@ msgstr ""
 msgid "Discard"
 msgstr ""
 
-#: src/strings.ts:1598
+#: src/strings.ts:1597
 msgid "Dismiss"
 msgstr ""
 
-#: src/strings.ts:1651
+#: src/strings.ts:1650
 msgid "Dismiss announcement"
 msgstr ""
 
@@ -2286,7 +2285,7 @@ msgstr ""
 msgid "Do you enjoy using Notesnook?"
 msgstr ""
 
-#: src/strings.ts:1264
+#: src/strings.ts:1263
 msgid "Documentation"
 msgstr ""
 
@@ -2294,15 +2293,15 @@ msgstr ""
 msgid "Documents"
 msgstr ""
 
-#: src/strings.ts:985
+#: src/strings.ts:984
 msgid "Don't have access to your authenticator app?"
 msgstr ""
 
-#: src/strings.ts:992
+#: src/strings.ts:991
 msgid "Don't have access to your email address?"
 msgstr ""
 
-#: src/strings.ts:1001
+#: src/strings.ts:1000
 msgid "Don't have access to your phone number?"
 msgstr ""
 
@@ -2310,23 +2309,23 @@ msgstr ""
 msgid "Don't have an account?"
 msgstr ""
 
-#: src/strings.ts:1833
+#: src/strings.ts:1832
 msgid "Don't have backup file?"
 msgstr ""
 
-#: src/strings.ts:1832
+#: src/strings.ts:1831
 msgid "Don't have your account recovery key?"
 msgstr ""
 
-#: src/strings.ts:1004
+#: src/strings.ts:1003
 msgid "Don't have your recovery codes?"
 msgstr ""
 
-#: src/strings.ts:1811
+#: src/strings.ts:1810
 msgid "Don't show again"
 msgstr ""
 
-#: src/strings.ts:1812
+#: src/strings.ts:1811
 msgid "Don't show again on this device?"
 msgstr ""
 
@@ -2334,7 +2333,7 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: src/strings.ts:1150
+#: src/strings.ts:1149
 msgid "Double spaced lines"
 msgstr ""
 
@@ -2342,15 +2341,15 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: src/strings.ts:1817
+#: src/strings.ts:1816
 msgid "Download all attachments"
 msgstr ""
 
-#: src/strings.ts:2327
+#: src/strings.ts:2326
 msgid "Download attachment"
 msgstr ""
 
-#: src/strings.ts:1861
+#: src/strings.ts:1860
 msgid "Download backup file"
 msgstr ""
 
@@ -2358,11 +2357,11 @@ msgstr ""
 msgid "Download cancelled"
 msgstr ""
 
-#: src/strings.ts:2219
+#: src/strings.ts:2218
 msgid "Download everything including attachments on sync"
 msgstr ""
 
-#: src/strings.ts:1291
+#: src/strings.ts:1290
 msgid "Download on desktop"
 msgstr ""
 
@@ -2395,23 +2394,23 @@ msgstr ""
 msgid "Downloading attachments"
 msgstr ""
 
-#: src/strings.ts:1705
+#: src/strings.ts:1704
 msgid "Downloading images"
 msgstr ""
 
-#: src/strings.ts:1771
+#: src/strings.ts:1770
 msgid "Drag & drop files here, or click to select files"
 msgstr ""
 
-#: src/strings.ts:1770
+#: src/strings.ts:1769
 msgid "Drop the files here"
 msgstr ""
 
-#: src/strings.ts:1664
+#: src/strings.ts:1663
 msgid "Drop your files here to attach"
 msgstr ""
 
-#: src/strings.ts:2570
+#: src/strings.ts:2569
 msgid "Due {date}"
 msgstr ""
 
@@ -2419,11 +2418,11 @@ msgstr ""
 msgid "Due date"
 msgstr ""
 
-#: src/strings.ts:2568
+#: src/strings.ts:2567
 msgid "Due today"
 msgstr ""
 
-#: src/strings.ts:925
+#: src/strings.ts:924
 msgid "Duplicate"
 msgstr ""
 
@@ -2431,15 +2430,15 @@ msgstr ""
 msgid "Earliest first"
 msgstr ""
 
-#: src/strings.ts:2430
+#: src/strings.ts:2429
 msgid "Easy access"
 msgstr ""
 
-#: src/strings.ts:1778
+#: src/strings.ts:1777
 msgid "Edit"
 msgstr ""
 
-#: src/strings.ts:2641
+#: src/strings.ts:2640
 msgid "Edit creation date"
 msgstr ""
 
@@ -2447,37 +2446,37 @@ msgstr ""
 msgid "Edit internal link"
 msgstr ""
 
-#: src/strings.ts:2246
-#: src/strings.ts:2274
+#: src/strings.ts:2245
+#: src/strings.ts:2273
 msgid "Edit link"
 msgstr ""
 
-#: src/strings.ts:2486
+#: src/strings.ts:2485
 msgid "Edit profile"
 msgstr ""
 
-#: src/strings.ts:1308
+#: src/strings.ts:1307
 msgid "Edit profile picture"
 msgstr ""
 
-#: src/strings.ts:1820
+#: src/strings.ts:1819
 msgid "Edit your full name"
 msgstr ""
 
-#: src/strings.ts:1143
-#: src/strings.ts:1527
+#: src/strings.ts:1142
+#: src/strings.ts:1526
 msgid "Editor"
 msgstr ""
 
-#: src/strings.ts:2597
+#: src/strings.ts:2596
 msgid "Education plan"
 msgstr ""
 
-#: src/strings.ts:1482
+#: src/strings.ts:1481
 msgid "Email"
 msgstr ""
 
-#: src/strings.ts:2443
+#: src/strings.ts:2442
 msgid "Email copied"
 msgstr ""
 
@@ -2489,27 +2488,27 @@ msgstr ""
 msgid "Email not confirmed"
 msgstr ""
 
-#: src/strings.ts:1554
+#: src/strings.ts:1553
 msgid "Email or password incorrect"
 msgstr ""
 
-#: src/strings.ts:1261
+#: src/strings.ts:1260
 msgid "Email support"
 msgstr ""
 
-#: src/strings.ts:858
+#: src/strings.ts:857
 msgid "Email updated to {email}"
 msgstr ""
 
-#: src/strings.ts:2353
+#: src/strings.ts:2352
 msgid "Embed"
 msgstr ""
 
-#: src/strings.ts:2333
+#: src/strings.ts:2332
 msgid "Embed properties"
 msgstr ""
 
-#: src/strings.ts:2329
+#: src/strings.ts:2328
 msgid "Embed settings"
 msgstr ""
 
@@ -2517,27 +2516,27 @@ msgstr ""
 msgid "Enable"
 msgstr ""
 
-#: src/strings.ts:1132
+#: src/strings.ts:1131
 msgid "Enable (Recommended)"
 msgstr ""
 
-#: src/strings.ts:1186
+#: src/strings.ts:1185
 msgid "Enable app lock"
 msgstr ""
 
-#: src/strings.ts:2013
+#: src/strings.ts:2012
 msgid "Enable editor margins"
 msgstr ""
 
-#: src/strings.ts:2477
+#: src/strings.ts:2476
 msgid "Enable ligatures for common symbols like →, ←, etc"
 msgstr ""
 
-#: src/strings.ts:2393
+#: src/strings.ts:2392
 msgid "Enable regex"
 msgstr ""
 
-#: src/strings.ts:2138
+#: src/strings.ts:2137
 msgid "Enable spell checker"
 msgstr ""
 
@@ -2545,7 +2544,7 @@ msgstr ""
 msgid "Enable two-factor authentication to add an extra layer of security to your account."
 msgstr ""
 
-#: src/strings.ts:1235
+#: src/strings.ts:1234
 msgid "Encrypt your backups for added security"
 msgstr ""
 
@@ -2553,27 +2552,27 @@ msgstr ""
 msgid "Encrypted and synced"
 msgstr ""
 
-#: src/strings.ts:2253
+#: src/strings.ts:2252
 msgid "Encrypted backup"
 msgstr ""
 
-#: src/strings.ts:1658
+#: src/strings.ts:1657
 msgid "Encrypted, private, secure."
 msgstr ""
 
-#: src/strings.ts:2682
+#: src/strings.ts:2681
 msgid "Encrypting"
 msgstr ""
 
-#: src/strings.ts:941
+#: src/strings.ts:940
 msgid "Encrypting attachment"
 msgstr ""
 
-#: src/strings.ts:1844
+#: src/strings.ts:1843
 msgid "Encryption key"
 msgstr ""
 
-#: src/strings.ts:821
+#: src/strings.ts:820
 msgid "End to end encrypted."
 msgstr ""
 
@@ -2581,23 +2580,23 @@ msgstr ""
 msgid "Enter 6 digit code"
 msgstr ""
 
-#: src/strings.ts:1080
+#: src/strings.ts:1079
 msgid "Enter account password"
 msgstr ""
 
-#: src/strings.ts:1081
+#: src/strings.ts:1080
 msgid "Enter account password to proceed."
 msgstr ""
 
-#: src/strings.ts:1853
+#: src/strings.ts:1852
 msgid "Enter account recovery key"
 msgstr ""
 
-#: src/strings.ts:1020
+#: src/strings.ts:1019
 msgid "Enter app lock password"
 msgstr ""
 
-#: src/strings.ts:1023
+#: src/strings.ts:1022
 msgid "Enter app lock pin"
 msgstr ""
 
@@ -2605,27 +2604,27 @@ msgstr ""
 msgid "Enter code from authenticator app"
 msgstr ""
 
-#: src/strings.ts:1512
+#: src/strings.ts:1511
 msgid "Enter email address"
 msgstr ""
 
-#: src/strings.ts:2381
+#: src/strings.ts:2380
 msgid "Enter embed source URL"
 msgstr ""
 
-#: src/strings.ts:1314
+#: src/strings.ts:1313
 msgid "Enter full name"
 msgstr ""
 
-#: src/strings.ts:1702
+#: src/strings.ts:1701
 msgid "Enter fullscreen"
 msgstr ""
 
-#: src/strings.ts:1491
+#: src/strings.ts:1490
 msgid "Enter notebook description"
 msgstr ""
 
-#: src/strings.ts:857
+#: src/strings.ts:856
 msgid "Enter notebook title"
 msgstr ""
 
@@ -2633,11 +2632,11 @@ msgstr ""
 msgid "Enter password"
 msgstr ""
 
-#: src/strings.ts:2099
+#: src/strings.ts:2098
 msgid "Enter pin or password to enable app lock."
 msgstr ""
 
-#: src/strings.ts:1005
+#: src/strings.ts:1004
 msgid "Enter recovery code"
 msgstr ""
 
@@ -2653,7 +2652,7 @@ msgstr ""
 msgid "Enter the 6 digit code sent to your phone number to continue logging in"
 msgstr ""
 
-#: src/strings.ts:2445
+#: src/strings.ts:2444
 msgid "Enter the gift code to redeem your subscription."
 msgstr ""
 
@@ -2661,27 +2660,27 @@ msgstr ""
 msgid "Enter the recovery code to continue logging in"
 msgstr ""
 
-#: src/strings.ts:2633
+#: src/strings.ts:2632
 msgid "Enter title"
 msgstr ""
 
-#: src/strings.ts:1494
+#: src/strings.ts:1493
 msgid "Enter verification code sent to your new email"
 msgstr ""
 
-#: src/strings.ts:1493
+#: src/strings.ts:1492
 msgid "Enter your new email"
 msgstr ""
 
-#: src/strings.ts:2100
+#: src/strings.ts:2099
 msgid "Enter your username"
 msgstr ""
 
-#: src/strings.ts:2437
+#: src/strings.ts:2436
 msgid "Error"
 msgstr ""
 
-#: src/strings.ts:1555
+#: src/strings.ts:1554
 msgid "Error applying promo code"
 msgstr ""
 
@@ -2689,7 +2688,7 @@ msgstr ""
 msgid "Error downloading file: {message}"
 msgstr ""
 
-#: src/strings.ts:1515
+#: src/strings.ts:1514
 msgid "Error getting codes"
 msgstr ""
 
@@ -2697,11 +2696,11 @@ msgstr ""
 msgid "Error loading themes"
 msgstr ""
 
-#: src/strings.ts:1076
+#: src/strings.ts:1075
 msgid "Error logging out"
 msgstr ""
 
-#: src/strings.ts:1010
+#: src/strings.ts:1009
 msgid "Error sending 2FA code"
 msgstr ""
 
@@ -2709,55 +2708,55 @@ msgstr ""
 msgid "Errors"
 msgstr ""
 
-#: src/strings.ts:1697
+#: src/strings.ts:1696
 msgid "Errors in {count} attachments"
 msgstr ""
 
-#: src/strings.ts:2482
+#: src/strings.ts:2481
 msgid "Essential plan"
 msgstr ""
 
-#: src/strings.ts:1629
+#: src/strings.ts:1628
 msgid "Events server"
 msgstr ""
 
-#: src/strings.ts:2423
+#: src/strings.ts:2422
 msgid "Every Notebook can have notes and sub notebooks."
 msgstr ""
 
-#: src/strings.ts:2425
+#: src/strings.ts:2424
 msgid "Everything related to my job in one place."
 msgstr ""
 
-#: src/strings.ts:2434
+#: src/strings.ts:2433
 msgid "Everything related to my school in one place."
 msgstr ""
 
-#: src/strings.ts:2451
+#: src/strings.ts:2450
 msgid "Execute"
 msgstr ""
 
-#: src/strings.ts:2450
+#: src/strings.ts:2449
 msgid "Execute a command..."
 msgstr ""
 
-#: src/strings.ts:2014
+#: src/strings.ts:2013
 msgid "Exit fullscreen"
 msgstr ""
 
-#: src/strings.ts:2385
+#: src/strings.ts:2384
 msgid "Expand"
 msgstr ""
 
-#: src/strings.ts:2478
+#: src/strings.ts:2477
 msgid "Expand sidebar"
 msgstr ""
 
-#: src/strings.ts:2083
+#: src/strings.ts:2082
 msgid "Experience the next level of private note taking\""
 msgstr ""
 
-#: src/strings.ts:2647
+#: src/strings.ts:2646
 msgid "Expiry date"
 msgstr ""
 
@@ -2774,7 +2773,6 @@ msgid "Expiry date set"
 msgstr ""
 
 #: src/strings.ts:2550
-#: src/strings.ts:2551
 msgid "Explore all plans"
 msgstr ""
 
@@ -2786,24 +2784,24 @@ msgstr ""
 msgid "Export again"
 msgstr ""
 
-#: src/strings.ts:1238
+#: src/strings.ts:1237
 msgid "Export all notes"
 msgstr ""
 
-#: src/strings.ts:1240
+#: src/strings.ts:1239
 msgid "Export all notes as pdf, markdown, html or text in a single zip file"
 msgstr ""
 
 #. placeholder {0}: format ? " " + format : ""
-#: src/strings.ts:2036
+#: src/strings.ts:2035
 msgid "Export as{0}"
 msgstr ""
 
-#: src/strings.ts:2648
+#: src/strings.ts:2647
 msgid "Export CSV"
 msgstr ""
 
-#: src/strings.ts:1386
+#: src/strings.ts:1385
 msgid "Export notes as PDF, Markdown and HTML with Notesnook Pro"
 msgstr ""
 
@@ -2811,39 +2809,39 @@ msgstr ""
 msgid "Exporting \"{title}\""
 msgstr ""
 
-#: src/strings.ts:1619
+#: src/strings.ts:1618
 msgid "Extracting files..."
 msgstr ""
 
-#: src/strings.ts:1808
+#: src/strings.ts:1807
 msgid "EXTREMELY DANGEROUS! This action is irreversible. All your data including notes, notebooks, attachments & settings will be deleted. This is a full account reset. Proceed with caution."
 msgstr ""
 
-#: src/strings.ts:1260
+#: src/strings.ts:1259
 msgid "Faced an issue or have a suggestion? Click here to create a bug report"
 msgstr ""
 
-#: src/strings.ts:2415
+#: src/strings.ts:2414
 msgid "Failed"
 msgstr ""
 
-#: src/strings.ts:2652
+#: src/strings.ts:2651
 msgid "Failed to attach file"
 msgstr ""
 
-#: src/strings.ts:1937
+#: src/strings.ts:1936
 msgid "Failed to copy note"
 msgstr ""
 
-#: src/strings.ts:1561
+#: src/strings.ts:1560
 msgid "Failed to decrypt backup"
 msgstr ""
 
-#: src/strings.ts:2003
+#: src/strings.ts:2002
 msgid "Failed to delete"
 msgstr ""
 
-#: src/strings.ts:1082
+#: src/strings.ts:1081
 msgid "Failed to delete account"
 msgstr ""
 
@@ -2851,19 +2849,19 @@ msgstr ""
 msgid "Failed to download file"
 msgstr ""
 
-#: src/strings.ts:1999
+#: src/strings.ts:1998
 msgid "Failed to install theme."
 msgstr ""
 
-#: src/strings.ts:949
+#: src/strings.ts:948
 msgid "Failed to open"
 msgstr ""
 
-#: src/strings.ts:868
+#: src/strings.ts:867
 msgid "Failed to publish note"
 msgstr ""
 
-#: src/strings.ts:2004
+#: src/strings.ts:2003
 msgid "Failed to register task"
 msgstr ""
 
@@ -2875,23 +2873,23 @@ msgstr ""
 msgid "Failed to send recovery email"
 msgstr ""
 
-#: src/strings.ts:1402
+#: src/strings.ts:1401
 msgid "Failed to send verification email"
 msgstr ""
 
-#: src/strings.ts:938
+#: src/strings.ts:937
 msgid "Failed to subscribe"
 msgstr ""
 
-#: src/strings.ts:2214
+#: src/strings.ts:2213
 msgid "Failed to take backup"
 msgstr ""
 
-#: src/strings.ts:2216
+#: src/strings.ts:2215
 msgid "Failed to take backup of your data. Do you want to continue logging out?"
 msgstr ""
 
-#: src/strings.ts:869
+#: src/strings.ts:868
 msgid "Failed to unpublish note"
 msgstr ""
 
@@ -2903,28 +2901,28 @@ msgstr ""
 msgid "Fallback method for 2FA enabled"
 msgstr ""
 
-#: src/strings.ts:2561
+#: src/strings.ts:2560
 msgid "FAQs"
 msgstr ""
 
-#: src/strings.ts:2033
+#: src/strings.ts:2032
 msgid "Favorite"
 msgstr ""
 
 #: src/strings.ts:321
-#: src/strings.ts:1522
+#: src/strings.ts:1521
 msgid "Favorites"
 msgstr ""
 
-#: src/strings.ts:2559
+#: src/strings.ts:2558
 msgid "Featured on"
 msgstr ""
 
-#: src/strings.ts:2427
+#: src/strings.ts:2426
 msgid "February 2022 Week 2"
 msgstr ""
 
-#: src/strings.ts:2428
+#: src/strings.ts:2427
 msgid "February 2022 Week 3"
 msgstr ""
 
@@ -2944,107 +2942,107 @@ msgstr ""
 msgid "File length mismatch. Expected {expectedSize} but got {currentSize} bytes. Please upload this file again from the attachment manager."
 msgstr ""
 
-#: src/strings.ts:2690
+#: src/strings.ts:2689
 msgid "File links cannot be opened in browsers. Please use the Notesnook desktop app."
 msgstr ""
 
-#: src/strings.ts:950
+#: src/strings.ts:949
 msgid "File mismatch"
 msgstr ""
 
-#: src/strings.ts:2684
+#: src/strings.ts:2683
 msgid "File size limit exceeded. Please upgrade your plan."
 msgstr ""
 
-#: src/strings.ts:946
+#: src/strings.ts:945
 msgid "File size should be less than {sizeInMB}"
 msgstr ""
 
-#: src/strings.ts:944
+#: src/strings.ts:943
 msgid "File too big"
 msgstr ""
 
-#: src/strings.ts:1479
+#: src/strings.ts:1478
 msgid "Filter attachments by filename, type or hash"
 msgstr ""
 
-#: src/strings.ts:1834
+#: src/strings.ts:1833
 msgid "Filter languages"
 msgstr ""
 
-#: src/strings.ts:2619
+#: src/strings.ts:2618
 msgid "Finish your purchase in the browser."
 msgstr ""
 
-#: src/strings.ts:1670
+#: src/strings.ts:1669
 msgid "Fix it"
 msgstr ""
 
-#: src/strings.ts:2016
+#: src/strings.ts:2015
 msgid "Focus mode"
 msgstr ""
 
-#: src/strings.ts:2174
+#: src/strings.ts:2173
 msgid "Follow"
 msgstr ""
 
-#: src/strings.ts:1276
+#: src/strings.ts:1275
 msgid "Follow us on Mastodon"
 msgstr ""
 
-#: src/strings.ts:1278
+#: src/strings.ts:1277
 msgid "Follow us on Mastodon for updates and news about Notesnook"
 msgstr ""
 
-#: src/strings.ts:1279
+#: src/strings.ts:1278
 msgid "Follow us on X"
 msgstr ""
 
-#: src/strings.ts:1280
+#: src/strings.ts:1279
 msgid "Follow us on X for updates and news about Notesnook"
 msgstr ""
 
-#: src/strings.ts:2288
+#: src/strings.ts:2287
 msgid "Font family"
 msgstr ""
 
-#: src/strings.ts:2475
+#: src/strings.ts:2474
 msgid "Font ligatures"
 msgstr ""
 
-#: src/strings.ts:2289
+#: src/strings.ts:2288
 msgid "Font size"
 msgstr ""
 
-#: src/strings.ts:2533
+#: src/strings.ts:2532
 msgid "For a monthly subscription, you can get a refund within 7 days of purchase. For a yearly subscription, we offer a full refund within 14 days of purchase. For a 5 year subscription, you can request a refund within 30 days of purchase."
 msgstr ""
 
-#: src/strings.ts:1687
+#: src/strings.ts:1686
 msgid "For a more integrated user experience, try out Notesnook for {platform}"
 msgstr ""
 
-#: src/strings.ts:1768
+#: src/strings.ts:1767
 msgid "for help regarding how to use the Notesnook Importer."
 msgstr ""
 
-#: src/strings.ts:2542
+#: src/strings.ts:2541
 msgid "for locking your notes as soon as app enters background"
 msgstr ""
 
-#: src/strings.ts:2206
+#: src/strings.ts:2205
 msgid "Force logout from all your other logged in devices."
 msgstr ""
 
-#: src/strings.ts:1097
+#: src/strings.ts:1096
 msgid "Force pull changes"
 msgstr ""
 
-#: src/strings.ts:1106
+#: src/strings.ts:1105
 msgid "Force push changes"
 msgstr ""
 
-#: src/strings.ts:2223
+#: src/strings.ts:2222
 msgid ""
 "Force push:\n"
 "Use this if changes made on this device are not appearing on other devices. This will overwrite the data on the server with the data from this device.\n"
@@ -3059,11 +3057,11 @@ msgstr ""
 msgid "Forgot password?"
 msgstr ""
 
-#: src/strings.ts:2576
+#: src/strings.ts:2575
 msgid "Free {duration} day trial, cancel any time"
 msgstr ""
 
-#: src/strings.ts:2480
+#: src/strings.ts:2479
 msgid "Free plan"
 msgstr ""
 
@@ -3075,55 +3073,55 @@ msgstr ""
 msgid "Friday"
 msgstr ""
 
-#: src/strings.ts:2383
+#: src/strings.ts:2382
 msgid "From code"
 msgstr ""
 
-#: src/strings.ts:2380
+#: src/strings.ts:2379
 msgid "From URL"
 msgstr ""
 
-#: src/strings.ts:2000
+#: src/strings.ts:1999
 msgid "Full name updated"
 msgstr ""
 
-#: src/strings.ts:2217
+#: src/strings.ts:2216
 msgid "Full offline mode"
 msgstr ""
 
-#: src/strings.ts:2335
+#: src/strings.ts:2334
 msgid "Full screen"
 msgstr ""
 
-#: src/strings.ts:2103
+#: src/strings.ts:2102
 msgid "General"
 msgstr ""
 
-#: src/strings.ts:1269
+#: src/strings.ts:1268
 msgid "Get helpful debug info about the app to help us find bugs."
 msgstr ""
 
-#: src/strings.ts:1293
+#: src/strings.ts:1292
 msgid "Get Notesnook app on your desktop and access all notes"
 msgstr ""
 
-#: src/strings.ts:2168
+#: src/strings.ts:2167
 msgid "Get Notesnook app on your iPhone and access all your notes on the go."
 msgstr ""
 
-#: src/strings.ts:2170
+#: src/strings.ts:2169
 msgid "Get Notesnook app on your iPhone or Android device and access all your notes on the go."
 msgstr ""
 
-#: src/strings.ts:1383
+#: src/strings.ts:1382
 msgid "Get Notesnook Pro"
 msgstr ""
 
-#: src/strings.ts:1368
+#: src/strings.ts:1367
 msgid "Get Notesnook Pro to enable automatic backups"
 msgstr ""
 
-#: src/strings.ts:2419
+#: src/strings.ts:2418
 msgid "Get Priority support"
 msgstr ""
 
@@ -3135,11 +3133,11 @@ msgstr ""
 msgid "Get started"
 msgstr ""
 
-#: src/strings.ts:2539
+#: src/strings.ts:2538
 msgid "Get this and so much more:"
 msgstr ""
 
-#: src/strings.ts:1886
+#: src/strings.ts:1885
 msgid "Getting encryption key..."
 msgstr ""
 
@@ -3151,55 +3149,55 @@ msgstr ""
 msgid "Getting recovery codes"
 msgstr ""
 
-#: src/strings.ts:2664
+#: src/strings.ts:2663
 msgid "Gift code required"
 msgstr ""
 
-#: src/strings.ts:2173
+#: src/strings.ts:2172
 msgid "GNU GENERAL PUBLIC LICENSE Version 3"
 msgstr ""
 
-#: src/strings.ts:2620
+#: src/strings.ts:2619
 msgid "Go back"
 msgstr ""
 
-#: src/strings.ts:2458
+#: src/strings.ts:2457
 msgid "Go back in tab"
 msgstr ""
 
-#: src/strings.ts:2236
+#: src/strings.ts:2235
 msgid "Go back to notebooks"
 msgstr ""
 
-#: src/strings.ts:2237
+#: src/strings.ts:2236
 msgid "Go back to tags"
 msgstr ""
 
-#: src/strings.ts:2457
+#: src/strings.ts:2456
 msgid "Go forward in tab"
 msgstr ""
 
-#: src/strings.ts:1814
+#: src/strings.ts:1813
 msgid "Go to"
 msgstr ""
 
-#: src/strings.ts:1815
+#: src/strings.ts:1814
 msgid "Go to #{tag}"
 msgstr ""
 
-#: src/strings.ts:1698
+#: src/strings.ts:1697
 msgid "Go to next page"
 msgstr ""
 
-#: src/strings.ts:1699
+#: src/strings.ts:1698
 msgid "Go to previous page"
 msgstr ""
 
-#: src/strings.ts:1305
+#: src/strings.ts:1304
 msgid "Go to web app"
 msgstr ""
 
-#: src/strings.ts:2550
+#: src/strings.ts:2549
 msgid "Google will remind you 2 days before your trial ends."
 msgstr ""
 
@@ -3211,7 +3209,7 @@ msgstr ""
 msgid "GROUP"
 msgstr ""
 
-#: src/strings.ts:1888
+#: src/strings.ts:1887
 msgid "Group added successfully"
 msgstr ""
 
@@ -3223,27 +3221,27 @@ msgstr ""
 msgid "Hash copied"
 msgstr ""
 
-#: src/strings.ts:2220
+#: src/strings.ts:2219
 msgid "Having problems with sync?"
 msgstr ""
 
-#: src/strings.ts:2565
+#: src/strings.ts:2564
 msgid "hdImages"
 msgstr ""
 
-#: src/strings.ts:2361
+#: src/strings.ts:2360
 msgid "Heading {level}"
 msgstr ""
 
-#: src/strings.ts:2290
+#: src/strings.ts:2289
 msgid "Headings"
 msgstr ""
 
-#: src/strings.ts:2396
+#: src/strings.ts:2395
 msgid "Height"
 msgstr ""
 
-#: src/strings.ts:1257
+#: src/strings.ts:1256
 msgid "Help and support"
 msgstr ""
 
@@ -3251,55 +3249,55 @@ msgstr ""
 msgid "Help improve Notesnook by sending completely anonymized"
 msgstr ""
 
-#: src/strings.ts:1376
+#: src/strings.ts:1375
 msgid "Hide"
 msgstr ""
 
-#: src/strings.ts:1183
+#: src/strings.ts:1182
 msgid "Hide app contents when you switch to other apps. This will also disable screenshot taking in the app."
 msgstr ""
 
-#: src/strings.ts:2179
+#: src/strings.ts:2178
 msgid "Hide note title"
 msgstr ""
 
-#: src/strings.ts:2293
+#: src/strings.ts:2292
 msgid "Highlight"
 msgstr ""
 
-#: src/strings.ts:910
+#: src/strings.ts:909
 msgid "History"
 msgstr ""
 
-#: src/strings.ts:1528
+#: src/strings.ts:1527
 msgid "Home"
 msgstr ""
 
-#: src/strings.ts:1127
+#: src/strings.ts:1126
 msgid "Homepage"
 msgstr ""
 
-#: src/strings.ts:1318
+#: src/strings.ts:1317
 msgid "Homepage changed to {name}"
 msgstr ""
 
-#: src/strings.ts:2342
+#: src/strings.ts:2341
 msgid "Horizontal rule"
 msgstr ""
 
-#: src/strings.ts:1799
+#: src/strings.ts:1798
 msgid "How do you want to recover your account?"
 msgstr ""
 
-#: src/strings.ts:1669
+#: src/strings.ts:1668
 msgid "How to fix it?"
 msgstr ""
 
-#: src/strings.ts:881
+#: src/strings.ts:880
 msgid "hr"
 msgstr ""
 
-#: src/strings.ts:2510
+#: src/strings.ts:2509
 msgid "I already have an account"
 msgstr ""
 
@@ -3323,15 +3321,15 @@ msgstr ""
 msgid "I have a recovery code"
 msgstr ""
 
-#: src/strings.ts:1887
+#: src/strings.ts:1886
 msgid "I have saved my key"
 msgstr ""
 
-#: src/strings.ts:2436
+#: src/strings.ts:2435
 msgid "I love cooking and collecting recipes."
 msgstr ""
 
-#: src/strings.ts:2221
+#: src/strings.ts:2220
 msgid "I understand"
 msgstr ""
 
@@ -3347,29 +3345,29 @@ msgstr ""
 msgid "If this continues to happen, please reach out to us via"
 msgstr ""
 
-#: src/strings.ts:2124
+#: src/strings.ts:2123
 msgid "If true, Notesnook will automatically start up when you turn on & login to your system."
 msgstr ""
 
-#: src/strings.ts:2127
+#: src/strings.ts:2126
 msgid "If true, Notesnook will start minimized to either the system tray or your system taskbar/dock. This setting only works with Auto start on system startup is enabled."
 msgstr ""
 
-#: src/strings.ts:1725
+#: src/strings.ts:1724
 msgid "If you can't scan the QR code above, enter this text instead (spaces don't matter)"
 msgstr ""
 
-#: src/strings.ts:1395
+#: src/strings.ts:1394
 msgid ""
 "If you didn't get an email from us or the confirmation link isn't\n"
 "            working,"
 msgstr ""
 
-#: src/strings.ts:1805
+#: src/strings.ts:1804
 msgid "If you don't have a recovery key, you can recover your data by restoring a Notesnook data backup file (.nnbackup)."
 msgstr ""
 
-#: src/strings.ts:2088
+#: src/strings.ts:2087
 msgid "If you face any issue, you can reach out to us anytime."
 msgstr ""
 
@@ -3377,23 +3375,23 @@ msgstr ""
 msgid "If you want to ask something in general or need some assistance, we would suggest that you"
 msgstr ""
 
-#: src/strings.ts:2347
+#: src/strings.ts:2346
 msgid "Image"
 msgstr ""
 
-#: src/strings.ts:1129
+#: src/strings.ts:1128
 msgid "Image Compression"
 msgstr ""
 
-#: src/strings.ts:2323
+#: src/strings.ts:2322
 msgid "Image properties"
 msgstr ""
 
-#: src/strings.ts:2319
+#: src/strings.ts:2318
 msgid "Image settings"
 msgstr ""
 
-#: src/strings.ts:948
+#: src/strings.ts:947
 msgid "Image size should be less than {sizeInMB}"
 msgstr ""
 
@@ -3405,23 +3403,23 @@ msgstr ""
 msgid "Images uploaded without compression are slow to load and take more bandwidth. We recommend compressing images unless you need image in original quality."
 msgstr ""
 
-#: src/strings.ts:1583
+#: src/strings.ts:1582
 msgid "Immediately"
 msgstr ""
 
-#: src/strings.ts:2151
+#: src/strings.ts:2150
 msgid "Import & export"
 msgstr ""
 
-#: src/strings.ts:1752
+#: src/strings.ts:1751
 msgid "Import completed"
 msgstr ""
 
-#: src/strings.ts:2649
+#: src/strings.ts:2648
 msgid "Import CSV"
 msgstr ""
 
-#: src/strings.ts:1767
+#: src/strings.ts:1766
 msgid "import guide"
 msgstr ""
 
@@ -3429,7 +3427,7 @@ msgstr ""
 msgid "Incoming"
 msgstr ""
 
-#: src/strings.ts:1838
+#: src/strings.ts:1837
 msgid "Incoming note"
 msgstr ""
 
@@ -3437,59 +3435,59 @@ msgstr ""
 msgid "Incorrect {type}"
 msgstr ""
 
-#: src/strings.ts:2405
+#: src/strings.ts:2404
 msgid "Increase {title}"
 msgstr ""
 
-#: src/strings.ts:2247
+#: src/strings.ts:2246
 msgid "Insert"
 msgstr ""
 
-#: src/strings.ts:2402
+#: src/strings.ts:2401
 msgid "Insert a {rows}x{columns} table"
 msgstr ""
 
-#: src/strings.ts:2352
+#: src/strings.ts:2351
 msgid "Insert a table"
 msgstr ""
 
-#: src/strings.ts:2354
+#: src/strings.ts:2353
 msgid "Insert an embed"
 msgstr ""
 
-#: src/strings.ts:2348
+#: src/strings.ts:2347
 msgid "Insert an image"
 msgstr ""
 
-#: src/strings.ts:2300
+#: src/strings.ts:2299
 msgid "Insert column left"
 msgstr ""
 
-#: src/strings.ts:2301
+#: src/strings.ts:2300
 msgid "Insert column right"
 msgstr ""
 
-#: src/strings.ts:2245
+#: src/strings.ts:2244
 msgid "Insert link"
 msgstr ""
 
-#: src/strings.ts:2307
+#: src/strings.ts:2306
 msgid "Insert row above"
 msgstr ""
 
-#: src/strings.ts:2308
+#: src/strings.ts:2307
 msgid "Insert row below"
 msgstr ""
 
-#: src/strings.ts:1685
+#: src/strings.ts:1684
 msgid "Install Notesnook"
 msgstr ""
 
-#: src/strings.ts:2159
+#: src/strings.ts:2158
 msgid "Install update"
 msgstr ""
 
-#: src/strings.ts:1720
+#: src/strings.ts:1719
 msgid "installs"
 msgstr ""
 
@@ -3497,15 +3495,15 @@ msgstr ""
 msgid "Invalid {type}"
 msgstr ""
 
-#: src/strings.ts:1992
+#: src/strings.ts:1991
 msgid "Invalid CORS proxy url"
 msgstr ""
 
-#: src/strings.ts:1483
+#: src/strings.ts:1482
 msgid "Invalid email"
 msgstr ""
 
-#: src/strings.ts:2657
+#: src/strings.ts:2656
 msgid "Invalid recovery key. Make sure to input your account recovery key, not a 2FA recovery code."
 msgstr ""
 
@@ -3513,12 +3511,12 @@ msgstr ""
 msgid "Issue created"
 msgstr ""
 
-#: src/strings.ts:991
-#: src/strings.ts:1000
+#: src/strings.ts:990
+#: src/strings.ts:999
 msgid "It may take a minute to receive your code."
 msgstr ""
 
-#: src/strings.ts:1591
+#: src/strings.ts:1590
 msgid "It seems that your changes could not be saved. What to do next:"
 msgstr ""
 
@@ -3526,7 +3524,7 @@ msgstr ""
 msgid "It took us a year to bring Notesnook to life. Share your experience and suggestions to help us improve it."
 msgstr ""
 
-#: src/strings.ts:2269
+#: src/strings.ts:2268
 msgid "Italic"
 msgstr ""
 
@@ -3539,7 +3537,7 @@ msgid "Item"
 msgstr ""
 
 #: src/strings.ts:311
-#: src/strings.ts:1704
+#: src/strings.ts:1703
 msgid "items"
 msgstr ""
 
@@ -3547,7 +3545,7 @@ msgstr ""
 msgid "Items"
 msgstr ""
 
-#: src/strings.ts:2171
+#: src/strings.ts:2170
 msgid "Join community"
 msgstr ""
 
@@ -3555,27 +3553,27 @@ msgstr ""
 msgid "join our community on Discord."
 msgstr ""
 
-#: src/strings.ts:1281
+#: src/strings.ts:1280
 msgid "Join our Discord server"
 msgstr ""
 
-#: src/strings.ts:1283
+#: src/strings.ts:1282
 msgid "Join our Discord server to chat with other users and the team"
 msgstr ""
 
-#: src/strings.ts:1273
+#: src/strings.ts:1272
 msgid "Join our Telegram group"
 msgstr ""
 
-#: src/strings.ts:1275
+#: src/strings.ts:1274
 msgid "Join our Telegram group to chat with other users and the team"
 msgstr ""
 
-#: src/strings.ts:2079
+#: src/strings.ts:2078
 msgid "Join the cause"
 msgstr ""
 
-#: src/strings.ts:2027
+#: src/strings.ts:2026
 msgid "Jump to group"
 msgstr ""
 
@@ -3583,19 +3581,19 @@ msgstr ""
 msgid "Keep"
 msgstr ""
 
-#: src/strings.ts:2022
+#: src/strings.ts:2021
 msgid "Keep open"
 msgstr ""
 
-#: src/strings.ts:1360
+#: src/strings.ts:1359
 msgid "Keep your data safe"
 msgstr ""
 
-#: src/strings.ts:2139
+#: src/strings.ts:2138
 msgid "Languages"
 msgstr ""
 
-#: src/strings.ts:2242
+#: src/strings.ts:2241
 msgid "Last edited at"
 msgstr ""
 
@@ -3615,7 +3613,7 @@ msgstr ""
 msgid "Learn more"
 msgstr ""
 
-#: src/strings.ts:978
+#: src/strings.ts:977
 msgid "Learn more about Monographs"
 msgstr ""
 
@@ -3627,7 +3625,7 @@ msgstr ""
 msgid "Least relevant first"
 msgstr ""
 
-#: src/strings.ts:1563
+#: src/strings.ts:1562
 msgid "Legal"
 msgstr ""
 
@@ -3635,15 +3633,15 @@ msgstr ""
 msgid "Let us know if you have faced any issue/bug while using Notesnook. We will try to fix it as soon as possible."
 msgstr ""
 
-#: src/strings.ts:2172
+#: src/strings.ts:2171
 msgid "License"
 msgstr ""
 
-#: src/strings.ts:1721
+#: src/strings.ts:1720
 msgid "Licensed under {license}"
 msgstr ""
 
-#: src/strings.ts:2338
+#: src/strings.ts:2337
 msgid "Lift list item"
 msgstr ""
 
@@ -3651,39 +3649,39 @@ msgstr ""
 msgid "Light"
 msgstr ""
 
-#: src/strings.ts:2368
+#: src/strings.ts:2367
 msgid "Line {line}, Column {column}"
 msgstr ""
 
-#: src/strings.ts:2631
+#: src/strings.ts:2630
 msgid "Line height"
 msgstr ""
 
-#: src/strings.ts:1153
+#: src/strings.ts:1152
 msgid "Line spacing changed"
 msgstr ""
 
-#: src/strings.ts:2273
+#: src/strings.ts:2272
 msgid "Link"
 msgstr ""
 
-#: src/strings.ts:912
+#: src/strings.ts:911
 msgid "Link copied"
 msgstr ""
 
-#: src/strings.ts:930
+#: src/strings.ts:929
 msgid "Link notebooks"
 msgstr ""
 
-#: src/strings.ts:2487
+#: src/strings.ts:2486
 msgid "Link notes"
 msgstr ""
 
-#: src/strings.ts:2278
+#: src/strings.ts:2277
 msgid "Link settings"
 msgstr ""
 
-#: src/strings.ts:2398
+#: src/strings.ts:2397
 msgid "Link text"
 msgstr ""
 
@@ -3695,7 +3693,7 @@ msgstr ""
 msgid "Link to note"
 msgstr ""
 
-#: src/strings.ts:852
+#: src/strings.ts:851
 msgid "Link to notebook"
 msgstr ""
 
@@ -3703,7 +3701,7 @@ msgstr ""
 msgid "Linked notes"
 msgstr ""
 
-#: src/strings.ts:1597
+#: src/strings.ts:1596
 msgid "Linking to a specific block is not available for locked notes."
 msgstr ""
 
@@ -3715,7 +3713,7 @@ msgstr ""
 msgid "Load from file"
 msgstr ""
 
-#: src/strings.ts:1696
+#: src/strings.ts:1695
 msgid "Loading"
 msgstr ""
 
@@ -3724,11 +3722,11 @@ msgstr ""
 msgid "Loading {0}, please wait..."
 msgstr ""
 
-#: src/strings.ts:1665
+#: src/strings.ts:1664
 msgid "Loading editor. Please wait..."
 msgstr ""
 
-#: src/strings.ts:1065
+#: src/strings.ts:1064
 msgid "Loading subscription details"
 msgstr ""
 
@@ -3736,35 +3734,35 @@ msgstr ""
 msgid "Loading themes..."
 msgstr ""
 
-#: src/strings.ts:1328
+#: src/strings.ts:1327
 msgid "Loading trash"
 msgstr ""
 
-#: src/strings.ts:974
+#: src/strings.ts:973
 msgid "Loading your archive"
 msgstr ""
 
-#: src/strings.ts:968
+#: src/strings.ts:967
 msgid "Loading your favorites"
 msgstr ""
 
-#: src/strings.ts:973
+#: src/strings.ts:972
 msgid "Loading your monographs"
 msgstr ""
 
-#: src/strings.ts:971
+#: src/strings.ts:970
 msgid "Loading your notebooks"
 msgstr ""
 
-#: src/strings.ts:969
+#: src/strings.ts:968
 msgid "Loading your notes"
 msgstr ""
 
-#: src/strings.ts:972
+#: src/strings.ts:971
 msgid "Loading your reminders"
 msgstr ""
 
-#: src/strings.ts:970
+#: src/strings.ts:969
 msgid "Loading your tags"
 msgstr ""
 
@@ -3776,19 +3774,19 @@ msgstr ""
 msgid "Lock note"
 msgstr ""
 
-#: src/strings.ts:1185
+#: src/strings.ts:1184
 msgid "Lock the app with a password or pin"
 msgstr ""
 
-#: src/strings.ts:902
+#: src/strings.ts:901
 msgid "Locked notes cannot be pinned"
 msgstr ""
 
-#: src/strings.ts:905
+#: src/strings.ts:904
 msgid "Locked notes cannot be published"
 msgstr ""
 
-#: src/strings.ts:2204
+#: src/strings.ts:2203
 msgid "Log out from all other devices"
 msgstr ""
 
@@ -3796,7 +3794,7 @@ msgstr ""
 msgid "Logged in as {email}"
 msgstr ""
 
-#: src/strings.ts:1075
+#: src/strings.ts:1074
 msgid "Logging out will clear all data stored on THIS DEVICE. Make sure you have synced all your changes before logging out."
 msgstr ""
 
@@ -3804,7 +3802,7 @@ msgstr ""
 msgid "Logging out. Please wait..."
 msgstr ""
 
-#: src/strings.ts:1783
+#: src/strings.ts:1782
 msgid "Logging you in"
 msgstr ""
 
@@ -3816,11 +3814,11 @@ msgstr ""
 msgid "Login failed"
 msgstr ""
 
-#: src/strings.ts:903
+#: src/strings.ts:902
 msgid "Login required"
 msgstr ""
 
-#: src/strings.ts:2672
+#: src/strings.ts:2671
 msgid "Login required to restore attachments"
 msgstr ""
 
@@ -3828,11 +3826,11 @@ msgstr ""
 msgid "Login successful"
 msgstr ""
 
-#: src/strings.ts:1363
+#: src/strings.ts:1362
 msgid "Login to encrypt and sync notes"
 msgstr ""
 
-#: src/strings.ts:2624
+#: src/strings.ts:2623
 msgid "Login to upload attachments. [Read more](https://help.notesnook.com/faqs/login-to-upload-attachments)"
 msgstr ""
 
@@ -3852,19 +3850,19 @@ msgstr ""
 msgid "Logout from this device"
 msgstr ""
 
-#: src/strings.ts:1413
+#: src/strings.ts:1412
 msgid "Long press on any item in list to enter multi-select mode."
 msgstr ""
 
-#: src/strings.ts:2373
+#: src/strings.ts:2372
 msgid "Make task list readonly"
 msgstr ""
 
-#: src/strings.ts:1039
+#: src/strings.ts:1038
 msgid "Manage account"
 msgstr ""
 
-#: src/strings.ts:1052
+#: src/strings.ts:1051
 msgid "Manage attachments"
 msgstr ""
 
@@ -3872,75 +3870,75 @@ msgstr ""
 msgid "Manage subscription on desktop"
 msgstr ""
 
-#: src/strings.ts:851
+#: src/strings.ts:850
 msgid "Manage tags"
 msgstr ""
 
-#: src/strings.ts:1040
+#: src/strings.ts:1039
 msgid "Manage your account related settings here"
 msgstr ""
 
-#: src/strings.ts:1053
+#: src/strings.ts:1052
 msgid "Manage your attachments in one place"
 msgstr ""
 
-#: src/strings.ts:1212
+#: src/strings.ts:1211
 msgid "Manage your backups and restore data"
 msgstr ""
 
-#: src/strings.ts:1246
+#: src/strings.ts:1245
 msgid "Manage your reminders"
 msgstr ""
 
-#: src/strings.ts:1084
+#: src/strings.ts:1083
 msgid "Manage your sync settings here"
 msgstr ""
 
-#: src/strings.ts:1441
+#: src/strings.ts:1440
 msgid "Mark important notes by adding them to favorites."
 msgstr ""
 
-#: src/strings.ts:1160
+#: src/strings.ts:1159
 msgid "Markdown shortcuts"
 msgstr ""
 
-#: src/strings.ts:1166
+#: src/strings.ts:1165
 msgid "Marketing emails"
 msgstr ""
 
-#: src/strings.ts:2386
+#: src/strings.ts:2385
 msgid "Match case"
 msgstr ""
 
-#: src/strings.ts:2387
+#: src/strings.ts:2386
 msgid "Match whole word"
 msgstr ""
 
-#: src/strings.ts:2295
+#: src/strings.ts:2294
 msgid "Math (inline)"
 msgstr ""
 
-#: src/strings.ts:2345
+#: src/strings.ts:2344
 msgid "Math & formulas"
 msgstr ""
 
-#: src/strings.ts:2041
+#: src/strings.ts:2040
 msgid "Maximize"
 msgstr ""
 
-#: src/strings.ts:2081
+#: src/strings.ts:2080
 msgid "Meet other privacy-minded people & talk to us directly about your concerns, issues and suggestions."
 msgstr ""
 
-#: src/strings.ts:2429
+#: src/strings.ts:2428
 msgid "Meetings"
 msgstr ""
 
-#: src/strings.ts:1780
+#: src/strings.ts:1779
 msgid "Member since {date}"
 msgstr ""
 
-#: src/strings.ts:2306
+#: src/strings.ts:2305
 msgid "Merge cells"
 msgstr ""
 
@@ -3954,19 +3952,19 @@ msgstr ""
 msgid "Migration failed"
 msgstr ""
 
-#: src/strings.ts:880
+#: src/strings.ts:879
 msgid "min"
 msgstr ""
 
-#: src/strings.ts:2010
+#: src/strings.ts:2009
 msgid "Minimal"
 msgstr ""
 
-#: src/strings.ts:2040
+#: src/strings.ts:2039
 msgid "Minimize"
 msgstr ""
 
-#: src/strings.ts:2128
+#: src/strings.ts:2127
 msgid "Minimize to system tray"
 msgstr ""
 
@@ -3982,39 +3980,39 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
-#: src/strings.ts:1632
+#: src/strings.ts:1631
 msgid "Monograph server"
 msgstr ""
 
-#: src/strings.ts:871
+#: src/strings.ts:870
 msgid "Monograph URL copied"
 msgstr ""
 
 #: src/strings.ts:322
-#: src/strings.ts:940
-#: src/strings.ts:1530
+#: src/strings.ts:939
+#: src/strings.ts:1529
 msgid "Monographs"
 msgstr ""
 
-#: src/strings.ts:1423
+#: src/strings.ts:1422
 msgid "Monographs can be encrypted with a secret key and shared with anyone."
 msgstr ""
 
-#: src/strings.ts:1418
+#: src/strings.ts:1417
 msgid "Monographs enable you to share your notes in a secure and private way."
 msgstr ""
 
 #: src/strings.ts:665
-#: src/strings.ts:1841
+#: src/strings.ts:1840
 msgid "Month"
 msgstr ""
 
 #: src/strings.ts:169
-#: src/strings.ts:1571
+#: src/strings.ts:1570
 msgid "Monthly"
 msgstr ""
 
-#: src/strings.ts:2325
+#: src/strings.ts:2324
 msgid "More"
 msgstr ""
 
@@ -4022,35 +4020,35 @@ msgstr ""
 msgid "Most relevant first"
 msgstr ""
 
-#: src/strings.ts:853
+#: src/strings.ts:852
 msgid "Move"
 msgstr ""
 
-#: src/strings.ts:2374
+#: src/strings.ts:2373
 msgid "Move all checked tasks to bottom"
 msgstr ""
 
-#: src/strings.ts:2302
+#: src/strings.ts:2301
 msgid "Move column left"
 msgstr ""
 
-#: src/strings.ts:2303
+#: src/strings.ts:2302
 msgid "Move column right"
 msgstr ""
 
-#: src/strings.ts:937
+#: src/strings.ts:936
 msgid "Move notebook"
 msgstr ""
 
-#: src/strings.ts:899
+#: src/strings.ts:898
 msgid "Move notes"
 msgstr ""
 
-#: src/strings.ts:2310
+#: src/strings.ts:2309
 msgid "Move row down"
 msgstr ""
 
-#: src/strings.ts:2309
+#: src/strings.ts:2308
 msgid "Move row up"
 msgstr ""
 
@@ -4062,27 +4060,27 @@ msgstr ""
 msgid "Move to top"
 msgstr ""
 
-#: src/strings.ts:856
+#: src/strings.ts:855
 msgid "Move to trash"
 msgstr ""
 
-#: src/strings.ts:1173
+#: src/strings.ts:1172
 msgid "Multi-layer encryption to most important notes"
 msgstr ""
 
-#: src/strings.ts:888
+#: src/strings.ts:887
 msgid "Name"
 msgstr ""
 
-#: src/strings.ts:2670
+#: src/strings.ts:2669
 msgid "Name is required."
 msgstr ""
 
-#: src/strings.ts:1689
+#: src/strings.ts:1688
 msgid "Native high-performance encryption"
 msgstr ""
 
-#: src/strings.ts:2454
+#: src/strings.ts:2453
 msgid "Navigate"
 msgstr ""
 
@@ -4090,11 +4088,11 @@ msgstr ""
 msgid "Never"
 msgstr ""
 
-#: src/strings.ts:1343
+#: src/strings.ts:1342
 msgid "Never ask again"
 msgstr ""
 
-#: src/strings.ts:1038
+#: src/strings.ts:1037
 msgid "Never hesitate to choose privacy"
 msgstr ""
 
@@ -4110,11 +4108,11 @@ msgstr ""
 msgid "New color"
 msgstr ""
 
-#: src/strings.ts:1847
+#: src/strings.ts:1846
 msgid "New Email"
 msgstr ""
 
-#: src/strings.ts:1152
+#: src/strings.ts:1151
 msgid "New lines will be double spaced (old ones won't be affected)."
 msgstr ""
 
@@ -4126,11 +4124,11 @@ msgstr ""
 msgid "New notebook"
 msgstr ""
 
-#: src/strings.ts:1481
+#: src/strings.ts:1480
 msgid "New password"
 msgstr ""
 
-#: src/strings.ts:1487
+#: src/strings.ts:1486
 msgid "New pin"
 msgstr ""
 
@@ -4142,11 +4140,11 @@ msgstr ""
 msgid "New tab"
 msgstr ""
 
-#: src/strings.ts:2460
+#: src/strings.ts:2459
 msgid "New tag"
 msgstr ""
 
-#: src/strings.ts:1369
+#: src/strings.ts:1368
 msgid "New update available"
 msgstr ""
 
@@ -4154,11 +4152,11 @@ msgstr ""
 msgid "New version"
 msgstr ""
 
-#: src/strings.ts:2025
+#: src/strings.ts:2024
 msgid "Newest - oldest"
 msgstr ""
 
-#: src/strings.ts:1141
+#: src/strings.ts:1140
 msgid "Newly created notes will be uncategorized"
 msgstr ""
 
@@ -4166,11 +4164,11 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
-#: src/strings.ts:2390
+#: src/strings.ts:2389
 msgid "Next match"
 msgstr ""
 
-#: src/strings.ts:2455
+#: src/strings.ts:2454
 msgid "Next tab"
 msgstr ""
 
@@ -4178,7 +4176,7 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: src/strings.ts:860
+#: src/strings.ts:859
 msgid "No application found to open {fileToOpen}"
 msgstr ""
 
@@ -4198,7 +4196,7 @@ msgstr ""
 msgid "No color selected"
 msgstr ""
 
-#: src/strings.ts:1232
+#: src/strings.ts:1231
 msgid "No directory selected"
 msgstr ""
 
@@ -4206,11 +4204,11 @@ msgstr ""
 msgid "No downloads in progress."
 msgstr ""
 
-#: src/strings.ts:1985
+#: src/strings.ts:1984
 msgid "No encryption key found"
 msgstr ""
 
-#: src/strings.ts:1666
+#: src/strings.ts:1665
 msgid "No headings found"
 msgstr ""
 
@@ -4226,7 +4224,7 @@ msgstr ""
 msgid "No note history available for this device."
 msgstr ""
 
-#: src/strings.ts:2504
+#: src/strings.ts:2503
 msgid "No notebooks selected to move"
 msgstr ""
 
@@ -4234,7 +4232,7 @@ msgstr ""
 msgid "No one can view this {type} except you."
 msgstr ""
 
-#: src/strings.ts:2627
+#: src/strings.ts:2626
 msgid "No password"
 msgstr ""
 
@@ -4242,7 +4240,7 @@ msgstr ""
 msgid "No references found of this note"
 msgstr ""
 
-#: src/strings.ts:1517
+#: src/strings.ts:1516
 msgid "No results found"
 msgstr ""
 
@@ -4250,7 +4248,7 @@ msgstr ""
 msgid "No results found for \"{query}\""
 msgstr ""
 
-#: src/strings.ts:1517
+#: src/strings.ts:1516
 msgid "No results found for {query}"
 msgstr ""
 
@@ -4266,7 +4264,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: src/strings.ts:2015
+#: src/strings.ts:2014
 msgid "Normal mode"
 msgstr ""
 
@@ -4287,11 +4285,11 @@ msgstr ""
 msgid "Note copied to clipboard"
 msgstr ""
 
-#: src/strings.ts:1950
+#: src/strings.ts:1949
 msgid "Note does not exist"
 msgstr ""
 
-#: src/strings.ts:816
+#: src/strings.ts:2696
 msgid "Note duplicated"
 msgstr ""
 
@@ -4303,11 +4301,11 @@ msgstr ""
 msgid "Note locked"
 msgstr ""
 
-#: src/strings.ts:846
+#: src/strings.ts:845
 msgid "Note restored from history"
 msgstr ""
 
-#: src/strings.ts:1586
+#: src/strings.ts:1585
 msgid "Note title"
 msgstr ""
 
@@ -4319,7 +4317,7 @@ msgstr ""
 msgid "Note version history is local only."
 msgstr ""
 
-#: src/strings.ts:1225
+#: src/strings.ts:1224
 msgid "NOTE: Creating a backup with attachments can take a while, and also fail completely. The app will try to resume/restart the backup in case of interruptions."
 msgstr ""
 
@@ -4328,11 +4326,11 @@ msgid "notebook"
 msgstr ""
 
 #: src/strings.ts:296
-#: src/strings.ts:1521
+#: src/strings.ts:1520
 msgid "Notebook"
 msgstr ""
 
-#: src/strings.ts:2490
+#: src/strings.ts:2489
 msgid "Notebook added"
 msgstr ""
 
@@ -4342,15 +4340,15 @@ msgstr ""
 
 #: src/strings.ts:258
 #: src/strings.ts:316
-#: src/strings.ts:1520
+#: src/strings.ts:1519
 msgid "Notebooks"
 msgstr ""
 
-#: src/strings.ts:1795
+#: src/strings.ts:1794
 msgid "NOTEBOOKS"
 msgstr ""
 
-#: src/strings.ts:2252
+#: src/strings.ts:2251
 msgid "Notebooks are the best way to organize your notes."
 msgstr ""
 
@@ -4359,7 +4357,7 @@ msgid "notes"
 msgstr ""
 
 #: src/strings.ts:315
-#: src/strings.ts:1519
+#: src/strings.ts:1518
 msgid "Notes"
 msgstr ""
 
@@ -4367,35 +4365,35 @@ msgstr ""
 msgid "Notes exported as {path} successfully"
 msgstr ""
 
-#: src/strings.ts:1751
+#: src/strings.ts:1750
 msgid "notes imported"
 msgstr ""
 
-#: src/strings.ts:2554
+#: src/strings.ts:2553
 msgid "Notesnook"
 msgstr ""
 
-#: src/strings.ts:2612
+#: src/strings.ts:2611
 msgid "Notesnook Circle"
 msgstr ""
 
-#: src/strings.ts:2614
+#: src/strings.ts:2613
 msgid "Notesnook Circle brings together trusted partners who share our commitment to privacy, transparency, and user freedom."
 msgstr ""
 
-#: src/strings.ts:2078
+#: src/strings.ts:2077
 msgid "Notesnook encrypts everything offline before syncing to your other devices. This means that no one can read your notes except you. Not even us."
 msgstr ""
 
-#: src/strings.ts:2153
+#: src/strings.ts:2152
 msgid "Notesnook Importer"
 msgstr ""
 
-#: src/strings.ts:1067
+#: src/strings.ts:1066
 msgid "Notesnook Pro"
 msgstr ""
 
-#: src/strings.ts:2185
+#: src/strings.ts:2184
 msgid ""
 "Notesnook uses the following DNS providers:\n"
 "\n"
@@ -4405,31 +4403,31 @@ msgid ""
 "This can sometimes bypass local ISP blockages on Notesnook traffic. Disable this if you want the app to use system's DNS settings."
 msgstr ""
 
-#: src/strings.ts:988
+#: src/strings.ts:987
 msgid "Notesnook will send you a 2FA code on your email when prompted"
 msgstr ""
 
-#: src/strings.ts:995
+#: src/strings.ts:994
 msgid "Notesnook will send you an SMS with a 2FA code when prompted"
 msgstr ""
 
-#: src/strings.ts:2148
+#: src/strings.ts:2147
 msgid "Notifications"
 msgstr ""
 
-#: src/strings.ts:1378
+#: src/strings.ts:1377
 msgid "Notifications disabled"
 msgstr ""
 
-#: src/strings.ts:2286
+#: src/strings.ts:2285
 msgid "Numbered list"
 msgstr ""
 
-#: src/strings.ts:1719
+#: src/strings.ts:1718
 msgid "of"
 msgstr ""
 
-#: src/strings.ts:1603
+#: src/strings.ts:1602
 msgid "Off"
 msgstr ""
 
@@ -4437,7 +4435,7 @@ msgstr ""
 msgid "Offline"
 msgstr ""
 
-#: src/strings.ts:2238
+#: src/strings.ts:2237
 msgid "Okay"
 msgstr ""
 
@@ -4445,11 +4443,11 @@ msgstr ""
 msgid "Old - new"
 msgstr ""
 
-#: src/strings.ts:1836
+#: src/strings.ts:1835
 msgid "Older version"
 msgstr ""
 
-#: src/strings.ts:2024
+#: src/strings.ts:2023
 msgid "Oldest - newest"
 msgstr ""
 
@@ -4457,11 +4455,11 @@ msgstr ""
 msgid "Once your password is changed, please make sure to save the new account recovery key"
 msgstr ""
 
-#: src/strings.ts:2572
+#: src/strings.ts:2571
 msgid "One time purchase, no auto-renewal"
 msgstr ""
 
-#: src/strings.ts:1772
+#: src/strings.ts:1771
 msgid "Only .zip files are supported."
 msgstr ""
 
@@ -4477,11 +4475,11 @@ msgstr ""
 msgid "Open in browser"
 msgstr ""
 
-#: src/strings.ts:1307
+#: src/strings.ts:1306
 msgid "Open in browser to manage subscription"
 msgstr ""
 
-#: src/strings.ts:2336
+#: src/strings.ts:2335
 msgid "Open in new tab"
 msgstr ""
 
@@ -4489,43 +4487,43 @@ msgstr ""
 msgid "Open issue"
 msgstr ""
 
-#: src/strings.ts:2276
+#: src/strings.ts:2275
 msgid "Open link"
 msgstr ""
 
-#: src/strings.ts:1864
+#: src/strings.ts:1863
 msgid "Open note"
 msgstr ""
 
-#: src/strings.ts:1381
+#: src/strings.ts:1380
 msgid "Open settings"
 msgstr ""
 
-#: src/strings.ts:2337
+#: src/strings.ts:2336
 msgid "Open source"
 msgstr ""
 
-#: src/strings.ts:1289
+#: src/strings.ts:1288
 msgid "Open source libraries used in Notesnook"
 msgstr ""
 
-#: src/strings.ts:1288
+#: src/strings.ts:1287
 msgid "Open source licenses"
 msgstr ""
 
-#: src/strings.ts:820
+#: src/strings.ts:819
 msgid "Open source."
 msgstr ""
 
-#: src/strings.ts:984
+#: src/strings.ts:983
 msgid "Open the two-factor authentication (TOTP) app to view your authentication code."
 msgstr ""
 
-#: src/strings.ts:2686
+#: src/strings.ts:2685
 msgid "Opening local file"
 msgstr ""
 
-#: src/strings.ts:1858
+#: src/strings.ts:1857
 msgid "Optional"
 msgstr ""
 
@@ -4533,11 +4531,11 @@ msgstr ""
 msgid "or email us at"
 msgstr ""
 
-#: src/strings.ts:2023
+#: src/strings.ts:2022
 msgid "Order by"
 msgstr ""
 
-#: src/strings.ts:2231
+#: src/strings.ts:2230
 msgid "Order ID"
 msgstr ""
 
@@ -4546,23 +4544,23 @@ msgstr ""
 msgid "Orphaned"
 msgstr ""
 
-#: src/strings.ts:2156
+#: src/strings.ts:2155
 msgid "Other"
 msgstr ""
 
-#: src/strings.ts:2357
+#: src/strings.ts:2356
 msgid "Outline list"
 msgstr ""
 
-#: src/strings.ts:2360
+#: src/strings.ts:2359
 msgid "Paragraph"
 msgstr ""
 
-#: src/strings.ts:2503
+#: src/strings.ts:2502
 msgid "Paragraphs"
 msgstr ""
 
-#: src/strings.ts:2112
+#: src/strings.ts:2111
 msgid "Partial backups contain all your data except attachments. They are created from data already available on your device and do not require an Internet connection."
 msgstr ""
 
@@ -4570,11 +4568,11 @@ msgstr ""
 msgid "Partially refunded"
 msgstr ""
 
-#: src/strings.ts:2414
+#: src/strings.ts:2413
 msgid "Passed"
 msgstr ""
 
-#: src/strings.ts:884
+#: src/strings.ts:883
 msgid "Password"
 msgstr ""
 
@@ -4602,7 +4600,7 @@ msgstr ""
 msgid "Password protection"
 msgstr ""
 
-#: src/strings.ts:2661
+#: src/strings.ts:2660
 msgid "Password required"
 msgstr ""
 
@@ -4610,35 +4608,35 @@ msgstr ""
 msgid "Password updated"
 msgstr ""
 
-#: src/strings.ts:2092
+#: src/strings.ts:2091
 msgid "Password/pin"
 msgstr ""
 
-#: src/strings.ts:2260
+#: src/strings.ts:2259
 msgid "Paste"
 msgstr ""
 
-#: src/strings.ts:2261
+#: src/strings.ts:2260
 msgid "Paste and match style"
 msgstr ""
 
-#: src/strings.ts:2382
+#: src/strings.ts:2381
 msgid "Paste embed code here. Only iframes are supported."
 msgstr ""
 
-#: src/strings.ts:2397
+#: src/strings.ts:2396
 msgid "Paste image URL here"
 msgstr ""
 
-#: src/strings.ts:2262
+#: src/strings.ts:2261
 msgid "Paste without formatting"
 msgstr ""
 
-#: src/strings.ts:2573
+#: src/strings.ts:2572
 msgid "Pay once and use for 5 years"
 msgstr ""
 
-#: src/strings.ts:2210
+#: src/strings.ts:2209
 msgid "Payment method"
 msgstr ""
 
@@ -4646,27 +4644,27 @@ msgstr ""
 msgid "PDF is password protected"
 msgstr ""
 
-#: src/strings.ts:1730
+#: src/strings.ts:1729
 msgid "phone number"
 msgstr ""
 
-#: src/strings.ts:1849
+#: src/strings.ts:1848
 msgid "Phone number"
 msgstr ""
 
-#: src/strings.ts:1008
+#: src/strings.ts:1007
 msgid "Phone number not entered"
 msgstr ""
 
-#: src/strings.ts:901
+#: src/strings.ts:900
 msgid "Pin"
 msgstr ""
 
-#: src/strings.ts:1691
+#: src/strings.ts:1690
 msgid "Pin notes in notifications drawer"
 msgstr ""
 
-#: src/strings.ts:929
+#: src/strings.ts:928
 msgid "Pin notification"
 msgstr ""
 
@@ -4674,66 +4672,66 @@ msgstr ""
 msgid "Pinned"
 msgstr ""
 
-#: src/strings.ts:2594
+#: src/strings.ts:2593
 msgid "Plan limits"
 msgstr ""
 
-#: src/strings.ts:2554
+#: src/strings.ts:2553
 msgid "Plans"
 msgstr ""
 
-#: src/strings.ts:1365
+#: src/strings.ts:1364
 msgid "Please confirm your email to sync notes"
 msgstr ""
 
-#: src/strings.ts:1003
+#: src/strings.ts:1002
 msgid "Please confirm your identity by entering a recovery code."
 msgstr ""
 
-#: src/strings.ts:982
-#: src/strings.ts:2244
+#: src/strings.ts:981
+#: src/strings.ts:2243
 msgid "Please confirm your identity by entering the authentication code from your authenticator app."
 msgstr ""
 
 #. placeholder {0}: phoneNumber ? phoneNumber : "your registered phone number."
-#: src/strings.ts:997
+#: src/strings.ts:996
 msgid "Please confirm your identity by entering the authentication code sent to {0}."
 msgstr ""
 
-#: src/strings.ts:990
+#: src/strings.ts:989
 msgid "Please confirm your identity by entering the authentication code sent to your email address."
 msgstr ""
 
-#: src/strings.ts:1910
+#: src/strings.ts:1909
 msgid "Please download a backup of your data as your account will be cleared before recovery."
 msgstr ""
 
-#: src/strings.ts:2008
+#: src/strings.ts:2007
 msgid "Please enable automatic backups to avoid losing important data."
 msgstr ""
 
-#: src/strings.ts:1513
-#: src/strings.ts:2663
+#: src/strings.ts:1512
+#: src/strings.ts:2662
 msgid "Please enter a valid email address"
 msgstr ""
 
-#: src/strings.ts:1955
+#: src/strings.ts:1954
 msgid "Please enter a valid hex color (e.g. #ffffff)"
 msgstr ""
 
-#: src/strings.ts:1514
+#: src/strings.ts:1513
 msgid "Please enter a valid phone number with country code"
 msgstr ""
 
-#: src/strings.ts:1636
+#: src/strings.ts:1635
 msgid "Please enter a valid URL"
 msgstr ""
 
-#: src/strings.ts:1621
+#: src/strings.ts:1620
 msgid "Please enter password of this backup file"
 msgstr ""
 
-#: src/strings.ts:2255
+#: src/strings.ts:2254
 msgid "Please enter the password to decrypt and restore this backup."
 msgstr ""
 
@@ -4741,27 +4739,27 @@ msgstr ""
 msgid "Please enter the password to unlock the PDF and view the content."
 msgstr ""
 
-#: src/strings.ts:1866
+#: src/strings.ts:1865
 msgid "Please enter the password to unlock this note"
 msgstr ""
 
-#: src/strings.ts:1863
+#: src/strings.ts:1862
 msgid "Please enter the password to view this version"
 msgstr ""
 
-#: src/strings.ts:1022
+#: src/strings.ts:1021
 msgid "Please enter your app lock password to continue"
 msgstr ""
 
-#: src/strings.ts:1024
+#: src/strings.ts:1023
 msgid "Please enter your app lock pin to continue"
 msgstr ""
 
-#: src/strings.ts:1018
+#: src/strings.ts:1017
 msgid "Please enter your password to continue"
 msgstr ""
 
-#: src/strings.ts:1934
+#: src/strings.ts:1933
 msgid "Please enter your vault password to continue"
 msgstr ""
 
@@ -4769,15 +4767,15 @@ msgstr ""
 msgid "Please fill all the fields to continue."
 msgstr ""
 
-#: src/strings.ts:1557
+#: src/strings.ts:1556
 msgid "Please grant notifications permission to add new reminders."
 msgstr ""
 
-#: src/strings.ts:2678
+#: src/strings.ts:2677
 msgid "Please login to download attachments."
 msgstr ""
 
-#: src/strings.ts:874
+#: src/strings.ts:873
 msgid "Please make sure you have saved the recovery key. Tap one more time to confirm."
 msgstr ""
 
@@ -4785,27 +4783,27 @@ msgstr ""
 msgid "Please note that we will respond to your issue on the given link. We recommend that you save it."
 msgstr ""
 
-#: src/strings.ts:1766
+#: src/strings.ts:1765
 msgid "Please refer to the"
 msgstr ""
 
-#: src/strings.ts:1558
+#: src/strings.ts:1557
 msgid "Please select the day to repeat the reminder on"
 msgstr ""
 
-#: src/strings.ts:1397
+#: src/strings.ts:1396
 msgid "please send us an email from your registered email address"
 msgstr ""
 
-#: src/strings.ts:2403
+#: src/strings.ts:2402
 msgid "Please set a table size"
 msgstr ""
 
-#: src/strings.ts:1559
+#: src/strings.ts:1558
 msgid "Please set title of the reminder"
 msgstr ""
 
-#: src/strings.ts:1988
+#: src/strings.ts:1987
 msgid "Please try again"
 msgstr ""
 
@@ -4817,16 +4815,16 @@ msgstr ""
 msgid "Please wait"
 msgstr ""
 
-#: src/strings.ts:1007
+#: src/strings.ts:1006
 msgid "Please wait before requesting a new code"
 msgstr ""
 
-#: src/strings.ts:1400
-#: src/strings.ts:1552
+#: src/strings.ts:1399
+#: src/strings.ts:1551
 msgid "Please wait before requesting another email"
 msgstr ""
 
-#: src/strings.ts:943
+#: src/strings.ts:942
 msgid "Please wait while we encrypt {name} for upload."
 msgstr ""
 
@@ -4838,11 +4836,11 @@ msgstr ""
 msgid "Please wait while we export your notes."
 msgstr ""
 
-#: src/strings.ts:1895
+#: src/strings.ts:1894
 msgid "Please wait while we finalize your account."
 msgstr ""
 
-#: src/strings.ts:1066
+#: src/strings.ts:1065
 msgid "Please wait while we load your subscription"
 msgstr ""
 
@@ -4850,15 +4848,15 @@ msgstr ""
 msgid "Please wait while we log you out."
 msgstr ""
 
-#: src/strings.ts:1916
+#: src/strings.ts:1915
 msgid "Please wait while we reset your account password."
 msgstr ""
 
-#: src/strings.ts:1614
+#: src/strings.ts:1613
 msgid "Please wait while we restore your backup..."
 msgstr ""
 
-#: src/strings.ts:1898
+#: src/strings.ts:1897
 msgid "Please wait while we send you recovery instructions"
 msgstr ""
 
@@ -4866,24 +4864,24 @@ msgstr ""
 msgid "Please wait while we sync all your data."
 msgstr ""
 
-#: src/strings.ts:1072
+#: src/strings.ts:1071
 msgid "Please wait while we verify your subscription"
 msgstr ""
 
-#: src/strings.ts:1784
-#: src/strings.ts:1891
+#: src/strings.ts:1783
+#: src/strings.ts:1890
 msgid "Please wait while you are authenticated."
 msgstr ""
 
-#: src/strings.ts:1903
+#: src/strings.ts:1902
 msgid "Please wait while your data is downloaded & decrypted."
 msgstr ""
 
-#: src/strings.ts:906
+#: src/strings.ts:905
 msgid "Preparing note for share"
 msgstr ""
 
-#: src/strings.ts:1616
+#: src/strings.ts:1615
 msgid "Preparing to restore backup file..."
 msgstr ""
 
@@ -4891,19 +4889,19 @@ msgstr ""
 msgid "PRESETS"
 msgstr ""
 
-#: src/strings.ts:2130
+#: src/strings.ts:2129
 msgid "Pressing \"—\" will hide the app in your system tray."
 msgstr ""
 
-#: src/strings.ts:2133
+#: src/strings.ts:2132
 msgid "Pressing \"X\" will hide the app in your system tray."
 msgstr ""
 
-#: src/strings.ts:2181
+#: src/strings.ts:2180
 msgid "Prevent note title from appearing in tab/window title."
 msgstr ""
 
-#: src/strings.ts:2324
+#: src/strings.ts:2323
 msgid "Preview attachment"
 msgstr ""
 
@@ -4911,43 +4909,43 @@ msgstr ""
 msgid "Preview not available, content is encrypted."
 msgstr ""
 
-#: src/strings.ts:2391
+#: src/strings.ts:2390
 msgid "Previous match"
 msgstr ""
 
-#: src/strings.ts:2456
+#: src/strings.ts:2455
 msgid "Previous tab"
 msgstr ""
 
-#: src/strings.ts:2035
+#: src/strings.ts:2034
 msgid "Print"
 msgstr ""
 
-#: src/strings.ts:2155
+#: src/strings.ts:2154
 msgid "Privacy"
 msgstr ""
 
-#: src/strings.ts:1162
+#: src/strings.ts:1161
 msgid "Privacy & security"
 msgstr ""
 
-#: src/strings.ts:1656
+#: src/strings.ts:1655
 msgid "Privacy comes first."
 msgstr ""
 
-#: src/strings.ts:828
+#: src/strings.ts:827
 msgid "Privacy for everyone"
 msgstr ""
 
-#: src/strings.ts:1181
+#: src/strings.ts:1180
 msgid "Privacy mode"
 msgstr ""
 
-#: src/strings.ts:2589
+#: src/strings.ts:2588
 msgid "privacy policy"
 msgstr ""
 
-#: src/strings.ts:1286
+#: src/strings.ts:1285
 msgid "Privacy policy"
 msgstr ""
 
@@ -4959,43 +4957,43 @@ msgstr ""
 msgid "private analytics and bug reports."
 msgstr ""
 
-#: src/strings.ts:822
+#: src/strings.ts:821
 msgid "Private."
 msgstr ""
 
-#: src/strings.ts:830
+#: src/strings.ts:829
 msgid "privileged few"
 msgstr ""
 
-#: src/strings.ts:1722
+#: src/strings.ts:1721
 msgid "Pro"
 msgstr ""
 
-#: src/strings.ts:2481
+#: src/strings.ts:2480
 msgid "Pro plan"
 msgstr ""
 
-#: src/strings.ts:2048
+#: src/strings.ts:2047
 msgid "Processing {collection}..."
 msgstr ""
 
-#: src/strings.ts:2047
+#: src/strings.ts:2046
 msgid "Processing..."
 msgstr ""
 
-#: src/strings.ts:1241
+#: src/strings.ts:1240
 msgid "Productivity"
 msgstr ""
 
-#: src/strings.ts:2144
+#: src/strings.ts:2143
 msgid "Profile"
 msgstr ""
 
-#: src/strings.ts:1956
+#: src/strings.ts:1955
 msgid "Profile updated"
 msgstr ""
 
-#: src/strings.ts:1867
+#: src/strings.ts:1866
 msgid "Properties"
 msgstr ""
 
@@ -5003,7 +5001,7 @@ msgstr ""
 msgid "Protect your notes"
 msgstr ""
 
-#: src/strings.ts:2192
+#: src/strings.ts:2191
 msgid "Proxy"
 msgstr ""
 
@@ -5015,7 +5013,7 @@ msgstr ""
 msgid "Publish note"
 msgstr ""
 
-#: src/strings.ts:2628
+#: src/strings.ts:2627
 msgid "Publish to the web"
 msgstr ""
 
@@ -5023,7 +5021,7 @@ msgstr ""
 msgid "Publish your note to share it with others. You can set a password to protect it."
 msgstr ""
 
-#: src/strings.ts:927
+#: src/strings.ts:926
 msgid "Published"
 msgstr ""
 
@@ -5039,39 +5037,39 @@ msgstr ""
 msgid "Published note link will be automatically deleted once it is viewed by someone."
 msgstr ""
 
-#: src/strings.ts:2582
+#: src/strings.ts:2581
 msgid "Purchase"
 msgstr ""
 
-#: src/strings.ts:1372
+#: src/strings.ts:1371
 msgid "Quick note"
 msgstr ""
 
-#: src/strings.ts:1242
+#: src/strings.ts:1241
 msgid "Quick note notification"
 msgstr ""
 
-#: src/strings.ts:1693
+#: src/strings.ts:1692
 msgid "Quick note widgets"
 msgstr ""
 
-#: src/strings.ts:2452
+#: src/strings.ts:2451
 msgid "Quick open"
 msgstr ""
 
-#: src/strings.ts:1244
+#: src/strings.ts:1243
 msgid "Quickly create a note from the notification"
 msgstr ""
 
-#: src/strings.ts:2344
+#: src/strings.ts:2343
 msgid "Quote"
 msgstr ""
 
-#: src/strings.ts:1358
+#: src/strings.ts:1357
 msgid "Rate Notesnook on App Store"
 msgstr ""
 
-#: src/strings.ts:1359
+#: src/strings.ts:1358
 msgid "Rate Notesnook on Play Store"
 msgstr ""
 
@@ -5083,51 +5081,51 @@ msgstr ""
 msgid "Read full release notes on Github"
 msgstr ""
 
-#: src/strings.ts:913
+#: src/strings.ts:912
 msgid "Read only"
 msgstr ""
 
-#: src/strings.ts:1266
+#: src/strings.ts:1265
 msgid "Read the documentation to learn more about Notesnook"
 msgstr ""
 
-#: src/strings.ts:1287
+#: src/strings.ts:1286
 msgid "Read the privacy policy"
 msgstr ""
 
-#: src/strings.ts:1285
+#: src/strings.ts:1284
 msgid "Read the terms of service"
 msgstr ""
 
-#: src/strings.ts:1617
+#: src/strings.ts:1616
 msgid "Reading backup file..."
 msgstr ""
 
-#: src/strings.ts:2556
+#: src/strings.ts:2555
 msgid "Ready to take the next step on your private note taking journey?"
 msgstr ""
 
-#: src/strings.ts:2234
+#: src/strings.ts:2233
 msgid "Receipt"
 msgstr ""
 
-#: src/strings.ts:1612
+#: src/strings.ts:1611
 msgid "RECENT BACKUPS"
 msgstr ""
 
-#: src/strings.ts:2467
+#: src/strings.ts:2466
 msgid "Recents"
 msgstr ""
 
-#: src/strings.ts:2410
+#: src/strings.ts:2409
 msgid "Recheck all"
 msgstr ""
 
-#: src/strings.ts:2002
+#: src/strings.ts:2001
 msgid "Rechecking failed"
 msgstr ""
 
-#: src/strings.ts:2435
+#: src/strings.ts:2434
 msgid "Recipes"
 msgstr ""
 
@@ -5135,7 +5133,7 @@ msgstr ""
 msgid "Recommended"
 msgstr ""
 
-#: src/strings.ts:2558
+#: src/strings.ts:2557
 msgid "Recommended by Privacy Guides"
 msgstr ""
 
@@ -5143,11 +5141,11 @@ msgstr ""
 msgid "Recover your account"
 msgstr ""
 
-#: src/strings.ts:1006
+#: src/strings.ts:1005
 msgid "Recovery codes copied!"
 msgstr ""
 
-#: src/strings.ts:1011
+#: src/strings.ts:1010
 msgid "Recovery codes saved!"
 msgstr ""
 
@@ -5159,35 +5157,35 @@ msgstr ""
 msgid "Recovery email sent!"
 msgstr ""
 
-#: src/strings.ts:877
+#: src/strings.ts:876
 msgid "Recovery key copied"
 msgstr ""
 
-#: src/strings.ts:875
+#: src/strings.ts:874
 msgid "Recovery key QR code saved"
 msgstr ""
 
-#: src/strings.ts:876
+#: src/strings.ts:875
 msgid "Recovery key text file saved"
 msgstr ""
 
-#: src/strings.ts:1917
+#: src/strings.ts:1916
 msgid "Recovery successful!"
 msgstr ""
 
-#: src/strings.ts:2447
+#: src/strings.ts:2446
 msgid "Redeem"
 msgstr ""
 
-#: src/strings.ts:2611
+#: src/strings.ts:2610
 msgid "Redeem code"
 msgstr ""
 
-#: src/strings.ts:2444
+#: src/strings.ts:2443
 msgid "Redeem gift code"
 msgstr ""
 
-#: src/strings.ts:2446
+#: src/strings.ts:2445
 msgid "Redeeming gift code"
 msgstr ""
 
@@ -5199,7 +5197,7 @@ msgstr ""
 msgid "Referenced in"
 msgstr ""
 
-#: src/strings.ts:936
+#: src/strings.ts:935
 msgid "References"
 msgstr ""
 
@@ -5207,7 +5205,7 @@ msgstr ""
 msgid "Regenerate"
 msgstr ""
 
-#: src/strings.ts:2098
+#: src/strings.ts:2097
 msgid "Register"
 msgstr ""
 
@@ -5215,7 +5213,7 @@ msgstr ""
 msgid "Release notes"
 msgstr ""
 
-#: src/strings.ts:2469
+#: src/strings.ts:2468
 msgid "Release track"
 msgstr ""
 
@@ -5223,19 +5221,19 @@ msgstr ""
 msgid "Relevance"
 msgstr ""
 
-#: src/strings.ts:1671
+#: src/strings.ts:1670
 msgid "Reload app"
 msgstr ""
 
-#: src/strings.ts:1829
+#: src/strings.ts:1828
 msgid "Relogin to your account"
 msgstr ""
 
-#: src/strings.ts:1797
+#: src/strings.ts:1796
 msgid "Remembered your password?"
 msgstr ""
 
-#: src/strings.ts:926
+#: src/strings.ts:925
 msgid "Remind me"
 msgstr ""
 
@@ -5243,7 +5241,7 @@ msgstr ""
 msgid "Remind me in"
 msgstr ""
 
-#: src/strings.ts:1507
+#: src/strings.ts:1506
 msgid "Remind me of..."
 msgstr ""
 
@@ -5255,11 +5253,11 @@ msgstr ""
 msgid "Reminder"
 msgstr ""
 
-#: src/strings.ts:1247
+#: src/strings.ts:1246
 msgid "Reminder notifications"
 msgstr ""
 
-#: src/strings.ts:1560
+#: src/strings.ts:1559
 msgid "Reminder time cannot be earlier than the current time."
 msgstr ""
 
@@ -5268,16 +5266,16 @@ msgid "reminders"
 msgstr ""
 
 #: src/strings.ts:318
-#: src/strings.ts:1245
-#: src/strings.ts:1523
+#: src/strings.ts:1244
+#: src/strings.ts:1522
 msgid "Reminders"
 msgstr ""
 
-#: src/strings.ts:1380
+#: src/strings.ts:1379
 msgid "Reminders cannot be set because notifications have been disabled from app settings. If you want to keep receiving reminder notifications, enable notifications for Notesnook from app settings."
 msgstr ""
 
-#: src/strings.ts:1954
+#: src/strings.ts:1953
 msgid "Reminders will not be active on this device as it does not support notifications."
 msgstr ""
 
@@ -5285,63 +5283,63 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: src/strings.ts:1176
+#: src/strings.ts:1175
 msgid "Remove all notes from the vault."
 msgstr ""
 
-#: src/strings.ts:1203
+#: src/strings.ts:1202
 msgid "Remove app lock password"
 msgstr ""
 
-#: src/strings.ts:1207
+#: src/strings.ts:1206
 msgid "Remove app lock password, app lock will be disabled if no other security method is enabled."
 msgstr ""
 
-#: src/strings.ts:1202
+#: src/strings.ts:1201
 msgid "Remove app lock pin"
 msgstr ""
 
-#: src/strings.ts:1205
+#: src/strings.ts:1204
 msgid "Remove app lock pin, app lock will be disabled if no other security method is enabled."
 msgstr ""
 
-#: src/strings.ts:897
+#: src/strings.ts:896
 msgid "Remove as default"
 msgstr ""
 
-#: src/strings.ts:2328
+#: src/strings.ts:2327
 msgid "Remove attachment"
 msgstr ""
 
-#: src/strings.ts:932
+#: src/strings.ts:931
 msgid "Remove from all"
 msgstr ""
 
-#: src/strings.ts:907
+#: src/strings.ts:906
 msgid "Remove from notebook"
 msgstr ""
 
-#: src/strings.ts:2468
+#: src/strings.ts:2467
 msgid "Remove from recents"
 msgstr ""
 
-#: src/strings.ts:1045
+#: src/strings.ts:1044
 msgid "Remove full name"
 msgstr ""
 
-#: src/strings.ts:2275
+#: src/strings.ts:2274
 msgid "Remove link"
 msgstr ""
 
-#: src/strings.ts:1041
+#: src/strings.ts:1040
 msgid "Remove profile picture"
 msgstr ""
 
-#: src/strings.ts:1048
+#: src/strings.ts:1047
 msgid "Remove your full name from profile"
 msgstr ""
 
-#: src/strings.ts:1042
+#: src/strings.ts:1041
 msgid "Remove your profile picture"
 msgstr ""
 
@@ -5353,7 +5351,7 @@ msgstr ""
 msgid "Rename file"
 msgstr ""
 
-#: src/strings.ts:892
+#: src/strings.ts:891
 msgid "Reorder"
 msgstr ""
 
@@ -5361,19 +5359,19 @@ msgstr ""
 msgid "Repeats daily at {date}"
 msgstr ""
 
-#: src/strings.ts:2388
+#: src/strings.ts:2387
 msgid "Replace"
 msgstr ""
 
-#: src/strings.ts:2389
+#: src/strings.ts:2388
 msgid "Replace all"
 msgstr ""
 
-#: src/strings.ts:2175
+#: src/strings.ts:2174
 msgid "Report"
 msgstr ""
 
-#: src/strings.ts:1258
+#: src/strings.ts:1257
 msgid "Report an issue"
 msgstr ""
 
@@ -5390,59 +5388,59 @@ msgstr ""
 msgid "Resend code{0}"
 msgstr ""
 
-#: src/strings.ts:1403
+#: src/strings.ts:1402
 msgid "Resend email"
 msgstr ""
 
-#: src/strings.ts:1821
+#: src/strings.ts:1820
 msgid "Reset"
 msgstr ""
 
-#: src/strings.ts:1913
+#: src/strings.ts:1912
 msgid "Reset account password"
 msgstr ""
 
-#: src/strings.ts:2495
+#: src/strings.ts:2494
 msgid "Reset homepage"
 msgstr ""
 
-#: src/strings.ts:1822
+#: src/strings.ts:1821
 msgid "Reset selection"
 msgstr ""
 
-#: src/strings.ts:1649
+#: src/strings.ts:1648
 msgid "Reset server urls"
 msgstr ""
 
-#: src/strings.ts:2031
+#: src/strings.ts:2030
 msgid "Reset sidebar"
 msgstr ""
 
-#: src/strings.ts:1148
+#: src/strings.ts:1147
 msgid "Reset the toolbar to default settings"
 msgstr ""
 
-#: src/strings.ts:1147
+#: src/strings.ts:1146
 msgid "Reset toolbar"
 msgstr ""
 
-#: src/strings.ts:1915
+#: src/strings.ts:1914
 msgid "Resetting account password ({progress})"
 msgstr ""
 
-#: src/strings.ts:1990
+#: src/strings.ts:1989
 msgid "Restart now"
 msgstr ""
 
-#: src/strings.ts:1648
+#: src/strings.ts:1647
 msgid "Restart the app for changes to take effect."
 msgstr ""
 
-#: src/strings.ts:1319
+#: src/strings.ts:1318
 msgid "Restart the app to apply the changes"
 msgstr ""
 
-#: src/strings.ts:1594
+#: src/strings.ts:1593
 msgid "Restart the app."
 msgstr ""
 
@@ -5450,31 +5448,31 @@ msgstr ""
 msgid "Restore"
 msgstr ""
 
-#: src/strings.ts:1236
+#: src/strings.ts:1235
 msgid "Restore backup"
 msgstr ""
 
-#: src/strings.ts:2417
+#: src/strings.ts:2416
 msgid "Restore backup?"
 msgstr ""
 
-#: src/strings.ts:891
+#: src/strings.ts:890
 msgid "Restore failed"
 msgstr ""
 
-#: src/strings.ts:1611
+#: src/strings.ts:1610
 msgid "Restore from files"
 msgstr ""
 
-#: src/strings.ts:1661
+#: src/strings.ts:1660
 msgid "Restore this version"
 msgstr ""
 
-#: src/strings.ts:1237
+#: src/strings.ts:1236
 msgid "Restore your data from a backup"
 msgstr ""
 
-#: src/strings.ts:850
+#: src/strings.ts:849
 msgid "Restored successfully"
 msgstr ""
 
@@ -5486,7 +5484,7 @@ msgstr ""
 msgid "Restoring {collection}..."
 msgstr ""
 
-#: src/strings.ts:1613
+#: src/strings.ts:1612
 msgid "Restoring backup..."
 msgstr ""
 
@@ -5502,7 +5500,7 @@ msgstr ""
 msgid "Reupload"
 msgstr ""
 
-#: src/strings.ts:2021
+#: src/strings.ts:2020
 msgid "Reveal in list"
 msgstr ""
 
@@ -5510,7 +5508,7 @@ msgstr ""
 msgid "Revoke"
 msgstr ""
 
-#: src/strings.ts:1180
+#: src/strings.ts:1179
 msgid "Revoke biometric unlocking"
 msgstr ""
 
@@ -5518,23 +5516,23 @@ msgstr ""
 msgid "Revoke vault fingerprint unlock"
 msgstr ""
 
-#: src/strings.ts:1294
+#: src/strings.ts:1293
 msgid "Roadmap"
 msgstr ""
 
-#: src/strings.ts:2049
+#: src/strings.ts:2048
 msgid "Root"
 msgstr ""
 
-#: src/strings.ts:2028
+#: src/strings.ts:2027
 msgid "Rotate left"
 msgstr ""
 
-#: src/strings.ts:2029
+#: src/strings.ts:2028
 msgid "Rotate right"
 msgstr ""
 
-#: src/strings.ts:2298
+#: src/strings.ts:2297
 msgid "Row properties"
 msgstr ""
 
@@ -5542,7 +5540,7 @@ msgstr ""
 msgid "Run file check"
 msgstr ""
 
-#: src/strings.ts:2070
+#: src/strings.ts:2069
 msgid "Safe & encrypted notes"
 msgstr ""
 
@@ -5574,11 +5572,11 @@ msgstr ""
 msgid "Save and continue"
 msgstr ""
 
-#: src/strings.ts:1049
+#: src/strings.ts:1048
 msgid "Save data recovery key"
 msgstr ""
 
-#: src/strings.ts:954
+#: src/strings.ts:953
 msgid "Save failed. Vault is locked"
 msgstr ""
 
@@ -5598,7 +5596,7 @@ msgstr ""
 msgid "Save to text file"
 msgstr ""
 
-#: src/strings.ts:1361
+#: src/strings.ts:1360
 msgid "Save your account recovery key"
 msgstr ""
 
@@ -5606,7 +5604,7 @@ msgstr ""
 msgid "Save your account recovery key in a safe place. You will need it to recover your account in case you forget your password."
 msgstr ""
 
-#: src/strings.ts:1051
+#: src/strings.ts:1050
 msgid "Save your data recovery key in a safe place. You will need it to recover your data in case you forget your password."
 msgstr ""
 
@@ -5614,15 +5612,15 @@ msgstr ""
 msgid "Save your recovery codes in a safe place. You will need them to recover your account in case you lose access to your two-factor authentication methods."
 msgstr ""
 
-#: src/strings.ts:2407
+#: src/strings.ts:2406
 msgid "Saved"
 msgstr ""
 
-#: src/strings.ts:2408
+#: src/strings.ts:2407
 msgid "Saving"
 msgstr ""
 
-#: src/strings.ts:1589
+#: src/strings.ts:1588
 msgid "Saving this note is taking too long. Copy your changes and restart the app to prevent data loss. If the problem persists, please report it to us at support@streetwriters.co."
 msgstr ""
 
@@ -5634,40 +5632,40 @@ msgstr ""
 msgid "Saving zip file. Please wait..."
 msgstr ""
 
-#: src/strings.ts:1723
+#: src/strings.ts:1722
 msgid "Scan the QR code with your authenticator app"
 msgstr ""
 
-#: src/strings.ts:2433
+#: src/strings.ts:2432
 msgid "School work"
 msgstr ""
 
-#: src/strings.ts:2506
+#: src/strings.ts:2505
 msgid "Scroll to bottom"
 msgstr ""
 
-#: src/strings.ts:2505
+#: src/strings.ts:2504
 msgid "Scroll to top"
 msgstr ""
 
-#: src/strings.ts:1511
-#: src/strings.ts:1529
+#: src/strings.ts:1510
+#: src/strings.ts:1528
 msgid "Search"
 msgstr ""
 
-#: src/strings.ts:1506
+#: src/strings.ts:1505
 msgid "Search a note"
 msgstr ""
 
-#: src/strings.ts:1504
+#: src/strings.ts:1503
 msgid "Search a note to link to"
 msgstr ""
 
-#: src/strings.ts:2449
+#: src/strings.ts:2448
 msgid "Search for notes, notebooks, and tags..."
 msgstr ""
 
-#: src/strings.ts:1539
+#: src/strings.ts:1538
 msgid "Search in {routeName}"
 msgstr ""
 
@@ -5719,67 +5717,67 @@ msgstr ""
 msgid "Search in Trash"
 msgstr ""
 
-#: src/strings.ts:2370
+#: src/strings.ts:2369
 msgid "Search languages"
 msgstr ""
 
-#: src/strings.ts:1492
+#: src/strings.ts:1491
 msgid "Search notebooks"
 msgstr ""
 
-#: src/strings.ts:1505
+#: src/strings.ts:1504
 msgid "Search or add a tag"
 msgstr ""
 
-#: src/strings.ts:1835
+#: src/strings.ts:1834
 msgid "Search themes"
 msgstr ""
 
-#: src/strings.ts:1509
+#: src/strings.ts:1508
 msgid "Searching for {query}..."
 msgstr ""
 
-#: src/strings.ts:879
+#: src/strings.ts:878
 msgid "sec"
 msgstr ""
 
-#: src/strings.ts:2154
+#: src/strings.ts:2153
 msgid "Security & privacy"
 msgstr ""
 
-#: src/strings.ts:2094
+#: src/strings.ts:2093
 msgid "Security key"
 msgstr ""
 
-#: src/strings.ts:1989
+#: src/strings.ts:1988
 msgid "Security key successfully registered."
 msgstr ""
 
-#: src/strings.ts:1295
+#: src/strings.ts:1294
 msgid "See what the future of Notesnook is going to be like."
 msgstr ""
 
-#: src/strings.ts:1335
+#: src/strings.ts:1334
 msgid "Select"
 msgstr ""
 
-#: src/strings.ts:1610
+#: src/strings.ts:1609
 msgid "Select a backup file from your device to restore backup"
 msgstr ""
 
-#: src/strings.ts:2500
+#: src/strings.ts:2499
 msgid "Select a notebook to move this notebook into, or unselect to move it to the root level."
 msgstr ""
 
-#: src/strings.ts:2109
+#: src/strings.ts:2108
 msgid "Select a theme"
 msgstr ""
 
-#: src/strings.ts:1227
+#: src/strings.ts:1226
 msgid "Select backup directory"
 msgstr ""
 
-#: src/strings.ts:1856
+#: src/strings.ts:1855
 msgid "Select backup file"
 msgstr ""
 
@@ -5795,15 +5793,15 @@ msgstr ""
 msgid "Select day of the week to repeat the reminder."
 msgstr ""
 
-#: src/strings.ts:1764
+#: src/strings.ts:1763
 msgid "Select files to import"
 msgstr ""
 
-#: src/strings.ts:1607
+#: src/strings.ts:1606
 msgid "Select folder where Notesnook backup files are stored to view and restore them from the app"
 msgstr ""
 
-#: src/strings.ts:1608
+#: src/strings.ts:1607
 msgid "Select folder with backup files"
 msgstr ""
 
@@ -5811,7 +5809,7 @@ msgstr ""
 msgid "Select how you would like to recieve the code"
 msgstr ""
 
-#: src/strings.ts:2365
+#: src/strings.ts:2364
 msgid "Select language"
 msgstr ""
 
@@ -5827,7 +5825,7 @@ msgstr ""
 msgid "Select notebooks you want to add note(s) to."
 msgstr ""
 
-#: src/strings.ts:2488
+#: src/strings.ts:2487
 msgid "Select notes to link to \"{title}\""
 msgstr ""
 
@@ -5835,11 +5833,11 @@ msgstr ""
 msgid "Select nth day of the month to repeat the reminder."
 msgstr ""
 
-#: src/strings.ts:1818
+#: src/strings.ts:1817
 msgid "Select profile picture"
 msgstr ""
 
-#: src/strings.ts:2494
+#: src/strings.ts:2493
 msgid "Select the default sidebar tab"
 msgstr ""
 
@@ -5847,11 +5845,11 @@ msgstr ""
 msgid "Select the folder that includes your backup files to list them here."
 msgstr ""
 
-#: src/strings.ts:2141
+#: src/strings.ts:2140
 msgid "Select the languages the spell checker should check in."
 msgstr ""
 
-#: src/strings.ts:2470
+#: src/strings.ts:2469
 msgid "Select the release track for Notesnook."
 msgstr ""
 
@@ -5863,7 +5861,7 @@ msgstr ""
 msgid "Self destruct"
 msgstr ""
 
-#: src/strings.ts:2176
+#: src/strings.ts:2175
 msgid "Send"
 msgstr ""
 
@@ -5879,47 +5877,47 @@ msgstr ""
 msgid "Send code via SMS"
 msgstr ""
 
-#: src/strings.ts:1860
+#: src/strings.ts:1859
 msgid "Send recovery email"
 msgstr ""
 
-#: src/strings.ts:1896
+#: src/strings.ts:1895
 msgid "Sending recovery email"
 msgstr ""
 
-#: src/strings.ts:1647
+#: src/strings.ts:1646
 msgid "Server url changed"
 msgstr ""
 
-#: src/strings.ts:1650
+#: src/strings.ts:1649
 msgid "Server urls reset"
 msgstr ""
 
-#: src/strings.ts:1628
+#: src/strings.ts:1627
 msgid "Server used for login/sign up and authentication."
 msgstr ""
 
-#: src/strings.ts:1633
+#: src/strings.ts:1632
 msgid "Server used to host your published notes."
 msgstr ""
 
-#: src/strings.ts:1631
+#: src/strings.ts:1630
 msgid "Server used to receive important notifications & events."
 msgstr ""
 
-#: src/strings.ts:1626
+#: src/strings.ts:1625
 msgid "Server used to sync your notes & other data between devices."
 msgstr ""
 
-#: src/strings.ts:1639
+#: src/strings.ts:1638
 msgid "Server with host {host} not found."
 msgstr ""
 
-#: src/strings.ts:2149
+#: src/strings.ts:2148
 msgid "Servers"
 msgstr ""
 
-#: src/strings.ts:2150
+#: src/strings.ts:2149
 msgid "Servers configuration"
 msgstr ""
 
@@ -5927,11 +5925,11 @@ msgstr ""
 msgid "Session expired"
 msgstr ""
 
-#: src/strings.ts:2202
+#: src/strings.ts:2201
 msgid "Sessions"
 msgstr ""
 
-#: src/strings.ts:977
+#: src/strings.ts:976
 msgid "Set a reminder"
 msgstr ""
 
@@ -5939,11 +5937,11 @@ msgstr ""
 msgid "Set as dark theme"
 msgstr ""
 
-#: src/strings.ts:898
+#: src/strings.ts:897
 msgid "Set as default"
 msgstr ""
 
-#: src/strings.ts:2492
+#: src/strings.ts:2491
 msgid "Set as homepage"
 msgstr ""
 
@@ -5951,31 +5949,31 @@ msgstr ""
 msgid "Set as light theme"
 msgstr ""
 
-#: src/strings.ts:1334
+#: src/strings.ts:1333
 msgid "Set automatic trash cleanup interval from Settings > Behaviour > Clean trash interval."
 msgstr ""
 
-#: src/strings.ts:2645
+#: src/strings.ts:2644
 msgid "Set expiry"
 msgstr ""
 
-#: src/strings.ts:1311
+#: src/strings.ts:1310
 msgid "Set full name"
 msgstr ""
 
-#: src/strings.ts:1253
+#: src/strings.ts:1252
 msgid "Set snooze time in minutes"
 msgstr ""
 
-#: src/strings.ts:1252
+#: src/strings.ts:1251
 msgid "Set the default time to snooze a reminder to when you press the snooze button on a notification."
 msgstr ""
 
-#: src/strings.ts:1224
+#: src/strings.ts:1223
 msgid "Set the interval to create a backup (with attachments) automatically."
 msgstr ""
 
-#: src/strings.ts:1221
+#: src/strings.ts:1220
 msgid "Set the interval to create a partial backup (without attachments) automatically."
 msgstr ""
 
@@ -5984,24 +5982,24 @@ msgid "Set your name"
 msgstr ""
 
 #: src/strings.ts:387
-#: src/strings.ts:1525
+#: src/strings.ts:1524
 msgid "Settings"
 msgstr ""
 
+#: src/strings.ts:1199
 #: src/strings.ts:1200
-#: src/strings.ts:1201
 msgid "Setup a new password for app lock"
 msgstr ""
 
-#: src/strings.ts:1197
+#: src/strings.ts:1196
 msgid "Setup a password to lock the app"
 msgstr ""
 
-#: src/strings.ts:1195
+#: src/strings.ts:1194
 msgid "Setup a pin to lock the app"
 msgstr ""
 
-#: src/strings.ts:2194
+#: src/strings.ts:2193
 msgid ""
 "Setup an HTTP/HTTPS/SOCKS proxy.\n"
 "\n"
@@ -6013,11 +6011,11 @@ msgid ""
 "To remove the proxy, simply erase everything in the input."
 msgstr ""
 
-#: src/strings.ts:1196
+#: src/strings.ts:1195
 msgid "Setup app lock password"
 msgstr ""
 
-#: src/strings.ts:1194
+#: src/strings.ts:1193
 msgid "Setup app lock pin"
 msgstr ""
 
@@ -6025,15 +6023,15 @@ msgstr ""
 msgid "Setup secondary 2FA method"
 msgstr ""
 
-#: src/strings.ts:979
+#: src/strings.ts:978
 msgid "Setup using an Authenticator app"
 msgstr ""
 
-#: src/strings.ts:986
+#: src/strings.ts:985
 msgid "Setup using email"
 msgstr ""
 
-#: src/strings.ts:993
+#: src/strings.ts:992
 msgid "Setup using SMS"
 msgstr ""
 
@@ -6041,11 +6039,11 @@ msgstr ""
 msgid "Share"
 msgstr ""
 
-#: src/strings.ts:1692
+#: src/strings.ts:1691
 msgid "Share & append to notes from anywhere"
 msgstr ""
 
-#: src/strings.ts:1342
+#: src/strings.ts:1341
 msgid "Share backup"
 msgstr ""
 
@@ -6053,7 +6051,7 @@ msgstr ""
 msgid "Share note"
 msgstr ""
 
-#: src/strings.ts:1788
+#: src/strings.ts:1787
 msgid "Share Notesnook with friends!"
 msgstr ""
 
@@ -6069,7 +6067,7 @@ msgstr ""
 msgid "Shortcut"
 msgstr ""
 
-#: src/strings.ts:2001
+#: src/strings.ts:2000
 msgid "Shortcut removed"
 msgstr ""
 
@@ -6085,7 +6083,7 @@ msgstr ""
 msgid "Sign up"
 msgstr ""
 
-#: src/strings.ts:1031
+#: src/strings.ts:1030
 msgid "Signed up on {date}"
 msgstr ""
 
@@ -6097,11 +6095,11 @@ msgstr ""
 msgid "Silent"
 msgstr ""
 
-#: src/strings.ts:2339
+#: src/strings.ts:2338
 msgid "Sink list item"
 msgstr ""
 
-#: src/strings.ts:2042
+#: src/strings.ts:2041
 msgid "Size"
 msgstr ""
 
@@ -6109,7 +6107,7 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: src/strings.ts:1830
+#: src/strings.ts:1829
 msgid "Skip & go directly to the app"
 msgstr ""
 
@@ -6117,19 +6115,19 @@ msgstr ""
 msgid "Skip introduction"
 msgstr ""
 
-#: src/strings.ts:1605
+#: src/strings.ts:1604
 msgid "Some exported notes are locked, Unlock to export them"
 msgstr ""
 
-#: src/strings.ts:1477
+#: src/strings.ts:1476
 msgid "Some notes are published"
 msgstr ""
 
-#: src/strings.ts:1667
+#: src/strings.ts:1666
 msgid "Something went wrong"
 msgstr ""
 
-#: src/strings.ts:2026
+#: src/strings.ts:2025
 msgid "Sort"
 msgstr ""
 
@@ -6137,55 +6135,55 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: src/strings.ts:2160
+#: src/strings.ts:2159
 msgid "Source code"
 msgstr ""
 
-#: src/strings.ts:2366
+#: src/strings.ts:2365
 msgid "Spaces"
 msgstr ""
 
-#: src/strings.ts:2604
+#: src/strings.ts:2603
 msgid "Special Offer"
 msgstr ""
 
-#: src/strings.ts:2137
+#: src/strings.ts:2136
 msgid "Spell check"
 msgstr ""
 
-#: src/strings.ts:2305
+#: src/strings.ts:2304
 msgid "Split cells"
 msgstr ""
 
-#: src/strings.ts:2471
+#: src/strings.ts:2470
 msgid "Stable"
 msgstr ""
 
-#: src/strings.ts:1113
+#: src/strings.ts:1112
 msgid "Start"
 msgstr ""
 
-#: src/strings.ts:1831
+#: src/strings.ts:1830
 msgid "Start account recovery"
 msgstr ""
 
-#: src/strings.ts:1826
+#: src/strings.ts:1825
 msgid "Start import"
 msgstr ""
 
-#: src/strings.ts:1823
+#: src/strings.ts:1822
 msgid "Start importing now"
 msgstr ""
 
-#: src/strings.ts:2125
+#: src/strings.ts:2124
 msgid "Start minimized"
 msgstr ""
 
-#: src/strings.ts:1758
+#: src/strings.ts:1757
 msgid "Start over"
 msgstr ""
 
-#: src/strings.ts:951
+#: src/strings.ts:950
 msgid "Start writing to create a new note"
 msgstr ""
 
@@ -6193,31 +6191,31 @@ msgstr ""
 msgid "Start writing to save your note."
 msgstr ""
 
-#: src/strings.ts:1602
+#: src/strings.ts:1601
 msgid "Start writing your note..."
 msgstr ""
 
-#: src/strings.ts:2233
+#: src/strings.ts:2232
 msgid "Status"
 msgstr ""
 
-#: src/strings.ts:2484
+#: src/strings.ts:2483
 msgid "Storage"
 msgstr ""
 
-#: src/strings.ts:1549
+#: src/strings.ts:1548
 msgid "Streaming not supported"
 msgstr ""
 
-#: src/strings.ts:2271
+#: src/strings.ts:2270
 msgid "Strikethrough"
 msgstr ""
 
-#: src/strings.ts:2235
+#: src/strings.ts:2234
 msgid "Subgroup 1"
 msgstr ""
 
-#: src/strings.ts:1995
+#: src/strings.ts:1994
 msgid "Subgroup added"
 msgstr ""
 
@@ -6225,15 +6223,15 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: src/strings.ts:2583
+#: src/strings.ts:2582
 msgid "Subscribe"
 msgstr ""
 
-#: src/strings.ts:2584
+#: src/strings.ts:2583
 msgid "Subscribe and start free trial"
 msgstr ""
 
-#: src/strings.ts:1026
+#: src/strings.ts:1025
 msgid "Subscribe to Pro"
 msgstr ""
 
@@ -6245,7 +6243,7 @@ msgstr ""
 msgid "Subscribed on iOS"
 msgstr ""
 
-#: src/strings.ts:1306
+#: src/strings.ts:1305
 msgid "Subscribed on web"
 msgstr ""
 
@@ -6257,7 +6255,7 @@ msgstr ""
 msgid "Subscribed using gift card"
 msgstr ""
 
-#: src/strings.ts:2282
+#: src/strings.ts:2281
 msgid "Subscript"
 msgstr ""
 
@@ -6265,11 +6263,11 @@ msgstr ""
 msgid "Subscription awarded from Streetwriters"
 msgstr ""
 
-#: src/strings.ts:1030
+#: src/strings.ts:1029
 msgid "Subscription details"
 msgstr ""
 
-#: src/strings.ts:1064
+#: src/strings.ts:1063
 msgid "Subscription not activated?"
 msgstr ""
 
@@ -6281,15 +6279,15 @@ msgstr ""
 msgid "Sunday"
 msgstr ""
 
-#: src/strings.ts:2283
+#: src/strings.ts:2282
 msgid "Superscript"
 msgstr ""
 
-#: src/strings.ts:1470
+#: src/strings.ts:1469
 msgid "Switch to search/replace mode"
 msgstr ""
 
-#: src/strings.ts:2146
+#: src/strings.ts:2145
 msgid "Sync"
 msgstr ""
 
@@ -6297,7 +6295,7 @@ msgstr ""
 msgid "Sync failed"
 msgstr ""
 
-#: src/strings.ts:1364
+#: src/strings.ts:1363
 msgid "Sync is disabled"
 msgstr ""
 
@@ -6305,19 +6303,19 @@ msgstr ""
 msgid "Sync now"
 msgstr ""
 
-#: src/strings.ts:914
+#: src/strings.ts:913
 msgid "Sync off"
 msgstr ""
 
-#: src/strings.ts:1624
+#: src/strings.ts:1623
 msgid "Sync server"
 msgstr ""
 
-#: src/strings.ts:1083
+#: src/strings.ts:1082
 msgid "Sync settings"
 msgstr ""
 
-#: src/strings.ts:1096
+#: src/strings.ts:1095
 msgid "Sync your notes in the background even when the app is closed. This is an experimental feature. If you face any issues, please turn it off."
 msgstr ""
 
@@ -6333,11 +6331,11 @@ msgstr ""
 msgid "Syncing your data"
 msgstr ""
 
-#: src/strings.ts:1703
+#: src/strings.ts:1702
 msgid "Syncing your notes"
 msgstr ""
 
-#: src/strings.ts:2351
+#: src/strings.ts:2350
 msgid "Table"
 msgstr ""
 
@@ -6345,11 +6343,11 @@ msgstr ""
 msgid "Table of contents"
 msgstr ""
 
-#: src/strings.ts:2296
+#: src/strings.ts:2295
 msgid "Table settings"
 msgstr ""
 
-#: src/strings.ts:2545
+#: src/strings.ts:2544
 msgid "tables, outlines, block level note linking"
 msgstr ""
 
@@ -6370,31 +6368,31 @@ msgid "tags"
 msgstr ""
 
 #: src/strings.ts:317
-#: src/strings.ts:1526
+#: src/strings.ts:1525
 msgid "Tags"
 msgstr ""
 
-#: src/strings.ts:1544
+#: src/strings.ts:1543
 msgid "Take a backup before logging out"
 msgstr ""
 
-#: src/strings.ts:1216
+#: src/strings.ts:1215
 msgid "Take a full backup of your data with all attachments"
 msgstr ""
 
-#: src/strings.ts:1218
+#: src/strings.ts:1217
 msgid "Take a partial backup of your data that does not include attachments"
 msgstr ""
 
-#: src/strings.ts:2350
+#: src/strings.ts:2349
 msgid "Take a photo using camera"
 msgstr ""
 
-#: src/strings.ts:1374
+#: src/strings.ts:1373
 msgid "Take note"
 msgstr ""
 
-#: src/strings.ts:1657
+#: src/strings.ts:1656
 msgid "Take notes privately."
 msgstr ""
 
@@ -6402,23 +6400,23 @@ msgstr ""
 msgid "Taking too long? Reload editor"
 msgstr ""
 
-#: src/strings.ts:1458
+#: src/strings.ts:1457
 msgid "Tap here to change sorting"
 msgstr ""
 
-#: src/strings.ts:1462
+#: src/strings.ts:1461
 msgid "Tap here to jump to a section"
 msgstr ""
 
-#: src/strings.ts:1370
+#: src/strings.ts:1369
 msgid "Tap here to update to the latest version"
 msgstr ""
 
-#: src/strings.ts:1593
+#: src/strings.ts:1592
 msgid "Tap on \"Dismiss\" and copy the contents of your note so they are not lost."
 msgstr ""
 
-#: src/strings.ts:1373
+#: src/strings.ts:1372
 msgid "Tap on \"Take note\" to add a note."
 msgstr ""
 
@@ -6438,7 +6436,7 @@ msgstr ""
 msgid "Tap to stop reordering"
 msgstr ""
 
-#: src/strings.ts:1354
+#: src/strings.ts:1353
 msgid "Tap to try again"
 msgstr ""
 
@@ -6446,19 +6444,19 @@ msgstr ""
 msgid "Tap twice to confirm you have saved the recovery key."
 msgstr ""
 
-#: src/strings.ts:2356
+#: src/strings.ts:2355
 msgid "Task list"
 msgstr ""
 
-#: src/strings.ts:2426
+#: src/strings.ts:2425
 msgid "Tasks"
 msgstr ""
 
-#: src/strings.ts:1163
+#: src/strings.ts:1162
 msgid "Telemetry"
 msgstr ""
 
-#: src/strings.ts:1496
+#: src/strings.ts:1495
 msgid ""
 "Tell us more about the issue you are facing.\n"
 "\n"
@@ -6469,11 +6467,11 @@ msgid ""
 "- Things you have tried etc."
 msgstr ""
 
-#: src/strings.ts:1495
+#: src/strings.ts:1494
 msgid "Tell us what happened"
 msgstr ""
 
-#: src/strings.ts:1284
+#: src/strings.ts:1283
 msgid "Terms of service"
 msgstr ""
 
@@ -6481,39 +6479,39 @@ msgstr ""
 msgid "Terms of Service "
 msgstr ""
 
-#: src/strings.ts:2591
+#: src/strings.ts:2590
 msgid "terms of use."
 msgstr ""
 
-#: src/strings.ts:1623
+#: src/strings.ts:1622
 msgid "Test connection"
 msgstr ""
 
-#: src/strings.ts:1646
+#: src/strings.ts:1645
 msgid "Test connection before changing server urls"
 msgstr ""
 
-#: src/strings.ts:2294
+#: src/strings.ts:2293
 msgid "Text color"
 msgstr ""
 
-#: src/strings.ts:2292
+#: src/strings.ts:2291
 msgid "Text direction"
 msgstr ""
 
-#: src/strings.ts:1787
+#: src/strings.ts:1786
 msgid "Thank you for choosing end-to-end encrypted note taking. Now you can sync your notes to unlimited devices."
 msgstr ""
 
-#: src/strings.ts:2051
+#: src/strings.ts:2050
 msgid "Thank you for reporting!"
 msgstr ""
 
-#: src/strings.ts:2562
+#: src/strings.ts:2561
 msgid "Thank you for subscribing"
 msgstr ""
 
-#: src/strings.ts:2599
+#: src/strings.ts:2598
 msgid "Thank you for the purchase"
 msgstr ""
 
@@ -6521,19 +6519,19 @@ msgstr ""
 msgid "Thank you for updating Notesnook! We will be applying some minor changes for a better note taking experience."
 msgstr ""
 
-#: src/strings.ts:2052
+#: src/strings.ts:2051
 msgid "Thank you for your feedback!"
 msgstr ""
 
-#: src/strings.ts:2086
+#: src/strings.ts:2085
 msgid "Thank you. You are the proof that privacy always comes first."
 msgstr ""
 
-#: src/strings.ts:1644
+#: src/strings.ts:1643
 msgid "The {title} at {url} is not compatible with this client."
 msgstr ""
 
-#: src/strings.ts:2644
+#: src/strings.ts:2643
 msgid "The incoming note could not be unlocked with the provided password. Enter the correct password for the incoming note"
 msgstr ""
 
@@ -6541,11 +6539,11 @@ msgstr ""
 msgid "The information above will be publically available at"
 msgstr ""
 
-#: src/strings.ts:2618
+#: src/strings.ts:2617
 msgid "The Notesnook Circle is exclusive to subscribers. Please consider subscribing to gain access to Notesnook Circle and enjoy additional benefits."
 msgstr ""
 
-#: src/strings.ts:2093
+#: src/strings.ts:2092
 msgid "The password/pin for unlocking the app."
 msgstr ""
 
@@ -6557,19 +6555,19 @@ msgstr ""
 msgid "The reminder will repeat every year on {date}."
 msgstr ""
 
-#: src/strings.ts:1713
+#: src/strings.ts:1712
 msgid "The reminder will start on {date} at {time}."
 msgstr ""
 
-#: src/strings.ts:2096
+#: src/strings.ts:2095
 msgid "The security key for unlocking the app. This is the most secure method."
 msgstr ""
 
-#: src/strings.ts:1642
+#: src/strings.ts:1641
 msgid "The URL you have given ({url}) does not point to the {server}."
 msgstr ""
 
-#: src/strings.ts:1118
+#: src/strings.ts:1117
 msgid "Themes"
 msgstr ""
 
@@ -6577,11 +6575,11 @@ msgstr ""
 msgid "There are no blocks in this note."
 msgstr ""
 
-#: src/strings.ts:2249
+#: src/strings.ts:2248
 msgid "These items will be **kept in your Trash for {interval} days** after which they will be permanently deleted."
 msgstr ""
 
-#: src/strings.ts:1921
+#: src/strings.ts:1920
 msgid "This action is IRREVERSIBLE."
 msgstr ""
 
@@ -6589,60 +6587,60 @@ msgstr ""
 msgid "This device"
 msgstr ""
 
-#: src/strings.ts:1684
+#: src/strings.ts:1683
 msgid "This error can be fixed by rebuilding the search index. This action won't result in any kind of data loss."
 msgstr ""
 
-#: src/strings.ts:1676
+#: src/strings.ts:1675
 msgid "This error can only be fixed by wiping & reseting the database. Beware that this will wipe all your data inside the database with no way to recover it later on. This WILL NOT change/affect/delete/wipe your data on the server but ONLY on this device."
 msgstr ""
 
-#: src/strings.ts:1680
+#: src/strings.ts:1679
 msgid "This error can only be fixed by wiping & reseting the Key Store and the database. This WILL NOT change/affect/delete/wipe your data on the server but ONLY on this device."
 msgstr ""
 
-#: src/strings.ts:1678
+#: src/strings.ts:1677
 msgid "This error means the at rest encryption key could not be decrypted. This can be due to data corruption or implementation change."
 msgstr ""
 
-#: src/strings.ts:1674
+#: src/strings.ts:1673
 msgid "This error usually means the database file is either corrupt or it could not be decrypted."
 msgstr ""
 
-#: src/strings.ts:1682
+#: src/strings.ts:1681
 msgid "This error usually means the search index is corrupted."
 msgstr ""
 
-#: src/strings.ts:2658
+#: src/strings.ts:2657
 msgid "This feature is not available on this plan."
 msgstr ""
 
-#: src/strings.ts:1935
+#: src/strings.ts:1934
 msgid "This image cannot be previewed"
 msgstr ""
 
-#: src/strings.ts:2585
+#: src/strings.ts:2584
 msgid "This is a one time purchase, no subscription."
 msgstr ""
 
-#: src/strings.ts:2046
+#: src/strings.ts:2045
 msgid "This may take a while"
 msgstr ""
 
-#: src/strings.ts:1102
-#: src/strings.ts:1111
+#: src/strings.ts:1101
+#: src/strings.ts:1110
 msgid "This must only be used for troubleshooting. Using it regularly for sync is not recommended and will lead to unexpected data loss and other issues. If you are having persistent issues with sync, please report them to us at support@streetwriters.co."
 msgstr ""
 
-#: src/strings.ts:2650
+#: src/strings.ts:2649
 msgid "This note is empty"
 msgstr ""
 
-#: src/strings.ts:1595
+#: src/strings.ts:1594
 msgid "This note is locked"
 msgstr ""
 
-#: src/strings.ts:953
+#: src/strings.ts:952
 msgid "This note is locked. Unlock note to save changes"
 msgstr ""
 
@@ -6658,11 +6656,11 @@ msgstr ""
 msgid "This note will be published to a public URL."
 msgstr ""
 
-#: src/strings.ts:2102
+#: src/strings.ts:2101
 msgid "This username will be used to distinguish between different credentials in your security key. Make sure it is unique."
 msgstr ""
 
-#: src/strings.ts:1304
+#: src/strings.ts:1303
 msgid "This version of Notesnook app does not support in-app purchases. Kindly login on the Notesnook web app to make the purchase."
 msgstr ""
 
@@ -6674,11 +6672,11 @@ msgstr ""
 msgid "Thursday"
 msgstr ""
 
-#: src/strings.ts:1843
+#: src/strings.ts:1842
 msgid "Time"
 msgstr ""
 
-#: src/strings.ts:1135
+#: src/strings.ts:1134
 msgid "Time format"
 msgstr ""
 
@@ -6691,76 +6689,76 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: src/strings.ts:1158
+#: src/strings.ts:1157
 msgid "Title format"
 msgstr ""
 
-#: src/strings.ts:2669
+#: src/strings.ts:2668
 msgid "Title is required"
 msgstr ""
 
-#: src/strings.ts:1189
+#: src/strings.ts:1188
 msgid "To use app lock, you must enable biometrics such as Fingerprint lock or Face ID on your phone."
 msgstr ""
 
-#: src/strings.ts:1813
+#: src/strings.ts:1812
 msgid "Toggle dark/light mode"
 msgstr ""
 
-#: src/strings.ts:2474
+#: src/strings.ts:2473
 msgid "Toggle focus mode"
 msgstr ""
 
-#: src/strings.ts:2363
+#: src/strings.ts:2362
 msgid "Toggle indentation mode"
 msgstr ""
 
-#: src/strings.ts:2392
+#: src/strings.ts:2391
 msgid "Toggle replace"
 msgstr ""
 
-#: src/strings.ts:2463
+#: src/strings.ts:2462
 msgid "Toggle theme"
 msgstr ""
 
-#: src/strings.ts:2143
+#: src/strings.ts:2142
 msgid "Toolbar"
 msgstr ""
 
-#: src/strings.ts:1149
+#: src/strings.ts:1148
 msgid "Toolbar reset to default preset"
 msgstr ""
 
-#: src/strings.ts:1327
-#: src/strings.ts:1524
+#: src/strings.ts:1326
+#: src/strings.ts:1523
 msgid "Trash"
 msgstr ""
 
-#: src/strings.ts:1326
+#: src/strings.ts:1325
 msgid "Trash cleared successfully!"
 msgstr ""
 
-#: src/strings.ts:1332
+#: src/strings.ts:1331
 msgid "Trash gets automatically cleaned up after {days} days"
 msgstr ""
 
-#: src/strings.ts:1330
+#: src/strings.ts:1329
 msgid "Trash gets automatically cleaned up daily"
 msgstr ""
 
-#: src/strings.ts:2552
+#: src/strings.ts:2551
 msgid "Try {plan} for free"
 msgstr ""
 
-#: src/strings.ts:1466
+#: src/strings.ts:1465
 msgid "Try compact mode to fit more items on screen"
 msgstr ""
 
-#: src/strings.ts:1825
+#: src/strings.ts:1824
 msgid "Try free for 14 days"
 msgstr ""
 
-#: src/strings.ts:2538
+#: src/strings.ts:2537
 msgid "Try it for free"
 msgstr ""
 
@@ -6772,19 +6770,19 @@ msgstr ""
 msgid "Tuesday"
 msgstr ""
 
-#: src/strings.ts:1087
+#: src/strings.ts:1086
 msgid "Turn off automatic syncing. Changes from this client will be synced only when you run sync manually."
 msgstr ""
 
-#: src/strings.ts:893
+#: src/strings.ts:892
 msgid "Turn off reminder"
 msgstr ""
 
-#: src/strings.ts:894
+#: src/strings.ts:893
 msgid "Turn on reminder"
 msgstr ""
 
-#: src/strings.ts:1093
+#: src/strings.ts:1092
 msgid "Turns off syncing completely on this device. Any changes made will remain local only and new changes from your other devices won't sync to this device."
 msgstr ""
 
@@ -6800,27 +6798,27 @@ msgstr ""
 msgid "Two-factor authentication enabled"
 msgstr ""
 
-#: src/strings.ts:1503
+#: src/strings.ts:1502
 msgid "Type # to search for headings"
 msgstr ""
 
-#: src/strings.ts:1510
+#: src/strings.ts:1509
 msgid "Type a keyword"
 msgstr ""
 
-#: src/strings.ts:1550
+#: src/strings.ts:1549
 msgid "Unable to resolve download url"
 msgstr ""
 
-#: src/strings.ts:1553
+#: src/strings.ts:1552
 msgid "Unable to send 2FA code"
 msgstr ""
 
-#: src/strings.ts:2498
+#: src/strings.ts:2497
 msgid "Unarchive"
 msgstr ""
 
-#: src/strings.ts:2270
+#: src/strings.ts:2269
 msgid "Underline"
 msgstr ""
 
@@ -6828,19 +6826,19 @@ msgstr ""
 msgid "Undo"
 msgstr ""
 
-#: src/strings.ts:855
+#: src/strings.ts:854
 msgid "Unfavorite"
 msgstr ""
 
-#: src/strings.ts:2595
+#: src/strings.ts:2594
 msgid "Unlimited"
 msgstr ""
 
-#: src/strings.ts:931
+#: src/strings.ts:930
 msgid "Unlink from all"
 msgstr ""
 
-#: src/strings.ts:854
+#: src/strings.ts:853
 msgid "Unlink notebook"
 msgstr ""
 
@@ -6848,11 +6846,11 @@ msgstr ""
 msgid "Unlock"
 msgstr ""
 
-#: src/strings.ts:2642
+#: src/strings.ts:2641
 msgid "Unlock incoming note"
 msgstr ""
 
-#: src/strings.ts:1384
+#: src/strings.ts:1383
 msgid "Unlock more colors with Notesnook Pro"
 msgstr ""
 
@@ -6861,19 +6859,19 @@ msgstr ""
 msgid "Unlock note"
 msgstr ""
 
-#: src/strings.ts:889
+#: src/strings.ts:888
 msgid "Unlock note to delete it"
 msgstr ""
 
-#: src/strings.ts:2653
+#: src/strings.ts:2652
 msgid "Unlock note to merge conflicts"
 msgstr ""
 
-#: src/strings.ts:1209
+#: src/strings.ts:1208
 msgid "Unlock the app with biometric authentication. This requires biometrics to be enabled on your device."
 msgstr ""
 
-#: src/strings.ts:1933
+#: src/strings.ts:1932
 msgid "Unlock vault"
 msgstr ""
 
@@ -6881,7 +6879,7 @@ msgstr ""
 msgid "Unlock with biometrics"
 msgstr ""
 
-#: src/strings.ts:1828
+#: src/strings.ts:1827
 msgid "Unlock with security key"
 msgstr ""
 
@@ -6889,19 +6887,19 @@ msgstr ""
 msgid "Unlock your notes"
 msgstr ""
 
-#: src/strings.ts:1179
+#: src/strings.ts:1178
 msgid "Unlock your vault with biometric authentication"
 msgstr ""
 
-#: src/strings.ts:1711
+#: src/strings.ts:1710
 msgid "Unlocking"
 msgstr ""
 
-#: src/strings.ts:900
+#: src/strings.ts:899
 msgid "Unpin"
 msgstr ""
 
-#: src/strings.ts:928
+#: src/strings.ts:927
 msgid "Unpin notification"
 msgstr ""
 
@@ -6909,20 +6907,20 @@ msgstr ""
 msgid "Unpublish"
 msgstr ""
 
-#: src/strings.ts:1478
+#: src/strings.ts:1477
 msgid "Unpublish notes to delete them"
 msgstr ""
 
-#: src/strings.ts:2097
+#: src/strings.ts:2096
 msgid "Unregister"
 msgstr ""
 
-#: src/strings.ts:2646
+#: src/strings.ts:2645
 msgid "Unset expiry"
 msgstr ""
 
 #: src/strings.ts:210
-#: src/strings.ts:2372
+#: src/strings.ts:2371
 msgid "Untitled"
 msgstr ""
 
@@ -6934,31 +6932,31 @@ msgstr ""
 msgid "Update available"
 msgstr ""
 
-#: src/strings.ts:1371
+#: src/strings.ts:1370
 msgid "Update now"
 msgstr ""
 
-#: src/strings.ts:2512
+#: src/strings.ts:2511
 msgid "Upgrade"
 msgstr ""
 
-#: src/strings.ts:1919
+#: src/strings.ts:1918
 msgid "Upgrade now"
 msgstr ""
 
-#: src/strings.ts:2511
+#: src/strings.ts:2510
 msgid "Upgrade plan"
 msgstr ""
 
-#: src/strings.ts:2537
+#: src/strings.ts:2536
 msgid "Upgrade plan to {plan} to use this feature."
 msgstr ""
 
-#: src/strings.ts:1940
+#: src/strings.ts:1939
 msgid "Upgrade to Notesnook Pro to add colors."
 msgstr ""
 
-#: src/strings.ts:1941
+#: src/strings.ts:1940
 msgid "Upgrade to Notesnook Pro to create more tags."
 msgstr ""
 
@@ -6966,7 +6964,7 @@ msgstr ""
 msgid "Upgrade to Pro"
 msgstr ""
 
-#: src/strings.ts:2610
+#: src/strings.ts:2609
 msgid "Upgrade to redeem"
 msgstr ""
 
@@ -6974,12 +6972,12 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: src/strings.ts:2349
+#: src/strings.ts:2348
 msgid "Upload from disk"
 msgstr ""
 
 #: src/strings.ts:511
-#: src/strings.ts:1652
+#: src/strings.ts:1651
 msgid "Uploaded"
 msgstr ""
 
@@ -7000,11 +6998,11 @@ msgstr ""
 msgid "Urgent"
 msgstr ""
 
-#: src/strings.ts:2399
+#: src/strings.ts:2398
 msgid "URL"
 msgstr ""
 
-#: src/strings.ts:1790
+#: src/strings.ts:1789
 msgid "Use"
 msgstr ""
 
@@ -7012,11 +7010,11 @@ msgstr ""
 msgid "Use {keyboardShortcut}+click to select multiple notebooks"
 msgstr ""
 
-#: src/strings.ts:1803
+#: src/strings.ts:1802
 msgid "Use a backup file"
 msgstr ""
 
-#: src/strings.ts:1901
+#: src/strings.ts:1900
 msgid "Use a data recovery key to reset your account password."
 msgstr ""
 
@@ -7024,43 +7022,43 @@ msgstr ""
 msgid "Use account password"
 msgstr ""
 
-#: src/strings.ts:2544
+#: src/strings.ts:2543
 msgid "Use advanced note taking features like"
 msgstr ""
 
-#: src/strings.ts:980
+#: src/strings.ts:979
 msgid "Use an authenticator app to generate 2FA codes."
 msgstr ""
 
-#: src/strings.ts:2183
+#: src/strings.ts:2182
 msgid "Use custom DNS"
 msgstr ""
 
-#: src/strings.ts:1124
+#: src/strings.ts:1123
 msgid "Use dark mode for the app"
 msgstr ""
 
-#: src/strings.ts:1622
+#: src/strings.ts:1621
 msgid "Use encryption key"
 msgstr ""
 
-#: src/strings.ts:1161
+#: src/strings.ts:1160
 msgid "Use markdown shortcuts in the editor"
 msgstr ""
 
-#: src/strings.ts:2136
+#: src/strings.ts:2135
 msgid "Use native OS titlebar instead of replacing it with a custom one. Requires app restart for changes to take effect."
 msgstr ""
 
-#: src/strings.ts:2134
+#: src/strings.ts:2133
 msgid "Use native titlebar"
 msgstr ""
 
-#: src/strings.ts:1800
+#: src/strings.ts:1799
 msgid "Use recovery key"
 msgstr ""
 
-#: src/strings.ts:1120
+#: src/strings.ts:1119
 msgid "Use system theme"
 msgstr ""
 
@@ -7077,43 +7075,43 @@ msgid ""
 "$day$: Current day (eg. Monday)"
 msgstr ""
 
-#: src/strings.ts:1100
+#: src/strings.ts:1099
 msgid "Use this if changes from other devices are not appearing on this device. This will overwrite the data on this device with the latest data from the server."
 msgstr ""
 
-#: src/strings.ts:1109
+#: src/strings.ts:1108
 msgid "Use this if changes made on this device are not appearing on other devices. This will overwrite the data on the server with the data from this device."
 msgstr ""
 
-#: src/strings.ts:2485
+#: src/strings.ts:2484
 msgid "used"
 msgstr ""
 
-#: src/strings.ts:1019
+#: src/strings.ts:1018
 msgid "User verification failed"
 msgstr ""
 
-#: src/strings.ts:2266
+#: src/strings.ts:2265
 msgid "Using {instance} (v{version})"
 msgstr ""
 
-#: src/strings.ts:2264
+#: src/strings.ts:2263
 msgid "Using official Notesnook instance"
 msgstr ""
 
-#: src/strings.ts:1710
+#: src/strings.ts:1709
 msgid "v{version} available"
 msgstr ""
 
-#: src/strings.ts:2660
+#: src/strings.ts:2659
 msgid "Value must be between {min} and {max}"
 msgstr ""
 
-#: src/strings.ts:1172
+#: src/strings.ts:1171
 msgid "Vault"
 msgstr ""
 
-#: src/strings.ts:1993
+#: src/strings.ts:1992
 msgid "Vault cleared"
 msgstr ""
 
@@ -7121,7 +7119,7 @@ msgstr ""
 msgid "Vault created"
 msgstr ""
 
-#: src/strings.ts:1994
+#: src/strings.ts:1993
 msgid "Vault deleted"
 msgstr ""
 
@@ -7129,15 +7127,15 @@ msgstr ""
 msgid "Vault fingerprint unlock"
 msgstr ""
 
-#: src/strings.ts:1932
+#: src/strings.ts:1931
 msgid "Vault locked"
 msgstr ""
 
-#: src/strings.ts:1931
+#: src/strings.ts:1930
 msgid "Vault unlocked"
 msgstr ""
 
-#: src/strings.ts:1401
+#: src/strings.ts:1400
 msgid "Verification email sent"
 msgstr ""
 
@@ -7145,19 +7143,19 @@ msgstr ""
 msgid "Verify"
 msgstr ""
 
-#: src/strings.ts:1070
+#: src/strings.ts:1069
 msgid "Verify subscription"
 msgstr ""
 
-#: src/strings.ts:1073
+#: src/strings.ts:1072
 msgid "Verify your subscription to Notesnook Pro"
 msgstr ""
 
-#: src/strings.ts:1904
+#: src/strings.ts:1903
 msgid "Verifying 2FA code"
 msgstr ""
 
-#: src/strings.ts:1890
+#: src/strings.ts:1889
 msgid "Verifying your email"
 msgstr ""
 
@@ -7177,27 +7175,27 @@ msgstr ""
 msgid "View all linked notebooks"
 msgstr ""
 
-#: src/strings.ts:1271
+#: src/strings.ts:1270
 msgid "View and share debug logs"
 msgstr ""
 
-#: src/strings.ts:1748
+#: src/strings.ts:1747
 msgid "View receipt"
 msgstr ""
 
-#: src/strings.ts:1061
+#: src/strings.ts:1060
 msgid "View recovery codes"
 msgstr ""
 
-#: src/strings.ts:2163
+#: src/strings.ts:2162
 msgid "View source code"
 msgstr ""
 
-#: src/strings.ts:1063
+#: src/strings.ts:1062
 msgid "View your recovery codes to recover your account in case you lose access to your two-factor authentication methods."
 msgstr ""
 
-#: src/strings.ts:2625
+#: src/strings.ts:2624
 msgid "Views"
 msgstr ""
 
@@ -7205,15 +7203,15 @@ msgstr ""
 msgid "Visit homepage"
 msgstr ""
 
-#: src/strings.ts:1351
+#: src/strings.ts:1350
 msgid "Wait 30 seconds to try again"
 msgstr ""
 
-#: src/strings.ts:1653
+#: src/strings.ts:1652
 msgid "Waiting for upload"
 msgstr ""
 
-#: src/strings.ts:1912
+#: src/strings.ts:1911
 msgid "We are creating a backup of your data. Please wait..."
 msgstr ""
 
@@ -7221,35 +7219,35 @@ msgstr ""
 msgid "We are sorry, it seems that the app crashed due to an error. You can submit a bug report below so we can fix this asap."
 msgstr ""
 
-#: src/strings.ts:1391
+#: src/strings.ts:1390
 msgid "We have sent you an email confirmation link. Please check your email inbox. If you cannot find the email, check your spam folder."
 msgstr ""
 
-#: src/strings.ts:2523
+#: src/strings.ts:2522
 msgid "We require credit card details to fight abuse and to make it seamless for you to upgrade. Your credit card is NOT charged until your free trial ends and your subscription starts. You will be notified via email of the upcoming charge before your trial ends."
 msgstr ""
 
-#: src/strings.ts:2178
+#: src/strings.ts:2177
 msgid "We send you occasional promotional offers & product updates on your email (once every month)."
 msgstr ""
 
-#: src/strings.ts:1168
+#: src/strings.ts:1167
 msgid "We will send you occasional promotional offers & product updates on your email (sent once every month)."
 msgstr ""
 
-#: src/strings.ts:1355
+#: src/strings.ts:1354
 msgid "We would love to know what you think!"
 msgstr ""
 
-#: src/strings.ts:2564
+#: src/strings.ts:2563
 msgid "We’re setting up your plan right now. We’ll notify you as soon as everything is ready."
 msgstr ""
 
-#: src/strings.ts:2334
+#: src/strings.ts:2333
 msgid "Web clip settings"
 msgstr ""
 
-#: src/strings.ts:2030
+#: src/strings.ts:2029
 msgid "Website"
 msgstr ""
 
@@ -7265,12 +7263,12 @@ msgstr ""
 msgid "Week"
 msgstr ""
 
-#: src/strings.ts:2638
+#: src/strings.ts:2637
 msgid "Week format"
 msgstr ""
 
 #: src/strings.ts:168
-#: src/strings.ts:1570
+#: src/strings.ts:1569
 msgid "Weekly"
 msgstr ""
 
@@ -7278,63 +7276,63 @@ msgstr ""
 msgid "Welcome back, {email}"
 msgstr ""
 
-#: src/strings.ts:1889
+#: src/strings.ts:1888
 msgid "Welcome back!"
 msgstr ""
 
-#: src/strings.ts:2598
+#: src/strings.ts:2597
 msgid "Welcome to Notesnook {plan}"
 msgstr ""
 
-#: src/strings.ts:2084
+#: src/strings.ts:2083
 msgid "Welcome to Notesnook Pro"
 msgstr ""
 
-#: src/strings.ts:1393
+#: src/strings.ts:1392
 msgid "What do I do if I am not getting the email?"
 msgstr ""
 
-#: src/strings.ts:2515
+#: src/strings.ts:2514
 msgid "What happens to my data if I switch plans?"
 msgstr ""
 
-#: src/strings.ts:2531
+#: src/strings.ts:2530
 msgid "What is your refund policy?"
 msgstr ""
 
-#: src/strings.ts:1668
+#: src/strings.ts:1667
 msgid "What went wrong?"
 msgstr ""
 
-#: src/strings.ts:2521
+#: src/strings.ts:2520
 msgid "Why do you need my credit card details for a free trial?"
 msgstr ""
 
-#: src/strings.ts:2395
+#: src/strings.ts:2394
 msgid "Width"
 msgstr ""
 
-#: src/strings.ts:2501
+#: src/strings.ts:2500
 msgid "Words"
 msgstr ""
 
-#: src/strings.ts:2424
+#: src/strings.ts:2423
 msgid "Work & Office"
 msgstr ""
 
-#: src/strings.ts:824
+#: src/strings.ts:823
 msgid "Write notes with freedom, no spying, no tracking."
 msgstr ""
 
-#: src/strings.ts:1375
+#: src/strings.ts:1374
 msgid "Write something..."
 msgstr ""
 
-#: src/strings.ts:1655
+#: src/strings.ts:1654
 msgid "Write with freedom."
 msgstr ""
 
-#: src/strings.ts:2072
+#: src/strings.ts:2071
 msgid "Write with freedom. Never compromise on privacy again."
 msgstr ""
 
@@ -7343,7 +7341,7 @@ msgid "Year"
 msgstr ""
 
 #: src/strings.ts:170
-#: src/strings.ts:1572
+#: src/strings.ts:1571
 msgid "Yearly"
 msgstr ""
 
@@ -7351,7 +7349,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: src/strings.ts:2528
+#: src/strings.ts:2527
 msgid "Yes, you can cancel your trial anytime. No questions asked."
 msgstr ""
 
@@ -7359,27 +7357,27 @@ msgstr ""
 msgid "You also agree to recieve marketing emails from us which you can opt-out of from app settings."
 msgstr ""
 
-#: src/strings.ts:2603
+#: src/strings.ts:2602
 msgid "You are already subscribed to this plan."
 msgstr ""
 
-#: src/strings.ts:2251
+#: src/strings.ts:2250
 msgid "You are editing \"{notebookTitle}\"."
 msgstr ""
 
-#: src/strings.ts:2044
+#: src/strings.ts:2043
 msgid "You are editing #{tag}"
 msgstr ""
 
-#: src/strings.ts:1782
+#: src/strings.ts:1781
 msgid "You are logging into the beta version of Notesnook. Switching between beta &amp; stable versions can cause weird issues including data loss. It is recommended that you do not use both simultaneously."
 msgstr ""
 
-#: src/strings.ts:1362
+#: src/strings.ts:1361
 msgid "You are not logged in"
 msgstr ""
 
-#: src/strings.ts:887
+#: src/strings.ts:886
 msgid "You are renaming color {color}"
 msgstr ""
 
@@ -7387,39 +7385,39 @@ msgstr ""
 msgid "You can also link a note to multiple Notebooks. Tap and hold any notebook to enable multi-select."
 msgstr ""
 
-#: src/strings.ts:2075
+#: src/strings.ts:2074
 msgid "You can change the theme at any time from Settings or the side menu."
 msgstr ""
 
-#: src/strings.ts:2606
+#: src/strings.ts:2605
 msgid "You can change your subscription plan from the web app"
 msgstr ""
 
-#: src/strings.ts:2432
+#: src/strings.ts:2431
 msgid "You can create shortcuts of frequently accessed notebooks in the side menu"
 msgstr ""
 
-#: src/strings.ts:2090
+#: src/strings.ts:2089
 msgid "You can import your notes from most other note taking apps."
 msgstr ""
 
-#: src/strings.ts:1437
+#: src/strings.ts:1436
 msgid "You can multi-select notes and move them to a notebook at once"
 msgstr ""
 
-#: src/strings.ts:1428
+#: src/strings.ts:1427
 msgid "You can pin frequently used Notebooks to the Side Menu to quickly access them."
 msgstr ""
 
-#: src/strings.ts:1171
+#: src/strings.ts:1170
 msgid "You can set a custom proxy URL to increase your privacy."
 msgstr ""
 
-#: src/strings.ts:1409
+#: src/strings.ts:1408
 msgid "You can swipe left anywhere in the app to start a new note."
 msgstr ""
 
-#: src/strings.ts:2057
+#: src/strings.ts:2056
 msgid ""
 "You can track your bug report at [{url}]({url}).\n"
 "\n"
@@ -7428,7 +7426,7 @@ msgid ""
 "If your issue is critical (e.g. notes not syncing, crashes etc.), please [join our Discord community](https://go.notesnook.com/discord) for one-to-one support."
 msgstr ""
 
-#: src/strings.ts:2066
+#: src/strings.ts:2065
 msgid ""
 "You can track your feature request at [{url}]({url}).\n"
 "\n"
@@ -7439,78 +7437,78 @@ msgstr ""
 msgid "You can track your issue at "
 msgstr ""
 
-#: src/strings.ts:1029
+#: src/strings.ts:1028
 msgid "You can use all premium features for free for the next 14 days"
 msgstr ""
 
-#: src/strings.ts:1059
+#: src/strings.ts:1058
 msgid "You can use fallback 2FA method incase you are unable to login via primary method"
 msgstr ""
 
-#: src/strings.ts:1451
+#: src/strings.ts:1450
 msgid "You can view & restore older versions of any note by going to its properties -> History."
 msgstr ""
 
-#: src/strings.ts:1750
+#: src/strings.ts:1749
 msgid "You have {count} custom dictionary words."
 msgstr ""
 
-#: src/strings.ts:2209
+#: src/strings.ts:2208
 msgid "You have been logged out from all other devices."
 msgstr ""
 
-#: src/strings.ts:2203
+#: src/strings.ts:2202
 msgid "You have been logged out."
 msgstr ""
 
-#: src/strings.ts:2602
+#: src/strings.ts:2601
 msgid "You have made a one time purchase. To change your plan please contact support."
 msgstr ""
 
-#: src/strings.ts:965
+#: src/strings.ts:964
 msgid "You have not added any notebooks yet"
 msgstr ""
 
-#: src/strings.ts:964
+#: src/strings.ts:963
 msgid "You have not added any tags yet"
 msgstr ""
 
-#: src/strings.ts:963
+#: src/strings.ts:962
 msgid "You have not created any notes yet"
 msgstr ""
 
-#: src/strings.ts:962
+#: src/strings.ts:961
 msgid "You have not favorited any notes yet"
 msgstr ""
 
-#: src/strings.ts:967
+#: src/strings.ts:966
 msgid "You have not published any monographs yet"
 msgstr ""
 
-#: src/strings.ts:966
+#: src/strings.ts:965
 msgid "You have not set any reminders yet"
 msgstr ""
 
-#: src/strings.ts:1546
+#: src/strings.ts:1545
 msgid "You have unsynced notes. Take a backup or sync your notes to avoid losing your critical data."
 msgstr ""
 
-#: src/strings.ts:1635
+#: src/strings.ts:1634
 msgid "You must log out in order to change/reset server URLs."
 msgstr ""
 
-#: src/strings.ts:2674
+#: src/strings.ts:2673
 msgid ""
 "You need to login to restore attachments from a backup file. [Read more](https://help.notesnook.com/faqs/login-to-restore-attachments-in-backup).\n"
 "  \n"
 "Continue without attachments?"
 msgstr ""
 
-#: src/strings.ts:837
+#: src/strings.ts:836
 msgid "You simply cannot get any better of a note taking app than @notesnook. The UI is clean and slick, it is feature rich, encrypted, reasonably priced (esp. for students & educators) & open source"
 msgstr ""
 
-#: src/strings.ts:1069
+#: src/strings.ts:1068
 msgid "You subscribed to Notesnook Pro on {date}. Verify this subscription?"
 msgstr ""
 
@@ -7538,7 +7536,7 @@ msgstr ""
 msgid "You will be logged out from all your devices"
 msgstr ""
 
-#: src/strings.ts:1852
+#: src/strings.ts:1851
 msgid "You will receive instructions on how to recover your account on this email"
 msgstr ""
 
@@ -7546,72 +7544,72 @@ msgstr ""
 msgid "Your account email will be changed without affecting your subscription or any other settings."
 msgstr ""
 
-#: src/strings.ts:1918
+#: src/strings.ts:1917
 msgid "Your account has been recovered."
 msgstr ""
 
 #: src/strings.ts:502
-#: src/strings.ts:1729
+#: src/strings.ts:1728
 msgid "Your account is now 100% secure against unauthorized logins."
 msgstr ""
 
-#: src/strings.ts:1857
+#: src/strings.ts:1856
 msgid "Your account password must be strong & unique."
 msgstr ""
 
-#: src/strings.ts:1035
+#: src/strings.ts:1034
 msgid "Your account will be downgraded in {days} days"
 msgstr ""
 
-#: src/strings.ts:1079
+#: src/strings.ts:1078
 msgid "Your account will be permanently deleted along with all your data, login credentials, and subscription information. This action is IRREVERSIBLE. Make sure you have saved a backup of your notes before proceeding."
 msgstr ""
 
-#: src/strings.ts:961
+#: src/strings.ts:960
 msgid "Your archive"
 msgstr ""
 
-#: src/strings.ts:2497
+#: src/strings.ts:2496
 msgid "Your archive is empty"
 msgstr ""
 
-#: src/strings.ts:1930
+#: src/strings.ts:1929
 msgid "Your backup is ready to download"
 msgstr ""
 
-#: src/strings.ts:1587
+#: src/strings.ts:1586
 msgid "Your changes could not be saved"
 msgstr ""
 
-#: src/strings.ts:1777
+#: src/strings.ts:1776
 msgid "Your changes have been saved and will be reflected after the app has refreshed."
 msgstr ""
 
-#: src/strings.ts:2110
+#: src/strings.ts:2109
 msgid "Your current 2FA method is {method}"
 msgstr ""
 
-#: src/strings.ts:2609
+#: src/strings.ts:2608
 msgid "Your current subscription does not allow changing plans"
 msgstr ""
 
-#: src/strings.ts:1802
+#: src/strings.ts:1801
 msgid "Your data recovery key is basically a hashed version of your password (plus some random salt). It can be used to decrypt your data for re-encryption."
 msgstr ""
 
-#: src/strings.ts:1855
+#: src/strings.ts:1854
 msgid "Your data recovery key will be used to decrypt your data"
 msgstr ""
 
-#: src/strings.ts:2517
+#: src/strings.ts:2516
 msgid "Your data remains 100% accessible regardless of what plan you are on. That includes your notes, notebooks, attachments, and anything else you might have created."
 msgstr ""
 
-#: src/strings.ts:1785
+#: src/strings.ts:1784
 msgid "Your email has been confirmed."
 msgstr ""
 
-#: src/strings.ts:2508
+#: src/strings.ts:2507
 msgid "Your email has been confirmed. You can now securely sync your encrypted notes across all devices."
 msgstr ""
 
@@ -7619,39 +7617,39 @@ msgstr ""
 msgid "Your email is not confirmed. Please confirm your email address to change account password."
 msgstr ""
 
-#: src/strings.ts:955
+#: src/strings.ts:954
 msgid "Your favorites"
 msgstr ""
 
-#: src/strings.ts:1032
+#: src/strings.ts:1031
 msgid "Your free trial ends on {date}"
 msgstr ""
 
-#: src/strings.ts:1405
+#: src/strings.ts:1404
 msgid "Your free trial has expired"
 msgstr ""
 
-#: src/strings.ts:1027
+#: src/strings.ts:1026
 msgid "Your free trial has started"
 msgstr ""
 
-#: src/strings.ts:1404
+#: src/strings.ts:1403
 msgid "Your free trial is ending soon"
 msgstr ""
 
-#: src/strings.ts:2637
+#: src/strings.ts:2636
 msgid "Your free trial is on-going. Your subscription will start on {trialExpiryDate}"
 msgstr ""
 
-#: src/strings.ts:1779
+#: src/strings.ts:1778
 msgid "Your full name"
 msgstr ""
 
-#: src/strings.ts:960
+#: src/strings.ts:959
 msgid "Your monographs"
 msgstr ""
 
-#: src/strings.ts:1313
+#: src/strings.ts:1312
 msgid "Your name is stored 100% end-to-end encrypted and only visible to you."
 msgstr ""
 
@@ -7659,31 +7657,31 @@ msgstr ""
 msgid "Your note will be unencrypted and removed from the vault."
 msgstr ""
 
-#: src/strings.ts:958
+#: src/strings.ts:957
 msgid "Your notebooks"
 msgstr ""
 
-#: src/strings.ts:956
+#: src/strings.ts:955
 msgid "Your notes"
 msgstr ""
 
-#: src/strings.ts:1893
+#: src/strings.ts:1892
 msgid "Your password is always hashed before leaving this device."
 msgstr ""
 
-#: src/strings.ts:833
+#: src/strings.ts:832
 msgid "Your privacy matters to us, no matter who you are. In a world where everyone is trying to spy on you, Notesnook encrypts all your data before it leaves your device. With Notesnook no one can ever sell your data again."
 msgstr ""
 
-#: src/strings.ts:1310
+#: src/strings.ts:1309
 msgid "Your profile pictrure is stored 100% end-to-end encrypted and only visible to you."
 msgstr ""
 
-#: src/strings.ts:1998
+#: src/strings.ts:1997
 msgid "Your refund has been issued. Please wait 24 hours before reaching out to us in case you do not receive your funds."
 msgstr ""
 
-#: src/strings.ts:959
+#: src/strings.ts:958
 msgid "Your reminders"
 msgstr ""
 
@@ -7691,31 +7689,31 @@ msgstr ""
 msgid "Your session has expired. Please enter password for {obfuscatedEmail} to continue."
 msgstr ""
 
-#: src/strings.ts:1036
+#: src/strings.ts:1035
 msgid "Your subscription ends on {date}"
 msgstr ""
 
-#: src/strings.ts:1996
+#: src/strings.ts:1995
 msgid "Your subscription has been canceled."
 msgstr ""
 
-#: src/strings.ts:1033
+#: src/strings.ts:1032
 msgid "Your subscription has ended"
 msgstr ""
 
-#: src/strings.ts:1037
+#: src/strings.ts:1036
 msgid "Your subscription renews on {date}"
 msgstr ""
 
-#: src/strings.ts:2054
+#: src/strings.ts:2053
 msgid "Your support request has been forwarded"
 msgstr ""
 
-#: src/strings.ts:2063
+#: src/strings.ts:2062
 msgid "Your support request has been forwarded to our support team. We will get back to you via email as soon as possible. If you don't receive an email from us within 24-48 hours, please send us an email directly at support@notesnook.com."
 msgstr ""
 
-#: src/strings.ts:957
+#: src/strings.ts:956
 msgid "Your tags"
 msgstr ""
 
@@ -7731,22 +7729,22 @@ msgstr ""
 msgid "Zipping"
 msgstr ""
 
-#: src/strings.ts:2473
+#: src/strings.ts:2472
 msgid "Zoom"
 msgstr ""
 
-#: src/strings.ts:2104
+#: src/strings.ts:2103
 msgid "Zoom factor"
 msgstr ""
 
-#: src/strings.ts:1701
+#: src/strings.ts:1700
 msgid "Zoom in"
 msgstr ""
 
-#: src/strings.ts:2105
+#: src/strings.ts:2104
 msgid "Zoom in or out the app content."
 msgstr ""
 
-#: src/strings.ts:1700
+#: src/strings.ts:1699
 msgid "Zoom out"
 msgstr ""

--- a/packages/intl/src/strings.ts
+++ b/packages/intl/src/strings.ts
@@ -813,7 +813,6 @@ $day$: Current day (eg. Monday)`,
   vaultCreated: () => t`Vault created`,
   noteUnlocked: () => t`Note unlocked`,
   noteCopied: () => t`Note copied to clipboard`,
-  noteDuplicated: () => t`Note duplicated`,
   introData: [
     {
       headings: [
@@ -2693,5 +2692,6 @@ Continue without attachments?`,
     t`Expiry date cannot be more than 1 year in the future`,
   expiryDateSet: () => t`Expiry date set`,
   creationDateCannotBeAfterLastEditedDate: () =>
-    t`Creation date cannot be after last edited date`
+    t`Creation date cannot be after last edited date`,
+  noteDuplicated: () => t`Note duplicated`
 };

--- a/packages/intl/src/strings.ts
+++ b/packages/intl/src/strings.ts
@@ -813,6 +813,7 @@ $day$: Current day (eg. Monday)`,
   vaultCreated: () => t`Vault created`,
   noteUnlocked: () => t`Note unlocked`,
   noteCopied: () => t`Note copied to clipboard`,
+  noteDuplicated: () => t`Note duplicated`,
   introData: [
     {
       headings: [


### PR DESCRIPTION
## Description
Adds a success message when a note is duplicated to improve user feedback.

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
This change only adds a success message and does not affect core duplication logic.

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
