### PR TITLE
mobile: show user-friendly error for invalid theme file upload

### DIFF
--- a/apps/mobile/app/common/filesystem/utils.ts
+++ b/apps/mobile/app/common/filesystem/utils.ts
@@ -192,7 +192,8 @@ export async function checkAndCreateDir(path: string) {
 }
 
 export const santizeUri = (uri: string) => {
-  return Platform.OS === "ios" ? decodeURI(uri).replace("file:///", "/") : uri;
+  const decoded = decodeURI(uri);
+  return Platform.OS === "ios" ? decoded.replace("file:///", "/") : decoded;
 };
 
 export function isSuccessStatusCode(statusCode: number) {

--- a/apps/mobile/app/screens/settings/theme-selector.tsx
+++ b/apps/mobile/app/screens/settings/theme-selector.tsx
@@ -64,6 +64,7 @@ import { MenuItemsList } from "../../utils/menu-items";
 import { AppFontSize, defaultBorderRadius } from "../../utils/size";
 import { DefaultAppStyles } from "../../utils/styles";
 import { openLinkInBrowser } from "../../utils/functions";
+import Clipboard from "@react-native-clipboard/clipboard";
 
 const THEME_SERVER_URL = "https://themes-api.notesnook.com";
 //@ts-ignore
@@ -470,11 +471,14 @@ function ThemeSelector() {
                         heading: strings.themeMissingRequiredFields(),
                         type: "error",
                         context: "global",
-                        actionText: strings.learnMore(),
+                        actionText: strings.copyLogs(),
                         func: () => {
-                          openLinkInBrowser(
-                            "https://help.notesnook.com/custom-themes/introduction"
-                          );
+                          Clipboard.setString(result.error || "");
+                          ToastManager.show({
+                            heading: strings.logsCopied(),
+                            type: "success",
+                            context: "global"
+                          });
                         }
                       });
                     } else {

--- a/apps/mobile/app/screens/settings/theme-selector.tsx
+++ b/apps/mobile/app/screens/settings/theme-selector.tsx
@@ -460,8 +460,27 @@ function ThemeSelector() {
                     return;
                   }
                   const result = validateTheme(json);
+
                   if (result.error) {
-                    ToastManager.error(new Error(result.error));
+                    if (
+                      typeof result.error === "string" &&
+                      result.error.includes("missing from the theme")
+                    ) {
+                      ToastManager.show({
+                        heading: strings.themeMissingRequiredFields(),
+                        type: "error",
+                        context: "global",
+                        actionText: strings.learnMore(),
+                        func: () => {
+                          openLinkInBrowser(
+                            "https://help.notesnook.com/custom-themes/introduction"
+                          );
+                        }
+                      });
+                    } else {
+                      ToastManager.error(new Error(result.error));
+                    }
+
                     return;
                   }
                   select(json, true);

--- a/apps/mobile/app/screens/settings/theme-selector.tsx
+++ b/apps/mobile/app/screens/settings/theme-selector.tsx
@@ -466,6 +466,9 @@ function ThemeSelector() {
                   }
                   select(json, true);
                 } catch (e) {
+                  if ((e as Error).message.includes("Code=3072")) {
+                    return;
+                  }
                   ToastManager.error(e as Error);
                 }
               }}

