### PR TITLE
fix date picker modal renders blank if themVariant is not set based on app's theme mode

### DIFF
--- a/apps/mobile/app/components/properties/date-meta.tsx
+++ b/apps/mobile/app/components/properties/date-meta.tsx
@@ -110,6 +110,7 @@ export const DateMeta = ({ item }: { item: Item }) => {
           }}
           maximumDate={new Date((item as Note).dateEdited)}
           isDarkModeEnabled={isDark}
+          themeVariant={isDark ? "dark" : "light"}
           is24Hour={db.settings.getTimeFormat() === "24-hour"}
           date={new Date(dateCreated)}
         />


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

On iOS if apps's theme mode is not same as the system, the date picker renders blank due to conflicting colors. This is fixed by providing the correct themeVariant to override systems default.

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
