### PR TITLE
web: set edited date as max date in note creation date edit's day picker

### DIFF
--- a/apps/web/src/dialogs/edit-note-creation-date-dialog.tsx
+++ b/apps/web/src/dialogs/edit-note-creation-date-dialog.tsx
@@ -77,7 +77,7 @@ export const EditNoteCreationDateDialog = DialogManager.register(
           text: strings.save(),
           onClick: async () => {
             try {
-              if (dateEdited && date.isAfter(dayjs(dateEdited))) {
+              if (dateEdited && date.isAfter(dayjs(dateEdited), "minute")) {
                 showToast(
                   "error",
                   strings.creationDateCannotBeAfterLastEditedDate()

--- a/apps/web/src/dialogs/edit-note-creation-date-dialog.tsx
+++ b/apps/web/src/dialogs/edit-note-creation-date-dialog.tsx
@@ -65,6 +65,7 @@ export const EditNoteCreationDateDialog = DialogManager.register(
           onClose(false);
         }}
         title={strings.editCreationDate()}
+        description={`${strings.note()}: ${strings.creationDateCannotBeAfterLastEditedDate()}`}
         negativeButton={{
           text: strings.cancel(),
           onClick: () => {
@@ -76,14 +77,10 @@ export const EditNoteCreationDateDialog = DialogManager.register(
           text: strings.save(),
           onClick: async () => {
             try {
-              if (date.isAfter(dayjs())) {
-                showToast("error", "Creation date cannot be in the future");
-                return;
-              }
               if (dateEdited && date.isAfter(dayjs(dateEdited))) {
                 showToast(
                   "error",
-                  "Creation date cannot be after last edited date"
+                  strings.creationDateCannotBeAfterLastEditedDate()
                 );
                 return;
               }
@@ -140,7 +137,7 @@ export const EditNoteCreationDateDialog = DialogManager.register(
                 width: 300
               }}
               selected={dayjs(date).toDate()}
-              maxDate={new Date()}
+              maxDate={new Date(dateEdited)}
               onSelect={(day) => {
                 if (!day) return;
                 const date = getFormattedDate(day, "date");

--- a/packages/intl/locale/en.po
+++ b/packages/intl/locale/en.po
@@ -1973,6 +1973,10 @@ msgstr "Created at"
 msgid "Creating a{0} backup"
 msgstr "Creating a{0} backup"
 
+#: src/strings.ts:2695
+msgid "Creation date cannot be after last edited date"
+msgstr "Creation date cannot be after last edited date"
+
 #: src/strings.ts:2049
 msgid "Credentials"
 msgstr "Credentials"

--- a/packages/intl/locale/pseudo-LOCALE.po
+++ b/packages/intl/locale/pseudo-LOCALE.po
@@ -1962,6 +1962,10 @@ msgstr ""
 msgid "Creating a{0} backup"
 msgstr ""
 
+#: src/strings.ts:2695
+msgid "Creation date cannot be after last edited date"
+msgstr ""
+
 #: src/strings.ts:2049
 msgid "Credentials"
 msgstr ""

--- a/packages/intl/src/strings.ts
+++ b/packages/intl/src/strings.ts
@@ -2690,5 +2690,7 @@ Continue without attachments?`,
   expiryDateMustBeInTheFuture: () => t`Expiry date must be in the future`,
   expiryDateCannotBeMoreThan1YearInTheFuture: () =>
     t`Expiry date cannot be more than 1 year in the future`,
-  expiryDateSet: () => t`Expiry date set`
+  expiryDateSet: () => t`Expiry date set`,
+  creationDateCannotBeAfterLastEditedDate: () =>
+    t`Creation date cannot be after last edited date`
 };


### PR DESCRIPTION

## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

web: set edited date as max date in note creation date edit's day picker

## QA Scope

Web only. Now in the date picker in note creation date's edit dialog, the days will be disabled after note's edit date

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [X] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [ ] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
