### PR TITLE
monograph: show error message for empty password on unlock

### DIFF
--- a/apps/monograph/app/components/monographpost/index.tsx
+++ b/apps/monograph/app/components/monographpost/index.tsx
@@ -387,10 +387,14 @@ function MonographLockscreen({
 }) {
   const [error, setError] = useState<string>();
   const [loading, setLoading] = useState<boolean>();
-  const password = useRef<string>();
+  const password = useRef<string>("");
 
   const unlock = useCallback(async () => {
-    if (!password.current) return;
+    if (!password.current) {
+      setError("Password is required.");
+      return;
+    }
+
     setError(undefined);
     setLoading(true);
     try {
@@ -470,7 +474,9 @@ function MonographLockscreen({
             }}
             autoFocus={true}
             autofillBackgroundColor="background-secondary"
-            onChange={(event) => (password.current = event.target.value)}
+            onChange={(event) => {
+              password.current = event.target.value;
+            }}
             onKeyUp={(e) => (e.key === "Enter" ? unlock() : null)}
             type="password"
             placeholder="Enter password to continue"
@@ -480,6 +486,7 @@ function MonographLockscreen({
             title="Unlock"
             sx={{ borderRadius: 100, px: 50, mt: 1 }}
             onClick={() => unlock()}
+            disabled={loading}
           >
             Unlock
           </Button>


### PR DESCRIPTION

## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

monograph: show error message for empty password on unlock

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [X] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [ ] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
