### PR TITLE
mobile: wrap title input into multiple lines for publish note

### DIFF
--- a/apps/mobile/app/components/sheets/publish-note/index.tsx
+++ b/apps/mobile/app/components/sheets/publish-note/index.tsx
@@ -264,6 +264,9 @@ const PublishNoteSheet = ({
             fwdRef={titleInput}
             multiline
             scrollEnabled
+            containerStyle={{
+              maxHeight: 100
+            }}
             placeholder={strings.noteTitle()}
             validators={[validators.required(strings.titleIsRequired())]}
           />

--- a/apps/mobile/app/components/sheets/publish-note/index.tsx
+++ b/apps/mobile/app/components/sheets/publish-note/index.tsx
@@ -262,6 +262,8 @@ const PublishNoteSheet = ({
             name="title"
             formRef={formRef}
             fwdRef={titleInput}
+            multiline
+            scrollEnabled
             placeholder={strings.noteTitle()}
             validators={[validators.required(strings.titleIsRequired())]}
           />


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Set the title input to be multiline so long titles will wrap and be scrollable.

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
