### PR TITLE
feat: Add Recent Searches feature in search bar

### DIFF
--- a/apps/mobile/app/screens/search/index.tsx
+++ b/apps/mobile/app/screens/search/index.tsx
@@ -24,22 +24,31 @@ import {
   VirtualizedGrouping
 } from "@notesnook/core";
 import { strings } from "@notesnook/intl";
+import { useThemeColors } from "@notesnook/theme";
 import React, { useEffect, useRef, useState } from "react";
+import { ScrollView, Text, TouchableOpacity, View } from "react-native";
 import { DatabaseLogger, db } from "../../common/database";
 import List from "../../components/list";
+import { IconButton } from "../../components/ui/icon-button";
 import SelectionHeader from "../../components/selection-header";
 import { useNavigationFocus } from "../../hooks/use-navigation-focus";
 import { ToastManager, eSubscribeEvent } from "../../services/event-manager";
 import { NavigationProps } from "../../services/navigation";
 import useNavigationStore from "../../stores/use-navigation-store";
+import { useRecentSearchStore } from "../../stores/use-recent-search-store";
 import { eGroupOptionsUpdated, eOnRefreshSearch } from "../../utils/events";
+import { AppFontSize } from "../../utils/size";
+import { DefaultAppStyles } from "../../utils/styles";
 import { SearchBar } from "./search-bar";
 export const Search = ({ route, navigation }: NavigationProps<"Search">) => {
   const [results, setResults] = useState<VirtualizedGrouping<Item>>();
   const [loading, setLoading] = useState(false);
   const [searchStatus, setSearchStatus] = useState<string>();
+  const [query, setQuery] = useState<string>("");
   const currentQuery = useRef<string>(undefined);
   const timer = useRef<NodeJS.Timeout>(undefined);
+  const recentSearches = useRecentSearchStore((state) => state.recentSearches);
+  const { colors } = useThemeColors();
   useNavigationFocus(navigation, {
     onFocus: (prev) => {
       useNavigationStore.getState().setFocusedRouteId(route.name);
@@ -52,6 +61,7 @@ export const Search = ({ route, navigation }: NavigationProps<"Search">) => {
 
   const onSearch = React.useCallback(
     async (query?: string) => {
+      setQuery(query || "");
       currentQuery.current = query;
       if (!query) {
         setResults(undefined);
@@ -59,6 +69,7 @@ export const Search = ({ route, navigation }: NavigationProps<"Search">) => {
         setSearchStatus(undefined);
         return;
       }
+      useRecentSearchStore.getState().addRecentSearch(query);
       try {
         setLoading(true);
         let results: VirtualizedGrouping<Item> | undefined;
@@ -150,18 +161,95 @@ export const Search = ({ route, navigation }: NavigationProps<"Search">) => {
         }}
         loading={loading}
       />
-      <List
-        data={results}
-        dataType={route.params?.type}
-        renderedInRoute={route.name}
-        groupType="search"
-        loading={loading}
-        placeholder={{
-          title: route.name,
-          paragraph: searchStatus || strings.searchInRoute(route.params?.title),
-          loading: strings.searchingFor(currentQuery.current as string)
-        }}
-      />
+      {!query && recentSearches.length > 0 ? (
+        <View
+          style={{
+            flex: 1,
+            paddingHorizontal: DefaultAppStyles.GAP
+          }}
+        >
+          <View
+            style={{
+              flexDirection: "row",
+              justifyContent: "space-between",
+              alignItems: "center",
+              marginBottom: DefaultAppStyles.GAP_SMALL
+            }}
+          >
+            <Text
+              style={{
+                fontSize: AppFontSize.sm,
+                fontFamily: "Inter-SemiBold",
+                color: colors.primary.paragraph
+              }}
+            >
+              {strings.recentSearches()}
+            </Text>
+            <TouchableOpacity
+              onPress={() => useRecentSearchStore.getState().clearRecentSearches()}
+            >
+              <Text
+                style={{
+                  fontSize: AppFontSize.xs,
+                  fontFamily: "Inter-Medium",
+                  color: colors.primary.accent
+                }}
+              >
+                {strings.clearAll()}
+              </Text>
+            </TouchableOpacity>
+          </View>
+          <ScrollView>
+            {recentSearches.map((search, index) => (
+              <TouchableOpacity
+                key={`${search}-${index}`}
+                style={{
+                  flexDirection: "row",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  paddingVertical: DefaultAppStyles.GAP_SMALL,
+                  borderBottomWidth: 1,
+                  borderBottomColor: colors.primary.border
+                }}
+                onPress={() => onSearch(search)}
+              >
+                <Text
+                  style={{
+                    fontSize: AppFontSize.sm,
+                    fontFamily: "Inter-Regular",
+                    color: colors.primary.paragraph,
+                    flex: 1
+                  }}
+                >
+                  {search}
+                </Text>
+                <IconButton
+                  name="close"
+                  size={AppFontSize.lg}
+                  color={colors.primary.icon}
+                  type="plain"
+                  onPress={() =>
+                    useRecentSearchStore.getState().removeRecentSearch(search)
+                  }
+                />
+              </TouchableOpacity>
+            ))}
+          </ScrollView>
+        </View>
+      ) : (
+        <List
+          data={results}
+          dataType={route.params?.type}
+          renderedInRoute={route.name}
+          groupType="search"
+          loading={loading}
+          placeholder={{
+            title: route.name,
+            paragraph: searchStatus || strings.searchInRoute(route.params?.title),
+            loading: strings.searchingFor(currentQuery.current as string)
+          }}
+        />
+      )}
       <SelectionHeader
         id={route.name}
         items={results}

--- a/apps/mobile/app/stores/use-recent-search-store.ts
+++ b/apps/mobile/app/stores/use-recent-search-store.ts
@@ -1,0 +1,71 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { create } from "zustand";
+import { MMKV } from "../common/database/mmkv";
+
+const RECENT_SEARCHES_KEY = "recentSearches";
+const MAX_RECENT_SEARCHES = 10;
+
+export interface RecentSearchStore {
+  recentSearches: string[];
+  addRecentSearch: (query: string) => void;
+  removeRecentSearch: (query: string) => void;
+  clearRecentSearches: () => void;
+}
+
+function loadRecentSearches(): string[] {
+  try {
+    const data = MMKV.getString(RECENT_SEARCHES_KEY);
+    if (!data) return [];
+    const parsed = JSON.parse(data);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveRecentSearches(searches: string[]): void {
+  MMKV.setString(RECENT_SEARCHES_KEY, JSON.stringify(searches));
+}
+
+export const useRecentSearchStore = create<RecentSearchStore>((set, get) => ({
+  recentSearches: loadRecentSearches(),
+
+  addRecentSearch: (query: string) => {
+    if (!query || !query.trim()) return;
+    const trimmedQuery = query.trim();
+    const searches = get().recentSearches.filter((s) => s !== trimmedQuery);
+    searches.unshift(trimmedQuery);
+    const limited = searches.slice(0, MAX_RECENT_SEARCHES);
+    saveRecentSearches(limited);
+    set({ recentSearches: limited });
+  },
+
+  removeRecentSearch: (query: string) => {
+    const searches = get().recentSearches.filter((s) => s !== query);
+    saveRecentSearches(searches);
+    set({ recentSearches: searches });
+  },
+
+  clearRecentSearches: () => {
+    MMKV.removeItem(RECENT_SEARCHES_KEY);
+    set({ recentSearches: [] });
+  }
+}));

--- a/apps/web/src/components/route-container/index.tsx
+++ b/apps/web/src/components/route-container/index.tsx
@@ -17,10 +17,11 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { PropsWithChildren, useEffect, useRef } from "react";
-import { Box } from "@theme-ui/components";
+import { PropsWithChildren, useEffect, useRef, useState } from "react";
+import { Box, Text } from "@theme-ui/components";
 import { Close, AddReminder, Menu } from "../icons";
 import { useStore as useSearchStore } from "../../stores/search-store";
+import { useRecentSearchStore } from "../../stores/recent-search-store";
 import useMobile from "../../hooks/use-mobile";
 import { debounce, usePromise } from "@notesnook/common";
 import Field from "../field";
@@ -66,6 +67,8 @@ function Header(props: RouteContainerProps) {
   const isSearching = useSearchStore((store) => store.isSearching);
   const query = useSearchStore((store) => store.query);
   const inputRef = useRef<HTMLInputElement>(null);
+  const [showRecents, setShowRecents] = useState(false);
+  const recentSearches = useRecentSearchStore((store) => store.recentSearches);
 
   useEffect(() => {
     if (inputRef.current && inputRef.current.value !== query) {
@@ -82,7 +85,8 @@ function Header(props: RouteContainerProps) {
       sx={{
         bg: type === "notebook" ? "background-secondary" : "transparent",
         zIndex: 2,
-        p: 1
+        p: 1,
+        position: "relative"
       }}
       className="route-container-header search-container"
       data-test-id="routeHeader"
@@ -127,12 +131,24 @@ function Header(props: RouteContainerProps) {
             : type
         )}
         onChange={debounce(
-          (e) => useSearchStore.setState({ query: e.target.value }),
+          (e) => {
+            const value = e.target.value;
+            useSearchStore.setState({ query: value });
+            setShowRecents(!value);
+            if (value) {
+              useRecentSearchStore.getState().addRecentSearch(value);
+            }
+          },
           250
         )}
+        onFocus={() => setShowRecents(!query)}
         onKeyUp={(e) => {
-          if (e.key === "Escape") useSearchStore.getState().resetSearch();
-          else useSearchStore.setState({ isSearching: true, searchType: type });
+          if (e.key === "Escape") {
+            useSearchStore.getState().resetSearch();
+            setShowRecents(false);
+          } else {
+            useSearchStore.setState({ isSearching: true, searchType: type });
+          }
         }}
         leftActions={[
           {
@@ -166,6 +182,86 @@ function Header(props: RouteContainerProps) {
             : [])
         ]}
       />
+      {showRecents && recentSearches.length > 0 && (
+        <Box
+          sx={{
+            position: "absolute",
+            top: "100%",
+            left: 0,
+            right: 0,
+            bg: "background",
+            border: "1px solid",
+            borderColor: "border",
+            borderRadius: "default",
+            mt: 1,
+            maxHeight: "300px",
+            overflowY: "auto",
+            zIndex: 10
+          }}
+        >
+          <Box
+            sx={{
+              p: 2,
+              borderBottom: "1px solid",
+              borderColor: "border",
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center"
+            }}
+          >
+            <Text variant="subBody" sx={{ fontWeight: "bold" }}>
+              {strings.recentSearches()}
+            </Text>
+            <Text
+              variant="subBody"
+              sx={{
+                color: "primary",
+                cursor: "pointer",
+                "&:hover": { opacity: 0.8 }
+              }}
+              onClick={() => useRecentSearchStore.getState().clearRecentSearches()}
+            >
+              {strings.clearAll()}
+            </Text>
+          </Box>
+          {recentSearches.map((search, index) => (
+            <Box
+              key={`${search}-${index}`}
+              sx={{
+                p: 2,
+                borderBottom: index < recentSearches.length - 1 ? "1px solid" : "none",
+                borderColor: "border",
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                cursor: "pointer",
+                "&:hover": { bg: "hover" }
+              }}
+              onClick={() => {
+                if (inputRef.current) inputRef.current.value = search;
+                useSearchStore.setState({ query: search, isSearching: true, searchType: type });
+                setShowRecents(false);
+              }}
+            >
+              <Text variant="body">{search}</Text>
+              <Text
+                variant="subBody"
+                sx={{
+                  color: "icon",
+                  cursor: "pointer",
+                  "&:hover": { color: "primary" }
+                }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  useRecentSearchStore.getState().removeRecentSearch(search);
+                }}
+              >
+                ✕
+              </Text>
+            </Box>
+          ))}
+        </Box>
+      )}
     </Box>
   );
 }

--- a/apps/web/src/components/route-container/index.tsx
+++ b/apps/web/src/components/route-container/index.tsx
@@ -135,9 +135,6 @@ function Header(props: RouteContainerProps) {
             const value = e.target.value;
             useSearchStore.setState({ query: value });
             setShowRecents(!value);
-            if (value) {
-              useRecentSearchStore.getState().addRecentSearch(value);
-            }
           },
           250
         )}
@@ -148,6 +145,11 @@ function Header(props: RouteContainerProps) {
             setShowRecents(false);
           } else {
             useSearchStore.setState({ isSearching: true, searchType: type });
+            if (e.key === "Enter") {
+              const value = e.currentTarget.value;
+              if (value) useRecentSearchStore.getState().addRecentSearch(value);
+              setShowRecents(false);
+            }
           }
         }}
         leftActions={[

--- a/apps/web/src/stores/recent-search-store.ts
+++ b/apps/web/src/stores/recent-search-store.ts
@@ -1,0 +1,63 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import createStore from "../common/store";
+import BaseStore from "./index";
+import Config from "../utils/config";
+
+const RECENT_SEARCHES_KEY = "recentSearches";
+const MAX_RECENT_SEARCHES = 10;
+
+class RecentSearchStore extends BaseStore<RecentSearchStore> {
+  recentSearches: string[] = [];
+
+  addRecentSearch = (query: string) => {
+    if (!query || !query.trim()) return;
+    const trimmedQuery = query.trim();
+    const searches = this.get().recentSearches.filter(
+      (s) => s !== trimmedQuery
+    );
+    searches.unshift(trimmedQuery);
+    const limited = searches.slice(0, MAX_RECENT_SEARCHES);
+    Config.set(RECENT_SEARCHES_KEY, limited);
+    this.set({ recentSearches: limited });
+  };
+
+  removeRecentSearch = (query: string) => {
+    const searches = this.get().recentSearches.filter((s) => s !== query);
+    Config.set(RECENT_SEARCHES_KEY, searches);
+    this.set({ recentSearches: searches });
+  };
+
+  clearRecentSearches = () => {
+    Config.remove(RECENT_SEARCHES_KEY);
+    this.set({ recentSearches: [] });
+  };
+}
+
+const [useRecentSearchStore] = createStore<RecentSearchStore>(
+  (set, get) => {
+    const savedSearches = Config.get<string[]>(RECENT_SEARCHES_KEY, []);
+    const store = new RecentSearchStore(set, get);
+    store.recentSearches = Array.isArray(savedSearches) ? savedSearches : [];
+    return store;
+  }
+);
+
+export { useRecentSearchStore };

--- a/packages/intl/src/strings.ts
+++ b/packages/intl/src/strings.ts
@@ -1014,6 +1014,8 @@ $day$: Current day (eg. Monday)`,
   logsDownloaded: () => t`Debug logs downloaded`,
   clearLogs: () => t`Clear logs`,
   clear: () => t`Clear`,
+  clearAll: () => t`Clear all`,
+  recentSearches: () => t`Recent searches`,
   clearLogsConfirmation: (key: string) =>
     t`Are you sure you want to clear all logs from ${key}?`,
   enterPasswordDesc: () => t`Please enter your password to continue`,


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Closes #9437 

1. Need to have a feature of _recent searches_, which can save up to 10 searched keywords.
2. Everytime a user types a keyword and then press _ENTER_, that keyword will be saved into the _recent searches_ feature.
3. User is able to press _Clear All_ button to remove all the keywords.

## Type of Change
- [  ] Bug fix
- [✔] Feature

## Visuals
- [✔] Attached relevant screenshots / screen recording / GIF
- [  ] N/A (not a feature or no UI changes)

## Testing
- [  ] Ran all E2E tests
- [  ] Ran all integration tests
- [  ] Added/updated tests for this change (if needed)
- [✔] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

The test are purely from UI testing.
<img width="671" height="309" alt="image" src="https://github.com/user-attachments/assets/12085699-e1ce-4016-ad80-7bac7a4d350d" />

After changes:
[Screencast from 12-07-26 11:31:44.webm](https://github.com/user-attachments/assets/3e2b21de-0f77-4590-9ef1-563e51286e58)

_(Additional note: Please ignore the weird symbols above the default strings. I don't know why it appears on my Notenook's local)_

## Platform
<!-- Describe which platforms this PR is related to -->

- [✔] Web
- [✔] Mobile
- [✔] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
