### PR TITLE
fix(document): Three spelling errors found in the help documentation

### DIFF
--- a/docs/help/contents/how-is-my-data-encrypted.md
+++ b/docs/help/contents/how-is-my-data-encrypted.md
@@ -21,7 +21,7 @@ On all three platforms we use the same exact library for all cryptographic funct
 
 > info Fun story
 >
-> When we first added encryption, we used AES-GCM-256 across platforms but the cross-platform compatbility was abyssmal. That is when I found out about the great libsodium. Written in C, wrappers available for all platforms...what more could I want?
+> When we first added encryption, we used AES-GCM-256 across platforms but the cross-platform compatibility was abyssmal. That is when I found out about the great libsodium. Written in C, wrappers available for all platforms...what more could I want?
 
 ## Process
 
@@ -65,7 +65,7 @@ On iOS and Android, the encryption key is stored in the phone's keychain.
 
 ### 4. Data encryption
 
-Encryption only takes place when you sync. Each item in the database is encrypted seperately using XChaCha-Poly1305-IETF.
+Encryption only takes place when you sync. Each item in the database is encrypted separately using XChaCha-Poly1305-IETF.
 
 #### How it works
 

--- a/docs/help/contents/recovering-your-account.md
+++ b/docs/help/contents/recovering-your-account.md
@@ -29,7 +29,7 @@ The first step to recovering your account consists of requesting an account reco
 5. On the next page, your email should be prefilled. If it isn't, fill it out.
    ![](/static/account-recovery/step-2.png)
 6. Click on `Send recovery email`
-7. If everything goes well, you should recieve an email from Notesnook in your inbox:
+7. If everything goes well, you should receive an email from Notesnook in your inbox:
    ![](/static/account-recovery/recovery_email.png)
    > info What if I didn't receive an email?
    >


### PR DESCRIPTION
## Description
- Fix three spelling errors in the help documentation: 
    - `recieve` → `receive` in `recovering-your-account.md`
    - `compatbility` → `compatibility` in `how-is-my-data-encrypted.md`
    - `seperately` → `separately` in `how-is-my-data-encrypted.md`

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [x] Web
- [x] Mobile
- [x] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
