### PR TITLE
mobile: fix images sometimes not saving after insert

### DIFF
--- a/apps/mobile/app/screens/editor/tiptap/types.ts
+++ b/apps/mobile/app/screens/editor/tiptap/types.ts
@@ -90,7 +90,6 @@ export type SavePayload = {
   data?: string;
   type?: "tiptap";
   sessionHistoryId?: number;
-  ignoreEdit: boolean;
   tabId: string;
   pendingChanges?: boolean;
   sourceNoteId?: string;

--- a/apps/mobile/app/screens/editor/tiptap/use-editor-events.tsx
+++ b/apps/mobile/app/screens/editor/tiptap/use-editor-events.tsx
@@ -149,7 +149,7 @@ const showActionsheet = async () => {
   }
 };
 
-type ContentMessage = { html: string; ignoreEdit: boolean };
+type ContentMessage = { html: string };
 
 export const useEditorEvents = (
   editor: useEditorType,
@@ -422,7 +422,6 @@ export const useEditorEvents = (
             noteId: saveNoteId,
             sourceNoteId: editorMessage.noteId,
             tabId: editorMessage.tabId,
-            ignoreEdit: (editorMessage.value as ContentMessage).ignoreEdit,
             pendingChanges: editorMessage.value?.pendingChanges,
             pendingChangesAt: editorMessage.value?.pendingChangesAt
           });
@@ -435,7 +434,6 @@ export const useEditorEvents = (
             noteId: saveNoteId,
             sourceNoteId: editorMessage.noteId,
             tabId: editorMessage.tabId,
-            ignoreEdit: false,
             pendingChanges: editorMessage.value?.pendingChanges,
             pendingChangesAt: editorMessage.value?.pendingChangesAt
           });

--- a/apps/mobile/app/screens/editor/tiptap/use-editor.ts
+++ b/apps/mobile/app/screens/editor/tiptap/use-editor.ts
@@ -260,7 +260,6 @@ export const useEditor = (
       id,
       data,
       type,
-      ignoreEdit,
       sessionHistoryId: currentSessionHistoryId,
       tabId,
       pendingChanges,
@@ -342,11 +341,6 @@ export const useEditor = (
         };
 
         noteData.title = title;
-
-        if (ignoreEdit) {
-          DatabaseLogger.log("Ignoring edits...");
-          noteData.dateEdited = note?.dateEdited;
-        }
 
         if (data) {
           noteData.content = {
@@ -984,7 +978,6 @@ export const useEditor = (
       title,
       content,
       type,
-      ignoreEdit,
       noteId,
       tabId,
       pendingChanges,
@@ -995,7 +988,6 @@ export const useEditor = (
       title?: string;
       content?: string;
       type: string;
-      ignoreEdit: boolean;
       tabId: string;
       pendingChanges?: boolean;
       sourceNoteId?: string;
@@ -1005,7 +997,6 @@ export const useEditor = (
         `saveContent... title: ${!!title}, content: ${!!content}, noteId: ${noteId}`
       );
       if (
-        ignoreEdit ||
         lock.current ||
         (currentLoadingNoteId.current &&
           currentLoadingNoteId.current === noteId)
@@ -1014,7 +1005,6 @@ export const useEditor = (
 
           lock.current: ${lock.current}
           currentLoadingNoteId.current: ${currentLoadingNoteId.current}
-          ignoreEdit: ${ignoreEdit}
         `);
         if (lock.current) {
           setTimeout(() => {
@@ -1051,7 +1041,6 @@ export const useEditor = (
         data: content,
         type: "tiptap",
         id: noteId,
-        ignoreEdit,
         sessionHistoryId: noteId ? editorSessionHistory.get(noteId) : undefined,
         tabId: tabId,
         pendingChanges,
@@ -1080,7 +1069,7 @@ export const useEditor = (
             saveNote(params);
           }
         },
-        ignoreEdit ? 0 : 150
+        150
       );
     },
     [editorSessionHistory, withTimer, onChange, saveNote]

--- a/packages/editor-mobile/src/hooks/useEditorController.ts
+++ b/packages/editor-mobile/src/hooks/useEditorController.ts
@@ -216,8 +216,7 @@ export function useEditorController({
         return;
       }
 
-      const timerPending = !!timers.current.change;
-      if (ignoreEdit && timerPending) {
+      if (ignoreEdit) {
         logger("info", "Ignoring ignoreEdit update, a save is already pending");
         return;
       }
@@ -227,8 +226,8 @@ export function useEditorController({
       const noteId = tabRef.current.session?.noteId;
       post(EditorEvents.contentchange, undefined, tabId, noteId);
       if (!editor) return;
-      if (timerPending) {
-        clearTimeout(timers.current?.change as any);
+      if (typeof timers.current.change === "number") {
+        clearTimeout(timers.current?.change);
       }
 
       timers.current.change = setTimeout(async () => {
@@ -246,7 +245,6 @@ export function useEditorController({
 
         const editedAt = Date.now();
         htmlContentRef.current = editor.getHTML();
-        timers.current.change = null;
 
         const params = [
           {

--- a/packages/editor-mobile/src/hooks/useEditorController.ts
+++ b/packages/editor-mobile/src/hooks/useEditorController.ts
@@ -215,13 +215,20 @@ export function useEditorController({
         logger("info", "Edit skipped, tab is in loading state");
         return;
       }
+
+      const timerPending = !!timers.current.change;
+      if (ignoreEdit && timerPending) {
+        logger("info", "Ignoring ignoreEdit update, a save is already pending");
+        return;
+      }
+
       const currentSessionId = globalThis.sessionId;
       const tabId = tabRef.current.id;
       const noteId = tabRef.current.session?.noteId;
       post(EditorEvents.contentchange, undefined, tabId, noteId);
       if (!editor) return;
-      if (typeof timers.current.change === "number") {
-        clearTimeout(timers.current?.change);
+      if (timerPending) {
+        clearTimeout(timers.current?.change as any);
       }
 
       timers.current.change = setTimeout(async () => {
@@ -239,6 +246,8 @@ export function useEditorController({
 
         const editedAt = Date.now();
         htmlContentRef.current = editor.getHTML();
+        timers.current.change = null;
+
         const params = [
           {
             html: htmlContentRef.current,
@@ -284,7 +293,7 @@ export function useEditorController({
           });
 
         logger("info", "Editor saving content", params[1], params[2]);
-      }, 300);
+      }, 100);
 
       countWords(5000);
     },


### PR DESCRIPTION
## Description
Fixes a bug where content changes tagged ignoreEdit: true (most notably image/attachment inserts) were sometimes silently not saved to the note.
Closes https://github.com/streetwriters/notesnook/issues/10135
Closes https://github.com/streetwriters/notesnook/issues/10091


## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
