### PR TITLE
mobile: improve recovery key readability

### DIFF
--- a/apps/mobile/app/components/sheets/recovery-key/index.jsx
+++ b/apps/mobile/app/components/sheets/recovery-key/index.jsx
@@ -230,7 +230,7 @@ class RecoveryKeySheet extends React.Component {
           >
             <Paragraph
               color={colors.primary.paragraph}
-              size={AppFontSize.sm}
+              size={AppFontSize.md}
               numberOfLines={2}
               selectable
               style={{
@@ -238,7 +238,9 @@ class RecoveryKeySheet extends React.Component {
                 maxWidth: "100%",
                 paddingRight: 10,
                 textAlign: "center",
-                textDecorationLine: "underline"
+                textDecorationLine: "underline",
+                letterSpacing: 0.5,
+                fontFamily: "monospace"
               }}
             >
               {this.state.key}


### PR DESCRIPTION
## Description
Improves the readability of the recovery key on mobile, making visually similar characters easier to distinguish.
Closes https://github.com/streetwriters/notesnook/issues/10011

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
