### PR TITLE
web: remove saving note taking too long toast

### DIFF
--- a/apps/web/src/components/editor/index.tsx
+++ b/apps/web/src/components/editor/index.tsx
@@ -96,30 +96,27 @@ export async function saveContent(
     ignoreEdit,
     length: content.length
   });
-  await Promise.race([
-    useEditorStore.getState().saveSessionContent(noteId, ignoreEdit, {
+
+  await useEditorStore
+    .getState()
+    .saveSessionContent(noteId, ignoreEdit, {
       type: "tiptap",
       data: content
-    }),
-    new Promise((_, reject) =>
-      setTimeout(
-        () => reject(new Error(strings.savingNoteTakingTooLong())),
-        30 * 1000
-      )
-    )
-  ]).catch((e) => {
-    const { hide } = showToast(
-      "error",
-      (e as Error).message,
-      [
-        {
-          text: strings.dismiss(),
-          onClick: () => hide()
-        }
-      ],
-      0
-    );
-  });
+    })
+
+    .catch((e) => {
+      const { hide } = showToast(
+        "error",
+        (e as Error).message,
+        [
+          {
+            text: strings.dismiss(),
+            onClick: () => hide()
+          }
+        ],
+        0
+      );
+    });
 }
 const deferredSave = debounceWithId(saveContent, 100);
 


### PR DESCRIPTION
## Description

The toast was being showing even in cases where the note actually got saved.

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [ ] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [x] Web
- [ ] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
