### PR TITLE
Sort code block languages by recently used

### DIFF
--- a/packages/editor/src/extensions/code-block/component.tsx
+++ b/packages/editor/src/extensions/code-block/component.tsx
@@ -236,8 +236,27 @@ type LanguageSelectorProps = {
   onClose: () => void;
 };
 function LanguageSelector(props: LanguageSelectorProps) {
-  const { onLanguageSelected, selectedLanguage, onClose } = props;
-  const [languages, setLanguages] = useState(Languages);
+  const { selectedLanguage, onClose } = props;
+  const recentlyUsed =
+    config.get<Record<string, number>>("recentlyUsedCodeBlockLanguages", {}) ??
+    {};
+
+  const [languages, setLanguages] = useState(() =>
+    [...Languages].sort((a, b) => {
+      const aCount = recentlyUsed[a.filename] || 0;
+      const bCount = recentlyUsed[b.filename] || 0;
+      if (aCount !== bCount) return bCount - aCount;
+      return 0;
+    })
+  );
+
+  const onLanguageSelected = (language: string) => {
+    props.onLanguageSelected(language);
+    config.set("recentlyUsedCodeBlockLanguages", {
+      ...recentlyUsed,
+      [language]: Date.now()
+    });
+  };
 
   return (
     <Popup onClose={onClose}>


### PR DESCRIPTION
## Description

This PR adds support for automatic sorting of code block languages by date used.

Closes #6242

## QA Scope

Test on web & mobile

## Type of Change
- [x] Bug fix
- [ ] Feature
