### PR TITLE
web: verify old password before creating backup during password update

### DIFF
--- a/apps/web/src/dialogs/settings/auth-settings.ts
+++ b/apps/web/src/dialogs/settings/auth-settings.ts
@@ -59,6 +59,9 @@ export const AuthenticationSettings: SettingsGroup[] = [
                   }
                 },
                 validate: async ({ oldPassword, newPassword }) => {
+                  const verify = await db.user.verifyPassword(oldPassword);
+                  if (!verify) return false;
+
                   try {
                     if (!(await createBackup({ noVerify: true }))) return false;
                     return (


### PR DESCRIPTION

## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

web: verify old password before creating backup during password update

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [X] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [ ] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
