### PR TITLE
Fix editor undo history reset on image delete

### DIFF
--- a/apps/web/src/components/editor/index.tsx
+++ b/apps/web/src/components/editor/index.tsx
@@ -252,16 +252,6 @@ const MemoizedEditorView = React.memo(EditorView, (prev, next) => {
     prev.session.activeSearchResultId === next.session.activeSearchResultId &&
     prev.session.nonce === next.session.nonce;
 
-  if (
-    "attachmentsLength" in prev.session &&
-    "attachmentsLength" in next.session
-  ) {
-    return (
-      baseConditions &&
-      prev.session.attachmentsLength === next.session.attachmentsLength
-    );
-  }
-
   if ("note" in prev.session && "note" in next.session) {
     return (
       baseConditions &&


### PR DESCRIPTION
## Description

This PR fixes an issue where undo history got reset after adding/removing an image.

Closes #10142 

## QA Scope

Test only on web.

- Ensure backspacing an image in the editor does not reset the undo history
- Ensure deleting an image from the properties or attachment manager reloads the note properly with the image removed.

## Type of Change
- [x] Bug fix
- [ ] Feature
