### PR TITLE
web: ensure full year range is visible in reminder dialog's day picker

### DIFF
--- a/apps/web/src/components/day-picker/index.tsx
+++ b/apps/web/src/components/day-picker/index.tsx
@@ -46,7 +46,21 @@ export function DayPicker(props: DayPickerProps) {
       maxDate,
       minDate
     },
-    years: { numberOfYears: 99 },
+    years: {
+      /**
+       * When minDate and maxDate are provided, we switch to "fluid" mode and calculate the number of years in a way that all valid years are visible.
+       *
+       * When not provided, use default mode and numberOfYears.
+       */
+      numberOfYears:
+        minDate && maxDate
+          ? Math.max(
+              Math.abs(maxDate.getFullYear() - selected.getFullYear()),
+              Math.abs(selected.getFullYear() - minDate.getFullYear())
+            ) * 2
+          : 99,
+      mode: minDate && maxDate ? "fluid" : "decade"
+    },
     calendar: {
       startDay: 0
     }
@@ -86,7 +100,10 @@ export function DayPicker(props: DayPickerProps) {
           <Button
             variant="icon"
             sx={{ p: 0 }}
-            {...subtractOffset({ months: 1 }, { disabled: isPrevMonthBeforeMin })}
+            {...subtractOffset(
+              { months: 1 },
+              { disabled: isPrevMonthBeforeMin }
+            )}
           >
             <ChevronLeft />
           </Button>

--- a/apps/web/src/components/day-picker/index.tsx
+++ b/apps/web/src/components/day-picker/index.tsx
@@ -55,8 +55,8 @@ export function DayPicker(props: DayPickerProps) {
       numberOfYears:
         minDate && maxDate
           ? Math.max(
-              Math.abs(maxDate.getFullYear() - selected.getFullYear()),
-              Math.abs(selected.getFullYear() - minDate.getFullYear())
+              Math.abs(maxDate.getFullYear() - selected.getFullYear()) + 1,
+              Math.abs(selected.getFullYear() - minDate.getFullYear()) + 1
             ) * 2
           : 99,
       mode: minDate && maxDate ? "fluid" : "decade"


### PR DESCRIPTION

## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

web: ensure full year range is visible in reminder dialog's day picker

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [X] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [ ] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
