### PR TITLE
Fix reminder notification permission

### DIFF
--- a/apps/mobile/app/services/notifications.ts
+++ b/apps/mobile/app/services/notifications.ts
@@ -35,7 +35,7 @@ import notifee, {
 import NetInfo from "@react-native-community/netinfo";
 import dayjs, { Dayjs } from "dayjs";
 import { encodeNonAsciiHTML } from "entities";
-import { Platform } from "react-native";
+import { AppState, Platform } from "react-native";
 import { db, setupDatabase } from "../common/database";
 import { MMKV } from "../common/database/mmkv";
 import { presentDialog } from "../components/dialog/functions";
@@ -45,7 +45,7 @@ import { useRelationStore } from "../stores/use-relation-store";
 import { useReminderStore } from "../stores/use-reminder-store";
 import { useSettingStore } from "../stores/use-setting-store";
 import { useUserStore } from "../stores/use-user-store";
-import { eOnLoadNote } from "../utils/events";
+import { eCloseSimpleDialog, eOnLoadNote } from "../utils/events";
 import { fluidTabsRef } from "../utils/global-refs";
 import { convertNoteToText } from "../utils/note-to-text";
 import { NotesnookModule } from "../utils/notesnook-module";
@@ -577,7 +577,7 @@ async function displayNotification({
 }
 
 function openSettingsDialog(context: string) {
-  return new Promise((resolve) => {
+  return new Promise<boolean>((resolve) => {
     presentDialog({
       title: strings.notificationsDisabled(),
       paragraph: strings.notificationsDisabledDesc(),
@@ -587,12 +587,35 @@ function openSettingsDialog(context: string) {
         Platform.OS === "ios"
           ? undefined
           : async () => {
-              resolve(true);
+              return checkAndRequestPermissions(false);
             },
       onClose: () => {
         resolve(false);
       },
       context: context
+    });
+  });
+}
+
+function waitForAppFocusAfterSettings(timeoutMs = 120000): Promise<void> {
+  return new Promise((resolve) => {
+    let didLeaveApp = AppState.currentState !== "active";
+    const timeout = setTimeout(() => {
+      subscription.remove();
+      resolve();
+    }, timeoutMs);
+
+    const subscription = AppState.addEventListener("change", (state) => {
+      if (state !== "active") {
+        didLeaveApp = true;
+        return;
+      }
+
+      if (didLeaveApp && state === "active") {
+        clearTimeout(timeout);
+        subscription.remove();
+        resolve();
+      }
     });
   });
 }
@@ -622,9 +645,21 @@ async function checkAndRequestPermissions(
       return true;
 
     if (promptUser) {
-      if (await openSettingsDialog("local")) {
-        await notifee.openNotificationSettings();
-        return false;
+      const waitForAppFocus = waitForAppFocusAfterSettings();
+      await notifee.openNotificationSettings();
+      await waitForAppFocus;
+      permissionStatus = await notifee.getNotificationSettings();
+
+      const authorized =
+        permissionStatus.authorizationStatus ===
+          AuthorizationStatus.AUTHORIZED &&
+        permissionStatus.android.alarm === 1;
+
+      if (authorized) {
+        eSendEvent(eCloseSimpleDialog);
+        return authorized;
+      } else {
+        return await openSettingsDialog("local");
       }
     }
 
@@ -634,7 +669,7 @@ async function checkAndRequestPermissions(
     if (permissionStatus.authorizationStatus === AuthorizationStatus.AUTHORIZED)
       return true;
     if (promptUser) {
-      await openSettingsDialog("local");
+      openSettingsDialog("local");
     }
     return false;
   }

--- a/apps/mobile/app/services/notifications.ts
+++ b/apps/mobile/app/services/notifications.ts
@@ -587,7 +587,7 @@ function openSettingsDialog(context: string) {
         Platform.OS === "ios"
           ? undefined
           : async () => {
-              return checkAndRequestPermissions(false);
+              resolve(true);
             },
       onClose: () => {
         resolve(false);
@@ -625,56 +625,66 @@ async function checkAndRequestPermissions(
 ): Promise<boolean> {
   let permissionStatus = await notifee.getNotificationSettings();
   if (Platform.OS === "android") {
-    if (
-      permissionStatus.authorizationStatus === AuthorizationStatus.AUTHORIZED &&
-      permissionStatus.android.alarm === 1
-    )
+    const hasNotificationPermission =
+      permissionStatus.authorizationStatus === AuthorizationStatus.AUTHORIZED;
+    const hasAlarmPermission = permissionStatus.android.alarm === 1;
+
+    if (hasNotificationPermission && hasAlarmPermission) {
       return true;
+    }
+
     if (permissionStatus.authorizationStatus === AuthorizationStatus.DENIED) {
       permissionStatus = await notifee.requestPermission();
     }
+
+    // Wait for user to return from exact alarm settings
     if (permissionStatus.android.alarm !== 1) {
+      const waitForAppFocus = waitForAppFocusAfterSettings();
+
       await notifee.openAlarmPermissionSettings();
+      await waitForAppFocus;
     }
     permissionStatus = await notifee.getNotificationSettings();
 
-    if (
+    const authorized =
       permissionStatus.authorizationStatus === AuthorizationStatus.AUTHORIZED &&
-      permissionStatus.android.alarm === 1
-    )
+      permissionStatus.android.alarm === 1;
+
+    if (authorized) {
       return true;
-
-    if (promptUser) {
-      const waitForAppFocus = waitForAppFocusAfterSettings();
-      await notifee.openNotificationSettings();
-      await waitForAppFocus;
-      permissionStatus = await notifee.getNotificationSettings();
-
-      const authorized =
-        permissionStatus.authorizationStatus ===
-          AuthorizationStatus.AUTHORIZED &&
-        permissionStatus.android.alarm === 1;
-
-      if (authorized) {
-        eSendEvent(eCloseSimpleDialog);
-        return authorized;
-      } else {
-        return await openSettingsDialog("local");
-      }
     }
 
-    return false;
-  } else {
-    permissionStatus = await notifee.requestPermission();
-    if (permissionStatus.authorizationStatus === AuthorizationStatus.AUTHORIZED)
-      return true;
     if (promptUser) {
-      openSettingsDialog("local");
+      const openSettings = await openSettingsDialog("local");
+      if (openSettings) {
+        const waitForAppFocus = waitForAppFocusAfterSettings();
+        await notifee.openNotificationSettings();
+        await waitForAppFocus;
+        permissionStatus = await notifee.getNotificationSettings();
+        const finalAuthorized =
+          permissionStatus.authorizationStatus ===
+            AuthorizationStatus.AUTHORIZED &&
+          permissionStatus.android.alarm === 1;
+        if (finalAuthorized) {
+          eSendEvent(eCloseSimpleDialog);
+          return true;
+        }
+      }
+      return false;
     }
     return false;
   }
-}
 
+  // iOS
+  permissionStatus = await notifee.requestPermission();
+  if (permissionStatus.authorizationStatus === AuthorizationStatus.AUTHORIZED) {
+    return true;
+  }
+  if (promptUser) {
+    await openSettingsDialog("local");
+  }
+  return false;
+}
 async function getTriggers(
   reminder: Reminder
 ): Promise<(Trigger & { id: string })[] | undefined> {


### PR DESCRIPTION
## Description
Improve the Android reminder notification permission flow by properly handling notification and exact alarm permissions. 
Closes https://github.com/streetwriters/notesnook/issues/9717

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
This change updates the Android permission flow for reminder notifications.

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