--- a/apps/mobile/app/screens/settings/theme-selector.tsx
+++ b/apps/mobile/app/screens/settings/theme-selector.tsx
@@ -441,7 +441,17 @@ function ThemeSelector() {
                   ReactNativeBlobUtil.fs
                     .unlink(themeJsonCopiedPath)
                     .catch(() => {});
-                  const json = JSON.parse(themeJson);
+                  let json;
+                  try {
+                    json = JSON.parse(themeJson);
+                  } catch (e) {
+                    ToastManager.show({
+                      heading: strings.invalidThemeFileFormat(),
+                      type: "error",
+                      context: "global"
+                    });
+                    return;
+                  }
                   const result = validateTheme(json);
                   if (result.error) {
                     ToastManager.error(new Error(result.error));

--- a/apps/mobile/app/screens/settings/theme-selector.tsx
+++ b/apps/mobile/app/screens/settings/theme-selector.tsx
@@ -63,6 +63,7 @@ import { getElevationStyle } from "../../utils/elevation";
 import { MenuItemsList } from "../../utils/menu-items";
 import { AppFontSize, defaultBorderRadius } from "../../utils/size";
 import { DefaultAppStyles } from "../../utils/styles";
+import { openLinkInBrowser } from "../../utils/functions";
 
 const THEME_SERVER_URL = "https://themes-api.notesnook.com";
 //@ts-ignore
@@ -448,7 +449,13 @@ function ThemeSelector() {
                     ToastManager.show({
                       heading: strings.invalidThemeFileFormat(),
                       type: "error",
-                      context: "global"
+                      context: "global",
+                      actionText: strings.learnMore(),
+                      func: () => {
+                        openLinkInBrowser(
+                          "https://help.notesnook.com/custom-themes/introduction"
+                        );
+                      }
                     });
                     return;
                   }

--- a/packages/intl/locale/en.po
+++ b/packages/intl/locale/en.po
@@ -7273,6 +7273,10 @@ msgstr "We are creating a backup of your data. Please wait..."
 msgid "We are sorry, it seems that the app crashed due to an error. You can submit a bug report below so we can fix this asap."
 msgstr "We are sorry, it seems that the app crashed due to an error. You can submit a bug report below so we can fix this asap."
 
+#: src/strings.ts:2700
+msgid "We couldn't load this theme. Please make sure the file is a valid theme export."
+msgstr "We couldn't load this theme. Please make sure the file is a valid theme export."
+
 #: src/strings.ts:1390
 msgid "We have sent you an email confirmation link. Please check your email inbox. If you cannot find the email, check your spam folder."
 msgstr "We have sent you an email confirmation link. Please check your email inbox. If you cannot find the email, check your spam folder."

--- a/packages/intl/locale/en.po
+++ b/packages/intl/locale/en.po
@@ -7277,6 +7277,10 @@ msgstr "We are sorry, it seems that the app crashed due to an error. You can sub
 msgid "We couldn't load this theme. Please make sure the file is a valid JSON theme file."
 msgstr "We couldn't load this theme. Please make sure the file is a valid JSON theme file."
 
+#: src/strings.ts:2693
+msgid "We couldn't load this theme. The file appears to be incomplete or missing required theme properties."
+msgstr "We couldn't load this theme. The file appears to be incomplete or missing required theme properties."
+
 #: src/strings.ts:1390
 msgid "We have sent you an email confirmation link. Please check your email inbox. If you cannot find the email, check your spam folder."
 msgstr "We have sent you an email confirmation link. Please check your email inbox. If you cannot find the email, check your spam folder."

--- a/packages/intl/locale/en.po
+++ b/packages/intl/locale/en.po
@@ -1868,6 +1868,10 @@ msgstr "Copy link"
 msgid "Copy link text"
 msgstr "Copy link text"
 
+#: src/strings.ts:2694
+msgid "Copy logs"
+msgstr "Copy logs"
+
 #: src/strings.ts:454
 msgid "Copy note"
 msgstr "Copy note"

--- a/packages/intl/locale/en.po
+++ b/packages/intl/locale/en.po
@@ -7274,8 +7274,8 @@ msgid "We are sorry, it seems that the app crashed due to an error. You can subm
 msgstr "We are sorry, it seems that the app crashed due to an error. You can submit a bug report below so we can fix this asap."
 
 #: src/strings.ts:2700
-msgid "We couldn't load this theme. Please make sure the file is a valid theme export."
-msgstr "We couldn't load this theme. Please make sure the file is a valid theme export."
+msgid "We couldn't load this theme. Please make sure the file is a valid JSON theme file."
+msgstr "We couldn't load this theme. Please make sure the file is a valid JSON theme file."
 
 #: src/strings.ts:1390
 msgid "We have sent you an email confirmation link. Please check your email inbox. If you cannot find the email, check your spam folder."

--- a/packages/intl/locale/pseudo-LOCALE.po
+++ b/packages/intl/locale/pseudo-LOCALE.po
@@ -7221,10 +7221,10 @@ msgstr ""
 
 #: src/strings.ts:474
 msgid "We are sorry, it seems that the app crashed due to an error. You can submit a bug report below so we can fix this asap."
-msgstr ""
+msgstr "<<<<<<< HEAD"
 
 #: src/strings.ts:2700
-msgid "We couldn't load this theme. Please make sure the file is a valid theme export."
+msgid "We couldn't load this theme. Please make sure the file is a valid JSON theme file."
 msgstr ""
 
 #: src/strings.ts:1390

--- a/packages/intl/locale/pseudo-LOCALE.po
+++ b/packages/intl/locale/pseudo-LOCALE.po
@@ -1857,6 +1857,10 @@ msgstr ""
 msgid "Copy link text"
 msgstr ""
 
+#: src/strings.ts:2694
+msgid "Copy logs"
+msgstr ""
+
 #: src/strings.ts:454
 msgid "Copy note"
 msgstr ""

--- a/packages/intl/locale/pseudo-LOCALE.po
+++ b/packages/intl/locale/pseudo-LOCALE.po
@@ -7227,6 +7227,10 @@ msgstr "<<<<<<< HEAD"
 msgid "We couldn't load this theme. Please make sure the file is a valid JSON theme file."
 msgstr ""
 
+#: src/strings.ts:2693
+msgid "We couldn't load this theme. The file appears to be incomplete or missing required theme properties."
+msgstr ""
+
 #: src/strings.ts:1390
 msgid "We have sent you an email confirmation link. Please check your email inbox. If you cannot find the email, check your spam folder."
 msgstr ""

--- a/packages/intl/locale/pseudo-LOCALE.po
+++ b/packages/intl/locale/pseudo-LOCALE.po
@@ -7223,6 +7223,10 @@ msgstr ""
 msgid "We are sorry, it seems that the app crashed due to an error. You can submit a bug report below so we can fix this asap."
 msgstr ""
 
+#: src/strings.ts:2700
+msgid "We couldn't load this theme. Please make sure the file is a valid theme export."
+msgstr ""
+
 #: src/strings.ts:1390
 msgid "We have sent you an email confirmation link. Please check your email inbox. If you cannot find the email, check your spam folder."
 msgstr ""

--- a/packages/intl/src/strings.ts
+++ b/packages/intl/src/strings.ts
@@ -2697,5 +2697,7 @@ Continue without attachments?`,
   maximumReminderDate: (maxDate: string) =>
     t`Maximum reminder date is ${maxDate}`,
   invalidThemeFileFormat: () =>
-    t`We couldn't load this theme. Please make sure the file is a valid JSON theme file.`
+    t`We couldn't load this theme. Please make sure the file is a valid JSON theme file.`,
+  themeMissingRequiredFields: () =>
+    t`We couldn't load this theme. The file appears to be incomplete or missing required theme properties.`
 };

--- a/packages/intl/src/strings.ts
+++ b/packages/intl/src/strings.ts
@@ -2697,5 +2697,5 @@ Continue without attachments?`,
   maximumReminderDate: (maxDate: string) =>
     t`Maximum reminder date is ${maxDate}`,
   invalidThemeFileFormat: () =>
-    t`We couldn't load this theme. Please make sure the file is a valid theme export.`
+    t`We couldn't load this theme. Please make sure the file is a valid JSON theme file.`
 };

