### PR TITLE
core: move inbox item processing outside the sync loop

### DIFF
--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -58,7 +58,6 @@ import {
   IFileStorage,
   IStorage,
   KVStorageAccessor,
-  PendingSyncItemsAccessor,
   StorageAccessor
 } from "../interfaces.js";
 import TokenManager from "./token-manager.js";
@@ -166,8 +165,9 @@ class Database {
 
   private _kv = new KVStorage(this.databaseReady.promise);
   kv: KVStorageAccessor = () => this._kv;
-  private _pendingSyncItems = new PendingSyncItems(this.databaseReady.promise);
-  pendingSyncItems: PendingSyncItemsAccessor = () => this._pendingSyncItems;
+  pendingSyncItems = new PendingSyncItems(
+    this.sql as unknown as DatabaseAccessor<RawDatabaseSchema>
+  );
   private _config: ConfigStorage = new ConfigStorage(
     this.databaseReady.promise
   );

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -58,6 +58,7 @@ import {
   IFileStorage,
   IStorage,
   KVStorageAccessor,
+  PendingSyncItemsAccessor,
   StorageAccessor
 } from "../interfaces.js";
 import TokenManager from "./token-manager.js";
@@ -85,6 +86,7 @@ import { LazyPromise } from "../utils/lazy-promise.js";
 import { InboxApiKeys } from "./inbox-api-keys.js";
 import { Circle } from "./circle.js";
 import { Wrapped } from "./wrapped.js";
+import { PendingSyncItems } from "../database/pending-sync-items.js";
 
 type EventSourceConstructor = new (
   uri: string,
@@ -164,6 +166,8 @@ class Database {
 
   private _kv = new KVStorage(this.databaseReady.promise);
   kv: KVStorageAccessor = () => this._kv;
+  private _pendingSyncItems = new PendingSyncItems(this.databaseReady.promise);
+  pendingSyncItems: PendingSyncItemsAccessor = () => this._pendingSyncItems;
   private _config: ConfigStorage = new ConfigStorage(
     this.databaseReady.promise
   );

--- a/packages/core/src/api/sync/index.ts
+++ b/packages/core/src/api/sync/index.ts
@@ -306,17 +306,17 @@ export class Sync {
   }
 
   async stop(options: SyncOptions) {
-    const pendingInboxItems = await this.db
-      .pendingSyncItems()
-      .getByType("inbox-item");
+    const pendingInboxItems = await this.db.pendingSyncItems.getByType(
+      "inbox-item"
+    );
     if (pendingInboxItems.length > 0) {
       const items = pendingInboxItems.map(
         (item) => JSON.parse(item.data) as SyncInboxItem
       );
       await handleInboxItems(items, this.db);
-      await this.db
-        .pendingSyncItems()
-        .remove(pendingInboxItems.map((item) => item.id));
+      await this.db.pendingSyncItems.remove(
+        pendingInboxItems.map((item) => item.id)
+      );
     }
 
     if (
@@ -602,7 +602,7 @@ export class Sync {
          * TODO: do this for other items as well
          */
         for (const item of inboxItems) {
-          await this.db.pendingSyncItems().add({
+          await this.db.pendingSyncItems.add({
             id: item.id,
             type: "inbox-item",
             data: JSON.stringify(item),

--- a/packages/core/src/api/sync/index.ts
+++ b/packages/core/src/api/sync/index.ts
@@ -306,6 +306,19 @@ export class Sync {
   }
 
   async stop(options: SyncOptions) {
+    const pendingInboxItems = await this.db
+      .pendingSyncItems()
+      .getByType("inbox-item");
+    if (pendingInboxItems.length > 0) {
+      const items = pendingInboxItems.map(
+        (item) => JSON.parse(item.data) as SyncInboxItem
+      );
+      await handleInboxItems(items, this.db);
+      await this.db
+        .pendingSyncItems()
+        .remove(pendingInboxItems.map((item) => item.id));
+    }
+
     if (
       (options.type === "send" || options.type === "full") &&
       (await this.collector.hasUnsyncedChanges())
@@ -584,7 +597,18 @@ export class Sync {
           return false;
         }
 
-        await handleInboxItems(inboxItems, this.db);
+        /**
+         * We will process the inbox items after sync is completed.
+         * TODO: do this for other items as well
+         */
+        for (const item of inboxItems) {
+          await this.db.pendingSyncItems().add({
+            id: item.id,
+            type: "inbox-item",
+            data: JSON.stringify(item),
+            dateCreated: Date.now()
+          });
+        }
 
         return true;
       }

--- a/packages/core/src/database/index.ts
+++ b/packages/core/src/database/index.ts
@@ -50,6 +50,7 @@ import {
   Monograph,
   Note,
   Notebook,
+  PendingSyncItem,
   Relation,
   Reminder,
   SessionContentItem,
@@ -97,6 +98,7 @@ export interface DatabaseSchema {
 }
 
 export type RawDatabaseSchema = DatabaseSchema & {
+  pendingsyncitems: PendingSyncItem;
   kv: {
     key: string;
     value?: string | null;

--- a/packages/core/src/database/migrations.ts
+++ b/packages/core/src/database/migrations.ts
@@ -507,6 +507,13 @@ export class NNMigrationProvider implements MigrationProvider {
             .addColumn("data", "text")
             .addColumn("dateCreated", "integer")
             .execute();
+
+          await db.schema
+            .createIndex("pending_sync_items_type")
+            .ifNotExists()
+            .on("pendingsyncitems")
+            .column("type")
+            .execute();
         }
       }
     };

--- a/packages/core/src/database/migrations.ts
+++ b/packages/core/src/database/migrations.ts
@@ -496,6 +496,18 @@ export class NNMigrationProvider implements MigrationProvider {
             .addColumn("errorContext", "text")
             .execute();
         }
+      },
+      "a-2026-07-06": {
+        async up(db) {
+          await db.schema
+            .createTable("pendingsyncitems")
+            .ifNotExists()
+            .addColumn("id", "text", (c) => c.primaryKey().unique().notNull())
+            .addColumn("type", "text")
+            .addColumn("data", "text")
+            .addColumn("dateCreated", "integer")
+            .execute();
+        }
       }
     };
   }

--- a/packages/core/src/database/pending-sync-items.ts
+++ b/packages/core/src/database/pending-sync-items.ts
@@ -17,37 +17,31 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { LazyDatabaseAccessor, RawDatabaseSchema } from "./index.js";
+import { DatabaseAccessor, RawDatabaseSchema } from "./index.js";
 import { PendingSyncItem } from "../types.js";
 
 export class PendingSyncItems {
-  private readonly db: LazyDatabaseAccessor<RawDatabaseSchema>;
-  constructor(db: LazyDatabaseAccessor) {
-    this.db = db as unknown as LazyDatabaseAccessor<RawDatabaseSchema>;
-  }
+  constructor(private readonly db: DatabaseAccessor<RawDatabaseSchema>) {}
 
   async add(item: PendingSyncItem) {
-    await this.db.then((db) =>
-      db.replaceInto("pendingsyncitems").values(item).execute()
-    );
+    await this.db().replaceInto("pendingsyncitems").values(item).execute();
   }
 
   async getByType(type: PendingSyncItem["type"]) {
-    const result = await this.db.then((db) =>
-      db
-        .selectFrom("pendingsyncitems")
-        .where("type", "==", type)
-        .selectAll()
-        .execute()
-    );
+    const result = await this.db()
+      .selectFrom("pendingsyncitems")
+      .where("type", "==", type)
+      .selectAll()
+      .execute();
     return result as PendingSyncItem[];
   }
 
   async remove(ids: string[]) {
     if (ids.length === 0) return;
 
-    await this.db.then((db) =>
-      db.deleteFrom("pendingsyncitems").where("id", "in", ids).execute()
-    );
+    await this.db()
+      .deleteFrom("pendingsyncitems")
+      .where("id", "in", ids)
+      .execute();
   }
 }

--- a/packages/core/src/database/pending-sync-items.ts
+++ b/packages/core/src/database/pending-sync-items.ts
@@ -1,0 +1,53 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { LazyDatabaseAccessor, RawDatabaseSchema } from "./index.js";
+import { PendingSyncItem } from "../types.js";
+
+export class PendingSyncItems {
+  private readonly db: LazyDatabaseAccessor<RawDatabaseSchema>;
+  constructor(db: LazyDatabaseAccessor) {
+    this.db = db as unknown as LazyDatabaseAccessor<RawDatabaseSchema>;
+  }
+
+  async add(item: PendingSyncItem) {
+    await this.db.then((db) =>
+      db.replaceInto("pendingsyncitems").values(item).execute()
+    );
+  }
+
+  async getByType(type: PendingSyncItem["type"]) {
+    const result = await this.db.then((db) =>
+      db
+        .selectFrom("pendingsyncitems")
+        .where("type", "==", type)
+        .selectAll()
+        .execute()
+    );
+    return result as PendingSyncItem[];
+  }
+
+  async remove(ids: string[]) {
+    if (ids.length === 0) return;
+
+    await this.db.then((db) =>
+      db.deleteFrom("pendingsyncitems").where("id", "in", ids).execute()
+    );
+  }
+}

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -25,7 +25,6 @@ import {
 } from "@notesnook/crypto";
 import { KVStorage } from "./database/kv.js";
 import { ConfigStorage } from "./database/config.js";
-import { PendingSyncItems } from "./database/pending-sync-items.js";
 
 export type Output<TOutputFormat extends DataFormat> =
   TOutputFormat extends "uint8array" ? Uint8Array : string;
@@ -146,5 +145,4 @@ export interface IFileStorage {
 export type StorageAccessor = () => IStorage;
 export type KVStorageAccessor = () => KVStorage;
 export type ConfigStorageAccessor = () => ConfigStorage;
-export type PendingSyncItemsAccessor = () => PendingSyncItems;
 export type CompressorAccessor = () => Promise<ICompressor>;

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -25,6 +25,7 @@ import {
 } from "@notesnook/crypto";
 import { KVStorage } from "./database/kv.js";
 import { ConfigStorage } from "./database/config.js";
+import { PendingSyncItems } from "./database/pending-sync-items.js";
 
 export type Output<TOutputFormat extends DataFormat> =
   TOutputFormat extends "uint8array" ? Uint8Array : string;
@@ -145,4 +146,5 @@ export interface IFileStorage {
 export type StorageAccessor = () => IStorage;
 export type KVStorageAccessor = () => KVStorage;
 export type ConfigStorageAccessor = () => ConfigStorage;
+export type PendingSyncItemsAccessor = () => PendingSyncItems;
 export type CompressorAccessor = () => Promise<ICompressor>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import { Cipher } from "@notesnook/crypto";
 import { isCipher } from "./utils/index.js";
+import { SyncableItemType } from "./api/sync/types.js";
 
 export type TimeFormat = "12-hour" | "24-hour";
 export type DayFormat = "short" | "long";
@@ -545,6 +546,13 @@ export interface InboxItemHistory extends BaseItem<"inboxitemhistory"> {
   status: "failed" | "success";
   source?: string;
   errorContext?: string;
+}
+
+export interface PendingSyncItem {
+  id: string;
+  type: SyncableItemType | "inbox-item";
+  data: string;
+  dateCreated: number;
 }
 
 export type Match = {


### PR DESCRIPTION

## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

core: move inbox item processing outside the sync loop

## QA Scope

- Test on web & mobile
- Ensure a large number of inbox items do not cause the sync to get stuck or error out
- Ensure all the inbox items get processed properly and show up after the sync completes. 

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [X] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [X] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
