### PR TITLE
Update importer to v2.4.5

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -20,7 +20,7 @@
         "@lingui/react": "5.1.2",
         "@mdi/js": "7.4.47",
         "@mdi/react": "1.6.1",
-        "@notesnook-importer/core": "^2.2.5",
+        "@notesnook-importer/core": "^2.4.5",
         "@notesnook/common": "file:../../packages/common",
         "@notesnook/core": "file:../../packages/core",
         "@notesnook/crypto": "file:../../packages/crypto",
@@ -302,7 +302,7 @@
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@notesnook-importer/core": "^2.2.5",
+        "@notesnook-importer/core": "^2.4.5",
         "@notesnook/common": "file:../common",
         "@notesnook/intl": "file:../intl",
         "@notesnook/theme": "file:../theme",
@@ -2873,14 +2873,14 @@
       }
     },
     "node_modules/@notesnook-importer/core": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@notesnook-importer/core/-/core-2.2.5.tgz",
-      "integrity": "sha512-S2ie0kgNG/PGdmCF81auvVX0+cvUekjBRzqyT7AYwYi6/z1JN+yGY9S8b1UVscOpm33T7/q6w9FphepEsDXNAA==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@notesnook-importer/core/-/core-2.4.5.tgz",
+      "integrity": "sha512-7Oqkw07CykwC/xzGrC6St4C/87QmXqK8UtmSxwE05fpz8DWoKEviJSWFa5fKY52umTphGvmtY23252dZ9J9EJg==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@notesnook-importer/enex": "file:../enex",
-        "@notesnook-importer/storage": "file:../storage",
-        "@notesnook-importer/znel": "file:../znel",
+        "@notesnook-importer/enex": "^2.3.5",
+        "@notesnook-importer/storage": "^2.3.5",
+        "@notesnook-importer/znel": "^2.3.5",
         "@stablelib/chacha20poly1305": "^1.0.1",
         "@streamparser/json": "^0.0.10",
         "@zip.js/zip.js": "^2.7.32",
