### PR TITLE
Fix notes lookup with non-existent tags

### DIFF
--- a/apps/web/src/components/placeholders/index.tsx
+++ b/apps/web/src/components/placeholders/index.tsx
@@ -19,7 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import { Button, Flex, Text } from "@theme-ui/components";
 import { TipContext, useTip } from "../../hooks/use-tip";
-import { Info, Sync } from "../icons";
+import { Error, Info, Sync } from "../icons";
 import { useStore as useAppStore } from "../../stores/app-store";
 import { strings } from "@notesnook/intl";
 
@@ -78,19 +78,23 @@ function Placeholder(props: PlaceholderProps) {
           px: 6
         }}
       >
-        <Flex
-          sx={{
-            border: "1px solid var(--accent)",
-            borderRadius: 50,
-            p: 1,
-            py: "1.5px"
-          }}
-        >
-          <Info color="accent" size={13} sx={{ mr: "small" }} />
-          <Text variant="subBody" sx={{ fontSize: 10 }} color="accent">
-            {strings.tip()}
-          </Text>
-        </Flex>
+        {tip.type === "error" ? (
+          <Error color="accent-error" size={13} />
+        ) : (
+          <Flex
+            sx={{
+              border: "1px solid var(--accent)",
+              borderRadius: 50,
+              p: 1,
+              py: "1.5px"
+            }}
+          >
+            <Info color="accent" size={13} sx={{ mr: "small" }} />
+            <Text variant="subBody" sx={{ fontSize: 10 }} color="accent">
+              {strings.tip()}
+            </Text>
+          </Flex>
+        )}
         <Text variant="subBody" sx={{ fontSize: "body", mt: 1 }}>
           {text || tip.text}
         </Text>

--- a/apps/web/src/hooks/use-tip.ts
+++ b/apps/web/src/hooks/use-tip.ts
@@ -55,6 +55,7 @@ export type Tip = {
   text: string;
   contexts: TipContext[];
   button?: TipButton;
+  type?: "info" | "warning" | "error";
 };
 
 const destructiveContexts: string[] = [];
@@ -110,8 +111,9 @@ export const useTip = (
 
 const tips: Tip[] = [
   {
-    text: `Wrap a query in double quotes to search for an exact match.`,
-    contexts: ["search"]
+    text: `No results found. Try searching with different keywords or check your spelling.`,
+    contexts: ["search"],
+    type: "error"
   },
   {
     text: "Hold Ctrl/Cmd & click on multiple items to select them.",

--- a/packages/core/src/api/lookup.ts
+++ b/packages/core/src/api/lookup.ts
@@ -155,6 +155,12 @@ export default class Lookup {
           ? await this.db.notebooks.all.ids()
           : [];
 
+      if (
+        (!!tag?.length && tag.length !== tagIds.length) ||
+        (!!color?.length && color.length !== colorIds.length)
+      )
+        return emptySearchResults();
+
       const defaultVault = await this.db.vaults.default();
       notes = notes.where((eb) => {
         const exprs = [];
@@ -1211,4 +1217,13 @@ function highlightRegexMatches(
 
 function removeDiacritics(s: string) {
   return s.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+}
+
+function emptySearchResults() {
+  return new VirtualizedGrouping<HighlightedResult>(
+    0,
+    20,
+    () => Promise.resolve([]),
+    () => Promise.resolve({ ids: [], items: [] })
+  );
 }

--- a/packages/core/src/api/lookup.ts
+++ b/packages/core/src/api/lookup.ts
@@ -1244,12 +1244,11 @@ async function isMatchingAllColorsAndTags(
     const resolvedColors = await db.colors.all
       .fields(["colors.id", "colors.title"])
       .records(colorIds);
-    console.log({ resolvedColors });
-    for (const [_, color] of Object.entries(resolvedColors)) {
-      console.log(color);
-      if (!color) return false;
-      if (colors.some((c) => c.toLowerCase() !== color.title.toLowerCase()))
-        return false;
+    const resolvedColorTitles = Object.values(resolvedColors).map((color) =>
+      color?.title.toLowerCase()
+    );
+    for (const color of colors) {
+      if (!resolvedColorTitles.includes(color.toLowerCase())) return false;
     }
   }
 
@@ -1257,10 +1256,11 @@ async function isMatchingAllColorsAndTags(
     const resolvedTags = await db.tags.all
       .fields(["tags.id", "tags.title"])
       .records(tagIds);
-    for (const [_, tag] of Object.entries(resolvedTags)) {
-      if (!tag) return false;
-      if (tags.some((c) => c.toLowerCase() !== tag.title.toLowerCase()))
-        return false;
+    const resolvedTagTitles = Object.values(resolvedTags).map((tag) =>
+      tag?.title.toLowerCase()
+    );
+    for (const tag of tags) {
+      if (!resolvedTagTitles.includes(tag.toLowerCase())) return false;
     }
   }
   return true;

--- a/packages/core/src/api/lookup.ts
+++ b/packages/core/src/api/lookup.ts
@@ -156,8 +156,13 @@ export default class Lookup {
           : [];
 
       if (
-        (!!tag?.length && tag.length !== tagIds.length) ||
-        (!!color?.length && color.length !== colorIds.length)
+        !(await isMatchingAllColorsAndTags(
+          this.db,
+          colorIds,
+          tagIds,
+          colored ? [] : color || [],
+          tagged ? [] : tag || []
+        ))
       )
         return emptySearchResults();
 
@@ -1226,4 +1231,37 @@ function emptySearchResults() {
     () => Promise.resolve([]),
     () => Promise.resolve({ ids: [], items: [] })
   );
+}
+
+async function isMatchingAllColorsAndTags(
+  db: Database,
+  colorIds: string[],
+  tagIds: string[],
+  colors: string[],
+  tags: string[]
+): Promise<boolean> {
+  if (colors.length > 0) {
+    const resolvedColors = await db.colors.all
+      .fields(["colors.id", "colors.title"])
+      .records(colorIds);
+    console.log({ resolvedColors });
+    for (const [_, color] of Object.entries(resolvedColors)) {
+      console.log(color);
+      if (!color) return false;
+      if (colors.some((c) => c.toLowerCase() !== color.title.toLowerCase()))
+        return false;
+    }
+  }
+
+  if (tags.length > 0) {
+    const resolvedTags = await db.tags.all
+      .fields(["tags.id", "tags.title"])
+      .records(tagIds);
+    for (const [_, tag] of Object.entries(resolvedTags)) {
+      if (!tag) return false;
+      if (tags.some((c) => c.toLowerCase() !== tag.title.toLowerCase()))
+        return false;
+    }
+  }
+  return true;
 }


### PR DESCRIPTION
## Description

This fixes the issue where searching for notes with non-existent tags (e.g. `tag: abc` where `abc` doesn't exist) returned all notes instead of no notes.

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [ ] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [ ] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
