### PR TITLE
ci: update workflows to use actions/checkout@v5

### DIFF
--- a/.github/workflows/android.e2e.yml
+++ b/.github/workflows/android.e2e.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Enable KVM
         run: |

--- a/.github/workflows/android.preview.firebase.yml
+++ b/.github/workflows/android.preview.firebase.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 

--- a/.github/workflows/android.publish.internal.yml
+++ b/.github/workflows/android.publish.internal.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: ./.github/actions/setup-node-with-cache

--- a/.github/workflows/android.publish.yml
+++ b/.github/workflows/android.publish.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: ./.github/actions/setup-node-with-cache

--- a/.github/workflows/core.tests.yml
+++ b/.github/workflows/core.tests.yml
@@ -35,7 +35,7 @@ jobs:
     needs: authorize
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 

--- a/.github/workflows/desktop.preview.yml
+++ b/.github/workflows/desktop.preview.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: ./.github/actions/setup-node-with-cache
@@ -56,7 +56,7 @@ jobs:
       macos-artifact-url: ${{ steps.artifact-upload-step.outputs.artifact-url }}
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: ./.github/actions/setup-node-with-cache
@@ -127,7 +127,7 @@ jobs:
       linux-x64-artifact-url: ${{ steps.artifact-upload-step.outputs.artifact-url }}
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: ./.github/actions/setup-node-with-cache
@@ -171,7 +171,7 @@ jobs:
       linux-arm64-artifact-url: ${{ steps.artifact-upload-step.outputs.artifact-url }}
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: ./.github/actions/setup-node-with-cache
@@ -215,7 +215,7 @@ jobs:
       windows-artifact-url: ${{ steps.artifact-upload-step.outputs.artifact-url }}
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: ./.github/actions/setup-node-with-cache

--- a/.github/workflows/desktop.publish.yml
+++ b/.github/workflows/desktop.publish.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: ./.github/actions/setup-node-with-cache
@@ -142,7 +142,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: ./.github/actions/setup-node-with-cache
@@ -246,7 +246,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: ./.github/actions/setup-node-with-cache
@@ -314,7 +314,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: ./.github/actions/setup-node-with-cache
@@ -378,7 +378,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v2

--- a/.github/workflows/desktop.tests.yml
+++ b/.github/workflows/desktop.tests.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: ./.github/actions/setup-node-with-cache
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: ./.github/actions/setup-node-with-cache
@@ -92,7 +92,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: ./.github/actions/setup-node-with-cache
@@ -126,7 +126,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: ./.github/actions/setup-node-with-cache

--- a/.github/workflows/editor.tests.yml
+++ b/.github/workflows/editor.tests.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: ./.github/actions/setup-node-with-cache

--- a/.github/workflows/help.publish.yml
+++ b/.github/workflows/help.publish.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/ios.preview.firebase.yml
+++ b/.github/workflows/ios.preview.firebase.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 

--- a/.github/workflows/ios.publish.yml
+++ b/.github/workflows/ios.publish.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: ./.github/actions/setup-node-with-cache

--- a/.github/workflows/monograph.publish.yml
+++ b/.github/workflows/monograph.publish.yml
@@ -22,7 +22,7 @@ jobs:
       id-token: write
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: ./.github/actions/setup-node-with-cache

--- a/.github/workflows/theme-builder.publish.yml
+++ b/.github/workflows/theme-builder.publish.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: ./.github/actions/setup-node-with-cache

--- a/.github/workflows/themes.publish.yml
+++ b/.github/workflows/themes.publish.yml
@@ -22,7 +22,7 @@ jobs:
       id-token: write
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Collect package metadata
         id: package_metadata

--- a/.github/workflows/vericrypt.publish.yml
+++ b/.github/workflows/vericrypt.publish.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: ./.github/actions/setup-node-with-cache

--- a/.github/workflows/web.preview.yml
+++ b/.github/workflows/web.preview.yml
@@ -19,7 +19,7 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/web.publish.yml
+++ b/.github/workflows/web.publish.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
         uses: ./.github/actions/setup-node-with-cache

--- a/.github/workflows/web.tests.yml
+++ b/.github/workflows/web.tests.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 

--- a/apps/mobile/.github/workflows/android-public-release.yml
+++ b/apps/mobile/.github/workflows/android-public-release.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 

--- a/apps/mobile/.github/workflows/android-release.yml
+++ b/apps/mobile/.github/workflows/android-release.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 


### PR DESCRIPTION
See https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/ for details.