### PR TITLE
mobile: fix unable to change plan on buy-plan screen

### DIFF
--- a/apps/mobile/app/components/paywall/index.tsx
+++ b/apps/mobile/app/components/paywall/index.tsx
@@ -112,7 +112,8 @@ const PayWall = (props: NavigationProps<"PayWall">) => {
       }
       setStep(Steps.buy);
     }
-  }, [pricingPlans, routeParams.state]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [routeParams.state]);
 
   useEffect(() => {
     let listener: NativeEventSubscription;


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

QA Scope:

On a free plan, go to Settings and click on App lock (locked feature). It will open upgrade plan sheet, click on upgrade. When the list of plan shows, you should be able to change the plan type monthly/yearly etc.

Closes https://github.com/streetwriters/notesnook/issues/10084

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [ ] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
