### PR TITLE
mobile: fix publish note title input scrolling to end on render

### DIFF
--- a/apps/mobile/app/components/sheets/publish-note/index.tsx
+++ b/apps/mobile/app/components/sheets/publish-note/index.tsx
@@ -79,6 +79,11 @@ const PublishNoteSheet = ({
   const isFeatureAvailable = useIsFeatureAvailable("monographAnalytics");
   const [isLocked, setIsLocked] = useState(false);
   const [publishing, setPublishing] = useState(false);
+  const [titleValue, setTitleValue] = useState(note.title || "");
+  const [titleSelection, setTitleSelection] = useState<
+    { start: number; end: number } | undefined
+  >({ start: 0, end: 0 });
+  const customTitle = useRef<string>("");
   const pwdInput = useRef<TextInput>(null);
   const titleInput = useRef<TextInput>(null);
   const monographData = useAsync(async () => {
@@ -94,6 +99,16 @@ const PublishNoteSheet = ({
       password: ""
     })
   );
+
+  useEffect(() => {
+    if (monographData.result) {
+      const title = monograph?.title || note.title || "";
+      customTitle.current = title; // only set once on load
+      setTitleValue(customTitle.current);
+      setTitleSelection({ start: 0, end: 0 });
+      setTimeout(() => setTitleSelection(undefined), 50);
+    }
+  }, [monographData.result]);
 
   useEffect(() => {
     (async () => {
@@ -262,6 +277,13 @@ const PublishNoteSheet = ({
             name="title"
             formRef={formRef}
             fwdRef={titleInput}
+            onChangeText={(value) => {
+              customTitle.current = value;
+              setTitleValue(value);
+            }}
+            value={titleValue}
+            selection={titleSelection}
+            onFocus={() => setTitleSelection(undefined)}
             placeholder={strings.noteTitle()}
             validators={[validators.required(strings.titleIsRequired())]}
           />

--- a/apps/mobile/app/components/sheets/publish-note/index.tsx
+++ b/apps/mobile/app/components/sheets/publish-note/index.tsx
@@ -79,10 +79,6 @@ const PublishNoteSheet = ({
   const isFeatureAvailable = useIsFeatureAvailable("monographAnalytics");
   const [isLocked, setIsLocked] = useState(false);
   const [publishing, setPublishing] = useState(false);
-  const [titleValue, setTitleValue] = useState(note.title || "");
-  const [titleSelection, setTitleSelection] = useState<
-    { start: number; end: number } | undefined
-  >({ start: 0, end: 0 });
   const customTitle = useRef<string>("");
   const pwdInput = useRef<TextInput>(null);
   const titleInput = useRef<TextInput>(null);
@@ -101,13 +97,20 @@ const PublishNoteSheet = ({
   );
 
   useEffect(() => {
-    if (monographData.result) {
-      const title = monograph?.title || note.title || "";
-      customTitle.current = title; // only set once on load
-      setTitleValue(customTitle.current);
-      setTitleSelection({ start: 0, end: 0 });
-      setTimeout(() => setTitleSelection(undefined), 50);
-    }
+    if (!monographData.result) return;
+
+    const title = monograph?.title || note.title || "";
+    customTitle.current = title;
+
+    setTimeout(() => {
+      titleInput.current?.setNativeProps({
+        text: title,
+        selection: {
+          start: 0,
+          end: 0
+        }
+      });
+    }, 50);
   }, [monographData.result]);
 
   useEffect(() => {
@@ -279,11 +282,8 @@ const PublishNoteSheet = ({
             fwdRef={titleInput}
             onChangeText={(value) => {
               customTitle.current = value;
-              setTitleValue(value);
             }}
-            value={titleValue}
-            selection={titleSelection}
-            onFocus={() => setTitleSelection(undefined)}
+            defaultValue={note.title}
             placeholder={strings.noteTitle()}
             validators={[validators.required(strings.titleIsRequired())]}
           />


### PR DESCRIPTION
## Description
In the Publish Note sheet, the title input was always scrolling to the end of the text on render, This was caused by React Native's `TextInput` defaulting the cursor/scroll position to the end when a long `defaultValue` is provided.

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
This is a minor UI/UX fix specific to React Native's TextInput scroll behavior. No logic or data flow was changed.

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off