### PR TITLE
desktop: Don't show window if any tray option enabled

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -138,7 +138,8 @@ async function createWindow() {
   mainWindow.setMenuBarVisibility(false);
   mainWindowState.manage(mainWindow);
 
-  if (cliOptions.hidden && !config.desktopSettings.minimizeToSystemTray)
+  if (cliOptions.hidden && !(config.desktopSettings.minimizeToSystemTray
+    || config.desktopSettings.closeToSystemTray))
     mainWindow.minimize();
 
   await mainWindow.webContents.loadURL(`${createURL(cliOptions, "/")}`);


### PR DESCRIPTION
## Description
If either system tray option is enabled, the `--hidden` cli flag should hide the window, as it should be obvious to the user that the app can be summoned from the tray. Relates #9902, flathub/com.notesnook.Notesnook#99

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [ ] Mobile
- [x] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
