### PR TITLE
mobile: add option to clear note version history

### DIFF
--- a/apps/mobile/app/components/note-history/index.tsx
+++ b/apps/mobile/app/components/note-history/index.tsx
@@ -165,6 +165,7 @@ export default function NoteHistory({
                   positiveText: strings.clear(),
                   negativeText: strings.cancel(),
                   positiveType: "errorShade",
+                  context: "local",
                   positivePress: async () => {
                     await db.noteHistory.clearSessions(note.id);
                     fwdRef.current?.hide();

--- a/apps/mobile/app/components/note-history/index.tsx
+++ b/apps/mobile/app/components/note-history/index.tsx
@@ -40,6 +40,7 @@ import Seperator from "../ui/seperator";
 import Paragraph from "../ui/typography/paragraph";
 import NotePreview from "./preview";
 import { presentDialog } from "../dialog/functions";
+import { Dialog } from "../dialog";
 
 const HistoryItem = ({
   index,
@@ -148,6 +149,7 @@ export default function NoteHistory({
   return (
     <View>
       <SheetProvider context="note_history" />
+      <Dialog context="local" />
       <DialogHeader
         title={strings.noteHistory()}
         padding={12}

--- a/apps/mobile/app/components/note-history/index.tsx
+++ b/apps/mobile/app/components/note-history/index.tsx
@@ -159,7 +159,7 @@ export default function NoteHistory({
               onPress: () => {
                 presentDialog({
                   title: strings.clearHistory(),
-                  paragraph: strings.clearHistoryConfirmation(1),
+                  paragraph: strings.clearHistoryConfirmation(),
                   positiveText: strings.clear(),
                   negativeText: strings.cancel(),
                   positiveType: "errorShade",

--- a/apps/mobile/app/components/note-history/index.tsx
+++ b/apps/mobile/app/components/note-history/index.tsx
@@ -29,7 +29,7 @@ import { ActionSheetRef, ScrollView } from "react-native-actions-sheet";
 import Icon from "react-native-vector-icons/MaterialCommunityIcons";
 import { db } from "../../common/database";
 import { useDBItem } from "../../hooks/use-db-item";
-import { presentSheet } from "../../services/event-manager";
+import { presentSheet, ToastManager } from "../../services/event-manager";
 import { openLinkInBrowser } from "../../utils/functions";
 import { AppFontSize } from "../../utils/size";
 import { DefaultAppStyles } from "../../utils/styles";
@@ -39,6 +39,7 @@ import { Pressable } from "../ui/pressable";
 import Seperator from "../ui/seperator";
 import Paragraph from "../ui/typography/paragraph";
 import NotePreview from "./preview";
+import { presentDialog } from "../dialog/functions";
 
 const HistoryItem = ({
   index,
@@ -58,9 +59,8 @@ const HistoryItem = ({
     const _start_time = getFormattedDate(start, "time");
     const _end_time = getFormattedDate(end + 60000, "time");
 
-    return `${_start_date} ${_start_time} - ${
-      _end_date === _start_date ? " " : _end_date + " "
-    }${_end_time}`;
+    return `${_start_date} ${_start_time} - ${_end_date === _start_date ? " " : _end_date + " "
+      }${_end_time}`;
   };
 
   const preview = useCallback(
@@ -112,7 +112,8 @@ const HistoryItem = ({
 };
 
 export default function NoteHistory({
-  note
+  note,
+  fwdRef
 }: {
   note: Note;
   fwdRef: RefObject<ActionSheetRef>;
@@ -147,7 +148,35 @@ export default function NoteHistory({
   return (
     <View>
       <SheetProvider context="note_history" />
-      <DialogHeader title={strings.noteHistory()} padding={12} />
+      <DialogHeader
+        title={strings.noteHistory()}
+        padding={12}
+        button={
+          history?.placeholders.length
+            ? {
+              title: strings.clearHistory(),
+              type: "secondary",
+              onPress: () => {
+                presentDialog({
+                  title: strings.clearHistory(),
+                  paragraph: strings.clearHistoryConfirmation(1),
+                  positiveText: strings.clear(),
+                  negativeText: strings.cancel(),
+                  positiveType: "errorShade",
+                  positivePress: async () => {
+                    await db.noteHistory.clearSessions(note.id);
+                    fwdRef.current?.hide();
+                    ToastManager.show({
+                      heading: strings.historyCleared(),
+                      type: "success"
+                    });
+                  }
+                });
+              }
+            }
+            : undefined
+        }
+      />
 
       <Seperator />
 

--- a/apps/mobile/app/components/note-history/preview.tsx
+++ b/apps/mobile/app/components/note-history/preview.tsx
@@ -112,19 +112,23 @@ export default function NotePreview({
       paragraph: strings.deleteNoteConfirmation(),
       positiveText: strings.delete(),
       negativeText: strings.cancel(),
-      context: "local",
+      context: "preview",
       positivePress: async () => {
-        if (note) {
+        if (session) {
+          await db.noteHistory.remove(session.id);
+          eSendEvent(eCloseSheet, "note_history");
+          Navigation.queueRoutesForUpdate();
+        } else if (note.type === "trash") {
           await db.trash.delete(note.id);
           useTrashStore.getState().refresh();
           useSelectionStore.getState().setSelectionMode();
-          ToastManager.show({
-            heading: strings.noteDeleted(),
-            type: "success",
-            context: "local"
-          });
-          eSendEvent(eCloseSheet);
         }
+        ToastManager.show({
+          heading: strings.noteDeleted(),
+          type: "success"
+        });
+
+        eSendEvent(eCloseSheet);
       },
       positiveType: "error"
     });
@@ -137,7 +141,7 @@ export default function NotePreview({
         width: "100%"
       }}
     >
-      <Dialog context="local" />
+      <Dialog context="preview" />
       <DialogHeader
         padding={12}
         title={content?.title || note.title || session?.session}

--- a/apps/mobile/app/components/note-history/preview.tsx
+++ b/apps/mobile/app/components/note-history/preview.tsx
@@ -107,14 +107,18 @@ export default function NotePreview({
   }, [note]);
 
   const deleteNote = async () => {
+    const isSession = !!session;
+
     presentDialog({
-      title: strings.deleteNote(),
-      paragraph: strings.deleteNoteConfirmation(),
+      title: isSession ? strings.deleteVersion() : strings.deleteNote(),
+      paragraph: isSession
+        ? strings.deleteVersionConfirmation()
+        : strings.deleteNoteConfirmation(),
       positiveText: strings.delete(),
       negativeText: strings.cancel(),
       context: "preview",
       positivePress: async () => {
-        if (session) {
+        if (isSession) {
           await db.noteHistory.remove(session.id);
           eSendEvent(eCloseSheet, "note_history");
           Navigation.queueRoutesForUpdate();
@@ -124,7 +128,7 @@ export default function NotePreview({
           useSelectionStore.getState().setSelectionMode();
         }
         ToastManager.show({
-          heading: strings.noteDeleted(),
+          heading: isSession ? strings.versionDeleted() : strings.noteDeleted(),
           type: "success"
         });
 

--- a/apps/mobile/app/components/selection-header/index.tsx
+++ b/apps/mobile/app/components/selection-header/index.tsx
@@ -170,147 +170,173 @@ export const SelectionHeader = React.memo(
           {!selectedItemsList.length
             ? null
             : (focusedRouteId === "Monographs"
-                ? [
-                    {
-                      title: strings.unpublish(),
-                      onPress: () => {
-                        presentDialog({
-                          title: strings.doActions.unpublish.note(
-                            selectedItemsList.length
-                          ),
-                          positiveText: strings.unpublish(),
-                          negativeText: strings.cancel(),
-                          positivePress: async () => {
-                            for (const id of selectedItemsList) {
-                              await db.monographs.unpublish(id);
-                            }
-                            Navigation.queueRoutesForUpdate();
-                            clearSelection();
-                          },
-                          positiveType: "errorShade"
-                        });
-                      },
-                      visible: true,
-                      icon: "delete"
-                    }
-                  ]
-                : [
-                    {
-                      title: strings.manageTags(),
-                      onPress: async () => {
-                        ManageTags.present(selectedItemsList);
-                      },
-                      visible: type === "note",
-                      icon: "pound"
-                    },
-                    {
-                      title: strings.export(),
-                      onPress: async () => {
-                        ExportNotesSheet.present(selectedItemsList);
-                      },
-                      visible: type === "note",
-                      icon: "export"
-                    },
-                    {
-                      title: strings.addToNotebook(),
-                      onPress: async () => {
-                        Navigation.navigate("LinkNotebooks", {
-                          noteIds: selectedItemsList
-                        });
-                      },
-                      visible: type === "note",
-                      icon: "plus"
-                    },
-                    {
-                      title: strings.unlinkNotebook(),
-                      onPress: async () => {
-                        if (!id) return;
-                        await db.notes.removeFromNotebook(
-                          id,
-                          ...selectedItemsList
-                        );
-                        updateNotebook(id);
+              ? [
+                {
+                  title: strings.unpublish(),
+                  onPress: () => {
+                    presentDialog({
+                      title: strings.doActions.unpublish.note(
+                        selectedItemsList.length
+                      ),
+                      positiveText: strings.unpublish(),
+                      negativeText: strings.cancel(),
+                      positivePress: async () => {
+                        for (const id of selectedItemsList) {
+                          await db.monographs.unpublish(id);
+                        }
                         Navigation.queueRoutesForUpdate();
                         clearSelection();
                       },
-                      visible: renderedInRoute === "Notebook",
-                      icon: "minus"
-                    },
-                    {
-                      title: strings.unfavorite(),
-                      onPress: addToFavorite,
-                      visible: focusedRouteId === "Favorites",
-                      icon: "star-off"
-                    },
-                    {
-                      title: strings.moveToTrash(),
-                      onPress: async () => {
-                        const selection = useSelectionStore.getState();
-                        if (!selection.selectionMode) return;
-                        await deleteItems(
-                          selection.selectionMode as ItemType,
-                          selection.selectedItemsList
-                        );
-                        selection.clearSelection();
-                        selection.setSelectionMode(undefined);
-                      },
-                      visible: type === "note" || type === "notebook",
-                      icon: "delete"
-                    },
-                    {
-                      title: strings.doActions.delete.unknown(
-                        type!,
+                      positiveType: "errorShade"
+                    });
+                  },
+                  visible: true,
+                  icon: "delete"
+                }
+              ]
+              : [
+                {
+                  title: strings.manageTags(),
+                  onPress: async () => {
+                    ManageTags.present(selectedItemsList);
+                  },
+                  visible: type === "note",
+                  icon: "pound"
+                },
+                {
+                  title: strings.export(),
+                  onPress: async () => {
+                    ExportNotesSheet.present(selectedItemsList);
+                  },
+                  visible: type === "note",
+                  icon: "export"
+                },
+                {
+                  title: strings.clearHistory(),
+                  onPress: async () => {
+                    presentDialog({
+                      title: strings.clearHistory(),
+                      paragraph: strings.clearHistoryConfirmation(
                         selectedItemsList.length
                       ),
-                      onPress: async () => {
-                        const selection = useSelectionStore.getState();
-                        if (!selection.selectionMode) return;
-                        await deleteItems(
-                          selection.selectionMode as ItemType,
-                          selection.selectedItemsList
-                        );
-                        selection.clearSelection();
-                        selection.setSelectionMode(undefined);
-                      },
-                      visible:
-                        type !== "trash" &&
-                        type !== "note" &&
-                        type !== "notebook",
-                      icon: "delete"
-                    },
-                    {
-                      title: strings.restore(),
-                      onPress: restoreItem,
-                      visible: type === "trash",
-                      icon: "delete-restore"
-                    },
-                    {
-                      title: strings.delete(),
-                      onPress: deleteItem,
-                      visible: type === "trash",
-                      icon: "delete"
-                    }
-                  ]
-              ).map((item) =>
-                !item.visible ? null : (
-                  <IconButton
-                    size={AppFontSize.lg}
-                    type="plain"
-                    tooltipText={item.title}
-                    tooltipPosition={NativeTooltip.POSITIONS.TOP}
-                    testID={`select-${item.icon}`}
-                    name={item.icon}
-                    key={item.title}
-                    color={colors.primary.icon}
-                    onPress={async () => {
-                      //@ts-ignore
-                      menuRef.current?.hide();
-                      if (Platform.OS === "ios") await sleep(300);
-                      item.onPress();
-                    }}
-                  />
-                )
-              )}
+                      positiveText: strings.clear(),
+                      negativeText: strings.cancel(),
+                      positiveType: "errorShade",
+                      positivePress: async () => {
+                        await db.noteHistory.clearSessions(...selectedItemsList);
+                        Navigation.queueRoutesForUpdate();
+                        clearSelection();
+
+                        ToastManager.show({
+                          heading: strings.historyCleared(),
+                          type: "success"
+                        });
+                      }
+                    });
+                  },
+                  visible: type === "note",
+                  icon: "history"
+                },
+                {
+                  title: strings.addToNotebook(),
+                  onPress: async () => {
+                    Navigation.navigate("LinkNotebooks", {
+                      noteIds: selectedItemsList
+                    });
+                  },
+                  visible: type === "note",
+                  icon: "plus"
+                },
+                {
+                  title: strings.unlinkNotebook(),
+                  onPress: async () => {
+                    if (!id) return;
+                    await db.notes.removeFromNotebook(
+                      id,
+                      ...selectedItemsList
+                    );
+                    updateNotebook(id);
+                    Navigation.queueRoutesForUpdate();
+                    clearSelection();
+                  },
+                  visible: renderedInRoute === "Notebook",
+                  icon: "minus"
+                },
+                {
+                  title: strings.unfavorite(),
+                  onPress: addToFavorite,
+                  visible: focusedRouteId === "Favorites",
+                  icon: "star-off"
+                },
+                {
+                  title: strings.moveToTrash(),
+                  onPress: async () => {
+                    const selection = useSelectionStore.getState();
+                    if (!selection.selectionMode) return;
+                    await deleteItems(
+                      selection.selectionMode as ItemType,
+                      selection.selectedItemsList
+                    );
+                    selection.clearSelection();
+                    selection.setSelectionMode(undefined);
+                  },
+                  visible: type === "note" || type === "notebook",
+                  icon: "delete"
+                },
+                {
+                  title: strings.doActions.delete.unknown(
+                    type!,
+                    selectedItemsList.length
+                  ),
+                  onPress: async () => {
+                    const selection = useSelectionStore.getState();
+                    if (!selection.selectionMode) return;
+                    await deleteItems(
+                      selection.selectionMode as ItemType,
+                      selection.selectedItemsList
+                    );
+                    selection.clearSelection();
+                    selection.setSelectionMode(undefined);
+                  },
+                  visible:
+                    type !== "trash" &&
+                    type !== "note" &&
+                    type !== "notebook",
+                  icon: "delete"
+                },
+                {
+                  title: strings.restore(),
+                  onPress: restoreItem,
+                  visible: type === "trash",
+                  icon: "delete-restore"
+                },
+                {
+                  title: strings.delete(),
+                  onPress: deleteItem,
+                  visible: type === "trash",
+                  icon: "delete"
+                }
+              ]
+            ).map((item) =>
+              !item.visible ? null : (
+                <IconButton
+                  size={AppFontSize.lg}
+                  type="plain"
+                  tooltipText={item.title}
+                  tooltipPosition={NativeTooltip.POSITIONS.TOP}
+                  testID={`select-${item.icon}`}
+                  name={item.icon}
+                  key={item.title}
+                  color={colors.primary.icon}
+                  onPress={async () => {
+                    //@ts-ignore
+                    menuRef.current?.hide();
+                    if (Platform.OS === "ios") await sleep(300);
+                    item.onPress();
+                  }}
+                />
+              )
+            )}
         </View>
 
         <IconButton

--- a/apps/mobile/app/components/selection-header/index.tsx
+++ b/apps/mobile/app/components/selection-header/index.tsx
@@ -212,32 +212,6 @@ export const SelectionHeader = React.memo(
                   icon: "export"
                 },
                 {
-                  title: strings.clearHistory(),
-                  onPress: async () => {
-                    presentDialog({
-                      title: strings.clearHistory(),
-                      paragraph: strings.clearHistoryConfirmation(
-                        selectedItemsList.length
-                      ),
-                      positiveText: strings.clear(),
-                      negativeText: strings.cancel(),
-                      positiveType: "errorShade",
-                      positivePress: async () => {
-                        await db.noteHistory.clearSessions(...selectedItemsList);
-                        Navigation.queueRoutesForUpdate();
-                        clearSelection();
-
-                        ToastManager.show({
-                          heading: strings.historyCleared(),
-                          type: "success"
-                        });
-                      }
-                    });
-                  },
-                  visible: type === "note",
-                  icon: "history"
-                },
-                {
                   title: strings.addToNotebook(),
                   onPress: async () => {
                     Navigation.navigate("LinkNotebooks", {

--- a/packages/intl/locale/en.po
+++ b/packages/intl/locale/en.po
@@ -1647,6 +1647,10 @@ msgstr "Clear data & reset account"
 msgid "Clear default notebook"
 msgstr "Clear default notebook"
 
+#: src/strings.ts:2800
+msgid "Clear history"
+msgstr "Clear history"
+
 #: src/strings.ts:1015
 msgid "Clear logs"
 msgstr "Clear logs"
@@ -2294,6 +2298,14 @@ msgstr "Delete account"
 #: src/strings.ts:2759
 msgid "Delete all"
 msgstr "Delete all"
+
+#: src/strings.ts:2805
+msgid "Delete all version history for {count} selected notes?"
+msgstr "Delete all version history for {count} selected notes?"
+
+#: src/strings.ts:2804
+msgid "Delete all version history for this note?"
+msgstr "Delete all version history for this note?"
 
 #: src/strings.ts:2732
 msgid "Delete attachment"
@@ -7532,6 +7544,10 @@ msgstr "Verifying your email"
 #: src/strings.ts:415
 msgid "Version"
 msgstr "Version"
+
+#: src/strings.ts:2801
+msgid "Version history cleared"
+msgstr "Version history cleared"
 
 #: src/strings.ts:50
 msgid "Vibrate"

--- a/packages/intl/locale/en.po
+++ b/packages/intl/locale/en.po
@@ -2299,11 +2299,7 @@ msgstr "Delete account"
 msgid "Delete all"
 msgstr "Delete all"
 
-#: src/strings.ts:2805
-msgid "Delete all version history for {count} selected notes?"
-msgstr "Delete all version history for {count} selected notes?"
-
-#: src/strings.ts:2804
+#: src/strings.ts:2802
 msgid "Delete all version history for this note?"
 msgstr "Delete all version history for this note?"
 

--- a/packages/intl/locale/en.po
+++ b/packages/intl/locale/en.po
@@ -138,7 +138,7 @@ msgstr "{count, plural, one {Are you sure you want to download all attachments o
 msgid "{count, plural, one {Are you sure you want to move this notebook to {selectedNotebookTitle}?} other {Are you sure you want to move these # notebooks {selectedNotebookTitle}?}}"
 msgstr "{count, plural, one {Are you sure you want to move this notebook to {selectedNotebookTitle}?} other {Are you sure you want to move these # notebooks {selectedNotebookTitle}?}}"
 
-#: generated/action-confirmations.ts:76
+#: generated/action-confirmations.ts:82
 msgid "{count, plural, one {Are you sure you want to permanently delete this item?} other {Are you sure you to permanently delete these items?}}"
 msgstr "{count, plural, one {Are you sure you want to permanently delete this item?} other {Are you sure you to permanently delete these items?}}"
 
@@ -149,6 +149,10 @@ msgstr "{count, plural, one {Are you sure you want to permanently delete this no
 #: generated/action-confirmations.ts:65
 msgid "{count, plural, one {Are you sure you want to permanently delete this notebook?} other {Are you sure you to permanently delete these notebooks?}}"
 msgstr "{count, plural, one {Are you sure you want to permanently delete this notebook?} other {Are you sure you to permanently delete these notebooks?}}"
+
+#: generated/action-confirmations.ts:69
+msgid "{count, plural, one {Are you sure you want to permanently delete this version?} other {Are you sure you to permanently delete these versions?}}"
+msgstr "{count, plural, one {Are you sure you want to permanently delete this version?} other {Are you sure you to permanently delete these versions?}}"
 
 #: src/strings.ts:135
 msgid "{count, plural, one {Attach image} other {Attach # images}}"
@@ -162,7 +166,7 @@ msgstr "{count, plural, one {Attachment deleted} other {# attachments deleted}}"
 msgid "{count, plural, one {Attachment downloaded at {path}} other {#/{total} attachments downloaded as a zip file at {path}}}"
 msgstr "{count, plural, one {Attachment downloaded at {path}} other {#/{total} attachments downloaded as a zip file at {path}}}"
 
-#: generated/actions.ts:216
+#: generated/actions.ts:222
 msgid "{count, plural, one {Color renamed} other {# colors renamed}}"
 msgstr "{count, plural, one {Color renamed} other {# colors renamed}}"
 
@@ -175,7 +179,7 @@ msgid "{count, plural, one {Delete color} other {Delete # colors}}"
 msgstr "{count, plural, one {Delete color} other {Delete # colors}}"
 
 #: generated/do-actions.ts:12
-#: generated/do-actions.ts:53
+#: generated/do-actions.ts:59
 msgid "{count, plural, one {Delete item} other {Delete # items}}"
 msgstr "{count, plural, one {Delete item} other {Delete # items}}"
 
@@ -194,6 +198,10 @@ msgstr "{count, plural, one {Delete reminder} other {Delete # reminders}}"
 #: generated/do-actions.ts:24
 msgid "{count, plural, one {Delete tag} other {Delete # tags}}"
 msgstr "{count, plural, one {Delete tag} other {Delete # tags}}"
+
+#: generated/do-actions.ts:36
+msgid "{count, plural, one {Delete version} other {Delete # versions}}"
+msgstr "{count, plural, one {Delete version} other {Delete # versions}}"
 
 #: generated/in-progress-actions.ts:16
 msgid "{count, plural, one {Deleting attachment...} other {Deleting # attachments...}}"
@@ -219,27 +227,27 @@ msgstr "{count, plural, one {Deleting reminder...} other {Deleting # reminders..
 msgid "{count, plural, one {Deleting tag...} other {Deleting # tags...}}"
 msgstr "{count, plural, one {Deleting tag...} other {Deleting # tags...}}"
 
-#: generated/do-actions.ts:274
+#: generated/do-actions.ts:280
 msgid "{count, plural, one {Download attachment} other {Download # attachments}}"
 msgstr "{count, plural, one {Download attachment} other {Download # attachments}}"
 
-#: generated/do-actions.ts:283
+#: generated/do-actions.ts:289
 msgid "{count, plural, one {Download item} other {Download # items}}"
 msgstr "{count, plural, one {Download item} other {Download # items}}"
 
-#: generated/do-actions.ts:208
+#: generated/do-actions.ts:214
 msgid "{count, plural, one {Edit item} other {Edit # items}}"
 msgstr "{count, plural, one {Edit item} other {Edit # items}}"
 
-#: generated/do-actions.ts:191
+#: generated/do-actions.ts:197
 msgid "{count, plural, one {Edit notebook} other {Edit # notebooks}}"
 msgstr "{count, plural, one {Edit notebook} other {Edit # notebooks}}"
 
-#: generated/do-actions.ts:195
+#: generated/do-actions.ts:201
 msgid "{count, plural, one {Edit reminder} other {Edit # reminders}}"
 msgstr "{count, plural, one {Edit reminder} other {Edit # reminders}}"
 
-#: generated/do-actions.ts:187
+#: generated/do-actions.ts:193
 msgid "{count, plural, one {Edit tag} other {Edit # tags}}"
 msgstr "{count, plural, one {Edit tag} other {Edit # tags}}"
 
@@ -255,41 +263,41 @@ msgstr "{count, plural, one {Item could not be published} other {# items could n
 msgid "{count, plural, one {Item could not be unpublished} other {# items could not be unpublished}}"
 msgstr "{count, plural, one {Item could not be unpublished} other {# items could not be unpublished}}"
 
-#: generated/actions.ts:208
+#: generated/actions.ts:214
 msgid "{count, plural, one {Item created} other {# items created}}"
 msgstr "{count, plural, one {Item created} other {# items created}}"
 
-#: generated/actions.ts:41
+#: generated/actions.ts:47
 msgid "{count, plural, one {Item deleted} other {# items deleted}}"
 msgstr "{count, plural, one {Item deleted} other {# items deleted}}"
 
-#: generated/actions.ts:179
+#: generated/actions.ts:185
 msgid "{count, plural, one {Item edited} other {# items edited}}"
 msgstr "{count, plural, one {Item edited} other {# items edited}}"
 
-#: generated/actions.ts:64
+#: generated/actions.ts:70
 msgid "{count, plural, one {Item moved to trash} other {# items moved to trash}}"
 msgstr "{count, plural, one {Item moved to trash} other {# items moved to trash}}"
 
-#: generated/actions.ts:80
-#: generated/actions.ts:93
+#: generated/actions.ts:86
+#: generated/actions.ts:99
 msgid "{count, plural, one {Item permanently deleted} other {# items permanently deleted}}"
 msgstr "{count, plural, one {Item permanently deleted} other {# items permanently deleted}}"
 
-#: generated/actions.ts:110
+#: generated/actions.ts:116
 msgid "{count, plural, one {Item published} other {# items published}}"
 msgstr "{count, plural, one {Item published} other {# items published}}"
 
-#: generated/actions.ts:225
+#: generated/actions.ts:231
 msgid "{count, plural, one {Item renamed} other {# items renamed}}"
 msgstr "{count, plural, one {Item renamed} other {# items renamed}}"
 
-#: generated/actions.ts:143
-#: generated/actions.ts:156
+#: generated/actions.ts:149
+#: generated/actions.ts:162
 msgid "{count, plural, one {Item restored} other {# items restored}}"
 msgstr "{count, plural, one {Item restored} other {# items restored}}"
 
-#: generated/actions.ts:127
+#: generated/actions.ts:133
 msgid "{count, plural, one {Item unpublished} other {# items unpublished}}"
 msgstr "{count, plural, one {Item unpublished} other {# items unpublished}}"
 
@@ -321,23 +329,23 @@ msgstr "{count, plural, one {Note deleted} other {# notes deleted}}"
 msgid "{count, plural, one {Note exported} other {# notes exported}}"
 msgstr "{count, plural, one {Note exported} other {# notes exported}}"
 
-#: generated/actions.ts:49
+#: generated/actions.ts:55
 msgid "{count, plural, one {Note moved to trash} other {# notes moved to trash}}"
 msgstr "{count, plural, one {Note moved to trash} other {# notes moved to trash}}"
 
-#: generated/actions.ts:72
+#: generated/actions.ts:78
 msgid "{count, plural, one {Note permanently deleted} other {# notes permanently deleted}}"
 msgstr "{count, plural, one {Note permanently deleted} other {# notes permanently deleted}}"
 
-#: generated/actions.ts:101
+#: generated/actions.ts:107
 msgid "{count, plural, one {Note published} other {# notes published}}"
 msgstr "{count, plural, one {Note published} other {# notes published}}"
 
-#: generated/actions.ts:135
+#: generated/actions.ts:141
 msgid "{count, plural, one {Note restored} other {# notes restored}}"
 msgstr "{count, plural, one {Note restored} other {# notes restored}}"
 
-#: generated/actions.ts:118
+#: generated/actions.ts:124
 msgid "{count, plural, one {Note unpublished} other {# notes unpublished}}"
 msgstr "{count, plural, one {Note unpublished} other {# notes unpublished}}"
 
@@ -345,7 +353,7 @@ msgstr "{count, plural, one {Note unpublished} other {# notes unpublished}}"
 msgid "{count, plural, one {Note will be automatically deleted from all other devices & any future changes won't get synced. Are you sure you want to continue?} other {# notes will be automatically deleted from all other devices & any future changes won't get synced. Are you sure you want to continue?}}"
 msgstr "{count, plural, one {Note will be automatically deleted from all other devices & any future changes won't get synced. Are you sure you want to continue?} other {# notes will be automatically deleted from all other devices & any future changes won't get synced. Are you sure you want to continue?}}"
 
-#: generated/actions.ts:187
+#: generated/actions.ts:193
 msgid "{count, plural, one {Notebook created} other {# notebooks created}}"
 msgstr "{count, plural, one {Notebook created} other {# notebooks created}}"
 
@@ -353,28 +361,28 @@ msgstr "{count, plural, one {Notebook created} other {# notebooks created}}"
 msgid "{count, plural, one {Notebook deleted} other {# notebooks deleted}}"
 msgstr "{count, plural, one {Notebook deleted} other {# notebooks deleted}}"
 
-#: generated/actions.ts:168
+#: generated/actions.ts:174
 msgid "{count, plural, one {Notebook edited} other {# notebooks edited}}"
 msgstr "{count, plural, one {Notebook edited} other {# notebooks edited}}"
 
-#: generated/actions.ts:53
+#: generated/actions.ts:59
 msgid "{count, plural, one {Notebook moved to trash} other {# notebooks moved to trash}}"
 msgstr "{count, plural, one {Notebook moved to trash} other {# notebooks moved to trash}}"
 
-#: generated/actions.ts:76
+#: generated/actions.ts:82
 msgid "{count, plural, one {Notebook permanently deleted} other {# notebooks permanently deleted}}"
 msgstr "{count, plural, one {Notebook permanently deleted} other {# notebooks permanently deleted}}"
 
-#: generated/actions.ts:139
+#: generated/actions.ts:145
 msgid "{count, plural, one {Notebook restored} other {# notebooks restored}}"
 msgstr "{count, plural, one {Notebook restored} other {# notebooks restored}}"
 
-#: generated/do-actions.ts:141
+#: generated/do-actions.ts:147
 msgid "{count, plural, one {Permanently delete attachment} other {Permanently delete # attachments}}"
 msgstr "{count, plural, one {Permanently delete attachment} other {Permanently delete # attachments}}"
 
-#: generated/do-actions.ts:145
-#: generated/do-actions.ts:156
+#: generated/do-actions.ts:151
+#: generated/do-actions.ts:162
 msgid "{count, plural, one {Permanently delete item} other {Permanently delete # items}}"
 msgstr "{count, plural, one {Permanently delete item} other {Permanently delete # items}}"
 
@@ -383,15 +391,15 @@ msgstr "{count, plural, one {Permanently delete item} other {Permanently delete 
 msgid "{count, plural, one {permanently deleting item...} other {permanently deleting # items...}}"
 msgstr "{count, plural, one {permanently deleting item...} other {permanently deleting # items...}}"
 
-#: generated/do-actions.ts:99
+#: generated/do-actions.ts:105
 msgid "{count, plural, one {Pin item} other {Pin # items}}"
 msgstr "{count, plural, one {Pin item} other {Pin # items}}"
 
-#: generated/do-actions.ts:84
+#: generated/do-actions.ts:90
 msgid "{count, plural, one {Pin note} other {Pin # notes}}"
 msgstr "{count, plural, one {Pin note} other {Pin # notes}}"
 
-#: generated/do-actions.ts:88
+#: generated/do-actions.ts:94
 msgid "{count, plural, one {Pin notebook} other {Pin # notebooks}}"
 msgstr "{count, plural, one {Pin notebook} other {Pin # notebooks}}"
 
@@ -399,11 +407,11 @@ msgstr "{count, plural, one {Pin notebook} other {Pin # notebooks}}"
 msgid "{count, plural, one {Prevent note from syncing} other {Prevent # notes from syncing}}"
 msgstr "{count, plural, one {Prevent note from syncing} other {Prevent # notes from syncing}}"
 
-#: generated/do-actions.ts:133
+#: generated/do-actions.ts:139
 msgid "{count, plural, one {Publish item} other {Publish # items}}"
 msgstr "{count, plural, one {Publish item} other {Publish # items}}"
 
-#: generated/do-actions.ts:124
+#: generated/do-actions.ts:130
 msgid "{count, plural, one {Publish note} other {Publish # notes}}"
 msgstr "{count, plural, one {Publish note} other {Publish # notes}}"
 
@@ -411,47 +419,47 @@ msgstr "{count, plural, one {Publish note} other {Publish # notes}}"
 msgid "{count, plural, one {Reminder deleted} other {# reminders deleted}}"
 msgstr "{count, plural, one {Reminder deleted} other {# reminders deleted}}"
 
-#: generated/do-actions.ts:253
+#: generated/do-actions.ts:259
 msgid "{count, plural, one {Remove attachment} other {Remove # attachments}}"
 msgstr "{count, plural, one {Remove attachment} other {Remove # attachments}}"
 
-#: generated/do-actions.ts:249
+#: generated/do-actions.ts:255
 msgid "{count, plural, one {Remove color} other {Remove # colors}}"
 msgstr "{count, plural, one {Remove color} other {Remove # colors}}"
 
-#: generated/do-actions.ts:266
+#: generated/do-actions.ts:272
 msgid "{count, plural, one {Remove item} other {Remove # items}}"
 msgstr "{count, plural, one {Remove item} other {Remove # items}}"
 
-#: generated/do-actions.ts:245
+#: generated/do-actions.ts:251
 msgid "{count, plural, one {Remove shortcut} other {Remove # shortcuts}}"
 msgstr "{count, plural, one {Remove shortcut} other {Remove # shortcuts}}"
 
-#: generated/do-actions.ts:216
+#: generated/do-actions.ts:222
 msgid "{count, plural, one {Rename attachment} other {Rename # attachments}}"
 msgstr "{count, plural, one {Rename attachment} other {Rename # attachments}}"
 
-#: generated/do-actions.ts:220
+#: generated/do-actions.ts:226
 msgid "{count, plural, one {Rename color} other {Rename # colors}}"
 msgstr "{count, plural, one {Rename color} other {Rename # colors}}"
 
-#: generated/do-actions.ts:237
+#: generated/do-actions.ts:243
 msgid "{count, plural, one {Rename item} other {Rename # items}}"
 msgstr "{count, plural, one {Rename item} other {Rename # items}}"
 
-#: generated/do-actions.ts:224
+#: generated/do-actions.ts:230
 msgid "{count, plural, one {Rename tag} other {Rename # tags}}"
 msgstr "{count, plural, one {Rename tag} other {Rename # tags}}"
 
-#: generated/do-actions.ts:179
+#: generated/do-actions.ts:185
 msgid "{count, plural, one {Restore item} other {Restore # items}}"
 msgstr "{count, plural, one {Restore item} other {Restore # items}}"
 
-#: generated/do-actions.ts:164
+#: generated/do-actions.ts:170
 msgid "{count, plural, one {Restore note} other {Restore # notes}}"
 msgstr "{count, plural, one {Restore note} other {Restore # notes}}"
 
-#: generated/do-actions.ts:168
+#: generated/do-actions.ts:174
 msgid "{count, plural, one {Restore notebook} other {Restore # notebooks}}"
 msgstr "{count, plural, one {Restore notebook} other {Restore # notebooks}}"
 
@@ -460,11 +468,11 @@ msgstr "{count, plural, one {Restore notebook} other {Restore # notebooks}}"
 msgid "{count, plural, one {Restoring item...} other {Restoring # items...}}"
 msgstr "{count, plural, one {Restoring item...} other {Restoring # items...}}"
 
-#: generated/actions.ts:195
+#: generated/actions.ts:201
 msgid "{count, plural, one {Shortcut created} other {# shortcuts created}}"
 msgstr "{count, plural, one {Shortcut created} other {# shortcuts created}}"
 
-#: generated/actions.ts:191
+#: generated/actions.ts:197
 msgid "{count, plural, one {Tag created} other {# tags created}}"
 msgstr "{count, plural, one {Tag created} other {# tags created}}"
 
@@ -472,29 +480,33 @@ msgstr "{count, plural, one {Tag created} other {# tags created}}"
 msgid "{count, plural, one {Tag deleted} other {# tags deleted}}"
 msgstr "{count, plural, one {Tag deleted} other {# tags deleted}}"
 
-#: generated/actions.ts:164
+#: generated/actions.ts:170
 msgid "{count, plural, one {Tag edited} other {# tags edited}}"
 msgstr "{count, plural, one {Tag edited} other {# tags edited}}"
 
-#: generated/do-actions.ts:76
+#: generated/do-actions.ts:82
 msgid "{count, plural, one {Unpin item} other {Unpin # items}}"
 msgstr "{count, plural, one {Unpin item} other {Unpin # items}}"
 
-#: generated/do-actions.ts:61
+#: generated/do-actions.ts:67
 msgid "{count, plural, one {Unpin note} other {Unpin # notes}}"
 msgstr "{count, plural, one {Unpin note} other {Unpin # notes}}"
 
-#: generated/do-actions.ts:65
+#: generated/do-actions.ts:71
 msgid "{count, plural, one {Unpin notebook} other {Unpin # notebooks}}"
 msgstr "{count, plural, one {Unpin notebook} other {Unpin # notebooks}}"
 
-#: generated/do-actions.ts:116
+#: generated/do-actions.ts:122
 msgid "{count, plural, one {Unpublish item} other {Unpublish # items}}"
 msgstr "{count, plural, one {Unpublish item} other {Unpublish # items}}"
 
-#: generated/do-actions.ts:107
+#: generated/do-actions.ts:113
 msgid "{count, plural, one {Unpublish note} other {Unpublish # notes}}"
 msgstr "{count, plural, one {Unpublish note} other {Unpublish # notes}}"
+
+#: generated/actions.ts:28
+msgid "{count, plural, one {Version deleted} other {# versions deleted}}"
+msgstr "{count, plural, one {Version deleted} other {# versions deleted}}"
 
 #: src/strings.ts:2510
 msgid "{count} characters"

--- a/packages/intl/locale/pseudo-LOCALE.po
+++ b/packages/intl/locale/pseudo-LOCALE.po
@@ -2288,11 +2288,7 @@ msgstr ""
 msgid "Delete all"
 msgstr ""
 
-#: src/strings.ts:2805
-msgid "Delete all version history for {count} selected notes?"
-msgstr ""
-
-#: src/strings.ts:2804
+#: src/strings.ts:2802
 msgid "Delete all version history for this note?"
 msgstr ""
 

--- a/packages/intl/locale/pseudo-LOCALE.po
+++ b/packages/intl/locale/pseudo-LOCALE.po
@@ -1647,6 +1647,10 @@ msgstr ""
 msgid "Clear default notebook"
 msgstr ""
 
+#: src/strings.ts:2800
+msgid "Clear history"
+msgstr ""
+
 #: src/strings.ts:1015
 msgid "Clear logs"
 msgstr ""
@@ -2282,6 +2286,14 @@ msgstr ""
 
 #: src/strings.ts:2759
 msgid "Delete all"
+msgstr ""
+
+#: src/strings.ts:2805
+msgid "Delete all version history for {count} selected notes?"
+msgstr ""
+
+#: src/strings.ts:2804
+msgid "Delete all version history for this note?"
 msgstr ""
 
 #: src/strings.ts:2732
@@ -7481,6 +7493,10 @@ msgstr ""
 
 #: src/strings.ts:415
 msgid "Version"
+msgstr ""
+
+#: src/strings.ts:2801
+msgid "Version history cleared"
 msgstr ""
 
 #: src/strings.ts:50

--- a/packages/intl/locale/pseudo-LOCALE.po
+++ b/packages/intl/locale/pseudo-LOCALE.po
@@ -138,7 +138,7 @@ msgstr ""
 msgid "{count, plural, one {Are you sure you want to move this notebook to {selectedNotebookTitle}?} other {Are you sure you want to move these # notebooks {selectedNotebookTitle}?}}"
 msgstr ""
 
-#: generated/action-confirmations.ts:76
+#: generated/action-confirmations.ts:82
 msgid "{count, plural, one {Are you sure you want to permanently delete this item?} other {Are you sure you to permanently delete these items?}}"
 msgstr ""
 
@@ -148,6 +148,10 @@ msgstr ""
 
 #: generated/action-confirmations.ts:65
 msgid "{count, plural, one {Are you sure you want to permanently delete this notebook?} other {Are you sure you to permanently delete these notebooks?}}"
+msgstr ""
+
+#: generated/action-confirmations.ts:69
+msgid "{count, plural, one {Are you sure you want to permanently delete this version?} other {Are you sure you to permanently delete these versions?}}"
 msgstr ""
 
 #: src/strings.ts:135
@@ -162,7 +166,7 @@ msgstr ""
 msgid "{count, plural, one {Attachment downloaded at {path}} other {#/{total} attachments downloaded as a zip file at {path}}}"
 msgstr ""
 
-#: generated/actions.ts:216
+#: generated/actions.ts:222
 msgid "{count, plural, one {Color renamed} other {# colors renamed}}"
 msgstr ""
 
@@ -175,7 +179,7 @@ msgid "{count, plural, one {Delete color} other {Delete # colors}}"
 msgstr ""
 
 #: generated/do-actions.ts:12
-#: generated/do-actions.ts:53
+#: generated/do-actions.ts:59
 msgid "{count, plural, one {Delete item} other {Delete # items}}"
 msgstr ""
 
@@ -193,6 +197,10 @@ msgstr ""
 
 #: generated/do-actions.ts:24
 msgid "{count, plural, one {Delete tag} other {Delete # tags}}"
+msgstr ""
+
+#: generated/do-actions.ts:36
+msgid "{count, plural, one {Delete version} other {Delete # versions}}"
 msgstr ""
 
 #: generated/in-progress-actions.ts:16
@@ -219,27 +227,27 @@ msgstr ""
 msgid "{count, plural, one {Deleting tag...} other {Deleting # tags...}}"
 msgstr ""
 
-#: generated/do-actions.ts:274
+#: generated/do-actions.ts:280
 msgid "{count, plural, one {Download attachment} other {Download # attachments}}"
 msgstr ""
 
-#: generated/do-actions.ts:283
+#: generated/do-actions.ts:289
 msgid "{count, plural, one {Download item} other {Download # items}}"
 msgstr ""
 
-#: generated/do-actions.ts:208
+#: generated/do-actions.ts:214
 msgid "{count, plural, one {Edit item} other {Edit # items}}"
 msgstr ""
 
-#: generated/do-actions.ts:191
+#: generated/do-actions.ts:197
 msgid "{count, plural, one {Edit notebook} other {Edit # notebooks}}"
 msgstr ""
 
-#: generated/do-actions.ts:195
+#: generated/do-actions.ts:201
 msgid "{count, plural, one {Edit reminder} other {Edit # reminders}}"
 msgstr ""
 
-#: generated/do-actions.ts:187
+#: generated/do-actions.ts:193
 msgid "{count, plural, one {Edit tag} other {Edit # tags}}"
 msgstr ""
 
@@ -255,41 +263,41 @@ msgstr ""
 msgid "{count, plural, one {Item could not be unpublished} other {# items could not be unpublished}}"
 msgstr ""
 
-#: generated/actions.ts:208
+#: generated/actions.ts:214
 msgid "{count, plural, one {Item created} other {# items created}}"
 msgstr ""
 
-#: generated/actions.ts:41
+#: generated/actions.ts:47
 msgid "{count, plural, one {Item deleted} other {# items deleted}}"
 msgstr ""
 
-#: generated/actions.ts:179
+#: generated/actions.ts:185
 msgid "{count, plural, one {Item edited} other {# items edited}}"
 msgstr ""
 
-#: generated/actions.ts:64
+#: generated/actions.ts:70
 msgid "{count, plural, one {Item moved to trash} other {# items moved to trash}}"
 msgstr ""
 
-#: generated/actions.ts:80
-#: generated/actions.ts:93
+#: generated/actions.ts:86
+#: generated/actions.ts:99
 msgid "{count, plural, one {Item permanently deleted} other {# items permanently deleted}}"
 msgstr ""
 
-#: generated/actions.ts:110
+#: generated/actions.ts:116
 msgid "{count, plural, one {Item published} other {# items published}}"
 msgstr ""
 
-#: generated/actions.ts:225
+#: generated/actions.ts:231
 msgid "{count, plural, one {Item renamed} other {# items renamed}}"
 msgstr ""
 
-#: generated/actions.ts:143
-#: generated/actions.ts:156
+#: generated/actions.ts:149
+#: generated/actions.ts:162
 msgid "{count, plural, one {Item restored} other {# items restored}}"
 msgstr ""
 
-#: generated/actions.ts:127
+#: generated/actions.ts:133
 msgid "{count, plural, one {Item unpublished} other {# items unpublished}}"
 msgstr ""
 
@@ -321,23 +329,23 @@ msgstr ""
 msgid "{count, plural, one {Note exported} other {# notes exported}}"
 msgstr ""
 
-#: generated/actions.ts:49
+#: generated/actions.ts:55
 msgid "{count, plural, one {Note moved to trash} other {# notes moved to trash}}"
 msgstr ""
 
-#: generated/actions.ts:72
+#: generated/actions.ts:78
 msgid "{count, plural, one {Note permanently deleted} other {# notes permanently deleted}}"
 msgstr ""
 
-#: generated/actions.ts:101
+#: generated/actions.ts:107
 msgid "{count, plural, one {Note published} other {# notes published}}"
 msgstr ""
 
-#: generated/actions.ts:135
+#: generated/actions.ts:141
 msgid "{count, plural, one {Note restored} other {# notes restored}}"
 msgstr ""
 
-#: generated/actions.ts:118
+#: generated/actions.ts:124
 msgid "{count, plural, one {Note unpublished} other {# notes unpublished}}"
 msgstr ""
 
@@ -345,7 +353,7 @@ msgstr ""
 msgid "{count, plural, one {Note will be automatically deleted from all other devices & any future changes won't get synced. Are you sure you want to continue?} other {# notes will be automatically deleted from all other devices & any future changes won't get synced. Are you sure you want to continue?}}"
 msgstr ""
 
-#: generated/actions.ts:187
+#: generated/actions.ts:193
 msgid "{count, plural, one {Notebook created} other {# notebooks created}}"
 msgstr ""
 
@@ -353,28 +361,28 @@ msgstr ""
 msgid "{count, plural, one {Notebook deleted} other {# notebooks deleted}}"
 msgstr ""
 
-#: generated/actions.ts:168
+#: generated/actions.ts:174
 msgid "{count, plural, one {Notebook edited} other {# notebooks edited}}"
 msgstr ""
 
-#: generated/actions.ts:53
+#: generated/actions.ts:59
 msgid "{count, plural, one {Notebook moved to trash} other {# notebooks moved to trash}}"
 msgstr ""
 
-#: generated/actions.ts:76
+#: generated/actions.ts:82
 msgid "{count, plural, one {Notebook permanently deleted} other {# notebooks permanently deleted}}"
 msgstr ""
 
-#: generated/actions.ts:139
+#: generated/actions.ts:145
 msgid "{count, plural, one {Notebook restored} other {# notebooks restored}}"
 msgstr ""
 
-#: generated/do-actions.ts:141
+#: generated/do-actions.ts:147
 msgid "{count, plural, one {Permanently delete attachment} other {Permanently delete # attachments}}"
 msgstr ""
 
-#: generated/do-actions.ts:145
-#: generated/do-actions.ts:156
+#: generated/do-actions.ts:151
+#: generated/do-actions.ts:162
 msgid "{count, plural, one {Permanently delete item} other {Permanently delete # items}}"
 msgstr ""
 
@@ -383,15 +391,15 @@ msgstr ""
 msgid "{count, plural, one {permanently deleting item...} other {permanently deleting # items...}}"
 msgstr ""
 
-#: generated/do-actions.ts:99
+#: generated/do-actions.ts:105
 msgid "{count, plural, one {Pin item} other {Pin # items}}"
 msgstr ""
 
-#: generated/do-actions.ts:84
+#: generated/do-actions.ts:90
 msgid "{count, plural, one {Pin note} other {Pin # notes}}"
 msgstr ""
 
-#: generated/do-actions.ts:88
+#: generated/do-actions.ts:94
 msgid "{count, plural, one {Pin notebook} other {Pin # notebooks}}"
 msgstr ""
 
@@ -399,11 +407,11 @@ msgstr ""
 msgid "{count, plural, one {Prevent note from syncing} other {Prevent # notes from syncing}}"
 msgstr ""
 
-#: generated/do-actions.ts:133
+#: generated/do-actions.ts:139
 msgid "{count, plural, one {Publish item} other {Publish # items}}"
 msgstr ""
 
-#: generated/do-actions.ts:124
+#: generated/do-actions.ts:130
 msgid "{count, plural, one {Publish note} other {Publish # notes}}"
 msgstr ""
 
@@ -411,47 +419,47 @@ msgstr ""
 msgid "{count, plural, one {Reminder deleted} other {# reminders deleted}}"
 msgstr ""
 
-#: generated/do-actions.ts:253
+#: generated/do-actions.ts:259
 msgid "{count, plural, one {Remove attachment} other {Remove # attachments}}"
 msgstr ""
 
-#: generated/do-actions.ts:249
+#: generated/do-actions.ts:255
 msgid "{count, plural, one {Remove color} other {Remove # colors}}"
 msgstr ""
 
-#: generated/do-actions.ts:266
+#: generated/do-actions.ts:272
 msgid "{count, plural, one {Remove item} other {Remove # items}}"
 msgstr ""
 
-#: generated/do-actions.ts:245
+#: generated/do-actions.ts:251
 msgid "{count, plural, one {Remove shortcut} other {Remove # shortcuts}}"
 msgstr ""
 
-#: generated/do-actions.ts:216
+#: generated/do-actions.ts:222
 msgid "{count, plural, one {Rename attachment} other {Rename # attachments}}"
 msgstr ""
 
-#: generated/do-actions.ts:220
+#: generated/do-actions.ts:226
 msgid "{count, plural, one {Rename color} other {Rename # colors}}"
 msgstr ""
 
-#: generated/do-actions.ts:237
+#: generated/do-actions.ts:243
 msgid "{count, plural, one {Rename item} other {Rename # items}}"
 msgstr ""
 
-#: generated/do-actions.ts:224
+#: generated/do-actions.ts:230
 msgid "{count, plural, one {Rename tag} other {Rename # tags}}"
 msgstr ""
 
-#: generated/do-actions.ts:179
+#: generated/do-actions.ts:185
 msgid "{count, plural, one {Restore item} other {Restore # items}}"
 msgstr ""
 
-#: generated/do-actions.ts:164
+#: generated/do-actions.ts:170
 msgid "{count, plural, one {Restore note} other {Restore # notes}}"
 msgstr ""
 
-#: generated/do-actions.ts:168
+#: generated/do-actions.ts:174
 msgid "{count, plural, one {Restore notebook} other {Restore # notebooks}}"
 msgstr ""
 
@@ -460,11 +468,11 @@ msgstr ""
 msgid "{count, plural, one {Restoring item...} other {Restoring # items...}}"
 msgstr ""
 
-#: generated/actions.ts:195
+#: generated/actions.ts:201
 msgid "{count, plural, one {Shortcut created} other {# shortcuts created}}"
 msgstr ""
 
-#: generated/actions.ts:191
+#: generated/actions.ts:197
 msgid "{count, plural, one {Tag created} other {# tags created}}"
 msgstr ""
 
@@ -472,28 +480,32 @@ msgstr ""
 msgid "{count, plural, one {Tag deleted} other {# tags deleted}}"
 msgstr ""
 
-#: generated/actions.ts:164
+#: generated/actions.ts:170
 msgid "{count, plural, one {Tag edited} other {# tags edited}}"
 msgstr ""
 
-#: generated/do-actions.ts:76
+#: generated/do-actions.ts:82
 msgid "{count, plural, one {Unpin item} other {Unpin # items}}"
 msgstr ""
 
-#: generated/do-actions.ts:61
+#: generated/do-actions.ts:67
 msgid "{count, plural, one {Unpin note} other {Unpin # notes}}"
 msgstr ""
 
-#: generated/do-actions.ts:65
+#: generated/do-actions.ts:71
 msgid "{count, plural, one {Unpin notebook} other {Unpin # notebooks}}"
 msgstr ""
 
-#: generated/do-actions.ts:116
+#: generated/do-actions.ts:122
 msgid "{count, plural, one {Unpublish item} other {Unpublish # items}}"
 msgstr ""
 
-#: generated/do-actions.ts:107
+#: generated/do-actions.ts:113
 msgid "{count, plural, one {Unpublish note} other {Unpublish # notes}}"
+msgstr ""
+
+#: generated/actions.ts:28
+msgid "{count, plural, one {Version deleted} other {# versions deleted}}"
 msgstr ""
 
 #: src/strings.ts:2510

--- a/packages/intl/scripts/generate-strings.mjs
+++ b/packages/intl/scripts/generate-strings.mjs
@@ -30,7 +30,8 @@ const DO_ACTIONS = [
       "notebook",
       "tag",
       "color",
-      "attachment"
+      "attachment",
+      "version"
     ]
   },
   { action: "unpin", label: "Unpin", dataTypes: ["note", "notebook"] },
@@ -73,7 +74,7 @@ const ACTIONS = [
   {
     action: "deleted",
     label: "deleted",
-    dataTypes: ["attachment", "reminder", "tag", "note", "notebook"]
+    dataTypes: ["attachment", "reminder", "tag", "note", "notebook", "version"]
   },
   {
     action: "movedToTrash",
@@ -121,12 +122,12 @@ const ACTION_CONFIRMATIONS = [
       "tag",
       "color",
       "attachment"
-    ],
+    ]
   },
   {
     action: "permanentlyDelete",
     label: "permanently delete",
-    dataTypes: ["note", "notebook"]
+    dataTypes: ["note", "notebook", "version"]
   }
 ];
 
@@ -209,6 +210,12 @@ const DATA_TYPES = {
     singularCamelCase: `Shortcut`,
     plural: `shortcuts`,
     pluralCamelCase: `Shortcuts`
+  },
+  version: {
+    singular: `version`,
+    singularCamelCase: `Version`,
+    plural: `versions`,
+    pluralCamelCase: `Versions`
   }
 };
 

--- a/packages/intl/src/strings.ts
+++ b/packages/intl/src/strings.ts
@@ -2799,5 +2799,11 @@ Continue without attachments?`,
   deleteItem: () => t`Delete item`,
   keepScreenOn: () => t`Keep screen on`,
   keepScreenOnDesc: () =>
-    t`Prevent the screen from turning off while the editor is focused.`
+    t`Prevent the screen from turning off while the editor is focused.`,
+  clearHistory: () => t`Clear history`,
+  historyCleared: () => t`Version history cleared`,
+  clearHistoryConfirmation: (count: number) =>
+    count === 1
+      ? t`Delete all version history for this note?`
+      : t`Delete all version history for ${count} selected notes?`
 };

--- a/packages/intl/src/strings.ts
+++ b/packages/intl/src/strings.ts
@@ -2802,8 +2802,5 @@ Continue without attachments?`,
     t`Prevent the screen from turning off while the editor is focused.`,
   clearHistory: () => t`Clear history`,
   historyCleared: () => t`Version history cleared`,
-  clearHistoryConfirmation: (count: number) =>
-    count === 1
-      ? t`Delete all version history for this note?`
-      : t`Delete all version history for ${count} selected notes?`
+  clearHistoryConfirmation: () => t`Delete all version history for this note?`
 };

--- a/packages/intl/src/strings.ts
+++ b/packages/intl/src/strings.ts
@@ -2802,5 +2802,9 @@ Continue without attachments?`,
     t`Prevent the screen from turning off while the editor is focused.`,
   clearHistory: () => t`Clear history`,
   historyCleared: () => t`Version history cleared`,
-  clearHistoryConfirmation: () => t`Delete all version history for this note?`
+  clearHistoryConfirmation: () => t`Delete all version history for this note?`,
+  deleteVersion: () => doActions.delete.version(1),
+  deleteVersionConfirmation: () =>
+    actionConfirmations.permanentlyDelete.version(1),
+  versionDeleted: () => actions.deleted.version(1)
 };


### PR DESCRIPTION
## Description
- Added a **Clear version history** action to the Note History sheet for individual notes.

[https://github.com/streetwriters/notesnook/issues/9723](https://github.com/streetwriters/notesnook/issues/9723)


## Type of Change
- [ ] Bug fix
- [x] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
This change only adds a UI action that calls the existing API.

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