--- a/packages/intl/src/strings.ts
+++ b/packages/intl/src/strings.ts
@@ -2695,5 +2695,7 @@ Continue without attachments?`,
     t`Creation date cannot be after last edited date`,
   noteDuplicated: () => t`Note duplicated`,
   maximumReminderDate: (maxDate: string) =>
-    t`Maximum reminder date is ${maxDate}`
+    t`Maximum reminder date is ${maxDate}`,
+  invalidThemeFileFormat: () =>
+    t`We couldn't load this theme. Please make sure the file is a valid theme export.`
 };

--- a/packages/intl/src/strings.ts
+++ b/packages/intl/src/strings.ts
@@ -2699,5 +2699,6 @@ Continue without attachments?`,
   invalidThemeFileFormat: () =>
     t`We couldn't load this theme. Please make sure the file is a valid JSON theme file.`,
   themeMissingRequiredFields: () =>
-    t`We couldn't load this theme. The file appears to be incomplete or missing required theme properties.`
+    t`We couldn't load this theme. The file appears to be incomplete or missing required theme properties.`,
+  copyLogs: () => t`Copy logs`
 };


### PR DESCRIPTION
## Description
Replaces technical JSON parse error with a user-friendly message when uploading invalid theme files in the theme import.

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
This change only improves error handling and user-facing messaging during theme file upload.

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
