### PR TITLE
mobile: preserve line breaks in shared plain text

### DIFF
--- a/apps/mobile/app/share/share.tsx
+++ b/apps/mobile/app/share/share.tsx
@@ -97,9 +97,10 @@ function makeHtmlFromUrl(url: string) {
 function makeHtmlFromPlainText(text: string) {
   if (!text) return "";
 
-  return `<p>${encodeHTML5(text)
-    .replace(/[\n]+/g, "\n")
-    .replace(/(?:\r\n|\r|\n)/g, "</p><p>")}</p>`;
+  return `<p>${text
+    .split(/\r\n|\r|\n/)
+    .map((line) => encodeHTML5(line))
+    .join("</p><p>")}</p>`;
 }
 
 type DefaultNote = {

--- a/apps/mobile/app/share/share.tsx
+++ b/apps/mobile/app/share/share.tsx
@@ -97,10 +97,10 @@ function makeHtmlFromUrl(url: string) {
 function makeHtmlFromPlainText(text: string) {
   if (!text) return "";
 
-  return `<p>${text
+  return text
     .split(/\r\n|\r|\n/)
-    .map((line) => encodeHTML5(line))
-    .join("</p><p>")}</p>`;
+    .map((line) => `<p>${encodeHTML5(line)}</p>`)
+    .join("");
 }
 
 type DefaultNote = {


### PR DESCRIPTION
## Description
Fixes an issue where shared plain text containing line breaks was rendered as a single paragraph in the share editor. The plain text to HTML conversion now preserves line breaks by converting each line into a separate paragraph before HTML encoding.
Fixes https://github.com/streetwriters/notesnook/issues/9207

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
Verified manually by sharing multiline text from another app and confirming that line breaks and paragraph formatting are preserved in the share editor and saved note.

## Platform

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed