### PR TITLE
Fix error on Android's search query

### DIFF
--- a/apps/mobile/app/screens/home/index.tsx
+++ b/apps/mobile/app/screens/home/index.tsx
@@ -30,6 +30,7 @@ import SettingsService from "../../services/settings";
 import useNavigationStore from "../../stores/use-navigation-store";
 import { useNotes } from "../../stores/use-notes-store";
 import { openEditor } from "../notes/common";
+import { db } from "../../common/database";
 
 export const Home = ({ navigation, route }: NavigationProps<"Notes">) => {
   const [notes, loading] = useNotes();
@@ -59,7 +60,8 @@ export const Home = ({ navigation, route }: NavigationProps<"Notes">) => {
             placeholder: strings.searchInRoute(route.name),
             type: "note",
             title: route.name,
-            route: route.name
+            route: route.name,
+            items: db.notes.all
           });
         }}
         id={route.name}

--- a/apps/mobile/app/stores/use-navigation-store.ts
+++ b/apps/mobile/app/stores/use-navigation-store.ts
@@ -74,13 +74,21 @@ export interface RouteParams extends ParamListBase {
   Tags: GenericRouteParam;
   Favorites: GenericRouteParam;
   Trash: GenericRouteParam;
-  Search: {
-    placeholder: string;
-    type: ItemType;
-    title: string;
-    route: RouteName;
-    items?: FilteredSelector<Item>;
-  };
+  Search:
+    | {
+        placeholder: string;
+        type: "note";
+        title: string;
+        route: RouteName;
+        items: FilteredSelector<Note>;
+      }
+    | {
+        placeholder: string;
+        type: Exclude<ItemType, "note">;
+        title: string;
+        route: RouteName;
+        items?: FilteredSelector<Item>;
+      };
   TaggedNotes: NotesScreenParams;
   ColoredNotes: NotesScreenParams;
   TopicNotes: NotesScreenParams;

--- a/packages/core/__tests__/lookup.test.js
+++ b/packages/core/__tests__/lookup.test.js
@@ -209,17 +209,4 @@ describe("notesWithHighlighting", () => {
       );
       expect(searchWithDiacritics.length).toBe(4);
     }));
-
-  test("search with a field filter should not throw when notes selector is undefined", () =>
-    databaseTest().then(async (db) => {
-      await db.notes.add({ title: "meeting notes" });
-
-      // a nonexistent tag filter matches everything (a separate, pre-existing
-      // quirk) — the point of this test is that it resolves instead of throwing
-      const filtered = await db.lookup.notesWithHighlighting(
-        "tag:meeting",
-        undefined
-      );
-      expect(filtered.length).toBe(1);
-    }));
 });

--- a/packages/core/__tests__/lookup.test.js
+++ b/packages/core/__tests__/lookup.test.js
@@ -209,4 +209,17 @@ describe("notesWithHighlighting", () => {
       );
       expect(searchWithDiacritics.length).toBe(4);
     }));
+
+  test("search with a field filter should not throw when notes selector is undefined", () =>
+    databaseTest().then(async (db) => {
+      await db.notes.add({ title: "meeting notes" });
+
+      // a nonexistent tag filter matches everything (a separate, pre-existing
+      // quirk) — the point of this test is that it resolves instead of throwing
+      const filtered = await db.lookup.notesWithHighlighting(
+        "tag:meeting",
+        undefined
+      );
+      expect(filtered.length).toBe(1);
+    }));
 });

--- a/packages/core/src/api/lookup.ts
+++ b/packages/core/src/api/lookup.ts
@@ -109,12 +109,12 @@ export default class Lookup {
 
   async notesWithHighlighting(
     query: string,
-    notes: FilteredSelector<Note>,
+    notes?: FilteredSelector<Note>,
     sortOptions?: SortOptions
   ): Promise<VirtualizedGrouping<HighlightedResult>> {
     const db = this.db.sql() as unknown as Kysely<RawDatabaseSchema>;
     const excludedIds = this.db.trash.cache.notes;
-
+    notes ||= this.db.notes.all;
     const {
       content,
       title,

--- a/packages/core/src/api/lookup.ts
+++ b/packages/core/src/api/lookup.ts
@@ -109,12 +109,11 @@ export default class Lookup {
 
   async notesWithHighlighting(
     query: string,
-    notes?: FilteredSelector<Note>,
+    notes: FilteredSelector<Note>,
     sortOptions?: SortOptions
   ): Promise<VirtualizedGrouping<HighlightedResult>> {
     const db = this.db.sql() as unknown as Kysely<RawDatabaseSchema>;
     const excludedIds = this.db.trash.cache.notes;
-    notes ||= this.db.notes.all;
     const {
       content,
       title,


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Closes #10055 
Closes #10101 

This PR fixes a crash that happens when searching with a field filter (e.g.` tag:meeting`) from the app's main Notes list.

1. On the Home/Notes screen, I pass a value for the `items` key, matching the same pattern already used by other screens (Favorites, Trash, etc.), to ensure _Search_ always receives a valid selector to search against.
2. When `notes` is `undefined`, I add a fallback to prevent the crash, mirroring the same guard the sibling `notes() `method in this file already has.

## Type of Change
- ✓ Bug fix
- [  ] Feature

## Visuals
- ✓ Attached relevant screenshots / screen recording / GIF
- [  ] N/A (not a feature or no UI changes)

Trying to reproduce the issue in my mobile:
<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/67ba18de-8ee4-4b47-8f12-8308a3e0ddca" />

## Testing
- [  ] Ran all E2E tests
- [  ] Ran all integration tests
- ✓ Added/updated tests for this change (if needed)
- [  ] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why

## Platform
<!-- Describe which platforms this PR is related to -->

- [  ] Web
- ✓ Mobile
- [  ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
