### PR TITLE
mobile: use FileViewer for image sharing on Android

### DIFF
--- a/apps/mobile/app/components/image-preview/index.tsx
+++ b/apps/mobile/app/components/image-preview/index.tsx
@@ -39,6 +39,7 @@ import Share from "react-native-share";
 import useGlobalSafeAreaInsets from "../../hooks/use-global-safe-area-insets";
 import { useSettingStore } from "../../stores/use-setting-store";
 import { DefaultAppStyles } from "../../utils/styles";
+import FileViewer from "react-native-file-viewer";
 
 const ImagePreview = () => {
   const { colors } = useThemeColors("dialog");
@@ -87,9 +88,8 @@ const ImagePreview = () => {
         return;
       }
       const attachment = await db.attachments.attachment(hash);
-      const path = `${cacheDir}/${
-        "NN_" + (await getFileNameWithExtension(hash, attachment?.mimeType))
-      }`;
+      const path = `${cacheDir}/${"NN_" + (await getFileNameWithExtension(hash, attachment?.mimeType))
+        }`;
       await RNFetchBlob.fs.mv(`${cacheDir}/${uri}`, path).catch(() => {
         /* empty */
       });
@@ -136,17 +136,23 @@ const ImagePreview = () => {
               borderWidth: 0
             }}
             onPress={async () => {
-              useSettingStore
-                .getState()
-                .setAppDidEnterBackgroundForAction(true);
-              await Share.open({
-                url: image
-              }).catch(() => {
-                /* empty */
-              });
-              useSettingStore
-                .getState()
-                .setAppDidEnterBackgroundForAction(false);
+              if (!image) return;
+
+              try {
+                if (Platform.OS === "android") {
+                  await FileViewer.open(image.replace("file://", ""), {
+                    showOpenWithDialog: true,
+                    showAppsSuggestions: true,
+                    shareFile: true
+                  } as any);
+                } else {
+                  await Share.open({
+                    url: image
+                  });
+                }
+              } catch (error) {
+                console.error(error);
+              }
             }}
           />
           <IconButton


### PR DESCRIPTION
## Description
Fixes image sharing from fullscreen image preview on Android by using the same FileViewer sharing flow already used elsewhere in the app for local files. This avoids issues with sharing cached image files via react-native-share.
Closes https://github.com/streetwriters/notesnook/issues/9837

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
This change updates Android-specific file sharing behavior

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
