### PR TITLE
editor: hide toolbar in readonly mode until a selection scoped tool needs to show in toolbar

### DIFF
--- a/packages/editor-mobile/src/components/editor.tsx
+++ b/packages/editor-mobile/src/components/editor.tsx
@@ -956,7 +956,7 @@ const Tiptap = ({
         </div>
 
         <TiptapEditorWrapper
-          key={tick + tab.id + "-editor"}
+          key={tick + tab.id + "-editor" + tab.session?.readonly}
           options={tiptapOptions}
           settings={settings}
           onEditorUpdate={(editor) => {

--- a/packages/editor/src/toolbar/tool-definitions.ts
+++ b/packages/editor/src/toolbar/tool-definitions.ts
@@ -399,6 +399,13 @@ export const READONLY_MOBILE_STATIC_TOOLBAR_GROUPS: ToolbarDefinition = [
   ]
 ];
 
+export const READONLY_MOBILE_TOOLBAR_NODES = [
+  "image",
+  "attachment",
+  "webclip",
+  "link"
+];
+
 const defaultPresets: Record<"default" | "minimal", ToolbarDefinition> = {
   default: [
     [

--- a/packages/editor/src/toolbar/toolbar.tsx
+++ b/packages/editor/src/toolbar/toolbar.tsx
@@ -22,7 +22,8 @@ import {
   getDefaultPresets,
   STATIC_TOOLBAR_GROUPS,
   MOBILE_STATIC_TOOLBAR_GROUPS,
-  READONLY_MOBILE_STATIC_TOOLBAR_GROUPS
+  READONLY_MOBILE_STATIC_TOOLBAR_GROUPS,
+  READONLY_MOBILE_TOOLBAR_NODES
 } from "./tool-definitions.js";
 import { useEffect, useMemo } from "react";
 import { Editor } from "../types.js";
@@ -67,6 +68,11 @@ export function Toolbar(props: ToolbarProps) {
     [tools, editor.isEditable, isMobile]
   );
 
+  const isEmptyReadonlyToolbar =
+    isMobile &&
+    !editor.isEditable &&
+    !READONLY_MOBILE_TOOLBAR_NODES.some((node) => editor.isActive(node));
+
   const setToolbarLocation = useToolbarStore(
     (store) => store.setToolbarLocation
   );
@@ -89,33 +95,35 @@ export function Toolbar(props: ToolbarProps) {
 
   return (
     <>
-      <Flex
-        className={["editor-toolbar", className].join(" ")}
-        sx={{
-          flexWrap: isMobile ? "nowrap" : "wrap",
-          overflowX: isMobile ? "auto" : "hidden",
-          bg: "background",
-          borderRadius: isMobile ? "0px" : "default",
-          ...sx
-        }}
-        {...flexProps}
-      >
-        {toolbarTools.map((tools) => {
-          return (
-            <ToolbarGroup
-              key={tools.join("")}
-              tools={tools}
-              editor={editor}
-              groupId={tools.join("")}
-              sx={{
-                borderRight: "1px solid var(--separator)",
-                ":last-of-type": { borderRight: "none" },
-                alignItems: "center"
-              }}
-            />
-          );
-        })}
-      </Flex>
+      {isEmptyReadonlyToolbar ? null : (
+        <Flex
+          className={["editor-toolbar", className].join(" ")}
+          sx={{
+            flexWrap: isMobile ? "nowrap" : "wrap",
+            overflowX: isMobile ? "auto" : "hidden",
+            bg: "background",
+            borderRadius: isMobile ? "0px" : "default",
+            ...sx
+          }}
+          {...flexProps}
+        >
+          {toolbarTools.map((tools) => {
+            return (
+              <ToolbarGroup
+                key={tools.join("")}
+                tools={tools}
+                editor={editor}
+                groupId={tools.join("")}
+                sx={{
+                  borderRight: "1px solid var(--separator)",
+                  ":last-of-type": { borderRight: "none" },
+                  alignItems: "center"
+                }}
+              />
+            );
+          })}
+        </Flex>
+      )}
       <EditorFloatingMenus editor={editor} />
     </>
   );


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Closes https://github.com/streetwriters/notesnook/issues/7916
Closes https://github.com/streetwriters/notesnook/issues/8203
Closes https://github.com/streetwriters/notesnook/issues/8354

## Type of Change
- [ ] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [ ] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [ ] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
