### PR TITLE
core: do not preserve pin state when duplicating notes

### DIFF
--- a/packages/core/src/collections/notes.ts
+++ b/packages/core/src/collections/notes.ts
@@ -434,6 +434,7 @@ export class Notes implements ICollection {
       const duplicateId = await this.db.notes.add({
         ...clone(note),
         id: undefined,
+        pinned: false,
         isGeneratedTitle: false,
         contentId: undefined,
         title: note.title + " (Copy)",


### PR DESCRIPTION
## Description
Prevent duplicated notes from inheriting the pinned state of the original note. Duplicated notes are now created as unpinned regardless of the source note's pin status.

Closes https://github.com/streetwriters/notesnook/issues/9742

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
This is a small logic change that explicitly resets the pinned state when creating a duplicate note

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
