### PR TITLE
web: fix weird scroll when toggling switch in attach files dialog

### DIFF
--- a/apps/web/src/dialogs/attach-files-dialog.tsx
+++ b/apps/web/src/dialogs/attach-files-dialog.tsx
@@ -208,7 +208,8 @@ export const AttachFilesDialog = DialogManager.register(
           style={{
             maxHeight: 350,
             display: "flex",
-            flexDirection: "column"
+            flexDirection: "column",
+            position: "relative"
           }}
         >
           {fileStates.map((state, index) => (


### PR DESCRIPTION


## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Apparently clicking on a checkbox can trigger scroll in ancestors. Similar bug here https://issues.chromium.org/issues/40782006

I found two fixes for this:

1. Replace all instances of `overflowY: "hidden"` with `overflowY: "clip"` in dialog component https://github.com/streetwriters/notesnook/blob/master/apps/web/src/components/dialog/index.tsx
2. Set `position: relative` to the scroll container that renders the switch components (The compress switch toggle for image files)

Opted for second fix, since the first fix might impact other dialogs.

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [X] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [ ] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
