### PR TITLE
web: fix recovery view header overflow on small screens

### DIFF
--- a/apps/web/src/views/recovery.tsx
+++ b/apps/web/src/views/recovery.tsx
@@ -174,7 +174,7 @@ function Recovery(props: RecoveryProps) {
               <Text
                 sx={{
                   display: "flex",
-                  alignSelf: "end",
+                  alignSelf: "center",
                   alignItems: "center"
                 }}
                 variant={"body"}
@@ -187,7 +187,9 @@ function Recovery(props: RecoveryProps) {
                   mt: 0,
                   ml: 2,
                   alignSelf: "start",
-                  alignItems: "center"
+                  alignItems: "center",
+                  textWrap: "wrap",
+                  textAlign: "right"
                 }}
                 variant={"secondary"}
                 onClick={() => openURL("/login")}

--- a/apps/web/src/views/recovery.tsx
+++ b/apps/web/src/views/recovery.tsx
@@ -175,7 +175,9 @@ function Recovery(props: RecoveryProps) {
                 sx={{
                   display: "flex",
                   alignSelf: "center",
-                  alignItems: "center"
+                  alignItems: "center",
+                  wordWrap: "break-word",
+                  wordBreak: "break-all"
                 }}
                 variant={"body"}
               >


### PR DESCRIPTION

## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

web: fix recovery view header overflow on small screens

### Before

<img width="886" height="584" alt="image" src="https://github.com/user-attachments/assets/e588d781-6e97-4a5b-b46e-e9a18f21364f" />

### After

<img width="886" height="584" alt="image" src="https://github.com/user-attachments/assets/2d4e01da-2bff-43d6-a32b-2b289c12e4a1" />

## QA Scope

Web only

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [X] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [ ] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
