### PR TITLE
mobile: display monograph view count

### DIFF
--- a/apps/mobile/app/components/sheets/publish-note/index.tsx
+++ b/apps/mobile/app/components/sheets/publish-note/index.tsx
@@ -168,6 +168,14 @@ const PublishNoteSheet = ({
     setPublishLoading(false);
   };
 
+  const analytics = useAsync(async () => {
+    if (!isFeatureAvailable?.isAllowed || !monograph) {
+      return { totalViews: 0 };
+    }
+
+    return await db.monographs.analytics(monograph.id);
+  }, [monograph?.id, isFeatureAvailable?.isAllowed]);
+
   return (
     <View
       style={{
@@ -396,6 +404,10 @@ const PublishNoteSheet = ({
                   }}
                 >
                   <Paragraph size={AppFontSize.sm}>{strings.views()}</Paragraph>
+
+                  <Paragraph size={AppFontSize.sm}>
+                    {analytics.result?.totalViews}
+                  </Paragraph>
                 </View>
               </View>
             </View>

--- a/apps/mobile/app/components/sheets/publish-note/index.tsx
+++ b/apps/mobile/app/components/sheets/publish-note/index.tsx
@@ -171,11 +171,19 @@ const PublishNoteSheet = ({
     setPublishLoading(false);
   };
 
+  const lastAnalyticsResult = useRef<Awaited<
+    ReturnType<typeof db.monographs.analytics>
+  > | null>(null);
+
   const analytics = useAsync(async () => {
     if (!isFeatureAvailable?.isAllowed || !monograph?.id || selfDestruct)
       return null;
-    return await db.monographs.analytics(monograph.id);
+    const result = await db.monographs.analytics(monograph.id);
+    if (result) lastAnalyticsResult.current = result;
+    return result;
   }, [monograph?.id, isFeatureAvailable?.isAllowed, selfDestruct]);
+
+  const analyticsData = analytics.result ?? lastAnalyticsResult.current;
 
   useEffect(() => {
     const prevState = previousAppState.current;
@@ -398,8 +406,8 @@ const PublishNoteSheet = ({
 
           {isFeatureAvailable?.isAllowed &&
           !selfDestruct &&
-          analytics?.result &&
-          analytics?.result?.totalViews > 0 ? (
+          analyticsData &&
+          analyticsData?.totalViews > 0 ? (
             <View
               style={{
                 flexDirection: "row",
@@ -425,7 +433,7 @@ const PublishNoteSheet = ({
                   <Paragraph size={AppFontSize.sm}>{strings.views()}</Paragraph>
 
                   <Paragraph size={AppFontSize.sm}>
-                    {analytics.result?.totalViews}
+                    {analyticsData?.totalViews}
                   </Paragraph>
                 </View>
               </View>

--- a/apps/mobile/app/components/sheets/publish-note/index.tsx
+++ b/apps/mobile/app/components/sheets/publish-note/index.tsx
@@ -54,6 +54,7 @@ import FormInput, {
   createFormRef,
   validators
 } from "../../ui/input/form-input";
+import { useAppState } from "../../../../app/hooks/use-app-state";
 
 async function fetchMonographData(noteId: string) {
   const monographId = db.monographs.monograph(noteId);
@@ -87,6 +88,8 @@ const PublishNoteSheet = ({
   const monograph = monographData.result?.monograph;
   const publishUrl = monograph && `${hosts.MONOGRAPH_HOST}/${monograph?.id}`;
   const isPublished = db.monographs.monograph(note?.id);
+  const appState = useAppState();
+  const previousAppState = useRef(appState);
 
   const formRef = useRef(
     createFormRef({
@@ -175,6 +178,15 @@ const PublishNoteSheet = ({
 
     return await db.monographs.analytics(monograph.id);
   }, [monograph?.id, isFeatureAvailable?.isAllowed]);
+
+  useEffect(() => {
+    const prevState = previousAppState.current;
+    previousAppState.current = appState;
+
+    if (appState === "active" && prevState !== "active" && monograph?.id) {
+      analytics.execute();
+    }
+  }, [appState, monograph?.id]);
 
   return (
     <View

--- a/apps/mobile/app/components/sheets/publish-note/index.tsx
+++ b/apps/mobile/app/components/sheets/publish-note/index.tsx
@@ -172,21 +172,25 @@ const PublishNoteSheet = ({
   };
 
   const analytics = useAsync(async () => {
-    if (!isFeatureAvailable?.isAllowed || !monograph) {
-      return { totalViews: 0 };
-    }
-
+    if (!isFeatureAvailable?.isAllowed || !monograph?.id || selfDestruct)
+      return null;
     return await db.monographs.analytics(monograph.id);
-  }, [monograph?.id, isFeatureAvailable?.isAllowed]);
+  }, [monograph?.id, isFeatureAvailable?.isAllowed, selfDestruct]);
 
   useEffect(() => {
     const prevState = previousAppState.current;
     previousAppState.current = appState;
 
-    if (appState === "active" && prevState !== "active" && monograph?.id) {
+    if (
+      appState === "active" &&
+      prevState !== "active" &&
+      isFeatureAvailable?.isAllowed &&
+      monograph?.id &&
+      !selfDestruct
+    ) {
       analytics.execute();
     }
-  }, [appState, monograph?.id]);
+  }, [appState, monograph?.id, selfDestruct, isFeatureAvailable?.isAllowed]);
 
   return (
     <View
@@ -392,7 +396,10 @@ const PublishNoteSheet = ({
             </View>
           </TouchableOpacity>
 
-          {isFeatureAvailable?.isAllowed ? (
+          {isFeatureAvailable?.isAllowed &&
+          !selfDestruct &&
+          analytics?.result &&
+          analytics?.result?.totalViews > 0 ? (
             <View
               style={{
                 flexDirection: "row",


### PR DESCRIPTION
## Description
Monograph view count was not displayed in the mobile publish sheet. The view count is now fetched using the monograph analytics API and displayed correctly for published monographs.

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
This change only wires the existing monograph analytics API into the mobile UI to display the view count. 
## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
