### PR TITLE
core: fix inverted sort order in search relevance ranking

### DIFF
--- a/packages/core/__tests__/lookup.test.js
+++ b/packages/core/__tests__/lookup.test.js
@@ -126,6 +126,68 @@ test("search should return restored notes", () =>
     expect(filtered).toHaveLength(1);
   }));
 
+test("search notes by relevance sorts best match first by default and with sortDirection desc, worst match first with sortDirection asc", () =>
+  databaseTest().then(async (db) => {
+    const goodId = await db.notes.add({
+      title: "apple",
+      content: { type: "tiptap", data: "<p>short exact title match</p>" }
+    });
+    const badId = await db.notes.add({
+      title:
+        "apple " + "filler word padding extra noise text here ".repeat(10),
+      content: { type: "tiptap", data: "<p>diluted long title match</p>" }
+    });
+
+    const byDefault = await db.lookup
+      .notesWithHighlighting("apple", db.notes.all)
+      .then((r) => r.ids());
+    expect(byDefault).toEqual([goodId, badId]);
+
+    const desc = await db.lookup
+      .notesWithHighlighting("apple", db.notes.all, {
+        sortBy: "relevance",
+        sortDirection: "desc"
+      })
+      .then((r) => r.ids());
+    expect(desc).toEqual([goodId, badId]);
+
+    const asc = await db.lookup
+      .notesWithHighlighting("apple", db.notes.all, {
+        sortBy: "relevance",
+        sortDirection: "asc"
+      })
+      .then((r) => r.ids());
+    expect(asc).toEqual([badId, goodId]);
+  }));
+
+test("search trash by relevance sorts best match first by default and with sortDirection desc, worst match first with sortDirection asc", () =>
+  databaseTest().then(async (db) => {
+    const goodId = await db.notes.add({ title: "meeting notes" });
+    await db.notes.moveToTrash(goodId);
+    const badId = await db.notes.add({
+      title: "meeting notes " + "xxxxxxxxxx ".repeat(10)
+    });
+    await db.notes.moveToTrash(badId);
+
+    const byDefault = await db.lookup
+      .trash("meeting notes")
+      .items()
+      .then((items) => items.map((i) => i.id));
+    expect(byDefault).toEqual([goodId, badId]);
+
+    const desc = await db.lookup
+      .trash("meeting notes")
+      .items(undefined, { sortBy: "relevance", sortDirection: "desc" })
+      .then((items) => items.map((i) => i.id));
+    expect(desc).toEqual([goodId, badId]);
+
+    const asc = await db.lookup
+      .trash("meeting notes")
+      .items(undefined, { sortBy: "relevance", sortDirection: "asc" })
+      .then((items) => items.map((i) => i.id));
+    expect(asc).toEqual([badId, goodId]);
+  }));
+
 test("search reminders", () =>
   databaseTest().then(async (db) => {
     await db.reminders.add({

--- a/packages/core/__tests__/lookup.test.js
+++ b/packages/core/__tests__/lookup.test.js
@@ -133,8 +133,7 @@ test("search notes by relevance sorts best match first by default and with sortD
       content: { type: "tiptap", data: "<p>short exact title match</p>" }
     });
     const badId = await db.notes.add({
-      title:
-        "apple " + "filler word padding extra noise text here ".repeat(10),
+      title: "apple " + "filler word padding extra noise text here ".repeat(10),
       content: { type: "tiptap", data: "<p>diluted long title match</p>" }
     });
 

--- a/packages/core/src/api/lookup.ts
+++ b/packages/core/src/api/lookup.ts
@@ -268,8 +268,8 @@ export default class Lookup {
     if (!sortOptions || sortOptions.sortBy === "relevance") {
       matches.values.sort(
         sortOptions?.sortDirection === "desc"
-          ? (a, b) => a.rank - b.rank
-          : (a, b) => b.rank - a.rank
+          ? (a, b) => b.rank - a.rank
+          : (a, b) => a.rank - b.rank
       );
       matches.ids = matches.values.map((c) => c.id);
     } else {
@@ -708,8 +708,8 @@ export default class Lookup {
     if (!sortOptions || sortOptions.sortBy === "relevance")
       sorted.sort(
         sortOptions?.sortDirection === "desc"
-          ? (a, b) => a[1].rank - b[1].rank
-          : (a, b) => b[1].rank - a[1].rank
+          ? (a, b) => b[1].rank - a[1].rank
+          : (a, b) => a[1].rank - b[1].rank
       );
     else {
       const selector = getSortSelectors(sortOptions)[sortOptions.sortDirection];

--- a/packages/core/src/api/lookup.ts
+++ b/packages/core/src/api/lookup.ts
@@ -267,9 +267,9 @@ export default class Lookup {
 
     if (!sortOptions || sortOptions.sortBy === "relevance") {
       matches.values.sort(
-        sortOptions?.sortDirection === "desc"
-          ? (a, b) => b.rank - a.rank
-          : (a, b) => a.rank - b.rank
+        (sortOptions?.sortDirection ?? "desc") === "desc"
+          ? (a, b) => a.rank - b.rank
+          : (a, b) => b.rank - a.rank
       );
       matches.ids = matches.values.map((c) => c.id);
     } else {
@@ -707,7 +707,7 @@ export default class Lookup {
 
     if (!sortOptions || sortOptions.sortBy === "relevance")
       sorted.sort(
-        sortOptions?.sortDirection === "desc"
+        (sortOptions?.sortDirection ?? "desc") === "desc"
           ? (a, b) => b[1].rank - a[1].rank
           : (a, b) => a[1].rank - b[1].rank
       );


### PR DESCRIPTION
## Description                                                                                                                                                 
  <!-- Add a detailed summary of what this feature/bugfix does -->
  
   Fix relevance sort order in note search and trash search (`packages/core/src/api/lookup.ts`). 

 **Bug**:
When no `sortDirection` was given, results showed the least relevant match first instead of the most relevant. 

**Cause**:
The sort comparator only checked for `sortDirection === "desc"`, so "no sort options" silently fell through to the same code path as `sortDirection:  "asc"`.                                                                                                                                                        
                                                                                                                                                                 
**Fix**:
Treat a missing `sortDirection` the same as `"desc"`. 
Note search and trash search rank matches on opposite scales (lower is better for note search's  bm25`, higher is better for trash search's `fuzzyjs` score), so each comparator keeps its own correct polarity — only the "missing direction" condition changed for both.
Verified with real note/trash data that `desc` and the default (no options) both return the most relevant result first, and `asc` returns it last.

## Type of Change
 - [x] Bug fix
 - [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [x] Added/updated tests for this change (if needed)
- [ ] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why

N/A

## Platform
- [x] Web
- [x] Mobile
- [x] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed