### PR TITLE
mobile: reflected published note title in published section

### DIFF
--- a/apps/mobile/app/components/sheets/publish-note/index.tsx
+++ b/apps/mobile/app/components/sheets/publish-note/index.tsx
@@ -90,10 +90,19 @@ const PublishNoteSheet = ({
 
   const formRef = useRef(
     createFormRef({
-      title: monograph?.title || note.title || "",
+      title: note.title || "",
       password: ""
     })
   );
+
+  useEffect(() => {
+    if (!monographData.result) return;
+    const title = monograph?.title || note.title || "";
+    formRef.current.setValue("title", title);
+    setTimeout(() => {
+      titleInput.current?.setNativeProps({ text: title });
+    }, 50);
+  }, [monographData.result, monograph]);
 
   useEffect(() => {
     (async () => {


### PR DESCRIPTION
## Description
Fixed the publish note sheet showing note title instead of the monograph title when reopening an already published note. 

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
UI state fix only, no logic or data changes.

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