@@ -2927,7 +2927,9 @@
       "license": "MIT"
     },
     "node_modules/@notesnook-importer/enex": {
-      "version": "2.2.3",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@notesnook-importer/enex/-/enex-2.3.5.tgz",
+      "integrity": "sha512-0+08XVhsQQFoEUrar3k07DuTluNho/FHxJ25n/DT+ug8kVraHHVqI40a2P9h8bW8iWxYs02Zq1n+N2uTv5qb+g==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "base64-js": "^1.5.1",
@@ -2940,11 +2942,15 @@
       }
     },
     "node_modules/@notesnook-importer/storage": {
-      "version": "2.2.3",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@notesnook-importer/storage/-/storage-2.3.5.tgz",
+      "integrity": "sha512-orvSK0XIcqlmiWmjQ3RzS3qZp7viBdCpAloX557Ml200LMSMGDsOtofYNv5IYllBETnqApERLPQaUzBSuviuvA==",
       "license": "GPL-3.0-or-later"
     },
     "node_modules/@notesnook-importer/znel": {
-      "version": "2.2.3",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@notesnook-importer/znel/-/znel-2.3.5.tgz",
+      "integrity": "sha512-s1kTA3EQ5OswBc0RvWnWgIm6/mIWvnh3iWmcOJcApIqhDwQziEkYiS+UMfuY9nOUyIWtepMe/WJ0Odk15uah9w==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "base64-js": "^1.5.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,7 +18,7 @@
     "@lingui/react": "5.1.2",
     "@mdi/js": "7.4.47",
     "@mdi/react": "1.6.1",
-    "@notesnook-importer/core": "^2.2.5",
+    "@notesnook-importer/core": "^2.4.5",
     "@notesnook/common": "file:../../packages/common",
     "@notesnook/core": "file:../../packages/core",
     "@notesnook/crypto": "file:../../packages/crypto",

--- a/apps/web/src/components/importer/components/file-provider-handler.tsx
+++ b/apps/web/src/components/importer/components/file-provider-handler.tsx
@@ -23,7 +23,7 @@ import {
   ProviderSettings,
   transform
 } from "@notesnook-importer/core";
-import { formatBytes } from "@notesnook/common";
+import { formatBytes, getFormattedDate } from "@notesnook/common";
 import { ScrollContainer } from "@notesnook/ui";
 import { Button, Flex, Input, Text } from "@theme-ui/components";
 import { xxhash64 } from "hash-wasm";
@@ -46,6 +46,12 @@ type Progress = {
   done: number;
 };
 
+type LogMessage = {
+  type: "info" | "error";
+  text: string;
+  date: number;
+};
+
 export function FileProviderHandler(props: FileProviderHandlerProps) {
   const { provider, onTransformFinished } = props;
   const [files, setFiles] = useState<File[]>([]);
@@ -55,7 +61,7 @@ export function FileProviderHandler(props: FileProviderHandlerProps) {
   });
   const [totalNoteCount, setTotalNoteCount] = useState(0);
   const [_, setCounter] = useState<number>(0);
-  const logs = useRef<string[]>([]);
+  const logs = useRef<LogMessage[]>([]);
 
   const onDrop = useCallback((acceptedFiles: File[]) => {
     setFiles((files) => {
@@ -85,22 +91,31 @@ export function FileProviderHandler(props: FileProviderHandlerProps) {
         clear: async () => undefined,
         get: async () => [],
         write: async (data) => {
-          logs.current.push(
-            `[${new Date().toLocaleString()}] Pushing ${
-              data.title
-            } into database`
-          );
+          logs.current.push({
+            type: "info",
+            date: Date.now(),
+            text: `Pushing ${data.title} into database`
+          });
 
-          await importNote(data);
+          const errors = await importNote(data);
+          errors.forEach((error) =>
+            logs.current.push({
+              type: "error",
+              date: Date.now(),
+              text: `Error importing ${data.title}: ${error}`
+            })
+          );
         },
         iterate: async function* () {
           return null;
         }
       },
       log: (message) => {
-        logs.current.push(
-          `[${new Date(message.date).toLocaleString()}] ${message.text}`
-        );
+        logs.current.push({
+          type: "info",
+          date: message.date,
+          text: message.text
+        });
         setCounter((s) => ++s);
       },
       reporter: () => {
@@ -176,7 +191,17 @@ export function FileProviderHandler(props: FileProviderHandlerProps) {
               >
                 {logs.current.map((c, index) => (
                   <>
-                    <span key={index.toString()}>{c}</span>
+                    <span
+                      key={index.toString()}
+                      style={{
+                        color:
+                          c.type === "error"
+                            ? "var(--paragraph-error)"
+                            : "inherit"
+                      }}
+                    >
+                      [{getFormattedDate(c.date, "date-time")}] {c.text}
+                    </span>
                     <br />
                   </>
                 ))}

--- a/apps/web/src/components/importer/components/file-provider-handler.tsx
+++ b/apps/web/src/components/importer/components/file-provider-handler.tsx
@@ -30,9 +30,11 @@ import { xxhash64 } from "hash-wasm";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useDropzone } from "react-dropzone";
 import { importNote } from "../../../utils/importer";
+import { PromptDialog } from "../../../dialogs/prompt";
 import Accordion from "../../accordion";
 import { TransformResult } from "../types";
 import { useStore as useAppStore } from "../../../stores/app-store";
+import { strings } from "@notesnook/intl";
 
 type FileProviderHandlerProps = {
   provider: IFileProvider;
@@ -103,6 +105,17 @@ export function FileProviderHandler(props: FileProviderHandlerProps) {
       },
       reporter: () => {
         setTotalNoteCount(++totalNotes);
+      },
+      options: {
+        colornote: {
+          getPassword: async (filename: string) => {
+            const password = await PromptDialog.show({
+              title: strings.colorNotePasswordFor(filename),
+              description: strings.colorNotPasswordForDesc()
+            });
+            return password || undefined;
+          }
+        }
       }
     };
 
@@ -224,6 +237,7 @@ export function FileProviderHandler(props: FileProviderHandlerProps) {
           </Text>
         </Text>
       </Flex>
+
       {files.length > 0 ? (
         <Accordion
           isClosed

--- a/apps/web/src/utils/importer.ts
+++ b/apps/web/src/utils/importer.ts
@@ -48,11 +48,18 @@ const colorMap: Record<string, string | undefined> = {
   yellow: "#FFC107"
 };
 
-export async function importNote(note: Note) {
+export async function importNote(note: Note): Promise<string[]> {
+  const errors: string[] = [];
   const encryptedAttachmentFieldsMap = await processAttachments(
     note.attachments
-  );
-  await processNote(note, encryptedAttachmentFieldsMap);
+  ).catch((e) => {
+    errors.push(e.message);
+    return {};
+  });
+  await processNote(note, encryptedAttachmentFieldsMap).catch((e) => {
+    errors.push(e.message);
+  });
+  return errors;
 }
 
 async function processAttachments(attachments: Note["attachments"]) {

--- a/docs/help/contents/importing-notes/import-notes-from-colornote.md
+++ b/docs/help/contents/importing-notes/import-notes-from-colornote.md
@@ -1,0 +1,15 @@
+---
+title: ColorNote
+---
+
+# How to import notes from ColorNote notes app?
+
+The following steps will help you import your notes from ColorNote easily.
+
+1. Download the ColorNote mobile app.
+2. Go to `Settings > Backup` and create a backup. Make sure to remember the password you set while creating the backup as it will be needed during import.
+3. Open the Notesnook app (web or desktop).
+4. Go to `Settings > Notesnook Importer` and select `ColorNote` from list of apps.
+5. Drop the backup file you exported earlier in the box or click anywhere to open system file picker to select the backup. 
+7. Click on "Start importing" and enter the password you used while creating the backup in the popup.
+8. Once importing completes you should see all your notes in Notesnook. If you face any issues during importing, [report it on github](https://github.com/streetwriters/notesnook).

--- a/docs/help/contents/importing-notes/import-notes-from-upnote.md
+++ b/docs/help/contents/importing-notes/import-notes-from-upnote.md
@@ -1,0 +1,22 @@
+---
+title: UpNote
+---
+
+# How to import notes from UpNote notes app?
+
+The following steps will help you import your notes from UpNote easily.
+
+1. Download the UpNote desktop app.
+2. Click on settings icon on the header. 
+3. Go to `General` tab in Settings
+4. Click on `Export All Notes`.
+5. Export from the `Export to HTML` option to download your notes. 
+6. Create a `.zip` file of the exported folder. 
+7. Open the Notesnook app (web or desktop).
+8. Go to `Settings > Notesnook Importer` and select `UpNote` from list of apps.
+9. Drop the `.zip` file you exported earlier in the box or click anywhere to open system file picker to select the backup and click "Start processing".
+10. Once importing completes you should see all your notes in Notesnook. If you face any issues during importing, [report it on github](https://github.com/streetwriters/notesnook).
+
+## Supported formats
+
+UpNote's export is a folder with HTML files for each note and a folder for attachments. Make sure to create a `.zip` of the exported folder before importing to Notesnook. The Notesnook Importer preserves all formatting, images, and attachments in the imported notes.

--- a/packages/editor/package-lock.json
+++ b/packages/editor/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@notesnook-importer/core": "^2.2.5",
+        "@notesnook-importer/core": "^2.4.5",
         "@notesnook/common": "file:../common",
         "@notesnook/intl": "file:../intl",
         "@notesnook/theme": "file:../theme",
@@ -980,14 +980,14 @@
       "dev": true
     },
     "node_modules/@notesnook-importer/core": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@notesnook-importer/core/-/core-2.2.5.tgz",
-      "integrity": "sha512-S2ie0kgNG/PGdmCF81auvVX0+cvUekjBRzqyT7AYwYi6/z1JN+yGY9S8b1UVscOpm33T7/q6w9FphepEsDXNAA==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@notesnook-importer/core/-/core-2.4.5.tgz",
+      "integrity": "sha512-7Oqkw07CykwC/xzGrC6St4C/87QmXqK8UtmSxwE05fpz8DWoKEviJSWFa5fKY52umTphGvmtY23252dZ9J9EJg==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@notesnook-importer/enex": "file:../enex",
-        "@notesnook-importer/storage": "file:../storage",
-        "@notesnook-importer/znel": "file:../znel",
+        "@notesnook-importer/enex": "^2.3.5",
+        "@notesnook-importer/storage": "^2.3.5",
+        "@notesnook-importer/znel": "^2.3.5",
         "@stablelib/chacha20poly1305": "^1.0.1",
         "@streamparser/json": "^0.0.10",
         "@zip.js/zip.js": "^2.7.32",
@@ -1028,7 +1028,9 @@
       }
     },
     "node_modules/@notesnook-importer/enex": {
-      "version": "2.2.3",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@notesnook-importer/enex/-/enex-2.3.5.tgz",
+      "integrity": "sha512-0+08XVhsQQFoEUrar3k07DuTluNho/FHxJ25n/DT+ug8kVraHHVqI40a2P9h8bW8iWxYs02Zq1n+N2uTv5qb+g==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "base64-js": "^1.5.1",
@@ -1041,11 +1043,15 @@
       }
     },
     "node_modules/@notesnook-importer/storage": {
-      "version": "2.2.3",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@notesnook-importer/storage/-/storage-2.3.5.tgz",
+      "integrity": "sha512-orvSK0XIcqlmiWmjQ3RzS3qZp7viBdCpAloX557Ml200LMSMGDsOtofYNv5IYllBETnqApERLPQaUzBSuviuvA==",
       "license": "GPL-3.0-or-later"
     },
     "node_modules/@notesnook-importer/znel": {
-      "version": "2.2.3",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@notesnook-importer/znel/-/znel-2.3.5.tgz",
+      "integrity": "sha512-s1kTA3EQ5OswBc0RvWnWgIm6/mIWvnh3iWmcOJcApIqhDwQziEkYiS+UMfuY9nOUyIWtepMe/WJ0Odk15uah9w==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "base64-js": "^1.5.1",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -30,7 +30,7 @@
   },
   "license": "GPL-3.0-or-later",
   "dependencies": {
-    "@notesnook-importer/core": "^2.2.5",
+    "@notesnook-importer/core": "^2.4.5",
     "@notesnook/common": "file:../common",
     "@notesnook/intl": "file:../intl",
     "@notesnook/theme": "file:../theme",

--- a/packages/intl/locale/en.po
+++ b/packages/intl/locale/en.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: src/strings.ts:2423
 msgid " \"Notebook > Notes\""
@@ -1795,6 +1801,10 @@ msgstr "Color scheme"
 #: src/strings.ts:1491
 msgid "Color title"
 msgstr "Color title"
+
+#: src/strings.ts:2796
+msgid "Colornote password for {filename}"
+msgstr "Colornote password for {filename}"
 
 #: src/strings.ts:309
 msgid "colors"
@@ -6877,6 +6887,10 @@ msgstr "The information above will be publically available at"
 #: src/strings.ts:2619
 msgid "The Notesnook Circle is exclusive to subscribers. Please consider subscribing to gain access to Notesnook Circle and enjoy additional benefits."
 msgstr "The Notesnook Circle is exclusive to subscribers. Please consider subscribing to gain access to Notesnook Circle and enjoy additional benefits."
+
+#: src/strings.ts:2798
+msgid "The password for decrypting the Colornote backup file."
+msgstr "The password for decrypting the Colornote backup file."
 
 #: src/strings.ts:2094
 msgid "The password/pin for unlocking the app."

--- a/packages/intl/locale/pseudo-LOCALE.po
+++ b/packages/intl/locale/pseudo-LOCALE.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: pseudo-LOCALE\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: src/strings.ts:2423
 msgid " \"Notebook > Notes\""
@@ -1783,6 +1789,10 @@ msgstr ""
 
 #: src/strings.ts:1491
 msgid "Color title"
+msgstr ""
+
+#: src/strings.ts:2796
+msgid "Colornote password for {filename}"
 msgstr ""
 
 #: src/strings.ts:309
@@ -6835,6 +6845,10 @@ msgstr ""
 
 #: src/strings.ts:2619
 msgid "The Notesnook Circle is exclusive to subscribers. Please consider subscribing to gain access to Notesnook Circle and enjoy additional benefits."
+msgstr "<<<<<<< HEAD"
+
+#: src/strings.ts:2798
+msgid "The password for decrypting the Colornote backup file."
 msgstr ""
 
 #: src/strings.ts:2094

--- a/packages/intl/src/strings.ts
+++ b/packages/intl/src/strings.ts
@@ -2791,5 +2791,9 @@ Continue without attachments?`,
   setupInboxKeys: () => t`Setup inbox keys`,
   enterPgpPublicKey: () => t`Enter your PGP public key`,
   enterPgpPrivateKey: () => t`Enter your PGP private key`,
-  expiryDateRemoved: () => t`Expiry date removed`
+  expiryDateRemoved: () => t`Expiry date removed`,
+  colorNotePasswordFor: (filename: string) =>
+    t`Colornote password for ${filename}`,
+  colorNotPasswordForDesc: () =>
+    t`The password for decrypting the Colornote backup file.`
 };


### PR DESCRIPTION
This fixes the following issues with importer:

- Handle line breaks in keep provider ([#311](https://github.com/streetwriters/notesnook-importer/pull/311))
- Remove skipping files log message ([#304](https://github.com/streetwriters/notesnook-importer/pull/304))
- Fix nested checklist markdown parsing ([#280](https://github.com/streetwriters/notesnook-importer/pull/280))
- Convert hard line breaks to single-spaced paragraphs ([#261](https://github.com/streetwriters/notesnook-importer/pull/261))
- Calculate missing dimension if possible for evernote images ([#268](https://github.com/streetwriters/notesnook-importer/pull/268))
- Fix every rich link parsing as internal link ([#269](https://github.com/streetwriters/notesnook-importer/pull/269))
- Fix extra lines when importing text files

It also adds support for these new note apps:

- Colornote (thanks to @01zulfi)
- Upnote (thanks to @01zulfi)