### PR TITLE
fix: adjust highlighted text color for contrast when dark mode

### DIFF
--- a/packages/editor/src/extensions/highlight/highlight.ts
+++ b/packages/editor/src/extensions/highlight/highlight.ts
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import "@tiptap/extension-text-style";
 import { Extension } from "@tiptap/core";
+import { colord } from "colord";
 import { config } from "../../utils/config.js";
 import { tiptapKeys } from "@notesnook/common";
 
@@ -70,9 +71,14 @@ export const Highlight = Extension.create<HighlightOptions>({
                 return {};
               }
 
-              return {
-                style: `background-color: ${attributes.backgroundColor}`
-              };
+              const style = `background-color: ${attributes.backgroundColor}`;
+
+              if (attributes.color) return { style };
+
+              const textColor = colord(attributes.backgroundColor).isDark()
+                ? "#ffffff"
+                : "#000000";
+              return { style: `${style}; color: ${textColor}` };
             }
           }
         }


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Closes #10092 

1. When the interface is changed into dark mode, highlighted text will be near impossible to be read.
2. This PR has tracked the fundamental issue, and add condition to alter the contrast of text color based on its background color.

## Type of Change
- [✔] Bug fix
- [  ] Feature

## Visuals
- [✔] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [✔] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->
Before changes (light mode):
<img width="845" height="358" alt="Screenshot from 2026-07-13 14-13-38" src="https://github.com/user-attachments/assets/78338f12-34da-474e-9d1c-99bd6c9bb144" />
Before changes (dark mode):
<img width="845" height="358" alt="Screenshot from 2026-07-13 14-13-33" src="https://github.com/user-attachments/assets/759c013e-8b38-433b-9ed6-3a8f2d8a6ac7" />

After changes (light mode):
<img width="766" height="270" alt="Screenshot from 2026-07-13 21-46-11" src="https://github.com/user-attachments/assets/431be7b2-6833-483e-95b2-bfbd7acf628f" />
Before changes (dark mode):
<img width="766" height="270" alt="Screenshot from 2026-07-13 21-46-40" src="https://github.com/user-attachments/assets/79d0e50e-3e18-49a0-ba5c-634c593c047c" />

## Platform
<!-- Describe which platforms this PR is related to -->

- [✔] Web
- [✔] Mobile
- [✔] Desktop

## Sign-off
- [✔] QA passed
- [✔] UI/UX passed
