### PR TITLE
Allow any width/height value in EmbedSizeOptions when inserting embed

### DIFF
--- a/packages/editor/src/toolbar/popups/embed-popup.tsx
+++ b/packages/editor/src/toolbar/popups/embed-popup.tsx
@@ -76,6 +76,7 @@ export function EmbedPopup(props: EmbedPopupProps) {
           let _src = src;
           let _width = size.width;
           let _height = size.height;
+
           if (embedSource === "code") {
             const document = new DOMParser().parseFromString(src, "text/html");
             if (document.getElementsByTagName("iframe").length <= 0)
@@ -103,11 +104,12 @@ export function EmbedPopup(props: EmbedPopupProps) {
           }
 
           const convertedUrl = convertUrlToEmbedUrl(_src);
-          if (!convertedUrl && embedSource === "url") {
-            return setError("Please provide a valid embed url.");
-          }
 
           if (convertedUrl) _src = convertedUrl;
+
+          if (!_src && embedSource === "url") {
+            return setError("Please provide a valid embed url.");
+          }
 
           if (_src.startsWith("javascript:")) {
             return setError("Embedding javascript code is not supported.");

--- a/packages/editor/src/toolbar/popups/embed-popup.tsx
+++ b/packages/editor/src/toolbar/popups/embed-popup.tsx
@@ -17,17 +17,17 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { Flex, Text } from "@theme-ui/components";
-import { useCallback, useState } from "react";
-import { Popup } from "../components/popup.js";
-import { Input, Textarea } from "@theme-ui/components";
-import { Embed, EmbedSizeOptions } from "../../extensions/embed/index.js";
-import { convertUrlToEmbedUrl } from "@social-embed/lib";
-import { InlineInput } from "../../components/inline-input/index.js";
-import { Tabs, Tab } from "../../components/tabs/index.js";
 import { strings } from "@notesnook/intl";
+import { convertUrlToEmbedUrl } from "@social-embed/lib";
+import { Flex, Input, Text, Textarea } from "@theme-ui/components";
+import { useCallback, useState } from "react";
+import { InlineInput } from "../../components/inline-input/index.js";
+import { Tab, Tabs } from "../../components/tabs/index.js";
+import { Embed, EmbedSizeOptions } from "../../extensions/embed/index.js";
+import { Popup } from "../components/popup.js";
 
 type EmbedSource = "url" | "code";
+
 export type EmbedPopupProps = {
   onClose: (embed?: Embed) => void;
   title: string;
@@ -38,33 +38,30 @@ export type EmbedPopupProps = {
 
 export function EmbedPopup(props: EmbedPopupProps) {
   const { onClose, onSizeChanged, title, embed } = props;
-  const [width, setWidth] = useState(embed?.width || 300);
-  const [height, setHeight] = useState(embed?.height || 150);
   const [src, setSrc] = useState(embed?.src || "");
   const [embedSource, setEmbedSource] = useState<EmbedSource>("url");
   const [error, setError] = useState<string | null>(null);
+  const [size, setSize] = useState<EmbedSizeOptions>({
+    width: 300,
+    height: 150
+  });
 
   const onSizeChange = useCallback(
     (newWidth?: number, newHeight?: number) => {
-      const size: EmbedSizeOptions = newWidth
-        ? {
-            width: newWidth,
-            height: newWidth * (height / width)
-          }
-        : newHeight
-        ? {
-            width: newHeight * (width / height),
-            height: newHeight
-          }
-        : {
-            width: 0,
-            height: 0
-          };
-      setWidth(size.width);
-      setHeight(size.height);
-      if (onSizeChanged) onSizeChanged(size);
+      const hasNewWidth = Number.isFinite(newWidth);
+      const hasNewHeight = Number.isFinite(newHeight);
+
+      if (!hasNewWidth && !hasNewHeight) return;
+      setSize((size) => {
+        const newSize = {
+          width: hasNewWidth ? ((newWidth || 0) as number) : size.width,
+          height: hasNewHeight ? ((newHeight || 0) as number) : size.height
+        };
+        if (onSizeChanged) onSizeChanged(newSize);
+        return newSize;
+      });
     },
-    [height, width, onSizeChanged]
+    [onSizeChanged]
   );
 
   return (
@@ -77,8 +74,8 @@ export function EmbedPopup(props: EmbedPopupProps) {
         onClick: () => {
           setError(null);
           let _src = src;
-          let _width = width;
-          let _height = height;
+          let _width = size.width;
+          let _height = size.height;
           if (embedSource === "code") {
             const document = new DOMParser().parseFromString(src, "text/html");
             if (document.getElementsByTagName("iframe").length <= 0)
@@ -147,7 +144,7 @@ export function EmbedPopup(props: EmbedPopupProps) {
                 label="width"
                 type="number"
                 placeholder={strings.width()}
-                value={width}
+                value={size.width}
                 sx={{
                   mr: 1,
                   fontSize: "body"
@@ -158,7 +155,7 @@ export function EmbedPopup(props: EmbedPopupProps) {
                 label="height"
                 type="number"
                 placeholder={strings.height()}
-                value={height}
+                value={size.height}
                 sx={{ fontSize: "body" }}
                 onChange={(e) =>
                   onSizeChange(undefined, e.target.valueAsNumber)

--- a/packages/editor/src/toolbar/popups/embed-popup.tsx
+++ b/packages/editor/src/toolbar/popups/embed-popup.tsx
@@ -99,7 +99,7 @@ export function EmbedPopup(props: EmbedPopupProps) {
               _height = parseInt(heightValue);
           }
 
-          if (!isValidUrl(src)) {
+          if (embedSource === "url" && !isValidUrl(src)) {
             return setError("Please provide a valid url.");
           }
 

--- a/packages/editor/src/toolbar/popups/embed-popup.tsx
+++ b/packages/editor/src/toolbar/popups/embed-popup.tsx
@@ -42,8 +42,8 @@ export function EmbedPopup(props: EmbedPopupProps) {
   const [embedSource, setEmbedSource] = useState<EmbedSource>("url");
   const [error, setError] = useState<string | null>(null);
   const [size, setSize] = useState<EmbedSizeOptions>({
-    width: 300,
-    height: 150
+    width: embed?.width || 300,
+    height: embed?.height || 150
   });
 
   const onSizeChange = useCallback(
@@ -156,7 +156,7 @@ export function EmbedPopup(props: EmbedPopupProps) {
                 label="width"
                 type="number"
                 placeholder={strings.width()}
-                value={size.width}
+                defaultValue={size.width}
                 sx={{
                   mr: 1,
                   fontSize: "body"
@@ -167,7 +167,7 @@ export function EmbedPopup(props: EmbedPopupProps) {
                 label="height"
                 type="number"
                 placeholder={strings.height()}
-                value={size.height}
+                defaultValue={size.height}
                 sx={{ fontSize: "body" }}
                 onChange={(e) =>
                   onSizeChange(undefined, e.target.valueAsNumber)

--- a/packages/editor/src/toolbar/popups/embed-popup.tsx
+++ b/packages/editor/src/toolbar/popups/embed-popup.tsx
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { strings } from "@notesnook/intl";
-import { convertUrlToEmbedUrl } from "@social-embed/lib";
+import { convertUrlToEmbedUrl, isValidUrl } from "@social-embed/lib";
 import { Flex, Input, Text, Textarea } from "@theme-ui/components";
 import { useCallback, useState } from "react";
 import { InlineInput } from "../../components/inline-input/index.js";
@@ -97,8 +97,18 @@ export function EmbedPopup(props: EmbedPopupProps) {
             if (heightValue && !isNaN(parseInt(heightValue)))
               _height = parseInt(heightValue);
           }
+
+          if (!isValidUrl(src)) {
+            return setError("Please provide a valid url.");
+          }
+
           const convertedUrl = convertUrlToEmbedUrl(_src);
+          if (!convertedUrl && embedSource === "url") {
+            return setError("Please provide a valid embed url.");
+          }
+
           if (convertedUrl) _src = convertedUrl;
+
           if (_src.startsWith("javascript:")) {
             return setError("Embedding javascript code is not supported.");
           }


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Allow any width/height value in EmbedSizeOptions when inserting embeds. Previously changing width would remove the height value and vice versa. This decouples width/height change by user so they can be any value.

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [x] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
