### PR TITLE
mobile: set default font size 1-400

### DIFF
--- a/apps/mobile/app/screens/settings/settings-data.tsx
+++ b/apps/mobile/app/screens/settings/settings-data.tsx
@@ -206,7 +206,7 @@ export const settingsGroups: SettingSection[] = [
               : status === SubscriptionStatus.ACTIVE
                 ? strings.subRenewOn(expiryDate)
                 : status === SubscriptionStatus.CANCELED ||
-                    status === SubscriptionStatus.PAUSED
+                  status === SubscriptionStatus.PAUSED
                   ? strings.subEndsOn(expiryDate)
                   : status === SubscriptionStatus.EXPIRED
                     ? subscriptionDaysLeft.time < -3
@@ -862,8 +862,8 @@ export const settingsGroups: SettingSection[] = [
             name: strings.defaultFontSize(),
             description: strings.defaultFontSizeDesc(),
             type: "input-selector",
-            minInputValue: 8,
-            maxInputValue: 120,
+            minInputValue: 1,
+            maxInputValue: 400,
             icon: "format-size",
             property: "defaultFontSize"
           },

--- a/apps/mobile/app/screens/settings/settings-data.tsx
+++ b/apps/mobile/app/screens/settings/settings-data.tsx
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { formatBytes } from "@notesnook/common";
+import { FONT_SIZE_BOUNDS, formatBytes } from "@notesnook/common";
 import {
   SubscriptionPlan,
   SubscriptionProvider,
@@ -862,8 +862,8 @@ export const settingsGroups: SettingSection[] = [
             name: strings.defaultFontSize(),
             description: strings.defaultFontSizeDesc(),
             type: "input-selector",
-            minInputValue: 1,
-            maxInputValue: 400,
+            minInputValue: FONT_SIZE_BOUNDS.MIN,
+            maxInputValue: FONT_SIZE_BOUNDS.MAX,
             icon: "format-size",
             property: "defaultFontSize"
           },


### PR DESCRIPTION
## Description
Added the range of default font size in settings/editor 1-400

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
No ui or functionality change

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
