### PR TITLE
web: improve "skip & go directly to app" wording

### DIFF
--- a/apps/web/src/views/auth.tsx
+++ b/apps/web/src/views/auth.tsx
@@ -40,7 +40,7 @@ import AuthContainer from "../components/auth-container";
 import { useTimer } from "../hooks/use-timer";
 import { ErrorText } from "../components/error-text";
 import { AuthenticatorType, User } from "@notesnook/core";
-import { showLogoutConfirmation } from "../dialogs/confirm";
+import { ConfirmDialog, showLogoutConfirmation } from "../dialogs/confirm";
 import { TaskManager } from "../common/task-manager";
 import { strings } from "@notesnook/intl";
 import { ScrollContainer } from "@notesnook/ui";
@@ -907,10 +907,19 @@ export function AuthForm<T extends AuthRoutes>(props: AuthFormProps<T>) {
           sx={{
             mt: 5,
             color: "paragraph",
-            textDecoration: "none"
+            textDecoration: "none",
+            position: "absolute",
+            top: 0,
+            right: 5
           }}
-          onClick={() => {
-            openURL("/notes/", { authenticated: false });
+          onClick={async () => {
+            const result = await ConfirmDialog.show({
+              title: strings.offlineMode(),
+              message: strings.offlineModeDesc(),
+              negativeButtonText: strings.cancel(),
+              positiveButtonText: strings.understand()
+            });
+            if (result) openURL("/notes/", { authenticated: false });
           }}
         >
           {strings.skipAndGoToApp()}

--- a/packages/intl/locale/en.po
+++ b/packages/intl/locale/en.po
@@ -1659,7 +1659,7 @@ msgstr "Clear data & reset account"
 msgid "Clear default notebook"
 msgstr "Clear default notebook"
 
-#: src/strings.ts:2800
+#: src/strings.ts:2803
 msgid "Clear history"
 msgstr "Clear history"
 
@@ -2311,7 +2311,7 @@ msgstr "Delete account"
 msgid "Delete all"
 msgstr "Delete all"
 
-#: src/strings.ts:2802
+#: src/strings.ts:2805
 msgid "Delete all version history for this note?"
 msgstr "Delete all version history for this note?"
 
@@ -4733,6 +4733,10 @@ msgstr "Off"
 msgid "Offline"
 msgstr "Offline"
 
+#: src/strings.ts:2810
+msgid "Offline mode"
+msgstr "Offline mode"
+
 #: src/strings.ts:2688
 msgid "OK"
 msgstr "OK"
@@ -6156,8 +6160,8 @@ msgid "Select folder with backup files"
 msgstr "Select folder with backup files"
 
 #: src/strings.ts:112
-msgid "Select how you would like to recieve the code"
-msgstr "Select how you would like to recieve the code"
+msgid "Select how you would like to receive the code"
+msgstr "Select how you would like to receive the code"
 
 #: src/strings.ts:2366
 msgid "Select language"
@@ -6476,10 +6480,6 @@ msgstr "Size"
 #: src/strings.ts:550
 msgid "Skip"
 msgstr "Skip"
-
-#: src/strings.ts:1831
-msgid "Skip & go directly to the app"
-msgstr "Skip & go directly to the app"
 
 #: src/strings.ts:673
 msgid "Skip introduction"
@@ -7435,6 +7435,10 @@ msgstr "Use native OS titlebar instead of replacing it with a custom one. Requir
 msgid "Use native titlebar"
 msgstr "Use native titlebar"
 
+#: src/strings.ts:1831
+msgid "Use offline"
+msgstr "Use offline"
+
 #: src/strings.ts:1801
 msgid "Use recovery key"
 msgstr "Use recovery key"
@@ -7484,6 +7488,10 @@ msgstr "User verification failed"
 #: src/strings.ts:2267
 msgid "Using {instance} (v{version})"
 msgstr "Using {instance} (v{version})"
+
+#: src/strings.ts:2812
+msgid "Using Notesnook without an account will **NOT** sync your notes across devices and could result in data loss if you lose access to your device or uninstall the app. Make sure to backup your notes regularly."
+msgstr "Using Notesnook without an account will **NOT** sync your notes across devices and could result in data loss if you lose access to your device or uninstall the app. Make sure to backup your notes regularly."
 
 #: src/strings.ts:2265
 msgid "Using official Notesnook instance"
@@ -7553,7 +7561,7 @@ msgstr "Verifying your email"
 msgid "Version"
 msgstr "Version"
 
-#: src/strings.ts:2801
+#: src/strings.ts:2804
 msgid "Version history cleared"
 msgstr "Version history cleared"
 
@@ -7768,8 +7776,8 @@ msgid "Yes, you can cancel your trial anytime. No questions asked."
 msgstr "Yes, you can cancel your trial anytime. No questions asked."
 
 #: src/strings.ts:106
-msgid "You also agree to recieve marketing emails from us which you can opt-out of from app settings."
-msgstr "You also agree to recieve marketing emails from us which you can opt-out of from app settings."
+msgid "You also agree to receive marketing emails from us which you can opt-out of from app settings."
+msgstr "You also agree to receive marketing emails from us which you can opt-out of from app settings."
 
 #: src/strings.ts:2604
 msgid "You are already subscribed to this plan."

--- a/packages/intl/locale/pseudo-LOCALE.po
+++ b/packages/intl/locale/pseudo-LOCALE.po
@@ -1659,7 +1659,7 @@ msgstr ""
 msgid "Clear default notebook"
 msgstr ""
 
-#: src/strings.ts:2800
+#: src/strings.ts:2803
 msgid "Clear history"
 msgstr ""
 
@@ -2300,7 +2300,7 @@ msgstr ""
 msgid "Delete all"
 msgstr ""
 
-#: src/strings.ts:2802
+#: src/strings.ts:2805
 msgid "Delete all version history for this note?"
 msgstr ""
 
@@ -4707,6 +4707,10 @@ msgstr ""
 msgid "Offline"
 msgstr ""
 
+#: src/strings.ts:2810
+msgid "Offline mode"
+msgstr ""
+
 #: src/strings.ts:2688
 msgid "OK"
 msgstr ""
@@ -6130,7 +6134,7 @@ msgid "Select folder with backup files"
 msgstr ""
 
 #: src/strings.ts:112
-msgid "Select how you would like to recieve the code"
+msgid "Select how you would like to receive the code"
 msgstr ""
 
 #: src/strings.ts:2366
@@ -6441,10 +6445,6 @@ msgstr ""
 
 #: src/strings.ts:550
 msgid "Skip"
-msgstr ""
-
-#: src/strings.ts:1831
-msgid "Skip & go directly to the app"
 msgstr ""
 
 #: src/strings.ts:673
@@ -7394,6 +7394,10 @@ msgstr ""
 msgid "Use native titlebar"
 msgstr ""
 
+#: src/strings.ts:1831
+msgid "Use offline"
+msgstr ""
+
 #: src/strings.ts:1801
 msgid "Use recovery key"
 msgstr ""
@@ -7433,6 +7437,10 @@ msgstr ""
 
 #: src/strings.ts:2267
 msgid "Using {instance} (v{version})"
+msgstr ""
+
+#: src/strings.ts:2812
+msgid "Using Notesnook without an account will **NOT** sync your notes across devices and could result in data loss if you lose access to your device or uninstall the app. Make sure to backup your notes regularly."
 msgstr ""
 
 #: src/strings.ts:2265
@@ -7503,7 +7511,7 @@ msgstr ""
 msgid "Version"
 msgstr ""
 
-#: src/strings.ts:2801
+#: src/strings.ts:2804
 msgid "Version history cleared"
 msgstr ""
 
@@ -7718,7 +7726,7 @@ msgid "Yes, you can cancel your trial anytime. No questions asked."
 msgstr ""
 
 #: src/strings.ts:106
-msgid "You also agree to recieve marketing emails from us which you can opt-out of from app settings."
+msgid "You also agree to receive marketing emails from us which you can opt-out of from app settings."
 msgstr ""
 
 #: src/strings.ts:2604

--- a/packages/intl/src/strings.ts
+++ b/packages/intl/src/strings.ts
@@ -103,13 +103,13 @@ export const strings = {
     2: () => t`and `,
     3: () => t`Privacy Policy. `,
     4: () =>
-      t`You also agree to recieve marketing emails from us which you can opt-out of from app settings.`
+      t`You also agree to receive marketing emails from us which you can opt-out of from app settings.`
   },
   alreadyHaveAccount: () => t`Already have an account?`,
   login: () => t`Login`,
   "2fa": () => t`Two factor authentication`,
   select2faMethod: () => t`Select method for two-factor authentication`,
-  select2faCodeHelpText: () => t`Select how you would like to recieve the code`,
+  select2faCodeHelpText: () => t`Select how you would like to receive the code`,
   "2faCodeHelpText": {
     email: () =>
       t`Enter the 6 digit code sent to your email to continue logging in`,
@@ -1828,7 +1828,7 @@ For example:
   cancelSub: () => t`Cancel subscription`,
   unlockWithSecurityKey: () => t`Unlock with security key`,
   reloginToYourAccount: () => t`Relogin to your account`,
-  skipAndGoToApp: () => t`Skip & go directly to the app`,
+  skipAndGoToApp: () => t`Use offline`,
   startAccountRecovery: () => t`Start account recovery`,
   dontHaveRecoveryKey: () => t`Don't have your account recovery key?`,
   dontHaveBackupFile: () => t`Don't have backup file?`,
@@ -2806,5 +2806,8 @@ Continue without attachments?`,
   deleteVersion: () => doActions.delete.version(1),
   deleteVersionConfirmation: () =>
     actionConfirmations.permanentlyDelete.version(1),
-  versionDeleted: () => actions.deleted.version(1)
+  versionDeleted: () => actions.deleted.version(1),
+  offlineMode: () => t`Offline mode`,
+  offlineModeDesc: () =>
+    t`Using Notesnook without an account will **NOT** sync your notes across devices and could result in data loss if you lose access to your device or uninstall the app. Make sure to backup your notes regularly.`
 };


### PR DESCRIPTION
## Description

This PR changes the "Skip & go directly to app" wording to "Use offline" which is more clear and direct. It also adds a prompt to notify users about the trade offs of using Notesnook offline.

## QA Scope

Test on web.

