### PR TITLE
mobile: fix share append content merging onto same line

### DIFF
--- a/apps/mobile/app/share/share.tsx
+++ b/apps/mobile/app/share/share.tsx
@@ -363,7 +363,10 @@ const ShareView = () => {
         : null;
       noteData = {
         content: {
-          data: (rawContent?.data || "") + "<br/>" + noteContent.current,
+          data:
+            (rawContent?.data || "") +
+            `<p data-spacing="single"><br></p>` +
+            noteContent.current,
           type: "tiptap"
         },
         id: note?.id,


### PR DESCRIPTION
Replace the bare <br/> separator with an explicit
<p data-spacing=single><br></p> paragraph. The bare <br/> was parsed into an implicit empty paragraph that inherited the live 'double spaced lines' setting; when that setting was off, the placeholder collapsed to zero height and appended content ran together on one line.

Fixes #9207

## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [ ] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
