### PR TITLE
mobile: unlink note from previous notebook in single-select mode

### DIFF
--- a/apps/mobile/app/screens/link-notebooks/index.tsx
+++ b/apps/mobile/app/screens/link-notebooks/index.tsx
@@ -163,7 +163,20 @@ const LinkNotebooks = (props: NavigationProps<"LinkNotebooks">) => {
   }, [noteIds]);
 
   const onSave = async () => {
-    const changedNotebooks = useNotebookSelectionStore.getState().selection;
+    const selectionState = useNotebookSelectionStore.getState();
+    const changedNotebooks = { ...selectionState.selection };
+
+    if (!selectionState.multiSelect) {
+      for (const id in selectionState.initialState) {
+        if (
+          selectionState.initialState[id] === "selected" &&
+          changedNotebooks[id] !== "selected"
+        ) {
+          changedNotebooks[id] = "deselected";
+        }
+      }
+    }
+
     for (const id in changedNotebooks) {
       const item = await db.notebooks.notebook(id);
       if (!item) continue;
@@ -207,11 +220,11 @@ const LinkNotebooks = (props: NavigationProps<"LinkNotebooks">) => {
         rightButton={
           hasSelection
             ? {
-                name: "restore",
-                onPress: () => {
-                  updateInitialSelectionState(noteIds);
-                }
+              name: "restore",
+              onPress: () => {
+                updateInitialSelectionState(noteIds);
               }
+            }
             : undefined
         }
       />


### PR DESCRIPTION
## Description
Fixes a bug where changing a note's linked notebook in single-select mode did not unlink the note from its previously selected notebook. Only the newly selected notebook got linked, while the old one stayed linked in the background even though the UI showed it as unselected.
Closes https://github.com/streetwriters/notesnook/issues/7348

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
Small, targeted logic fix 

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
