### PR TITLE
web: add top margin to unlock view error text

### DIFF
--- a/apps/web/src/components/unlock/index.tsx
+++ b/apps/web/src/components/unlock/index.tsx
@@ -115,7 +115,7 @@ export function UnlockView(props: UnlockViewProps) {
           }
         }}
       />
-      {isWrong && <ErrorText error="Wrong password" />}
+      {isWrong && <ErrorText sx={{ mt: 1 }} error="Wrong password" />}
       <Button
         mt={3}
         variant="accent"


### PR DESCRIPTION

## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

web: add top margin to unlock view error text

<img width="715" height="706" alt="image" src="https://github.com/user-attachments/assets/18fee921-df00-437d-b97d-da484baabaff" />


## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [X] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [ ] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
