### PR TITLE
web: don't allow note expiry to be set beyond 1 year in the future

### DIFF
--- a/apps/web/src/dialogs/note-expiry-date-dialog.tsx
+++ b/apps/web/src/dialogs/note-expiry-date-dialog.tsx
@@ -54,19 +54,26 @@ export const NoteExpiryDateDialog = DialogManager.register(
     return (
       <Dialog
         isOpen={true}
-        title={"Set Custom Expiry Date"}
+        title={strings.setExpiry()}
         onClose={() => onClose(false)}
         width={400}
         positiveButton={{
           text: strings.done(),
           onClick: async () => {
             if (date.isBefore(dayjs())) {
-              showToast("error", "Expiry date must be in the future");
+              showToast("error", strings.expiryDateMustBeInTheFuture());
+              return;
+            }
+            if (date.isAfter(dayjs().add(1, "year"))) {
+              showToast(
+                "error",
+                strings.expiryDateCannotBeMoreThan1YearInTheFuture()
+              );
               return;
             }
             await db.notes.setExpiryDate(date.valueOf(), noteId);
             store.refresh();
-            showToast("success", "Expiry date set");
+            showToast("success", strings.expiryDateSet());
             onClose(true);
           }
         }}

--- a/packages/intl/locale/en.po
+++ b/packages/intl/locale/en.po
@@ -2767,6 +2767,18 @@ msgstr "Experience the next level of private note taking\""
 msgid "Expiry date"
 msgstr "Expiry date"
 
+#: src/strings.ts:2692
+msgid "Expiry date cannot be more than 1 year in the future"
+msgstr "Expiry date cannot be more than 1 year in the future"
+
+#: src/strings.ts:2690
+msgid "Expiry date must be in the future"
+msgstr "Expiry date must be in the future"
+
+#: src/strings.ts:2693
+msgid "Expiry date set"
+msgstr "Expiry date set"
+
 #: src/strings.ts:2550
 msgid "Explore all plans"
 msgstr "Explore all plans"

--- a/packages/intl/locale/pseudo-LOCALE.po
+++ b/packages/intl/locale/pseudo-LOCALE.po
@@ -2756,6 +2756,18 @@ msgstr ""
 msgid "Expiry date"
 msgstr ""
 
+#: src/strings.ts:2692
+msgid "Expiry date cannot be more than 1 year in the future"
+msgstr ""
+
+#: src/strings.ts:2690
+msgid "Expiry date must be in the future"
+msgstr ""
+
+#: src/strings.ts:2693
+msgid "Expiry date set"
+msgstr ""
+
 #: src/strings.ts:2550
 msgid "Explore all plans"
 msgstr ""

--- a/packages/intl/src/strings.ts
+++ b/packages/intl/src/strings.ts
@@ -2686,5 +2686,9 @@ Continue without attachments?`,
   openingLocalFileDesc: (filePath: string) =>
     t`Are you sure you want to open this file: ${filePath}?`,
   cantOpenFileLinksInBrowsers: () =>
-    t`File links cannot be opened in browsers. Please use the Notesnook desktop app.`
+    t`File links cannot be opened in browsers. Please use the Notesnook desktop app.`,
+  expiryDateMustBeInTheFuture: () => t`Expiry date must be in the future`,
+  expiryDateCannotBeMoreThan1YearInTheFuture: () =>
+    t`Expiry date cannot be more than 1 year in the future`,
+  expiryDateSet: () => t`Expiry date set`
 };


### PR DESCRIPTION

## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

web: don't allow note expiry to be set beyond 1 year in the future

## QA Scope

Web only

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [X] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [ ] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
