### PR TITLE
Editor transactions with `ignoreEdit` will no longer trigger save

### DIFF
--- a/apps/mobile/app/screens/editor/tiptap/use-editor.ts
+++ b/apps/mobile/app/screens/editor/tiptap/use-editor.ts
@@ -949,6 +949,7 @@ export const useEditor = (
         `saveContent... title: ${!!title}, content: ${!!content}, noteId: ${noteId}`
       );
       if (
+        ignoreEdit ||
         lock.current ||
         (currentLoadingNoteId.current &&
           currentLoadingNoteId.current === noteId)
@@ -957,6 +958,7 @@ export const useEditor = (
 
           lock.current: ${lock.current}
           currentLoadingNoteId.current: ${currentLoadingNoteId.current}
+          ignoreEdit: ${ignoreEdit}
         `);
         if (lock.current) {
           setTimeout(() => {

--- a/apps/web/src/components/editor/tiptap.tsx
+++ b/apps/web/src/components/editor/tiptap.tsx
@@ -329,7 +329,8 @@ function TipTap(props: TipTapProps) {
 
         const preventSave = transaction?.getMeta("preventSave") as boolean;
         const ignoreEdit = transaction.getMeta("ignoreEdit") as boolean;
-        if (preventSave || !editor.isEditable || !onChange) return;
+        if (ignoreEdit || preventSave || !editor.isEditable || !onChange)
+          return;
 
         if (!autoSave.current) return;
 


### PR DESCRIPTION
## Description

This fixes a critical issue where opening a note automatically triggers a save event causing stale content to overwrite newly synced changes. ~This is a partial fix because it is still possible (although rare) for a user to make a change in a stale editor causing an overwrite. A proper fix would ensure that the content being saved is latest.~

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [ ] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [x] Web
- [x] Mobile
- [x] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
