### PR TITLE
mobile: fix unset note expiry date

### DIFF
--- a/apps/mobile/app/components/date-picker/index.tsx
+++ b/apps/mobile/app/components/date-picker/index.tsx
@@ -19,7 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import React from "react";
 import { useThemeColors } from "@notesnook/theme";
 import { useRef } from "react";
-import { View } from "react-native";
+import { useWindowDimensions, View } from "react-native";
 import { defaultBorderRadius } from "../../utils/size";
 import { DefaultAppStyles } from "../../utils/styles";
 import DatePicker from "react-native-date-picker";
@@ -33,6 +33,9 @@ export default function DatePickerComponent(props: {
 }) {
   const { colors, isDark } = useThemeColors();
   const dateRef = useRef<Date>(dayjs().add(1, "day").toDate());
+
+  const { width } = useWindowDimensions();
+
   return (
     <View
       style={{
@@ -46,6 +49,9 @@ export default function DatePickerComponent(props: {
       }}
     >
       <DatePicker
+        style={{
+          width: width * 0.8 - DefaultAppStyles.GAP * 2
+        }}
         theme={isDark ? "dark" : "light"}
         mode="date"
         minimumDate={dayjs().add(1, "day").toDate()}

--- a/apps/mobile/app/components/date-picker/index.tsx
+++ b/apps/mobile/app/components/date-picker/index.tsx
@@ -32,7 +32,7 @@ export default function DatePickerComponent(props: {
   onCancel: () => void;
 }) {
   const { colors, isDark } = useThemeColors();
-  const dateRef = useRef<Date>(dayjs().add(1, "day").toDate());
+  const dateRef = useRef<Date>(dayjs().add(1, "week").toDate());
 
   const { width } = useWindowDimensions();
 

--- a/apps/mobile/app/components/list-items/note/index.tsx
+++ b/apps/mobile/app/components/list-items/note/index.tsx
@@ -55,6 +55,7 @@ import { TimeSince } from "../../ui/time-since";
 import Heading from "../../ui/typography/heading";
 import Paragraph from "../../ui/typography/paragraph";
 import dayjs from "dayjs";
+import { ExpiryDate } from "../../ui/expiry-date";
 
 type NoteItemProps = {
   item: Note | BaseTrashItem<Note>;
@@ -256,6 +257,21 @@ const NoteItem = ({
                     textStyle={{
                       fontSize: AppFontSize.xxs
                     }}
+                    short
+                    iconSize={AppFontSize.xxs}
+                    style={{
+                      justifyContent: "flex-start",
+                      paddingVertical: DefaultAppStyles.GAP_VERTICAL_SMALL / 2,
+                      alignSelf: "flex-start"
+                    }}
+                  />
+                ) : null}
+
+                {item.expiryDate?.value ? (
+                  <ExpiryDate
+                    note={item as Note}
+                    color={color?.colorCode}
+                    textStyle={{ fontSize: AppFontSize.xxs }}
                     short
                     iconSize={AppFontSize.xxs}
                     style={{

--- a/apps/mobile/app/components/ui/expiry-date/index.tsx
+++ b/apps/mobile/app/components/ui/expiry-date/index.tsx
@@ -42,22 +42,10 @@ export const ExpiryDate = ({
   short?: boolean;
 } & ButtonProps) => {
   const { colors } = useThemeColors();
-
   const expiryValue = note?.expiryDate?.value;
   if (!expiryValue) return null;
 
-  const expiryDate = dayjs(expiryValue);
-  const now = dayjs();
-  const isToday = expiryDate.isSame(now, "day");
-  const isTomorrow = expiryDate.isSame(now.add(1, "day"), "day");
-
-  const formattedDate = isToday
-    ? "Today"
-    : isTomorrow
-      ? "Tomorrow"
-      : expiryDate.format("DD MMM YYYY");
-
-  const isUrgent = isToday || isTomorrow;
+  const formattedDate = dayjs(expiryValue).format("DD MMM YYYY");
 
   return (
     <Button
@@ -66,9 +54,6 @@ export const ExpiryDate = ({
       fontSize={textStyle?.fontSize || AppFontSize.xs}
       iconSize={iconSize || AppFontSize.sm}
       type="secondary"
-      buttonType={
-        isUrgent ? { text: color || colors.primary.accent } : undefined
-      }
       textStyle={{
         marginRight: 0,
         ...textStyle

--- a/apps/mobile/app/components/ui/expiry-date/index.tsx
+++ b/apps/mobile/app/components/ui/expiry-date/index.tsx
@@ -1,0 +1,86 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+import { Note } from "@notesnook/core";
+import { useThemeColors } from "@notesnook/theme";
+import React from "react";
+import { TextStyle, ViewStyle } from "react-native";
+import { AppFontSize, defaultBorderRadius } from "../../../utils/size";
+import { DefaultAppStyles } from "../../../utils/styles";
+import { Button, ButtonProps } from "../button";
+import dayjs from "dayjs";
+
+export const ExpiryDate = ({
+  note,
+  color,
+  style,
+  textStyle,
+  iconSize,
+  short,
+  ...props
+}: {
+  note: Note;
+  color?: string;
+  style?: ViewStyle;
+  textStyle?: TextStyle;
+  iconSize?: number;
+  short?: boolean;
+} & ButtonProps) => {
+  const { colors } = useThemeColors();
+
+  const expiryValue = note?.expiryDate?.value;
+  if (!expiryValue) return null;
+
+  const expiryDate = dayjs(expiryValue);
+  const now = dayjs();
+  const isToday = expiryDate.isSame(now, "day");
+  const isTomorrow = expiryDate.isSame(now.add(1, "day"), "day");
+
+  const formattedDate = isToday
+    ? "Today"
+    : isTomorrow
+      ? "Tomorrow"
+      : expiryDate.format("DD MMM YYYY");
+
+  const isUrgent = isToday || isTomorrow;
+
+  return (
+    <Button
+      title={formattedDate}
+      icon="bomb"
+      fontSize={textStyle?.fontSize || AppFontSize.xs}
+      iconSize={iconSize || AppFontSize.sm}
+      type="secondary"
+      buttonType={
+        isUrgent ? { text: color || colors.primary.accent } : undefined
+      }
+      textStyle={{
+        marginRight: 0,
+        ...textStyle
+      }}
+      style={{
+        height: "auto",
+        borderRadius: defaultBorderRadius,
+        borderColor: colors.primary.border,
+        paddingHorizontal: DefaultAppStyles.GAP_SMALL,
+        ...(style as ViewStyle)
+      }}
+      {...props}
+    />
+  );
+};

--- a/apps/mobile/app/hooks/use-actions.tsx
+++ b/apps/mobile/app/hooks/use-actions.tsx
@@ -1180,11 +1180,13 @@ export const useActions = ({
       },
       {
         id: "expiry-date",
-        title: item.expiryDate ? strings.unsetExpiry() : strings.setExpiry(),
-        icon: item.expiryDate ? "bomb-off" : "bomb",
+        title: item.expiryDate?.value
+          ? strings.unsetExpiry()
+          : strings.setExpiry(),
+        icon: item.expiryDate.value ? "bomb-off" : "bomb",
         locked: !features?.expiringNotes?.isAllowed,
         onPress: async () => {
-          if (item.expiryDate) {
+          if (item.expiryDate?.value) {
             await db.notes.setExpiryDate(null, item.id);
             setItem((await db.notes.note(item.id)) as Item);
           } else {

--- a/apps/mobile/app/hooks/use-actions.tsx
+++ b/apps/mobile/app/hooks/use-actions.tsx
@@ -69,7 +69,11 @@ import { useSelectionStore } from "../stores/use-selection-store";
 import { useSettingStore } from "../stores/use-setting-store";
 import { useTagStore } from "../stores/use-tag-store";
 import { useUserStore } from "../stores/use-user-store";
-import { eCloseSheet, eUpdateNoteInEditor } from "../utils/events";
+import {
+  eCloseSheet,
+  eMenuItemUpdate,
+  eUpdateNoteInEditor
+} from "../utils/events";
 import { deleteItems } from "../utils/functions";
 import { convertNoteToText } from "../utils/note-to-text";
 import { NotesnookModule } from "../utils/notesnook-module";
@@ -1188,7 +1192,8 @@ export const useActions = ({
         onPress: async () => {
           if (item.expiryDate?.value) {
             await db.notes.setExpiryDate(null, item.id);
-
+            Navigation.queueRoutesForUpdate();
+            eSendEvent(eMenuItemUpdate);
             ToastManager.show({
               message: strings.expiryDateRemoved(),
               type: "success",
@@ -1218,7 +1223,8 @@ export const useActions = ({
                   onConfirm={async (date) => {
                     close?.();
                     await db.notes.setExpiryDate(date.getTime(), item.id);
-
+                    Navigation.queueRoutesForUpdate();
+                    eSendEvent(eMenuItemUpdate);
                     ToastManager.show({
                       message: strings.expiryDateSet(),
                       type: "success",

--- a/apps/mobile/app/hooks/use-actions.tsx
+++ b/apps/mobile/app/hooks/use-actions.tsx
@@ -1188,6 +1188,13 @@ export const useActions = ({
         onPress: async () => {
           if (item.expiryDate?.value) {
             await db.notes.setExpiryDate(null, item.id);
+
+            ToastManager.show({
+              message: strings.expiryDateRemoved(),
+              type: "success",
+              context: "local"
+            });
+
             setItem((await db.notes.note(item.id)) as Item);
           } else {
             if (features && !features?.expiringNotes.isAllowed) {
@@ -1211,6 +1218,13 @@ export const useActions = ({
                   onConfirm={async (date) => {
                     close?.();
                     await db.notes.setExpiryDate(date.getTime(), item.id);
+
+                    ToastManager.show({
+                      message: strings.expiryDateSet(),
+                      type: "success",
+                      context: "local"
+                    });
+
                     setItem((await db.notes.note(item.id)) as Item);
                   }}
                 />

--- a/apps/mobile/app/hooks/use-actions.tsx
+++ b/apps/mobile/app/hooks/use-actions.tsx
@@ -1183,7 +1183,7 @@ export const useActions = ({
         title: item.expiryDate?.value
           ? strings.unsetExpiry()
           : strings.setExpiry(),
-        icon: item.expiryDate.value ? "bomb-off" : "bomb",
+        icon: item.expiryDate?.value ? "bomb-off" : "bomb",
         locked: !features?.expiringNotes?.isAllowed,
         onPress: async () => {
           if (item.expiryDate?.value) {

--- a/packages/intl/locale/en.po
+++ b/packages/intl/locale/en.po
@@ -2783,6 +2783,10 @@ msgstr "Expiry date cannot be more than 1 year in the future"
 msgid "Expiry date must be in the future"
 msgstr "Expiry date must be in the future"
 
+#: src/strings.ts:2706
+msgid "Expiry date removed"
+msgstr "Expiry date removed"
+
 #: src/strings.ts:2693
 msgid "Expiry date set"
 msgstr "Expiry date set"

--- a/packages/intl/locale/pseudo-LOCALE.po
+++ b/packages/intl/locale/pseudo-LOCALE.po
@@ -2772,6 +2772,10 @@ msgstr ""
 msgid "Expiry date must be in the future"
 msgstr ""
 
+#: src/strings.ts:2706
+msgid "Expiry date removed"
+msgstr ""
+
 #: src/strings.ts:2693
 msgid "Expiry date set"
 msgstr ""

--- a/packages/intl/src/strings.ts
+++ b/packages/intl/src/strings.ts
@@ -2702,5 +2702,6 @@ Continue without attachments?`,
     t`We couldn't load this theme. The file appears to be incomplete or missing required theme properties.`,
   copyLogs: () => t`Copy logs`,
   permissionRequiredToSaveQRCode: () =>
-    t`Permission required to save QR-Code to Gallery`
+    t`Permission required to save QR-Code to Gallery`,
+  expiryDateRemoved: () => t`Expiry date removed`
 };


### PR DESCRIPTION
## Description
Fixed the ability to remove or unset an expiry date from a note on mobile.

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
Only fixed the condition to set/unset checks behaviour

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
