### PR TITLE
Clean up new documentation

### DIFF
--- a/docs/help/.vitepress/sidebar.mjs
+++ b/docs/help/.vitepress/sidebar.mjs
@@ -21,13 +21,22 @@ export const sidebar = [
     text: "Organizing notes",
     collapsed: false,
     items: [
-      { text: "Notebooks", link: "/organizing-notes/organize-notes-using-notebooks" },
+      {
+        text: "Notebooks",
+        link: "/organizing-notes/organize-notes-using-notebooks"
+      },
       { text: "Tags", link: "/organizing-notes/organize-notes-using-tags" },
       { text: "Colors", link: "/organizing-notes/organize-notes-using-colors" },
-      { text: "Favorites", link: "/organizing-notes/organize-notes-using-favorites" },
+      {
+        text: "Favorites",
+        link: "/organizing-notes/organize-notes-using-favorites"
+      },
       { text: "Pins", link: "/organizing-notes/pin-notes" },
       { text: "Archive", link: "/organizing-notes/archive-notes" },
-      { text: "Side menu shortcuts", link: "/organizing-notes/side-menu-shortcuts" },
+      {
+        text: "Side menu shortcuts",
+        link: "/organizing-notes/side-menu-shortcuts"
+      },
       { text: "Reminders", link: "/reminders" }
     ]
   },
@@ -46,18 +55,33 @@ export const sidebar = [
     text: "Editor",
     collapsed: false,
     items: [
-      { text: "Editor toolbar", link: "/rich-text-editor/rich-text-editor-toolbar" },
+      {
+        text: "Editor toolbar",
+        link: "/rich-text-editor/rich-text-editor-toolbar"
+      },
       { text: "Tabs & panes", link: "/rich-text-editor/editor-tabs-and-panes" },
-      { text: "Personalizing the editor", link: "/rich-text-editor/personalizing-rich-text-editor" },
-      { text: "Markdown shortcuts", link: "/rich-text-editor/markdown-notes-editing" },
-      { text: "Headings", link: "/rich-text-editor/headings-and-collapsible-sections" },
+      {
+        text: "Personalizing the editor",
+        link: "/rich-text-editor/personalizing-rich-text-editor"
+      },
+      {
+        text: "Markdown shortcuts",
+        link: "/rich-text-editor/markdown-notes-editing"
+      },
+      {
+        text: "Headings",
+        link: "/rich-text-editor/headings-and-collapsible-sections"
+      },
       { text: "Tables", link: "/rich-text-editor/tables" },
       { text: "Task lists", link: "/rich-text-editor/task-and-todo-lists" },
       { text: "Outline lists", link: "/rich-text-editor/outline-lists" },
       { text: "Callouts", link: "/rich-text-editor/callouts" },
       { text: "Code blocks", link: "/rich-text-editor/code-blocks" },
       { text: "Math & formulas", link: "/rich-text-editor/math-and-formulas" },
-      { text: "Images & embeds", link: "/rich-text-editor/images-attachments-and-embeds" },
+      {
+        text: "Images & embeds",
+        link: "/rich-text-editor/images-attachments-and-embeds"
+      },
       { text: "Find & replace", link: "/rich-text-editor/search-and-replace" }
     ]
   },
@@ -67,27 +91,63 @@ export const sidebar = [
     items: [
       { text: "Overview", link: "/importing-notes/" },
       { text: "Evernote", link: "/importing-notes/import-notes-from-evernote" },
-      { text: "Google Keep", link: "/importing-notes/import-notes-from-googlekeep" },
+      {
+        text: "Google Keep",
+        link: "/importing-notes/import-notes-from-googlekeep"
+      },
       { text: "Joplin", link: "/importing-notes/import-notes-from-joplin" },
       { text: "Obsidian", link: "/importing-notes/import-notes-from-obsidian" },
-      { text: "Simplenote", link: "/importing-notes/import-notes-from-simplenote" },
-      { text: "Standard Notes", link: "/importing-notes/import-notes-from-standardnotes" },
-      { text: "ColorNote", link: "/importing-notes/import-notes-from-colornote" },
+      {
+        text: "Simplenote",
+        link: "/importing-notes/import-notes-from-simplenote"
+      },
+      {
+        text: "Standard Notes",
+        link: "/importing-notes/import-notes-from-standardnotes"
+      },
+      {
+        text: "ColorNote",
+        link: "/importing-notes/import-notes-from-colornote"
+      },
       { text: "UpNote", link: "/importing-notes/import-notes-from-upnote" },
-      { text: "Skiff Pages", link: "/importing-notes/import-notes-from-skiff-pages" },
-      { text: "Zoho Notebook", link: "/importing-notes/import-notes-from-zoho-notebook" },
-      { text: "Fusebase (Nimbus Note)", link: "/importing-notes/import-notes-from-fusebase" },
-      { text: "Markdown files", link: "/importing-notes/import-notes-from-markdown-files" },
-      { text: "HTML files", link: "/importing-notes/import-notes-from-html-files" },
-      { text: "Plaintext files", link: "/importing-notes/import-notes-from-plaintext-files" },
-      { text: "TextBundle files", link: "/importing-notes/import-notes-from-textbundle-files" }
+      {
+        text: "Skiff Pages",
+        link: "/importing-notes/import-notes-from-skiff-pages"
+      },
+      {
+        text: "Zoho Notebook",
+        link: "/importing-notes/import-notes-from-zoho-notebook"
+      },
+      {
+        text: "Fusebase (Nimbus Note)",
+        link: "/importing-notes/import-notes-from-fusebase"
+      },
+      {
+        text: "Markdown files",
+        link: "/importing-notes/import-notes-from-markdown-files"
+      },
+      {
+        text: "HTML files",
+        link: "/importing-notes/import-notes-from-html-files"
+      },
+      {
+        text: "Plaintext files",
+        link: "/importing-notes/import-notes-from-plaintext-files"
+      },
+      {
+        text: "TextBundle files",
+        link: "/importing-notes/import-notes-from-textbundle-files"
+      }
     ]
   },
   {
     text: "Backup & export",
     collapsed: false,
     items: [
-      { text: "Backup and restore", link: "/backup-and-restore-notes-in-notesnook" },
+      {
+        text: "Backup and restore",
+        link: "/backup-and-restore-notes-in-notesnook"
+      },
       { text: "Exporting notes", link: "/export-notes-from-notesnook" },
       { text: "Attachments & files", link: "/attachments-and-files" }
     ]
@@ -133,20 +193,44 @@ export const sidebar = [
     text: "Mobile",
     collapsed: false,
     items: [
-      { text: "Home screen widgets", link: "/mobile-integration/home-screen-widgets" },
-      { text: "Android quick actions", link: "/mobile-integration/android-quick-actions" },
-      { text: "Pin to notifications", link: "/mobile-integration/pin-notes-to-notifications" },
-      { text: "Quick notes", link: "/mobile-integration/quick-note-from-notification" },
-      { text: "Share from other apps", link: "/mobile-integration/share-things-from-other-apps" }
+      {
+        text: "Home screen widgets",
+        link: "/mobile-integration/home-screen-widgets"
+      },
+      {
+        text: "Android quick actions",
+        link: "/mobile-integration/android-quick-actions"
+      },
+      {
+        text: "Pin to notifications",
+        link: "/mobile-integration/pin-notes-to-notifications"
+      },
+      {
+        text: "Quick notes",
+        link: "/mobile-integration/quick-note-from-notification"
+      },
+      {
+        text: "Share from other apps",
+        link: "/mobile-integration/share-things-from-other-apps"
+      }
     ]
   },
   {
     text: "Desktop",
     collapsed: false,
     items: [
-      { text: "Auto start", link: "/desktop-integration/auto-start-on-system-startup" },
-      { text: "System tray menu", link: "/desktop-integration/system-tray-menu" },
-      { text: "Jumplist & dock menu", link: "/desktop-integration/jumplist-and-dock-menu" },
+      {
+        text: "Auto start",
+        link: "/desktop-integration/auto-start-on-system-startup"
+      },
+      {
+        text: "System tray menu",
+        link: "/desktop-integration/system-tray-menu"
+      },
+      {
+        text: "Jumplist & dock menu",
+        link: "/desktop-integration/jumplist-and-dock-menu"
+      },
       { text: "Spell checker", link: "/desktop-integration/spell-checker" },
       {
         text: "Updates & advanced",
@@ -161,8 +245,14 @@ export const sidebar = [
       { text: "Customizing the app", link: "/customizing-notesnook" },
       { text: "Using themes", link: "/custom-themes/using-themes" },
       { text: "How themes work", link: "/custom-themes/introduction" },
-      { text: "Theme Builder", link: "/custom-themes/create-a-theme-with-theme-builder" },
-      { text: "Install from file", link: "/custom-themes/install-a-theme-from-file" },
+      {
+        text: "Theme Builder",
+        link: "/custom-themes/create-a-theme-with-theme-builder"
+      },
+      {
+        text: "Install from file",
+        link: "/custom-themes/install-a-theme-from-file"
+      },
       { text: "Publish a theme", link: "/custom-themes/publish-a-theme" }
     ]
   },
@@ -182,8 +272,11 @@ export const sidebar = [
     collapsed: false,
     items: [
       { text: "Inbox API", link: "/inbox-api/getting-started" },
-      { text: "Self-hosting the Inbox API", link: "/inbox-api/self-hosting-inbox-api" },
-      { text: "Self-hosting Notesnook", link: "/self-hosting" },
+      {
+        text: "Self-hosting the Inbox API",
+        link: "/inbox-api/self-hosting-inbox-api"
+      },
+      //      { text: "Self-hosting Notesnook", link: "/self-hosting" },
       { text: "Notesnook Wrapped", link: "/notesnook-wrapped" }
     ]
   },
@@ -191,9 +284,15 @@ export const sidebar = [
     text: "FAQs",
     collapsed: false,
     items: [
-      { text: "What are merge conflicts?", link: "/faqs/what-are-merge-conflicts" },
+      {
+        text: "What are merge conflicts?",
+        link: "/faqs/what-are-merge-conflicts"
+      },
       { text: "Is there an ETA for X feature?", link: "/faqs/is-there-an-eta" },
-      { text: "Login to upload attachments", link: "/faqs/login-to-upload-attachments" },
+      {
+        text: "Login to upload attachments",
+        link: "/faqs/login-to-upload-attachments"
+      },
       {
         text: "Login to restore attachments",
         link: "/faqs/login-to-restore-attachments-in-backup"

--- a/docs/help/.vitepress/theme/components/PlanTag.vue
+++ b/docs/help/.vitepress/theme/components/PlanTag.vue
@@ -31,7 +31,7 @@ const tier = computed(() => PLANS[props.plan.toLowerCase()] ?? PLANS.pro);
 </script>
 
 <template>
-  <span class="nn-plan-tag" :class="`nn-plan-tag--${plan.toLowerCase()}`" :title="tier.title">
+  <span class="nn-plan-tag ignore-header" :class="`nn-plan-tag--${plan.toLowerCase()}`" :title="tier.title">
     {{ tier.label }}
     <span v-if="note" class="nn-plan-tag__note">· {{ note }}</span>
   </span>

--- a/docs/help/contents/attachments-and-files.md
+++ b/docs/help/contents/attachments-and-files.md
@@ -22,6 +22,7 @@ Trying to insert an attachment while logged out shows `{{notLoggedIn}}` with the
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Put the cursor where the file should go.
 2. Open the insert menu (the `+` button on the toolbar).
 3. Choose `{{attachment}}` for any file, or `{{image}}` → `{{uploadFromDisk}}` for a picture.
@@ -29,20 +30,21 @@ Trying to insert an attachment while logged out shows `{{notLoggedIn}}` with the
 
 Shortcuts: `Ctrl/Cmd + Shift + A` for an attachment, `Ctrl/Cmd + Shift + I` for an image. You can also drag files straight into the editor.
 == Mobile
+
 1. Put the cursor where the file should go.
 2. Open the insert menu (the `+` button on the toolbar).
 3. Choose `{{attachment}}` for any file, or `{{image}}` for a picture.
 4. Under `{{image}}` you also get `{{takePhotoUsingCamera}}`, which is mobile only.
-:::
+   :::
 
 Notesnook hashes each file first, so attaching the same file twice reuses the copy that is already uploaded instead of consuming your storage again.
 
 ## File size and storage limits
 
-| | Free | Essential | Pro | Believer |
-| --- | --- | --- | --- | --- |
-| Maximum file size | 10 MB | 100 MB | 1 GB | 5 GB |
-| Storage per month | 50 MB | 1 GB | 10 GB | 25 GB |
+|                   | Free  | Essential | Pro   | Believer |
+| ----------------- | ----- | --------- | ----- | -------- |
+| Maximum file size | 10 MB | 100 MB    | 1 GB  | 5 GB     |
+| Storage per month | 50 MB | 1 GB      | 10 GB | 25 GB    |
 
 Storage counts **attachments only** — images, files, audio and web clips. Your notes never count against it. If a file is over your plan's limit, the upload is refused with a message telling you the size you are allowed. Full details are on [Plans & limits](/plans-and-limits).
 
@@ -81,15 +83,15 @@ The search box at the top filters the list by filename. On desktop and web you c
 
 Open an attachment's menu — right click on desktop and web, tap the item on mobile — for:
 
-| Action | What it does |
-| --- | --- |
-| `{{previewAttachment}}` | Opens images and PDFs without downloading them (desktop and web) |
-| `{{linkedNotes}}` | Lists the notes that use this file; picking one opens it |
-| `{{fileCheck}}` | Verifies the uploaded file is intact and decryptable |
-| `{{rename}}` | Changes the filename |
-| `Download` | Saves the file to your device |
-| `Reupload` | Replaces a broken upload — you must pick the same file, the hash has to match |
-| `{{deletePermanently}}` (`{{delete}}` on mobile) | Removes the file from your account and from the notes that use it |
+| Action                                           | What it does                                                                  |
+| ------------------------------------------------ | ----------------------------------------------------------------------------- |
+| `{{previewAttachment}}`                          | Opens images and PDFs without downloading them (desktop and web)              |
+| `{{linkedNotes}}`                                | Lists the notes that use this file; picking one opens it                      |
+| `{{fileCheck}}`                                  | Verifies the uploaded file is intact and decryptable                          |
+| `{{rename}}`                                     | Changes the filename                                                          |
+| `Download`                                       | Saves the file to your device                                                 |
+| `Reupload`                                       | Replaces a broken upload — you must pick the same file, the hash has to match |
+| `{{deletePermanently}}` (`{{delete}}` on mobile) | Removes the file from your account and from the notes that use it             |
 
 `Download`, `{{fileCheck}}` and `{{delete}}` also work on a multi-selection from the toolbar at the top of the desktop and web list.
 
@@ -120,15 +122,17 @@ Anything that has not finished uploading is lost when you clear the cache. Let u
 
 ## Deleting an attachment
 
-Deleting an attachment removes it from your account **and** from every note that references it — attachments are not moved to [Trash](/trash) the way notes are. The deleted record itself is kept for **7 days** before it is cleaned up, so the deletion has time to reach your other devices.
+Deleting an attachment removes it from your account **and** from every note that references it — attachments are not moved to [Trash](/trash) the way notes are.
 
-::: warning Attachments inside locked notes are protected
-If a file is used by a note in your [private vault](/lock-notes-with-private-vault), deleting it fails with `This attachment is inside a locked note.` Unlock the note first if you really want the file gone.
-:::
-
-## Why is my storage full when I deleted my notes?
+## What is an orphaned attachment?
 
 Deleting a note does not delete the files it contained — they become **orphaned** attachments and keep occupying storage. Open the attachment manager, switch to `{{orphaned}}`, and delete what you no longer need.
+
+## Why is my storage full when I deleted my attachments?
+
+<!---Reviewer: Is the time correct?-->
+
+Your monthly storage limit resets on the first of the month at midnight UTC. Deleting attachments does not give you storage back.
 
 <GetNotesnook action="pricing" title="Need more room for files?" text="The free plan gives you 50 MB a month and a 10 MB file size cap. Paid plans go up to 25 GB a month with 5 GB files — and every file stays end-to-end encrypted on all of them." />
 

--- a/docs/help/contents/attachments-and-files.md
+++ b/docs/help/contents/attachments-and-files.md
@@ -130,8 +130,6 @@ Deleting a note does not delete the files it contained — they become **orphane
 
 ## Why is my storage full when I deleted my attachments?
 
-<!---Reviewer: Is the time correct?-->
-
 Your monthly storage limit resets on the first of the month at midnight UTC. Deleting attachments does not give you storage back.
 
 <GetNotesnook action="pricing" title="Need more room for files?" text="The free plan gives you 50 MB a month and a 10 MB file size cap. Paid plans go up to 25 GB a month with 5 GB files — and every file stays end-to-end encrypted on all of them." />

--- a/docs/help/contents/backup-and-restore-notes-in-notesnook.md
+++ b/docs/help/contents/backup-and-restore-notes-in-notesnook.md
@@ -13,12 +13,14 @@ Since all your data is end-to-end encrypted, we have no way to restore your acco
 
 ::::tabs key:platform
 == Desktop/Web
+
 1. Go to Settings
 2. Scroll down in the Settings navigation menu and click on `{{backupExport}}` section
 3. Click on `Create backup` under `{{backupNow}}` heading to create a new `.nnbackupz` file
 
 ![Create backup web in Notesnook](/create-backup-web.png)
 == Mobile
+
 1. Go to Settings from Sidebar
 2. Scroll down to `{{backupRestore}}`
 3. Tap on `{{backups}}`
@@ -37,6 +39,7 @@ For maximum safety against potential data loss, you can enable daily, weekly or 
 
 ::::tabs key:platform
 == Desktop
+
 1. Go to Settings
 2. Scroll down in the Settings navigation menu and click on `{{backupExport}}` section
 3. Select the Automatic backups interval from the dropdown
@@ -53,10 +56,11 @@ On the **web** app there is no way to automatically save backups to a folder, th
 
 ![Auto backups web in Notesnook](/auto-backups-web.png)
 == Mobile
+
 1. Go to Settings > Backup & Restore
 2. Press Backups
 3. Select automatic backup frequency to enable automatic backups
-::::
+   ::::
 
 ## Encrypted Backups (Recommended)
 
@@ -64,14 +68,15 @@ To keep your backups secure & private, it is recommended that you enable encrypt
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Go to Settings
 2. Scroll down in the Settings navigation menu and click on `{{backupExport}}` section
 3. Click on the toggle next to `{{backupEncryption}}` to enable/disable encrypted backups
-== Mobile
-1. Go to `{{settings}}` > `Backup & Restore`
-2. Tap on `{{backups}}`
-3. Tap on the toggle next to `{{backupEncryption}}` to enable/disable encrypted backups
-:::
+   == Mobile
+4. Go to `{{settings}}` > `Backup & Restore`
+5. Tap on `{{backups}}`
+6. Tap on the toggle next to `{{backupEncryption}}` to enable/disable encrypted backups
+   :::
 
 ::: info
 Backups are always encrypted with your account password.
@@ -79,15 +84,22 @@ Backups are always encrypted with your account password.
 
 # Restore a backup
 
-At any point in time, you can restore a backup to recover lost data. However, **to restore a backup, you must be logged in to your Notesnook account.** Backups created on one account can be restored on another Notesnook account.
+::: danger Potential data loss
+**Always create a backup before restoring one**, to avoid losing data. Restoring a backup replaces your current content in-place — anything that changed since that backup was taken will be reverted. Entirely new content (like new notes) will not be impacted.
+:::
+
+At any point in time, you can restore a backup to recover lost data. Backups created on one account can be restored on another Notesnook account.
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Go to Settings
 2. Scroll down in the Settings navigation menu and click on `{{backupExport}}` section
 3. Click on `{{restore}}` button next to `{{restoreBackup}}` heading
 4. Select the `.nnbackupz` or `.nnbackup` file from your PC that you want to restore.
+
 == Mobile
+
 1. Go to Settings from Sidebar
 2. Scroll down to `Backup & Restore` section
 3. Tap on `{{restoreBackup}}`

--- a/docs/help/contents/backup-and-restore-notes-in-notesnook.md
+++ b/docs/help/contents/backup-and-restore-notes-in-notesnook.md
@@ -72,10 +72,12 @@ To keep your backups secure & private, it is recommended that you enable encrypt
 1. Go to Settings
 2. Scroll down in the Settings navigation menu and click on `{{backupExport}}` section
 3. Click on the toggle next to `{{backupEncryption}}` to enable/disable encrypted backups
-   == Mobile
-4. Go to `{{settings}}` > `Backup & Restore`
-5. Tap on `{{backups}}`
-6. Tap on the toggle next to `{{backupEncryption}}` to enable/disable encrypted backups
+
+== Mobile
+
+1. Go to `{{settings}}` > `Backup & Restore`
+2. Tap on `{{backups}}`
+3. Tap on the toggle next to `{{backupEncryption}}` to enable/disable encrypted backups
    :::
 
 ::: info

--- a/docs/help/contents/deleting-your-account.md
+++ b/docs/help/contents/deleting-your-account.md
@@ -19,13 +19,15 @@ Deleting your account immediately and permanently erases all your notes, noteboo
 3. Go to Settings
 4. Go to `{{account}}`
 5. Click on `{{deleteAccount}}`
-   == Mobile
-6. Open the Notesnook app
-7. Make sure you are logged in
-8. Go to Settings
-9. Go to `{{account}}` then `{{manageAccount}}`
-10. Tap on `{{deleteAccount}}`
-    :::
+
+== Mobile
+
+1. Open the Notesnook app
+2. Make sure you are logged in
+3. Go to Settings
+4. Go to `{{account}}` then `{{manageAccount}}`
+5. Tap on `{{deleteAccount}}`
+   :::
 
 ## FAQs
 

--- a/docs/help/contents/deleting-your-account.md
+++ b/docs/help/contents/deleting-your-account.md
@@ -1,6 +1,6 @@
 ---
 title: Deleting your account
-description: No questions asked! You can delete your account anytime from mobile and desktop apps with a single click and delete all your data
+description: No questions asked! You can delete your account anytime from the mobile and desktop apps with a single click and delete all your data
 ---
 
 # Deleting your account
@@ -13,18 +13,19 @@ Deleting your account immediately and permanently erases all your notes, noteboo
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Open Notesnook web or desktop app
 2. Make sure you are logged in
 3. Go to Settings
 4. Go to `{{account}}`
 5. Click on `{{deleteAccount}}`
-== Mobile
-1. Open the Notesnook app
-2. Make sure you are logged in
-3. Go to Settings
-4. Go to `{{account}}` then `{{manageAccount}}`
-5. Tap on `{{deleteAccount}}`
-:::
+   == Mobile
+6. Open the Notesnook app
+7. Make sure you are logged in
+8. Go to Settings
+9. Go to `{{account}}` then `{{manageAccount}}`
+10. Tap on `{{deleteAccount}}`
+    :::
 
 ## FAQs
 

--- a/docs/help/contents/gift-cards.md
+++ b/docs/help/contents/gift-cards.md
@@ -31,20 +31,21 @@ You can't redeem a gift code on an account with an active Notesnook subscription
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Go to `{{settings}}`
 2. Go to `{{subDetails}}`
 3. Click on `{{redeemGiftCode}}` button
 4. Enter the gift code you received
 5. Click on `{{submit}}` and wait for the app to verify your gift code.
 6. Once the process succeeds, you should be upgraded to Pro.
-== Mobile
-1. Go to `{{settings}}`
-2. Go to `{{account}}`
-3. Tap on `{{redeemGiftCode}}`
-4. Enter the gift code you received
-5. Tap on `{{redeem}}` and wait for the app to verify your gift code.
-6. Once the process succeeds, you should be upgraded to Pro.
-:::
+   == Mobile
+7. Go to `{{settings}}`
+8. Go to `{{account}}`
+9. Tap on `{{redeemGiftCode}}`
+10. Enter the gift code you received
+11. Tap on `{{redeem}}` and wait for the app to verify your gift code.
+12. Once the process succeeds, you should be upgraded to Pro.
+    :::
 
 ::: info
 Once you redeem a gift code, the person who purchased it will receive an email informing them that one of their gift codes was claimed. The email **does not** contain any information about who claimed the gift code.
@@ -78,7 +79,7 @@ No. Gift cards are a one-time purchase.
 
 ### Can I use cryptocurrency to purchase a gift card?
 
-Currently, no. But we are actively working on a solution to support this so stay tuned.
+Yes! You can do so over at [Proxystore.](https://digitalgoods.proxysto.re/en)
 
 ## Related pages
 

--- a/docs/help/contents/gift-cards.md
+++ b/docs/help/contents/gift-cards.md
@@ -38,14 +38,16 @@ You can't redeem a gift code on an account with an active Notesnook subscription
 4. Enter the gift code you received
 5. Click on `{{submit}}` and wait for the app to verify your gift code.
 6. Once the process succeeds, you should be upgraded to Pro.
-   == Mobile
-7. Go to `{{settings}}`
-8. Go to `{{account}}`
-9. Tap on `{{redeemGiftCode}}`
-10. Enter the gift code you received
-11. Tap on `{{redeem}}` and wait for the app to verify your gift code.
-12. Once the process succeeds, you should be upgraded to Pro.
-    :::
+
+== Mobile
+
+1. Go to `{{settings}}`
+2. Go to `{{account}}`
+3. Tap on `{{redeemGiftCode}}`
+4. Enter the gift code you received
+5. Tap on `{{redeem}}` and wait for the app to verify your gift code.
+6. Once the process succeeds, you should be upgraded to Pro.
+   :::
 
 ::: info
 Once you redeem a gift code, the person who purchased it will receive an email informing them that one of their gift codes was claimed. The email **does not** contain any information about who claimed the gift code.

--- a/docs/help/contents/index.md
+++ b/docs/help/contents/index.md
@@ -5,8 +5,7 @@ description: Your complete and free resource to using Notesnook as a daily note 
 
 hero:
   name: Notesnook Help
-  text: Everything you can do with Notesnook
-  tagline: Step-by-step guides for the web, desktop and mobile apps — written for the way you actually use them.
+  tagline: Helping you discover everything you can do with Notesnook
   image:
     src: /logo.png
     alt: Notesnook

--- a/docs/help/contents/lock-notes-with-private-vault.md
+++ b/docs/help/contents/lock-notes-with-private-vault.md
@@ -13,36 +13,42 @@ Adding notes to private vault is useful when you do not want anyone to read your
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Go to Settings
 2. Go to `{{vault}}` in `{{privacyAndSecurity}}` section
 3. Click on `{{create}}` button
 4. Enter the password for your vault (this password will be used to open all locked notes)
 5. Click on `{{create}}` in the dialog to create the vault.
+
 == Mobile
+
 1. Go to Settings from Sidebar
 2. Scroll down to `{{privacyAndSecurity}}` section
 3. Tap on `{{createVault}}`
 4. Enter password for the vault (this password will be used to open all locked notes)
 5. Tap on `{{create}}` button to create the vault.
-:::
+   :::
 
 ## Lock a note
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Right click on any note
 2. Select `{{lock}}` from the context menu
 3. Enter the password for the vault
 4. Press `Enter` key to lock the note
+
 == Mobile
+
 1. Tap the ![Three dot button](/three-dot-button.png) button on a note
 2. Tap on `{{lock}}` button in the note properties
 3. Enter password for the vault
 4. Press on `{{lock}}` to add note to vault.
-:::
+   :::
 
 ::: danger Locking a note deletes its history
-When a note moves into the vault, every stored [version of that note](/note-version-history) is deleted. Restore anything you still need from history **before** you lock it.
+When a note moves into the vault, every stored [version of that note](/note-version-history) is deleted. Restore or copy anything you still need from history **before** you lock it.
 :::
 
 ## Open/edit/delete a locked note
@@ -53,16 +59,19 @@ To open, edit or delete a locked note, you must provide the password for the vau
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Right click on any note
 2. Select `{{unlock}}` from the context menu
 3. Enter the password for the vault in dialog.
 4. Click on Unlock to remove note from vault
+
 == Mobile
+
 1. Tap the ![Three dot button](/three-dot-button.png) button on a note
 2. Tap on `{{unlock}}` button in the note properties
 3. Enter password for the vault
 4. Tap on `{{unlock}}` to remove note from vault.
-:::
+   :::
 
 ## How long the vault stays unlocked
 
@@ -70,14 +79,17 @@ Once you enter your vault password, the vault stays unlocked for a while so you 
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Go to `{{settings}}`.
 2. Open `{{vault}}`.
 3. Set `{{lockVaultAfter}}` to `1`, `5`, `10`, `15`, `30`, `45` minutes, `1 hour` or `Never`.
+
 == Mobile
+
 1. Go to `{{settings}}`.
 2. Open `{{privacyAndSecurity}}` > `{{vault}}`.
 3. Set `{{lockVaultAfter}}`.
-:::
+   :::
 
 `{{never}}` keeps the vault open until you close the app or lock it yourself. The setting only appears once a vault exists.
 
@@ -93,57 +105,66 @@ Turning biometrics on doesn't replace your vault password, and it doesn't travel
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Go to Settings
 2. Go to `{{vault}}` in `{{privacyAndSecurity}}` section
 3. Click on `{{change}}` button next to `{{changeVaultPassword}}` heading
 4. Enter the old and new password for the vault
 5. Click on `{{changePassword}}` to update the password
+
 == Mobile
+
 1. Go to Settings from Sidebar.
 2. Scroll down to `{{privacyAndSecurity}}` section
 3. Tap on `{{vault}}`
 4. Press on `{{changeVaultPassword}}`
 5. Enter the old and new password for the vault
 6. Click on Change to update password
-:::
+   :::
 
 ## Clear vault
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Go to Settings
 2. Go to `{{vault}}` in `{{privacyAndSecurity}}` section
 3. Click on `{{clear}}` button next to `{{clearVault}}` heading
 4. Enter your vault password and click on clear vault. All notes in the vault will be deleted.
+
 == Mobile
+
 1. Go to Settings from Sidebar.
 2. Scroll down to `{{privacyAndSecurity}}` section
 3. Tap on `{{vault}}`
 4. Tap on `{{clearVault}}`
 5. Enter your vault password and tap on `{{clear}}`. All notes in the vault will be deleted.
-:::
+   :::
 
 ## Delete vault
 
 In the event that you have forgotten your vault password, you can delete the vault and (optionally) delete all the notes in it.
 
 ::: danger Permanent data loss
-Deleting the vault only requires your account password, but if you also choose to delete all the notes in it, those notes are permanently and irrecoverably destroyed — not just unlocked. Because of end-to-end encryption, there is no way for Notesnook to recover a forgotten vault password or restore deleted vault notes afterwards.
+Deleting the vault only requires your account password, but if you also choose to delete all the notes in it, those notes are permanently and irrecoverably destroyed. Because of end-to-end encryption, there is no way for Notesnook to recover a forgotten vault password or restore deleted vault notes afterwards.
 :::
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Go to Settings
 2. Go to `{{vault}}` in `{{privacyAndSecurity}}` section
 3. Click on `{{delete}}` button next to `{{deleteVault}}` heading
 4. Enter your account password and click on `{{deleteVault}}` to delete the vault
+
 == Mobile
+
 1. Go to Settings from Sidebar.
 2. Scroll down to `{{privacyAndSecurity}}` section
 3. Tap on `{{vault}}`
 4. Tap on `{{deleteVault}}`
 5. Enter your account password and tap on `{{delete}}` to delete the vault
-:::
+   :::
 
 ## Related pages
 

--- a/docs/help/contents/mobile-integration/android-quick-actions.md
+++ b/docs/help/contents/mobile-integration/android-quick-actions.md
@@ -11,8 +11,8 @@ keywords:
 
 # Quick actions on Android
 
-::: danger This page is Android only.
-The iOS app has its own share extension — see [share things from other apps](/mobile-integration/share-things-from-other-apps).
+::: info This page is Android only.
+The iOS app has its own share extension — see [share things from other apps.](/mobile-integration/share-things-from-other-apps)
 :::
 
 Android gives Notesnook three ways to start writing without opening the app first, plus a way to pin any note, notebook, tag or color to your launcher.

--- a/docs/help/contents/mobile-integration/home-screen-widgets.md
+++ b/docs/help/contents/mobile-integration/home-screen-widgets.md
@@ -9,6 +9,7 @@ Basic home screen widgets are availble on both Android & iOS for quick note taki
 
 :::tabs key:platform
 == iOS
+
 1. Long press on home screen
 2. Tap on the + button on top left
 3. Select Notesnook Quick Note widget and add it to home screen
@@ -16,7 +17,9 @@ Basic home screen widgets are availble on both Android & iOS for quick note taki
 ![Home widget](/static/mobile-integration/ios-quick-note-widget.png)
 
 4. Tap on the widget to directly launch the editor in the app.
+
 == Android
+
 1. Long press on home screen
 2. Tap on widgets
 3. Add Notesnook widget to home screen
@@ -24,17 +27,17 @@ Basic home screen widgets are availble on both Android & iOS for quick note taki
 ![Home widget](/static/mobile-integration/android-quick-note-widget.png)
 
 4. Tap on the widget to quickly take a note without launching the app.
-:::
+   :::
 
 ## Which widgets are available?
 
 Android ships three widgets; iOS ships one.
 
-| Widget | Android | iOS | What it does |
-| --- | --- | --- | --- |
-| `{{quickNoteTitle}}` (`Quick Note` on iOS) | Yes | Yes | Opens a small note-taking screen straight from the home screen. |
-| `{{note}}` | Yes | No | Shows the title and first line of a note you pick, and opens that note when tapped. |
-| `{{reminders}}` | Yes | No | Lists your upcoming reminders and lets you add a new one. |
+| Widget                                     | Android | iOS | What it does                                                                        |
+| ------------------------------------------ | ------- | --- | ----------------------------------------------------------------------------------- |
+| `{{quickNoteTitle}}` (`Quick Note` on iOS) | Yes     | Yes | Opens a small note-taking screen straight from the home screen.                     |
+| `{{note}}`                                 | Yes     | No  | Shows the title and first line of a note you pick, and opens that note when tapped. |
+| `{{reminders}}`                            | Yes     | No  | Lists your upcoming reminders and lets you add a new one.                           |
 
 ### Quick note
 

--- a/docs/help/contents/mobile-integration/quick-note-from-notification.md
+++ b/docs/help/contents/mobile-integration/quick-note-from-notification.md
@@ -5,9 +5,6 @@ description: Write a note straight from your Android notification shade, without
 
 # Quick notes from notifications <PlanTag plan="pro" note="Android only" />
 
-::: danger This feature is Android only.
-:::
-
 Taking a note from the notification drawer requires a Pro plan and is available on Android only — see [Plans & limits](/plans-and-limits).
 
 A simple, quick and convenient way to take notes on your phone from notifications. This works the same way as a messaging/chat app allows you to reply to messages from notifications.

--- a/docs/help/contents/note-links-and-backlinks.md
+++ b/docs/help/contents/note-links-and-backlinks.md
@@ -14,24 +14,27 @@ schema: howto
 
 Put the cursor where you want the link, press `Ctrl+Shift+K` (`⌘+Shift+K` on macOS), pick the note you want, and Notesnook inserts a link to it. The link works in both directions: the note you linked to lists your note under `{{referencedIn}}`, so you never have to maintain a back-link by hand.
 
-Note links are internal links. They use the `nn://` scheme instead of `http://`, they never leave your device unencrypted, and they keep working after you rename or move a note because they point at the note's ID, not its title.
+Note links are internal links. They use the `nn://` scheme instead of `http://`, they never leave your device unencrypted, and they keep working after you rename or move a note because they point at the note's internal ID, not its title.
 
 ## Link a note to another note
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Open the note and place the cursor where the link should go. Selecting some text first turns that text into the link.
 2. Press `Ctrl+Shift+K`, or click `{{noteLink}}` in the editor toolbar — it sits next to `{{link}}`.
 3. In the `{{newInternalLink}}` dialog, use the `{{searchNoteToLinkPlaceholder}}` box to find the note.
 4. Click the note to select it.
 5. Click `{{insertLink}}`.
+
 == Mobile
+
 1. Open the note and place the cursor where the link should go.
 2. Tap `{{noteLink}}` in the editor toolbar.
 3. Use the `{{searchNoteToLinkPlaceholder}}` box to find the note.
 4. Tap the note to select it.
 5. Tap `{{createLink}}`.
-:::
+   :::
 
 The link appears as the note's title (or as the text you had selected). Tapping or clicking it opens that note.
 
@@ -43,6 +46,7 @@ Block-level note links are part of the [Essential plan and above](/plans-and-lim
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Press `Ctrl+Shift+K` and select the note, as above.
 2. The dialog now lists every block in that note, each tagged with its block type.
 3. Use the search box to narrow the list. Type `#` first to search headings only — the placeholder reads `Type # to search for headings`.
@@ -50,6 +54,7 @@ Block-level note links are part of the [Essential plan and above](/plans-and-lim
 
 To pick a different note, click the `{{linkNoteSelectedNote}}` button at the top of the dialog to deselect it.
 == Mobile
+
 1. Tap `{{noteLink}}` and select the note, as above.
 2. Under `{{linkNoteToSection}}` the sheet lists every block in that note, each tagged with its block type.
 3. Use the search box to narrow the list. Type `#` first to search headings only.
@@ -68,22 +73,25 @@ A note in your [private vault](/lock-notes-with-private-vault) can be linked to 
 
 Every note keeps two lists:
 
-- **`{{linkedNotes}}`** — notes that this note links *out* to.
-- **`{{referencedIn}}`** — notes that link *in* to this note. These are your backlinks, and they're built automatically.
+- **`{{linkedNotes}}`** — notes that this note links _out_ to.
+- **`{{referencedIn}}`** — notes that link _in_ to this note. These are your backlinks, and they're built automatically.
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Open the note.
 2. Click `{{properties}}` in the action bar at the top right of the editor.
 3. At the top of the panel, switch between the two lists with the two icon buttons. The count and the current list name are shown on the right.
 4. Click any note in the list to open it.
 5. Click the arrow next to an entry to expand it — under `{{linkedNotes}}` you get the exact blocks you linked to, and under `{{referencedIn}}` you get each sentence containing the link, with the link text highlighted. Click one to open the note scrolled to that spot.
+
 == Mobile
+
 1. Press the ![Three dot button](/three-dot-button.png) button on a note.
 2. Press `{{references}}`.
 3. Switch between the `{{linkedNotes}}` and `{{referencedIn}}` tabs.
 4. Tap an entry to open the note, or expand it to see the individual blocks and jump straight to them.
-:::
+   :::
 
 When a note has nothing to show you'll see `{{notLinked}}` or `{{notReferenced}}`
 
@@ -95,11 +103,13 @@ Every note has a permanent internal link of the form `nn://note/<note id>`. A bl
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Right click on a note to open the `Note properties` menu.
 2. Click `{{copyLink}}`.
 
 A `{{linkCopied}}` toast confirms it. The link is copied as plain text, as HTML and as Markdown, so pasting into another note produces a ready-made link.
 == Mobile
+
 1. Press the ![Three dot button](/three-dot-button.png) button on a note.
 2. Press `{{copyLink}}`.
 
@@ -109,7 +119,7 @@ A `{{linkCopied}}` toast shows the copied link.
 Notebooks, tags and colors have internal links too — `nn://notebook/<id>`, `nn://tag/<id>` and `nn://color/<id>` — copied the same way from their own menus.
 
 ::: tip Opening links from outside the app
-Internal links only resolve inside Notesnook. A `nn://` link pasted into a browser or another app won't open anything. To share a note with someone who doesn't use Notesnook, [publish it as a monograph](/publish-notes-with-monographs) instead.
+Internal links only resolve inside Notesnook. A `nn://` link pasted into a browser or another app will open the Notesnook app. To share a note with someone who doesn't use Notesnook, [publish it as a monograph](/publish-notes-with-monographs) instead.
 :::
 
 ## Related pages

--- a/docs/help/contents/notes/note-actions.md
+++ b/docs/help/contents/notes/note-actions.md
@@ -18,10 +18,13 @@ Every note has a menu of actions on it. Right click a note on desktop or web, or
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Right click on a note in the list to open the `Note properties` menu.
 
 Some of the same switches also live in the editor: open a note, then click `{{properties}}` in the action bar at the top right.
+
 == Mobile
+
 1. Press the ![Three dot button](/three-dot-button.png) button on a note.
 
 The sheet that opens holds every action for that note.
@@ -33,8 +36,10 @@ The sheet that opens holds every action for that note.
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Right click on the note.
 2. Click `{{openInNewTab}}`.
+
 == Mobile
 There is no `{{openInNewTab}}` action on mobile.
 :::
@@ -45,11 +50,13 @@ There is no `{{openInNewTab}}` action on mobile.
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Right click on the note, or select several notes and right click.
 2. Open `{{notebooks}}`.
 3. Click `{{unlinkFromAll}}`.
 
 The action only appears when at least one of the selected notes is already in a notebook.
+
 == Mobile
 There is no bulk unlink action on mobile. Press the ![Three dot button](/three-dot-button.png) button, press `{{addToNotebook}}`, and unselect the notebooks one by one.
 :::
@@ -60,11 +67,13 @@ There is no bulk unlink action on mobile. Press the ![Three dot button](/three-d
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Right click on the note, or select several notes and right click.
 2. Open `Tags`.
 3. Click `{{removeFromAll}}`.
 
 The action only appears when at least one of the selected notes already has a tag.
+
 == Mobile
 There is no bulk remove action on mobile. Press the ![Three dot button](/three-dot-button.png) button, press `{{addTags}}`, and remove the tags one by one.
 :::
@@ -75,14 +84,17 @@ There is no bulk remove action on mobile. Press the ![Three dot button](/three-d
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Right click on the note.
 2. Click `{{readOnly}}`.
 
 The editor's `{{properties}}` panel has the same `{{readOnly}}` switch, and it applies to any note tab that is already open.
+
 == Mobile
+
 1. Press the ![Three dot button](/three-dot-button.png) button on the note.
 2. Press `{{readOnly}}`.
-:::
+   :::
 
 A read-only note shows a small pencil-lock icon in the notes list.
 
@@ -92,11 +104,14 @@ A read-only note shows a small pencil-lock icon in the notes list.
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Right click on the note.
 2. Click `{{duplicate}}`.
 
 `{{duplicate}}` also works on a multiple selection: select several notes first and every one of them is copied.
+
 == Mobile
+
 1. Press the ![Three dot button](/three-dot-button.png) button on the note.
 2. Press `{{duplicate}}`.
 
@@ -109,27 +124,33 @@ A `{{noteDuplicated}}` toast confirms it.
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Right click on the note.
 2. Click `{{copyLink}}`.
+
 == Mobile
+
 1. Press the ![Three dot button](/three-dot-button.png) button on the note.
 2. Press `{{copyLink}}`.
-:::
+   :::
 
 Either way a `{{linkCopied}}` toast confirms it.
 
 ## Copy a note as text or Markdown
 
-This copies the note's *content* to the clipboard, not a link to it — for pasting into an email, a chat, or another app.
+This copies the note's _content_ to the clipboard, not a link to it — for pasting into an email, a chat, or another app.
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Right click on the note.
 2. Open `{{copyAs}}`.
 3. Choose `Text` for plain text, or `Markdown` to keep headings, lists, bold and links as Markdown syntax.
 
 A `{{noteCopied}}` toast confirms it.
+
 == Mobile
+
 1. Press the ![Three dot button](/three-dot-button.png) button on the note.
 2. Press `{{copy}}`.
 
@@ -142,10 +163,12 @@ If the note is in your [private vault](/lock-notes-with-private-vault) you'll be
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Right click on the note.
 2. Click `{{print}}`.
 
 The note is rendered as a PDF and handed to your system print dialog, so you can send it to a printer or save it as a PDF file.
+
 == Mobile
 There is no print action on mobile. Press the ![Three dot button](/three-dot-button.png) button, press `{{export}}`, choose `PDF`, and print or share the resulting file from there.
 :::
@@ -156,6 +179,7 @@ Useful after an import, when notes arrive stamped with the day you imported them
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Open the note.
 2. Click `{{properties}}` in the action bar at the top right.
 3. Next to `{{createdAt}}`, click the pencil icon.
@@ -163,8 +187,9 @@ Useful after an import, when notes arrive stamped with the day you imported them
 5. Click `{{save}}`.
 
 The creation date cannot be later than the note's last edited date. If you pick a later one, Notesnook refuses with `{{creationDateCannotBeAfterLastEditedDate}}`.
+
 == Mobile
-Editing a note's creation date is not available on mobile. Do it on the desktop app or on web — the change syncs to your phone.
+Editing a note's creation date is not available on mobile. Do it on the desktop app or on web, the change will sync to your phone.
 :::
 
 ## Keep a note off sync
@@ -177,12 +202,15 @@ Turning `{{syncOff}}` on for a note deletes it from every other device you're si
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Right click on the note.
 2. Click `{{syncOff}}`.
 3. Confirm `Prevent note from syncing` with `{{yes}}`.
 
-Turning it back off syncs the note again from that device. The editor `{{properties}}` panel carries the same switch, labelled `{{disableSync}}`. The action only appears when you're logged in.
+Turning it off syncs the note again from that device. The editor `{{properties}}` panel carries the same switch, labelled `{{disableSync}}`. The action only appears when you're logged in.
+
 == Mobile
+
 1. Press the ![Three dot button](/three-dot-button.png) button on the note.
 2. Press `{{syncOff}}`.
 
@@ -197,14 +225,17 @@ A local-only note shows a crossed-out sync icon in the notes list.
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Open the note.
 2. Click `{{properties}}` in the action bar at the top right.
 3. Switch between `{{linkedNotes}}` and `{{referencedIn}}` at the top of the panel.
+
 == Mobile
+
 1. Press the ![Three dot button](/three-dot-button.png) button on the note.
 2. Press `{{references}}`.
 3. Switch between the `{{linkedNotes}}` and `{{referencedIn}}` tabs.
-:::
+   :::
 
 See [note links](/note-links-and-backlinks) for what these lists contain and how to jump to an individual paragraph.
 

--- a/docs/help/contents/notesnook-wrapped.md
+++ b/docs/help/contents/notesnook-wrapped.md
@@ -45,7 +45,7 @@ On mobile, the summary card has a `Share with friends` button. It captures the c
 On desktop and web there is no share button — the summary card is on screen for you to screenshot.
 
 ::: info It really is local
-The summary card itself says so: *Generated 100% locally on your device.* Wrapped reads your local database directly. It needs no account, no internet connection, and no telemetry.
+Notesnook simply couldn't do it otherwise. Notesnook has no idea how many words are in your notes, encryption makes it impossible for us to do it any other way.
 :::
 
 ## Related pages

--- a/docs/help/contents/plans-and-limits.md
+++ b/docs/help/contents/plans-and-limits.md
@@ -26,7 +26,7 @@ faqs:
 
 Notesnook has four plans — **Free**, **Essential**, **Pro** and **Believer** — plus an **Education** plan and a grandfathered **Pro (legacy)** plan for long-time subscribers.
 
-Everything that makes Notesnook *Notesnook* is on the free plan: unlimited notes, unlimited devices, end-to-end encryption, sync, backups, the [private vault](/lock-notes-with-private-vault), and [publishing with monographs](/publish-notes-with-monographs). Paid plans raise the storage limits and unlock conveniences on top.
+Everything that makes Notesnook _Notesnook_ is on the free plan: unlimited notes, unlimited devices, end-to-end encryption, sync, backups, the [private vault](/lock-notes-with-private-vault), and [publishing with monographs](/publish-notes-with-monographs). Paid plans raise the storage limits and unlock conveniences on top.
 
 ::: tip Plans are cumulative
 Each plan includes everything from the plans below it. A feature marked <PlanTag plan="essential" /> works on Essential, Pro **and** Believer. A feature marked <PlanTag plan="pro" /> works on Pro **and** Believer.
@@ -34,24 +34,22 @@ Each plan includes everything from the plans below it. A feature marked <PlanTag
 
 ## What each plan gives you
 
-| | Free | Essential | Pro | Believer |
-| --- | --- | --- | --- | --- |
-| Notes | Unlimited | Unlimited | Unlimited | Unlimited |
-| Devices | Unlimited | Unlimited | Unlimited | Unlimited |
-| Storage per month | 50 MB | 1 GB | 10 GB | 25 GB |
-| Maximum file size | 10 MB | 100 MB | 1 GB | 5 GB |
-| Notebooks | 50 | 500 | Unlimited | Unlimited |
-| Tags | 50 | 500 | Unlimited | Unlimited |
-| Colors | 7 | 20 | Unlimited | Unlimited |
-| Active reminders | 10 | 50 | Unlimited | Unlimited |
-| Side menu shortcuts | 10 | Unlimited | Unlimited | Unlimited |
-| Note versions kept | 100 | 1,000 | Unlimited | Unlimited |
+|                     | Free      | Essential | Pro       | Believer  |
+| ------------------- | --------- | --------- | --------- | --------- |
+| Notes               | Unlimited | Unlimited | Unlimited | Unlimited |
+| Devices             | Unlimited | Unlimited | Unlimited | Unlimited |
+| Storage per month   | 50 MB     | 1 GB      | 10 GB     | 25 GB     |
+| Maximum file size   | 10 MB     | 100 MB    | 1 GB      | 5 GB      |
+| Notebooks           | 50        | 500       | Unlimited | Unlimited |
+| Tags                | 50        | 500       | Unlimited | Unlimited |
+| Colors              | 7         | 20        | Unlimited | Unlimited |
+| Active reminders    | 10        | 50        | Unlimited | Unlimited |
+| Side menu shortcuts | 10        | Unlimited | Unlimited | Unlimited |
+| Note versions kept  | 100       | 1,000     | Unlimited | Unlimited |
 
-Storage counts **attachments only** — images, files, audio and web clips. Your notes themselves never count against it, however many you write.
+Storage counts **attachments only**, meaning images, files, audio and web clips. Your notes themselves never count against it, however many you write.
 
 ## Features unlocked by Essential
-
-These work on Essential, Pro and Believer.
 
 - [Task lists](/rich-text-editor/task-and-todo-lists) — checkable, sortable to-do blocks inside a note
 - [Outline lists](/rich-text-editor/outline-lists) — collapsible nested bullets
@@ -66,20 +64,18 @@ These work on Essential, Pro and Believer.
 
 ## Features unlocked by Pro
 
-These work on Pro and Believer.
-
 - [App lock](/app-lock) — lock the whole app with a PIN, password, biometrics or a security key
 - [Expiring notes](/notes/note-expiry) — have a note delete itself on a date you choose
-- [Default notebook and tag](/organizing-notes/organize-notes-using-notebooks) — send every new note somewhere automatically
+- [Set a default notebook and tag](/organizing-notes/organize-notes-using-notebooks) — send every new note somewhere automatically
 - [Custom home screen](/customizing-notesnook) and default sidebar tab
 - [Full-quality images](/attachments-and-files) — upload without compression
 - [Sync controls](/sync/sync-settings) — turn off automatic, realtime or all syncing
 - [Import and export tables as CSV](/rich-text-editor/tables)
 - [Monograph view counts](/publish-notes-with-monographs)
 - [Two-factor authentication by SMS](/two-factor-authentication)
-- Keep trash forever — disable [automatic trash cleanup](/trash)
+- Disable [automatic trash cleanup](/trash)
 - Font ligatures in the editor
-- Saving a custom [editor toolbar](/rich-text-editor/rich-text-editor-toolbar) layout
+- Save a custom [editor toolbar](/rich-text-editor/rich-text-editor-toolbar) layout
 - On Android: [pin a note to your notifications](/mobile-integration/pin-notes-to-notifications), [write notes from the notification drawer](/mobile-integration/quick-note-from-notification), and pin notes to your launcher
 
 ## Believer
@@ -88,7 +84,7 @@ Believer includes everything above and exists for people who want to fund privat
 
 ## Education plan
 
-The Education plan gives students and teachers **Pro features and Pro limits**. It is not sold from the plan grid — [contact us](https://notesnook.com/contact-us) to apply. Education plans do not include a free trial.
+The Education plan gives students and teachers **Pro features and Pro limits**. It is not sold from the plan grid. [Contact us](https://notesnook.com/education) to apply. Education plans do not include a trial.
 
 ## Pro (legacy)
 
@@ -96,7 +92,7 @@ If you subscribed before the current plans existed, you keep a grandfathered **P
 
 ## Regional pricing
 
-Notesnook is priced for where you live. In many countries the paid plans are sold at a regional discount, applied automatically — there is no code to enter.
+Notesnook Pro is priced for where you live. In many countries the paid plans are sold at a regional discount, and it's applied automatically.
 
 When a regional price applies, the plan shows the standard price struck through next to a badge reading **“N% off in {your country}”**, and you are charged the discounted amount in your local currency. On Android and iOS the same regional tiers are used through Google Play and the App Store.
 
@@ -105,10 +101,10 @@ If you think your country should be included, [tell us](https://notesnook.com/co
 ## Free trials
 
 | Billing period | Free trial | Refund window |
-| --- | --- | --- |
-| Monthly | 7 days | 7 days |
-| Yearly | 14 days | 14 days |
-| 5 year | 30 days | 30 days |
+| -------------- | ---------- | ------------- |
+| Monthly        | 14 days    | 14 days       |
+| Yearly         | 14 days    | 14 days       |
+| 5 year         | 14 days    | 14 days       |
 
 You can trial **each plan once**. Trials give you the full plan, so a feature you unlock during a trial stops working when the trial ends unless you subscribe. The Education plan has no trial.
 
@@ -116,6 +112,7 @@ You can trial **each plan once**. Trials give you the full plan, so a feature yo
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Go to `{{settings}}`.
 2. Open `{{subDetails}}`.
 3. Choose `{{changePlan}}` to move up or down a tier — the difference is prorated — or turn off `Auto renew` to stop the subscription at the end of the period.
@@ -127,7 +124,7 @@ Subscriptions bought on mobile are managed by the store that sold them.
 1. Go to `{{settings}}`.
 2. Open `{{account}}`.
 3. Tap your subscription. If it was bought on the store you are using, this opens Google Play or App Store subscription management; otherwise Notesnook tells you where the subscription was bought so you can manage it there.
-:::
+   :::
 
 Refunds are self-service inside the app on subscriptions bought through Notesnook's own checkout, within the window listed above.
 
@@ -137,7 +134,7 @@ Refunds are self-service inside the app on subscriptions bought through Notesnoo
 
 You go back to free-plan limits, which means:
 
-- you can't create *new* items above the free caps, but everything you already have stays;
+- you can't create _new_ items above the free caps, but everything you already have stays;
 - paid-only settings are switched off — app lock is disabled, a custom home screen resets to the default, and a custom toolbar layout returns to the standard one;
 - attachments you already uploaded stay downloadable, even if you're over the free storage limit.
 

--- a/docs/help/contents/plans-and-limits.md
+++ b/docs/help/contents/plans-and-limits.md
@@ -84,7 +84,7 @@ Believer includes everything above and exists for people who want to fund privat
 
 ## Education plan
 
-The Education plan gives students and teachers **Pro features and Pro limits**. It is not sold from the plan grid. [Contact us](https://notesnook.com/education) to apply. Education plans do not include a trial.
+The Education plan gives students and teachers **Pro features and Pro limits**. It is not sold from the plan grid. You can [apply for the discount here](https://notesnook.com/education). Education plans do not include a trial.
 
 ## Pro (legacy)
 

--- a/docs/help/contents/privacy-mode.md
+++ b/docs/help/contents/privacy-mode.md
@@ -12,7 +12,7 @@ keywords:
 
 Privacy mode stops other software from seeing what's on your screen while Notesnook is open — screenshots, screen recorders and remote-desktop tools get a blank window instead of your notes.
 
-::: info Not available on Linux
+::: warning Not available on Linux
 Privacy mode is not available on Linux.
 :::
 
@@ -23,15 +23,18 @@ Privacy mode enables some OS specific settings to enhance your privacy while wor
 
 :::tabs key:platform
 == Desktop
+
 1. Go to `{{settings}}`
 2. Scroll down to `{{securityPrivacy}}` section
 3. Click on `{{privacy}}`
 4. Click on toggle next to `{{privacyMode}}` to enable/disable privacy mode.
+
 == Mobile
+
 1. Go to `{{settings}}`
 2. Scroll down to `{{privacyAndSecurity}}`
 3. Tap on `{{privacyMode}}` to enable/disable it
-:::
+   :::
 
 ::: info
 Privacy mode will prevent all screen capturing software from capturing Notesnook. This includes softwares like TeamViewer, AnyDesk & RustDesk etc.
@@ -45,9 +48,11 @@ Separately from privacy mode, the desktop and web apps can keep the open note's 
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Go to `{{settings}}`.
 2. Open `{{privacyAndSecurity}}` > `{{privacy}}`.
 3. Turn on `{{hideNoteTitle}}`.
+
 == Mobile
 Mobile hides note content from the app switcher as part of privacy mode above; there is no separate title setting.
 :::

--- a/docs/help/contents/publish-notes-with-monographs.md
+++ b/docs/help/contents/publish-notes-with-monographs.md
@@ -16,27 +16,34 @@ Sharing a note with someone can be such a tedious task. You have to copy/downloa
 With Notesnook, you don't need to do that anymore. Monographs enable you to share your notes with anyone in a single click. Once a note is published as a monograph, you get a public URL which you can share with anyone. They don't need to download Notesnook or install any extra software — it's just like a blog, only simpler.
 
 ::: warning Size limit
-Currently, monographs are limited to 15 MB in size. This includes attachments as well. If you try to publish a note larger than 15 MB, you'll get an error.
+Currently, monographs are limited to 15 MB in size. This also includes attachments, like images. If you try to publish a note larger than 15 MB, you'll get an error.
 :::
 
 ## How to publish a note?
 
+::: warning A monograph is a public URL
+Anyone with the link can open a monograph unless you set a password. Notesnook cannot tell who has opened it, and an unprotected monograph can be indexed if the link is posted publicly. Use password protection for anything sensitive, and unpublish when you are done.
+:::
+
 :::tabs key:platform
 == Desktop/Web
+
 1. Right click on a note
 2. Click on `{{publish}}` from Note properties to open publish note dialog.
 3. Click on `{{publish}}` button to publish note.
 4. Copy the URL and send it to respective person.
+
 == Mobile
+
 1. Tap on ![Three dot button](/three-dot-button.png) button on a note.
 2. Tap on `{{publish}}` to open Publish note sheet
 3. Tap on `{{publish}}` button to publish note.
 4. Copy the URL and send it to respective person.
-:::
+   :::
 
 ## Password protection
 
-When you are sharing sensitive information with someone, you can encrypt the monograph with a password. Only someone who has the password can decrypt and read the contents of the note. While you are on the Publish note dialog, turn on password protection and enter a password for the monograph. Then click publish to publish the note.
+When you are sharing sensitive information with someone, you can encrypt the monograph with a password. Only someone who has the password can decrypt and read the contents of the note. While you are on the Publish note dialog, enter a password for the monograph. Then click publish to publish the note.
 
 ## Self destruct
 
@@ -46,16 +53,23 @@ Self destruct means that the published note can be viewed only once. Once someon
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Right click on a note
 2. Click on `{{publish}}` to open publish note popup
 3. Click on `{{unpublish}}` button to unpublish note
+
 == Mobile
+
 1. Tap on ![Three dot button](/three-dot-button.png) button on a published note
 2. Tap on `{{publish}}` to open Publish note sheet
 3. Tap on `{{unpublish}}` button to unpublish note
-:::
+   :::
 
 ## Once a note is published
+
+:::warning
+**Published notes cannot be deleted while published.**
+:::
 
 Opening `{{publish}}` on a note that is already published gives you the full set of actions rather than a single toggle:
 
@@ -73,15 +87,6 @@ The publish view shows how many times a monograph has been opened. View counts a
 ## Links and embeds in a published note <PlanTag plan="essential" />
 
 Links and embedded content inside a note are preserved in the published monograph on the [Essential plan and above](/plans-and-limits).
-
-## What cannot be published
-
-- **Locked notes.** A note in the [private vault](/lock-notes-with-private-vault) cannot be published — unlock it first if you want to share it.
-- A **published note cannot be moved to trash**. Unpublish it first, then delete it.
-
-::: warning A monograph is a public URL
-Anyone with the link can open a monograph unless you set a password. Notesnook cannot tell who has opened it, and an unprotected monograph can be indexed if the link is posted publicly. Use password protection for anything sensitive, and unpublish when you are done.
-:::
 
 ## Related pages
 

--- a/docs/help/contents/recovering-your-account.md
+++ b/docs/help/contents/recovering-your-account.md
@@ -37,9 +37,12 @@ The recent versions of Notesnook have updated the login flow. It is now **mandat
 7. If everything goes well, you should receive an email from Notesnook in your inbox:
 
 ![Recovery email in Notesnook](/static/account-recovery/recovery_email.png)
+
 ::: info What if I didn't receive an email?
 _Check your spam/junk folder if you haven't received one & [contact us](mailto:support@streetwriters.co) if you still don't find it._
-::: 8. Click on `Reset your password` button in the email. This will take you to the account recovery page.
+:::
+
+8. Click on `Reset your password` button in the email. This will take you to the account recovery page.
 
 <!--Needs Validation? I don't think you can request recovery from mobile--->
 

--- a/docs/help/contents/recovering-your-account.md
+++ b/docs/help/contents/recovering-your-account.md
@@ -7,7 +7,7 @@ description: Forgot your Notesnook password? Recover your account with your data
 
 Notesnook is one of the few end-to-end encrypted software that allows users to recover their account in case they forget their passwords. Here is a detailed step-by-step guide into how you can recover your Notesnook account.
 
-::: warning You will be logged out
+::: danger You will be logged out
 For account recovery to work reliably, you will be force logged out from all your other devices. It is recommended that you save & backup all your data on your other devices before continuing.
 :::
 
@@ -26,16 +26,20 @@ The recent versions of Notesnook have updated the login flow. It is now **mandat
 2. Enter your email & continue
 3. Verify your 2FA & continue
 4. On the next page, click on `{{forgotPassword}}`
-   ![Step in Notesnook](/static/account-recovery/step-1.png)
+
+![Step in Notesnook](/static/account-recovery/step-1.png)
+
 5. On the next page, your email should be prefilled. If it isn't, fill it out.
-   ![Step in Notesnook](/static/account-recovery/step-2.png)
+
+![Step in Notesnook](/static/account-recovery/step-2.png)
+
 6. Click on `{{sendRecoveryEmail}}`
 7. If everything goes well, you should receive an email from Notesnook in your inbox:
-   ![Recovery email in Notesnook](/static/account-recovery/recovery_email.png)
-   ::: info What if I didn't receive an email?
-   _Check your spam/junk folder if you haven't received one & [contact us](mailto:support@streetwriters.co) if you still don't find it._
-   :::
-8. Click on `Reset your password` button in the email. This will take you to the account recovery page.
+
+![Recovery email in Notesnook](/static/account-recovery/recovery_email.png)
+::: info What if I didn't receive an email?
+_Check your spam/junk folder if you haven't received one & [contact us](mailto:support@streetwriters.co) if you still don't find it._
+::: 8. Click on `Reset your password` button in the email. This will take you to the account recovery page.
 
 <!--Needs Validation? I don't think you can request recovery from mobile--->
 

--- a/docs/help/contents/recovering-your-account.md
+++ b/docs/help/contents/recovering-your-account.md
@@ -5,7 +5,7 @@ description: Forgot your Notesnook password? Recover your account with your data
 
 # Recovering your account
 
-Notesnook is one of the few end-to-end encrypted software that allows users to recovery their account in case they forget their passwords. Here is a detailed step-by-step guide into how you can recover your Notesnook account.
+Notesnook is one of the few end-to-end encrypted software that allows users to recover their account in case they forget their passwords. Here is a detailed step-by-step guide into how you can recover your Notesnook account.
 
 ::: warning You will be logged out
 For account recovery to work reliably, you will be force logged out from all your other devices. It is recommended that you save & backup all your data on your other devices before continuing.
@@ -21,6 +21,7 @@ The recent versions of Notesnook have updated the login flow. It is now **mandat
 
 ::::tabs key:platform
 == Desktop/Web
+
 1. Go to [Notesnook Login page](https://app.notesnook.com/login)
 2. Enter your email & continue
 3. Verify your 2FA & continue
@@ -35,10 +36,14 @@ The recent versions of Notesnook have updated the login flow. It is now **mandat
    _Check your spam/junk folder if you haven't received one & [contact us](mailto:support@streetwriters.co) if you still don't find it._
    :::
 8. Click on `Reset your password` button in the email. This will take you to the account recovery page.
+
+<!--Needs Validation? I don't think you can request recovery from mobile--->
+
 == Mobile
+
 1. Open the Notesnook app
 2. Go to the Login page
-::::
+   ::::
 
 ## Choosing an account recovery method
 

--- a/docs/help/contents/reminders.md
+++ b/docs/help/contents/reminders.md
@@ -13,6 +13,7 @@ Free accounts can have up to 10 active reminders at a time. Essential raises the
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Right click on a note to open the `Note properties` menu
 2. Click on `{{remindMe}}` to open the add reminder dialog
 3. Enter a title for the reminder and description (optional)
@@ -21,7 +22,9 @@ Free accounts can have up to 10 active reminders at a time. Essential raises the
    - **Repeat** (paid plans only): Create a recurring reminder (daily, weekly, monthly, or yearly)
 5. Select your notification preference (Silent, Vibrate, or Urgent)
 6. Click `{{add}}` to save the reminder
+
 == Mobile
+
 1. Press the ![Three dot button](/three-dot-button.png) button on a note
 2. Tap `{{remindMe}}` to open the add reminder dialog
 3. Enter a title for the reminder and description (optional)
@@ -31,7 +34,7 @@ Free accounts can have up to 10 active reminders at a time. Essential raises the
    - **Permanent** _(Android only)_: A persistent reminder that shows up every day
 5. Select your notification preference (Silent, Vibrate, or Urgent)
 6. Tap the checkmark button on top right to save the reminder
-:::
+   :::
 
 ## Creating a standalone reminder
 
@@ -39,20 +42,23 @@ You can also create reminders without attaching them to a specific note. This is
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Go to the `{{reminders}}` screen from the side menu
 2. Click the add reminder button (![Plus icon](/plus-reminder-icon.png)) on top right
 3. Enter a title for the reminder and description (optional)
 4. Choose your reminder type (Once or Repeat)
 5. Select your notification preference (Silent, Vibrate, or Urgent)
 6. Click `{{add}}` to save the reminder
+
 == Mobile
+
 1. Go to the `{{reminders}}` screen from the side menu
 2. Tap the add reminder button (![Plus icon](/plus-button-mobile.png)) on bottom right
 3. Enter a title for the reminder and description (optional)
 4. Choose your reminder type (Once, Repeat, or Permanent on Android)
 5. Select your notification preference (Silent, Vibrate, or Urgent)
 6. Tap the checkmark button on top right to save the reminder
-:::
+   :::
 
 ## Configuring recurring reminders <PlanTag plan="essential" />
 
@@ -67,8 +73,6 @@ When you select **Repeat** mode, you can customize how often you want to be remi
 - **Monthly**: Pick specific dates of the month
 - **Yearly**: Choose the month and day for your yearly reminder
 
----
-
 ## Notification preferences
 
 Choose how you want to be notified:
@@ -80,8 +84,6 @@ Choose how you want to be notified:
 ::: info
 Reminders require notification permissions. You'll be asked to enable notifications when you create your first reminder.
 :::
-
----
 
 ## Editing or viewing reminders
 
@@ -95,14 +97,17 @@ Deactivating a reminder stops it from notifying you without deleting it, so you 
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Go to the `{{reminders}}` screen from the side menu.
 2. Right click on the reminder.
 3. Click `{{deactivate}}` to switch it off, or `{{activate}}` to switch it back on.
+
 == Mobile
+
 1. Go to the `{{reminders}}` screen from the side menu.
 2. Press the ![Three dot button](/three-dot-button.png) button on the reminder.
 3. Tap `{{turnOffReminder}}` to switch it off, or `{{turnOnReminder}}` to switch it back on.
-:::
+   :::
 
 ## Snooze a reminder
 
@@ -110,11 +115,13 @@ When a reminder fires you can push it back instead of dismissing it.
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Click the reminder notification. The reminder preview opens.
 2. Under `{{remindMeIn}}`, click `5 minutes`, `10 minutes`, `15 minutes` or `1 hour`.
 
 The reminder fires again after the interval you picked.
 == Mobile
+
 1. Expand the reminder notification in your notification shade.
 2. Tap the snooze action on it — `Remind in 5 min` on Android, `Remind me in 5 min` on iOS. Both labels show your default snooze time.
 
@@ -135,9 +142,7 @@ The default is `5` minutes. This is the interval the snooze button on a reminder
 
 On Android 8 and above this opens the system notification channel settings for Notesnook's urgent reminder channel, where the sound is set. On older Android versions you pick the sound from a list inside the app. There is no sound setting on iOS.
 
----
-
-## Permanent reminders (Android only)
+## Permanent reminders <PlanTag plan="essential" note="Android only"/>
 
 **Permanent reminders** are available only on Android devices. Unlike one-time or recurring reminders, permanent reminders persist every day and won't disappear after triggering. This is useful for important daily tasks or notes you want constant access to.
 

--- a/docs/help/contents/rich-text-editor/code-blocks.md
+++ b/docs/help/contents/rich-text-editor/code-blocks.md
@@ -17,43 +17,49 @@ A code block keeps code as code: monospaced, syntax highlighted, indentation pre
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Place the cursor on an empty line.
 2. Click the `+` (Insert) button in the toolbar.
 3. Choose `Code block`.
 
 You can also press `Ctrl+Shift+C` (`⌘+Shift+C` on macOS). If you press it with text selected, the selected text becomes the code block's contents, line breaks and all. Pressing it again while the cursor is inside a code block turns the block back into normal paragraphs.
+
 == Mobile
+
 1. Place the cursor on an empty line.
 2. Tap the `+` (Insert) button in the bottom toolbar.
 3. Choose `Code block` from the `Choose a block to insert` sheet.
-:::
+   :::
 
 ![The insert block menu in the Notesnook editor, with Code block listed alongside Task list, Outline list, Math & formulas and Callout](/screenshots/editor-insert-block-menu.png)
 
-### Type ` ``` ` instead
+### Type ` ``` ` instead <PlanTag plan="essential"/>
 
-On an empty line, type three backticks followed by a space or Enter — ` ``` ` — and the line becomes a code block. Add a language name straight after the backticks to set the language at the same time: ` ```javascript `. The name has to be plain lowercase letters, so ` ```c++ ` and ` ```objective-c ` won't trigger it — pick those from the language menu instead. Three tildes (` ~~~ `) work the same way.
+On an empty line, type three backticks followed by a space or Enter — ` ``` ` — and the line becomes a code block. Add a language name straight after the backticks to set the language at the same time: ` ```javascript `. The name has to be plain lowercase letters, so ` ```c++ ` and ` ```objective-c ` won't trigger it — pick those from the language menu instead. Three tildes (`~~~`) work the same way.
 
-::: info Markdown shortcuts need Essential
-Typing ` ``` ` relies on [Markdown shortcuts](/rich-text-editor/markdown-notes-editing), which are part of the [Essential plan and above](/plans-and-limits). They are **off by default on web and desktop** — turn on `{{mardownShortcuts}}` in `{{settings}}` → `{{customization}}` → `{{editor}}` first. On mobile they are on by default. The toolbar button and `Ctrl+Shift+C` work on every plan.
+::: info Markdown shortcuts need to be enabled.
+Typing ` ``` ` relies on [Markdown shortcuts.](/rich-text-editor/markdown-notes-editing) They are **off by default on web and desktop** — turn on `{{mardownShortcuts}}` in `{{settings}}` → `{{customization}}` → `{{editor}}` first. On mobile they are on by default. The toolbar button and `Ctrl+Shift+C` work on every plan.
 :::
 
 ## Choose the language
 
 ![A code block in the Notesnook editor showing the footer bar with the caret position, indentation mode, language and copy button](/screenshots/editor-code-block.png)
 
-Every code block has a language button in the bar along its bottom edge showing the current language — `Plaintext` until you change it.
+Every code block has a language button in the bar along its bottom edge showing the current language. The default is `Plaintext` until you change the language once.
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Click the language name at the bottom of the code block.
 2. Type in the `{{searchLanguages}}` box to filter the list — it matches both language names and their aliases (searching `js` finds JavaScript).
 3. Click the language you want, or press `Enter` to take the first result.
+
 == Mobile
+
 1. Tap the language name at the bottom of the code block.
 2. In the `{{selectLanguage}}` sheet, type in `{{searchLanguages}}` to filter the list.
 3. Tap the language you want.
-:::
+   :::
 
 There are **297 languages** to choose from, each highlighted with its own grammar.
 

--- a/docs/help/contents/rich-text-editor/editor-tabs-and-panes.md
+++ b/docs/help/contents/rich-text-editor/editor-tabs-and-panes.md
@@ -19,6 +19,7 @@ The Notesnook editor keeps every note you open in a tab, so you can jump between
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Right-click a note in the list and choose `{{openInNewTab}}`. Middle-clicking the note does the same thing.
 2. Or click the `{{newTab}}` button in the editor's top bar to open an empty tab, then start writing.
 
@@ -26,16 +27,17 @@ You can also drag a note from the list onto the tab strip to open it in a new ta
 
 In the desktop app there are keyboard shortcuts for all of this:
 
-| Action | Shortcut |
-| --- | --- |
-| New tab | `Ctrl+T` |
-| Close the active tab | `Ctrl+W` |
-| Close all tabs | `Ctrl+Shift+W` |
-| Next tab | `Ctrl+Tab` |
-| Previous tab | `Ctrl+Shift+Tab` |
+| Action               | Shortcut         |
+| -------------------- | ---------------- |
+| New tab              | `Ctrl+T`         |
+| Close the active tab | `Ctrl+W`         |
+| Close all tabs       | `Ctrl+Shift+W`   |
+| Next tab             | `Ctrl+Tab`       |
+| Previous tab         | `Ctrl+Shift+Tab` |
 
 In the web app the browser owns most of those combinations, so only tab switching is bound: `Ctrl+Alt+→` for the next tab and `Ctrl+Alt+←` for the previous one. On macOS use `Command` wherever the table says `Ctrl`.
 == Mobile
+
 1. Open a note. It takes over the current tab.
 2. To keep it and start another note, tap the **number badge** in the editor header — it shows how many tabs are open — and then tap `+` in the `Tabs` sheet.
 
@@ -121,7 +123,7 @@ Previewing a PDF attachment opens it in a full-screen viewer instead of a pane.
 
 :::tabs key:platform
 == Desktop/Web
-Click `{{focusMode}}` in the status bar at the bottom of the window. The side menu and the notes list disappear and only the editor is left. Click `{{normalMode}}` to bring them back.
+Click the sunglasses in the status bar at the bottom of the window. The side menu and the notes list disappear and only the editor is left. Click the glasses again to bring them back.
 
 While focus mode is on, a second button appears next to it: `{{enterFullScreen}}`. That one hands the whole screen to Notesnook; `{{exitFullScreen}}` or the `Esc` key returns you to the window.
 == Mobile
@@ -159,9 +161,9 @@ Each one shows the total, and how many are inside your current selection.
 
 ::: warning Very long notes stop saving automatically
 Above **100,000 words** the status bar shows `{{autoSaveOff}}`. From then on the note is saved only when you ask it to — press `Ctrl+S`, or click the save indicator at the right of the status bar (`{{clickToSave}}`). The same indicator tells you whether the current note is saved.
-:::
+Even when autosave is off, notes are still saved when you switch away from the current editor tab.
 == Mobile
-Word and character statistics are shown on desktop and web only.
+Word statistics are shown at the top left of the editor. Tapping the count flips the view to the current character count.
 :::
 
 ## Related pages

--- a/docs/help/contents/rich-text-editor/images-attachments-and-embeds.md
+++ b/docs/help/contents/rich-text-editor/images-attachments-and-embeds.md
@@ -14,7 +14,7 @@ keywords:
 Notes aren't only text. You can drop an image into a note, attach a file of any type, play back an audio recording, preview a PDF beside what you're writing, and embed a video or a post from the web. Everything you attach is encrypted before it leaves your device.
 
 ::: info You need an account to attach anything
-Attachments are uploaded to your encrypted storage, so Notesnook asks you to log in the first time you try to add one — the message reads `{{notLoggedIn}}` on desktop and web, and `{{loginRequired}}` on mobile. On mobile your email also has to be confirmed. Storage and maximum file size depend on your plan; see [plans & limits](/plans-and-limits).
+Attachments are uploaded to your encrypted storage, so Notesnook asks you to log in the first time you try to add one — the message reads `{{notLoggedIn}}` on desktop and web, and `{{loginRequired}}` on mobile. Storage and maximum file size depend on your plan; see [plans & limits](/plans-and-limits).
 :::
 
 <!-- TODO: screenshot — a note containing an image, a file attachment and an embedded video -->
@@ -23,6 +23,7 @@ Attachments are uploaded to your encrypted storage, so Notesnook asks you to log
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Put the cursor where the image should go.
 2. Click the ![Toolbar plus](/toolbar-plus.png) button in the toolbar and choose `{{image}}`.
 3. Pick `{{uploadFromDisk}}` (or press `Ctrl+Shift+I`) and select one or more image files, or pick `{{attachImageFromURL}}` and paste a link.
@@ -31,13 +32,15 @@ Attachments are uploaded to your encrypted storage, so Notesnook asks you to log
 Two shortcuts skip the menu entirely:
 
 - **Drag and drop** — drag image files from your file manager straight onto the editor.
-- **Paste** — paste an image from your clipboard. If the clipboard holds text *and* a file, Notesnook pastes the text.
+- **Paste** — paste an image from your clipboard. If the clipboard holds text _and_ a file, Notesnook pastes the text.
+
 == Mobile
+
 1. Tap where the image should go.
 2. Tap the `+` button in the toolbar at the bottom of the screen and choose `{{image}}`.
 3. Choose `{{uploadFromDisk}}` to pick from your gallery, `{{takePhotoUsingCamera}}` to shoot one now, or `{{attachImageFromURL}}` to paste a link.
 4. Confirm in the sheet that appears; the image is encrypted and inserted into the note.
-:::
+   :::
 
 ::: info Images from a URL are downloaded, not hot-linked
 When you use `{{attachImageFromURL}}`, Notesnook downloads the image and stores it as one of your attachments. The note never asks the original website for the file, so opening the note doesn't tell that site anything about you.
@@ -52,13 +55,14 @@ Images are compressed before upload by default, which keeps them small and fast 
 When the `{{attachingFiles}}` dialog is set to ask, each image has a `{{compress}}` toggle. Turn it off for full quality, then click `{{insert}}`.
 
 To change what happens by default, go to `{{settings}}` > `{{customization}}` > `{{behaviour}}` > `{{imageCompression}}` and choose `{{askEveryTime}}`, `{{enableRecommended}}` or `{{disable}}`.
+
 == Mobile
 The sheet shown when you attach an image has a `Compress (recommended)` checkbox. Clear it for full quality.
 
 To change the default, go to `{{settings}}` > `{{customization}}` > `{{behavior}}` > `{{imageCompression}}`.
 :::
 
-On a free or Essential plan, choosing full quality tells you which plan you need — on mobile the option is greyed out as well. See [plans & limits](/plans-and-limits).
+On a plan that doesn't support full quality images, the option is greyed out. Attempting to change it will ask you to upgrade your plan.
 
 ## Resize and align an image
 
@@ -71,6 +75,7 @@ Alignment lives in the same toolbar, as three buttons: `{{alignLeft}}`, the cent
 :::tabs key:platform
 == Desktop/Web
 Selecting an image floats a small toolbar above it with `{{previewAttachment}}`, `{{downloadAttachment}}`, the three alignment buttons and `{{imageProperties}}`.
+
 == Mobile
 Selecting an image adds an `{{imageSettings}}` button to the toolbar at the bottom. Tap it for `{{downloadAttachment}}`, alignment and `{{imageProperties}}`. `{{previewAttachment}}` is available directly in the toolbar.
 :::

--- a/docs/help/contents/rich-text-editor/outline-lists.md
+++ b/docs/help/contents/rich-text-editor/outline-lists.md
@@ -42,7 +42,7 @@ Press `Enter` to start the next item, exactly as in any other list.
 On an empty line, type `-o` followed by a space and the line becomes the first item of an outline list.
 
 ::: info Markdown shortcuts need Essential
-`-o ` is a [Markdown shortcut.](/rich-text-editor/markdown-notes-editing)Markdown shortcuts are **off by default on web and desktop**: turn on `{{mardownShortcuts}}` in `{{settings}}` → `{{customization}}` → `{{editor}}`. On mobile they are on by default. The toolbar button and `Ctrl+Shift+O` do not depend on that setting.
+`-o ` is a [Markdown shortcut.](/rich-text-editor/markdown-notes-editing) Markdown shortcuts are **off by default on web and desktop**: turn on `{{mardownShortcuts}}` in `{{settings}}` → `{{customization}}` → `{{editor}}`. On mobile they are on by default. The toolbar button and `Ctrl+Shift+O` do not depend on that setting.
 :::
 
 ## Nest an item under another

--- a/docs/help/contents/rich-text-editor/outline-lists.md
+++ b/docs/help/contents/rich-text-editor/outline-lists.md
@@ -15,22 +15,23 @@ An outline list is a nested list whose items **fold**. Any item with children ge
 
 That is the whole difference from a normal bullet list: a bullet list nests too, but everything in it is always visible. An outline list hides and shows branches, which makes it the better choice for meeting structures, project breakdowns, book outlines and anything else you scroll past more often than you read.
 
-Outline lists are part of the [Essential plan and above](/plans-and-limits).
-
 ## Create an outline list
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Place the cursor on an empty line, or select the lines you want to convert.
 2. Click the `+` (Insert) button in the toolbar.
 3. Choose `{{outlineList}}`.
 
 `Ctrl+Shift+O` (`⌘+Shift+O` on macOS) does the same thing, and toggles the list back to plain paragraphs if you press it inside one.
+
 == Mobile
+
 1. Place the cursor on an empty line, or select the lines you want to convert.
 2. Tap the `+` (Insert) button in the bottom toolbar.
 3. Choose `{{outlineList}}` from the `{{chooseBlockToInsert}}` sheet.
-:::
+   :::
 
 Press `Enter` to start the next item, exactly as in any other list.
 
@@ -41,17 +42,20 @@ Press `Enter` to start the next item, exactly as in any other list.
 On an empty line, type `-o` followed by a space and the line becomes the first item of an outline list.
 
 ::: info Markdown shortcuts need Essential
-`-o ` is a [Markdown shortcut](/rich-text-editor/markdown-notes-editing), part of the [Essential plan and above](/plans-and-limits) — the same plan outline lists themselves need. Markdown shortcuts are **off by default on web and desktop**: turn on `{{mardownShortcuts}}` in `{{settings}}` → `{{customization}}` → `{{editor}}`. On mobile they are on by default. The toolbar button and `Ctrl+Shift+O` do not depend on that setting.
+`-o ` is a [Markdown shortcut.](/rich-text-editor/markdown-notes-editing)Markdown shortcuts are **off by default on web and desktop**: turn on `{{mardownShortcuts}}` in `{{settings}}` → `{{customization}}` → `{{editor}}`. On mobile they are on by default. The toolbar button and `Ctrl+Shift+O` do not depend on that setting.
 :::
 
 ## Nest an item under another
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Put the cursor in the item you want to move in.
 2. Press `Tab` to nest it under the item above.
 3. Press `Shift+Tab` to move it back out one level.
+
 == Mobile
+
 1. Tap into the item you want to move in.
 2. Tap `{{indent}}` in the bottom toolbar to nest it one level deeper.
 3. Tap `{{outdent}}` to move it back out.
@@ -65,11 +69,13 @@ As soon as an item has something nested under it, it becomes a parent and grows 
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Click the arrow in the margin to the left of a parent item — or put the cursor anywhere in that item and press `Ctrl+Space` (`⌘+Space` on macOS).
 2. Everything nested under it folds away; the item itself stays visible.
 
 Repeat to expand it again.
 == Mobile
+
 1. Tap the arrow in the margin to the left of a parent item.
 2. Everything nested under it folds away.
 

--- a/docs/help/contents/rich-text-editor/outline-lists.md
+++ b/docs/help/contents/rich-text-editor/outline-lists.md
@@ -41,7 +41,7 @@ Press `Enter` to start the next item, exactly as in any other list.
 
 On an empty line, type `-o` followed by a space and the line becomes the first item of an outline list.
 
-::: info Markdown shortcuts need Essential
+::: info Markdown shortcuts need to be enabled
 `-o ` is a [Markdown shortcut.](/rich-text-editor/markdown-notes-editing) Markdown shortcuts are **off by default on web and desktop**: turn on `{{mardownShortcuts}}` in `{{settings}}` → `{{customization}}` → `{{editor}}`. On mobile they are on by default. The toolbar button and `Ctrl+Shift+O` do not depend on that setting.
 :::
 

--- a/docs/help/contents/rich-text-editor/personalizing-rich-text-editor.md
+++ b/docs/help/contents/rich-text-editor/personalizing-rich-text-editor.md
@@ -66,7 +66,7 @@ Go to `{{settings}}` > `{{customization}}` > `{{editor}}` > `{{titleFormat}}` to
 
 You can use a combination of above templates in the note title. For example `Note $count$ - $date$` will become `Note 150 - 06-22-2023`.
 
-**$headline$**: Up to first 60 characters of the note's first paragraph or heading. This will keep updating the title as headline of the note changes until you manually edit the title. Shouldn't be used in combination with other templates.
+**$headline$**: Up to first 60 characters of the note's first paragraph or heading. This will keep updating the title as headline of the note changes until you manually edit the title. This shouldn't be used in combination with other templates.
 
 ## Paragraph spacing
 

--- a/docs/help/contents/rich-text-editor/rich-text-editor-toolbar.md
+++ b/docs/help/contents/rich-text-editor/rich-text-editor-toolbar.md
@@ -11,8 +11,6 @@ The notes editor toolbar has all the basic tools for rich formatting of your not
 
 ## Adding blocks to a note
 
-<!-- Why is this here? --->
-
 1. Focus inside the note where you want to insert a block.
 2. Click on the ![Toolbar plus](/toolbar-plus.png) button on the toolbar.
 3. Select the block you want to insert; for example a task list.

--- a/docs/help/contents/rich-text-editor/rich-text-editor-toolbar.md
+++ b/docs/help/contents/rich-text-editor/rich-text-editor-toolbar.md
@@ -11,16 +11,18 @@ The notes editor toolbar has all the basic tools for rich formatting of your not
 
 ## Adding blocks to a note
 
+<!-- Why is this here? --->
+
 1. Focus inside the note where you want to insert a block.
 2. Click on the ![Toolbar plus](/toolbar-plus.png) button on the toolbar.
 3. Select the block you want to insert; for example a task list.
 
 ![Toolbar](/toolbar-blocks.png)
 
-## Customzing editor toolbar
+## Customzing editor toolbar <PlanTag plan="pro"/>
 
 ::: info
-Toolbar configuration is automatically synced across all your devices.
+Toolbar configuration is automatically synced across all your devices. Notesnook does not sync the desktop toolbars to mobile, and vice versa.
 :::
 
 One of the great features of the editor is the ability to customize the editor toolbar to fit your own needs. There's usually many tools in an editor toolbar and being able to hide the tools you never use and just keep what you use more frequently on top helps focus on your note taking.
@@ -55,14 +57,16 @@ The toolbar always uses one of three presets, shown at the top of the `{{customi
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Go to `{{settings}}` > `{{customization}}` > `{{editor}}` > `{{customizeToolbar}}`.
 2. Select `{{default}}`, `{{minimal}}` or `{{custom}}`.
 
 Editing groups or tools while `{{default}}` or `{{minimal}}` is selected switches you to `{{custom}}` automatically.
 == Mobile
+
 1. Go to `{{settings}}` > `{{customization}}` > `{{editor}}` > `{{customizeToolbar}}`.
 2. Under `{{presets}}`, tap `{{default}}`, `{{minimal}}` or `{{custom}}`.
-:::
+   :::
 
 Saving a `{{custom}}` preset requires a Pro plan — `{{default}}` and `{{minimal}}` are available on every plan. See [Plans & limits](/plans-and-limits).
 
@@ -76,6 +80,7 @@ Mobile keeps a separate toolbar layout for each device class — phone, small ta
 == Desktop/Web
 There is no reset action. Select the `{{default}}` preset on the `{{customizeToolbar}}` screen to go back to the stock toolbar.
 == Mobile
+
 1. Go to `{{settings}}` > `{{customization}}` > `{{editor}}`.
 2. Tap `{{resetToolbar}}`.
 
@@ -104,10 +109,12 @@ Click on the `+` button on a group header to add any disabled tools into the gro
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Hover on a group header.
 2. Click on the `+` button to add a subgroup.
 3. Drag and drop tools into the subgroup.
 4. Tools in the subgroup will be collapsed into a drop down.
+
 == Mobile
 You can create a subgroup by clicking on collapse button on a tool. Tools in the subgroup will be collapsed into a popup.
 :::
@@ -121,18 +128,22 @@ You can remove a group and all it's tools from the toolbar.
 1. Hover on a group header
 2. Click on the trash icon to delete the group.
 3. All the tools in the group will be moved to `Disabled items` section at the bottom.
+
 == Mobile
+
 1. Click on the `-` button on a group header to remove the group
 2. Tools removed from a group can be added back with the `+` button on the group header.
-:::
+   :::
 
 ### Disable a tool
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Hover on a tool header
 2. Click on the trash icon to disable the tool.
 3. Deleted tools in the group will be moved to `Disabled items` section at the bottom.
+
 == Mobile
 A tool can be disabled from the toolbar by clicking on the `-` button on the tool.
 :::

--- a/docs/help/contents/search-and-navigation.md
+++ b/docs/help/contents/search-and-navigation.md
@@ -11,7 +11,7 @@ keywords:
 
 # How do I search my notes in Notesnook?
 
-Every list view has a search box at the top of it. Type into it and Notesnook searches the notes in *that* view — the whole notes list, one notebook, one tag, favorites, trash — matching both note titles and the text inside notes, and showing you the matching passages.
+Every list view has a search box at the top of it. Type into it and Notesnook searches the notes in _that_ view — the whole notes list, one notebook, one tag, favorites, trash — matching both note titles and the text inside notes, and showing you the matching passages.
 
 Search runs on your device against the local database. Nothing about what you search for is sent anywhere.
 
@@ -19,30 +19,32 @@ Search runs on your device against the local database. Nothing about what you se
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Click the search box at the top of the list. It's labelled after the view you're in — `Search in Notes`, `Search in Notebook`, `Search in Trash` and so on.
 2. Type your query. Results appear as you type.
 3. Press `Escape`, or click the ✕ in the box, to clear the search and go back to the full list.
 
 `Ctrl+F` (`⌘+F` on macOS) puts the cursor in that box whenever the editor isn't focused. If you're in a note, `Ctrl+F` opens the editor's own find bar instead.
 == Mobile
+
 1. Tap the bar at the top of the screen — it reads `Search in Notes`, `Search in Notebook` and so on, depending on the view.
 2. Type your query. Results appear as you type.
 3. Tap the back arrow to return to the list.
-:::
+   :::
 
 ## What is actually searched
 
-| You're searching | Matched on |
-| --- | --- |
-| Notes | Title and the full text of the note |
-| Notebooks | Title and description |
-| Tags | Title |
-| Reminders | Title and description |
-| Attachments | Filename, file type and hash |
-| Trash | Deleted notes and notebooks |
+| You're searching | Matched on                          |
+| ---------------- | ----------------------------------- |
+| Notes            | Title and the full text of the note |
+| Notebooks        | Title and description               |
+| Tags             | Title                               |
+| Reminders        | Title and description               |
+| Attachments      | Filename, file type and hash        |
+| Trash            | Deleted notes and notebooks         |
 
 ::: info Locked notes
-The content of a note in your [private vault](/lock-notes-with-private-vault) is encrypted, so it is never added to the search index. Locked notes are found by their titles only. This is a deliberate limitation of end-to-end encryption, not a bug.
+The content of a note in your [private vault](/lock-notes-with-private-vault) is encrypted, so it is never added to the search index. Locked notes are found by their titles only. This is a limitation of end-to-end encryption, not a bug.
 :::
 
 ## Read the results and jump to a match
@@ -51,12 +53,15 @@ A note that matched shows its title with the matching words highlighted, and the
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Click the arrow next to a result to expand it. Each matching passage in the note is listed underneath, with the matched words highlighted.
 2. Click a passage to open the note scrolled straight to that spot.
 3. Middle-click a passage to open it in a new tab instead.
 
 Passages are only shown in the detailed list. Switching the notes list to compact view collapses results to titles.
+
 == Mobile
+
 1. Tap a result to open the note.
 
 Matching passages are highlighted in the result so you can see the context before opening it.
@@ -78,18 +83,18 @@ The command palette is a desktop and web feature. Press `Ctrl+Shift+P` (`⌘+Shi
 Move with `↑` and `↓`, run with `⏎`. Press `Delete` on an entry under recents, or click the ✕ on it, to drop it from the list.
 
 ::: info Not on mobile
-The command palette and quick open are keyboard features of the desktop and web apps. On mobile, use the search bar and the side menu.
+The command palette and quick open are only features of the **desktop and web apps**. On mobile, use the search bar and the side menu.
 :::
 
 ## Jump to a note by name
 
 Quick open is a desktop and web feature. Press `Ctrl+P` (`⌘+P` on macOS) for **quick open**. It searches your notes, notebooks, tags and reminders by title and opens whatever you pick. With the box empty it lists your recent items and the notes already open in tabs.
 
-| Key | What it does |
-| --- | --- |
-| `⏎` | Open the highlighted item |
-| `Ctrl+⏎` / `⌘+⏎` | Open the highlighted note in a new tab |
-| `Shift+⏎` | Open a new tab titled with whatever you typed |
+| Key              | What it does                                  |
+| ---------------- | --------------------------------------------- |
+| `⏎`              | Open the highlighted item                     |
+| `Ctrl+⏎` / `⌘+⏎` | Open the highlighted note in a new tab        |
+| `Shift+⏎`        | Open a new tab titled with whatever you typed |
 
 `Shift+⏎` is the fast way to turn a search that found nothing into a new note: type the title you were looking for, press `Shift+⏎`, and start writing.
 
@@ -97,6 +102,7 @@ Quick open is a desktop and web feature. Press `Ctrl+P` (`⌘+P` on macOS) for *
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Press `Ctrl+,` (`⌘+,` on macOS), or open `{{settings}}` from the side menu.
 2. Type into the `{{search}}` box at the top of the settings sidebar.
 
@@ -111,12 +117,15 @@ The notebooks and tags lists have their own filter box, separate from note searc
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Open `{{notebooks}}` or `Tags` from the side menu.
 2. Type into the `Filter notebooks...` or `Filter tags...` box at the bottom of the list.
+
 == Mobile
+
 1. Open `{{notebooks}}` or `Tags` in the side menu.
 2. Type into the `Filter notebooks...` or `Filter tags...` box at the bottom of the list.
-:::
+   :::
 
 Clearing the box restores the full list.
 
@@ -126,26 +135,29 @@ Sorting is set per view, and separately for each individual notebook, tag and co
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Click the sort icon in the group header at the top of the list.
 2. Open `{{orderBy}}` and choose the direction.
 3. Open `{{sortBy}}` and choose the key.
+
 == Mobile
+
 1. Tap the sort icon in the group header at the top of the list.
 2. Tap the direction button next to `{{sortBy}}` to flip between ascending and descending.
 3. Tap a key under `{{sortBy}}`.
-:::
+   :::
 
 There are seven sort keys. Which ones are offered depends on the list you're in:
 
-| Sort by | Available in |
-| --- | --- |
-| `Date created` | Everywhere except trash |
-| `Date edited` | Everywhere except trash and tags — and, on mobile, except reminders |
-| `Date modified` | Tags, and reminders on mobile |
-| `Date deleted` | Trash |
-| `Due date` | Reminders |
-| `{{title}}` | Everywhere |
-| `Relevance` | Search results |
+| Sort by         | Available in                                                        |
+| --------------- | ------------------------------------------------------------------- |
+| `Date created`  | Everywhere except trash                                             |
+| `Date edited`   | Everywhere except trash and tags — and, on mobile, except reminders |
+| `Date modified` | Tags, and reminders on mobile                                       |
+| `Date deleted`  | Trash                                                               |
+| `Due date`      | Reminders                                                           |
+| `{{title}}`     | Everywhere                                                          |
+| `Relevance`     | Search results                                                      |
 
 The direction labels change with the key: `{{aToZ}}` / `{{zToA}}` for `{{title}}`, `{{earliestFirst}}` / `{{latestFirst}}` for `Due date`, `{{mostRelevantFirst}}` / `{{leastRelevantFirst}}` for `Relevance`, and `{{oldestToNewest}}` / `{{newestToOldest}}` for the date keys.
 
@@ -153,22 +165,25 @@ The direction labels change with the key: `{{aToZ}}` / `{{zToA}}` for `{{title}}
 
 Grouping splits the list into labelled sections. Six modes are available:
 
-| `{{groupBy}}` | Result |
-| --- | --- |
+| `{{groupBy}}` | Result                                 |
+| ------------- | -------------------------------------- |
 | `{{default}}` | Today, Yesterday, This week, and so on |
-| `None` | One flat list, no headers |
-| `Abc` | One section per first letter |
-| `Year` | One section per year |
-| `{{month}}` | One section per month |
-| `Week` | One section per week |
+| `None`        | One flat list, no headers              |
+| `Abc`         | One section per first letter           |
+| `Year`        | One section per year                   |
+| `{{month}}`   | One section per month                  |
+| `Week`        | One section per week                   |
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Click the sort icon in the group header.
 2. Open `{{groupBy}}` and pick a mode.
 
 Clicking the group header itself opens `{{jumpToGroup}}`, which scrolls the list straight to any section.
+
 == Mobile
+
 1. Tap the sort icon in the group header.
 2. Scroll to `{{groupBy}}` and pick a mode.
 
@@ -183,10 +198,13 @@ Compact mode drops each row to a single line: title, plus small icons for locked
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Click the view icon next to the sort icon in the group header.
 
 It's available on the notes, favorites and notebooks lists, and it also collapses search results to their titles.
+
 == Mobile
+
 1. Tap the list-view icon next to the sort icon in the group header.
 
 Notes, notebooks and search results each remember their own setting.

--- a/docs/help/contents/self-hosting.md
+++ b/docs/help/contents/self-hosting.md
@@ -15,8 +15,6 @@ Every Notesnook app — web, desktop and mobile — lets you replace the servers
 
 ## Getting Started
 
-<!---Reviewer's note: I'm assuming you will merge @ibaraki-douji's PR https://github.com/streetwriters/notesnook-sync-server/pull/106, which fixes some oversights in the current setup's docker compose. That's the configuration this guide is referring to, just with links pointing to `master`.-->
-
 This guide assumes you are already familiar with the command line and basic systems security. Notesnook is not responsible for issues that may arise from improper configuration of the server. You are fully responsible for making adequate backups and for the security of your data and server.
 
 ### Hardware requirements

--- a/docs/help/contents/self-hosting.md
+++ b/docs/help/contents/self-hosting.md
@@ -13,24 +13,176 @@ keywords:
 
 Every Notesnook app — web, desktop and mobile — lets you replace the servers it talks to with your own. You point the app at four URLs, test them, save, and the app restarts against your infrastructure. Your notes stay end-to-end encrypted either way; self-hosting means the encrypted data never touches Notesnook's machines.
 
-## Which servers can I point elsewhere?
+## Getting Started
 
-Exactly four, all four required:
+<!---Reviewer's note: I'm assuming you will merge @ibaraki-douji's PR https://github.com/streetwriters/notesnook-sync-server/pull/106, which fixes some oversights in the current setup's docker compose. That's the configuration this guide is referring to, just with links pointing to `master`.-->
 
-| Server | What it does |
-| --- | --- |
-| `{{syncServer}}` | *"Server used to sync your notes & other data between devices."* |
-| `{{authServer}}` | *"Server used for login/sign up and authentication."* |
-| `{{sseServer}}` | *"Server used to receive important notifications & events."* |
-| `{{monographServer}}` | *"Server used to host your published notes."* |
+This guide assumes you are already familiar with the command line and basic systems security. Notesnook is not responsible for issues that may arise from improper configuration of the server. You are fully responsible for making adequate backups and for the security of your data and server.
+
+### Hardware requirements
+
+- Operating System: Linux.
+- RAM: 1 Gigabyte.
+- CPU: Any ARM or x86 cpu, as long as it supports AVX.
+- Storage: 20 gigabytes.
+
+### Prerequisites
+
+1. Docker
+2. Docker Compose
+3. wget
+4. curl
+5. (optional) A reverse proxy, like Caddy or Ngnix.
+
+This guide assumes you already have a Linux server set up and ready to go.
+
+### Installation
+
+1. Create a directory where your configuration files will go.
+
+`mkdir notesnook-sync-server`
+
+2. Enter this directory.
+
+`cd notesnook-sync-server`
+
+3. Download the `docker-compose.yml` file.
+
+`wget https://raw.githubusercontent.com/streetwriters/notesnook-sync-server/master/docker-compose.yml`
+
+4. Download the `.env` file, this is where most (if not all) of your configuration belongs.
+
+`wget https://raw.githubusercontent.com/streetwriters/notesnook-sync-server/master/.env`
+
+You should now have two files in your directory:
+
+- `docker-compose.yml`
+- `.env`
+
+### Configuration
+
+Open the `.env` file into an editor. This guide will go over the minimum you need to change.
+
+:::warning This guide does not cover setting up an SMTP server!
+You **will have to** do this if you plan on using the password reset feature, or want to use email-based two factor auth (the default). If you don't change the two factor method after creating your account, you may become locked out of the account. You have been warned.
+:::
+
+#### `INSTANCE_NAME`
+
+This is used by the Notesnook clients to show which server you are connecting to on the login/signup pages. It should be unique to your server, something like `john-doe-notesnook-server` is adequate. The default value _also_ works, but we recommend you change it.
+
+#### `NOTESNOOK_API_SECRET`
+
+This is used by the server to validate access tokens. It should be a long, random value. If you need to create one, use this command. `openssl rand -hex 32`
+
+#### `DISABLE_SIGNUPS`
+
+This is a setting you should change after signing up, unless you want your server to be open registration.
+
+#### Public URLs
+
+Public URLs are how the servers can generate valid publicly accessible URLs for different things like email confirmation, password reset links etc. These URLs must be accessible from _outside_ of where you are hosting your servers (e.g. by using a reverse proxy like Nginx).
+
+| Variable                        | Description                                                                                         | Example                                                         |
+| ------------------------------- | --------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `NOTESNOOK_APP_PUBLIC_URL`      | If you're self-hosting the web app too, you put the url to it here, otherwise, leave it alone.      | [https://app.notesnook.com/](/self-hosting#public-urls)         |
+| `MONOGRAPH_PUBLIC_URL`          | This is the url for the monograph server, it is also where published notes will be accessible from. | [https://monogr.ph/](/self-hosting#public-urls)                 |
+| `AUTH_SERVER_PUBLIC_URL`        | This is the url for the auth server.                                                                | [https://auth.streetwriters.co/](/self-hosting#public-urls)     |
+| `ATTACHMENTS_SERVER_PUBLIC_URL` | This is the url for the attachments server. It's where your attachments will be downloaded from.    | [https://attachments.notesnook.com/](/self-hosting#public-urls) |
+
+You don't need to configure the sse/events server's public url in the `.env` file, but it is required to forward it through your reverse proxy.
+
+#### Starting the server
+
+Now that you've configured the server, let's take it for a test-drive!
+
+Run `docker compose up -d`, and Docker Compose will make the magic happen.
+
+Once everything is shown as started, wait a moment, and then run `docker compose ps`
+
+You should see something like this:
+
+```
+3c39da9194db   streetwriters/sse:latest                   "./Streetwriters.Mes…"   38 minutes ago   Up 38 minutes (healthy)   0.0.0.0:7264->7264/tcp, :::7264->7264/tcp  notesnook-sse-server-1
+19c4a6536578   streetwriters/monograph:latest             "docker-entrypoint.s…"   38 minutes ago   Up 38 minutes (healthy)   0.0.0.0:6264->3000/tcp, [::]:6264->3000/tcp  notesnook-monograph-server-1
+7b9db61b5d0d   streetwriters/notesnook-sync:latest        "./Notesnook.API"        38 minutes ago   Up 38 minutes (healthy)   0.0.0.0:5264->5264/tcp, :::5264->5264/tcp  notesnook-notesnook-server-1
+6491b172817e   streetwriters/identity:latest              "./Streetwriters.Ide…"   38 minutes ago   Up 38 minutes (healthy)   0.0.0.0:8264->8264/tcp, :::8264->8264/tcp  notesnook-identity-server-1
+bfb71f21e57b   minio/minio:RELEASE.2024-07-29T22-14-52Z   "/usr/bin/docker-ent…"   38 minutes ago   Up 38 minutes (healthy)   0.0.0.0:9000->9000/tcp, :::9000->9000/tcp  notesnook-notesnook-s3-1
+d27f6207fb93   mongo:7.0.12                               "docker-entrypoint.s…"   38 minutes ago   Up 38 minutes (healthy)   27017/tcp  notesnook-notesnook-db-1
+2bde52e0102d   willfarrell/autoheal:latest                "/docker-entrypoint …"   38 minutes ago   Up 38 minutes (healthy)  notesnook-autoheal-1
+```
+
+Everything should show as healthy, and there should be 7 containers listed at this point. If there are less than 7, or any show as unhealthy, something went wrong. Our [Discord community](https://go.notesnook.com/discord) may be able to assist you.
+
+#### Exposing to the internet
+
+Running the Docker containers on device is all well and good, but if you want to connect your other devices, sync your notes to them, you'll need to expose the servers over the internet. Even if you only require local access, it is recommended that you use something like Tailscale or Cloudflare Tunnels to securely & reliably expose the Notesnook servers.
+
+:::warning HTTPS is required.
+**HTTPS is required by the browser and mobile apps**. Notesnook does not necessarily mandate this, but your browser and mobile operating system may.
+:::
+
+This guide will cover hosting Notesnook using a Cloudflare Tunnel, as we believe it is the easiest option, doesn't require port forwarding, and HTTPS is automatically set up.
+
+1. Log into the Cloudflare dashboard. We're assuming you already have your domain name set up and added to your Cloudflare account. If you don't, do that now.
+2. In the dashboard, on the sidebar, find `Protect & connect`, open the drop down for `Networking`, and choose `Tunnels`.
+3. On the top right of the page that loads, select `Create Tunnel`.
+4. Name your tunnel, then select `Create tunnel` again.
+5. Select `Docker` from the list of options and copy the command. We'll use values from it later.
+6. Open up the `docker-compose.yml` file, and at the bottom of the `services:` section, add this:
+
+```
+  cloudflare:
+    image: cloudflare/cloudflared:latest
+    networks:
+      - notesnook
+    depends_on:
+      - monograph-server
+    command:
+```
+
+7. Now, paste in the command you copied from the cloudflare dash, it should look like this: `docker run cloudflare/cloudflared:latest tunnel --no-autoupdate run --token eyJh...J9`
+
+8. Remove `docker run cloudflare/cloudflared:latest` from the beginning of the command, and save your changes to the file.
+
+9. Restart your Docker containers by running `docker compose down` and `docker compose up -d`. In a moment, everything should start back up, and the continue button on the cloudflare dash will light up, allowing you to proceed.
+
+10. Now you add your domains that you configured earlier to the newly created tunnel. To do this, click on your new tunnel in the dashboard, then select `Routes` at the top.
+
+11. Click `Add route`, then select `Published application`. You'll configure your subdomain, and for the `Service URL` field you should see the table below. Repeat this for each service listed.
+
+:::tip What to do if you changed the port configuration
+If you changed ports for a service, **use the configured port** instead of the default ones shown below. If you haven't already, you may additionally need to double check that your `docker-compose.yml` file doesn't use the defaults.
+:::
+
+| Service            | Service URL                                                             |
+| ------------------ | ----------------------------------------------------------------------- |
+| Sync server        | [http://notesnook-server:5264](/self-hosting/#exposing-to-the-internet) |
+| Monograph server   | [http://monograph-server:3000](/self-hosting/#exposing-to-the-internet) |
+| Events/SSE server  | [http://sse-server:7264](/self-hosting/#exposing-to-the-internet)       |
+| Attachments server | [http://notesnook-s3:9000](/self-hosting/#exposing-to-the-internet)     |
+| Auth server        | [http://identity-server:8264](/self-hosting/#exposing-to-the-internet)  |
+
+:::info
+The attachments server doesn't get entered into the client, the public url is used by the sync server to generate signed S3 links. Those are scoped to a specific hostname.
+:::
+
+You should now [configure your client](/self-hosting/#point-notesnook-at-your-own-servers) to ensure that everything is publicly accessible, everything should be now. The `{{testConnection}}` button is the easiest way to do this, as it will tell you which server is not reachable, should anything be wrong.
+
+## What servers do I need to configure in my client?
+
+Four, and all of them are required.
+
+| Server                | What it does                                                     |
+| --------------------- | ---------------------------------------------------------------- |
+| `{{syncServer}}`      | _"Server used to sync your notes & other data between devices."_ |
+| `{{authServer}}`      | _"Server used for login/sign up and authentication."_            |
+| `{{sseServer}}`       | _"Server used to receive important notifications & events."_     |
+| `{{monographServer}}` | _"Server used to host your published notes."_                    |
 
 By default these are `https://api.notesnook.com`, `https://auth.streetwriters.co`, `https://events.streetwriters.co` and `https://monogr.ph`.
 
 The apps validate all four together — you cannot self-host the sync server and leave the others pointing at Notesnook. `{{allServerUrlsRequired}}`
-
-::: info Where the server side lives
-The apps in this repository are the client half. The servers themselves — and their setup instructions — are in the [notesnook-sync-server](https://github.com/streetwriters/notesnook-sync-server) repository. Set those up and get them reachable before you touch the app settings below.
-:::
 
 ## You must be logged out to change server URLs
 
@@ -38,22 +190,25 @@ Every field and button on the servers screen is disabled while you are signed in
 
 This is not an arbitrary restriction. Your account, your keys and your data live on whichever backend you were using; switching backends while logged in would leave the app holding a session the new server knows nothing about.
 
-::: warning Log out first, and back up first
-Log out of Notesnook before changing these URLs, and take a [backup](/backup-and-restore-notes-in-notesnook) beforehand. An account on Notesnook's servers does not exist on your own — you sign up again on your instance, and you bring your notes over by restoring your backup. **Notesnook cannot move an account between backends for you.**
+::: warning Make a backup, then log out.
+Take a [backup](/backup-and-restore-notes-in-notesnook) before logging out of notesnook to change your server configuration. An account on Notesnook's servers does not exist on your own. You'll have to sign up again on your instance, and you bring your notes over by restoring your backup. **Notesnook cannot move an account between backends for you.**
 :::
 
 ## Point Notesnook at your own servers
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Log out.
 2. Open `{{settings}}` → `{{customization}}` → `{{servers}}`.
 3. Fill in all four URLs — `{{syncServer}}`, `{{authServer}}`, `{{sseServer}}` and `{{monographServer}}`. Each field shows an example such as `e.g. http://localhost:4326`.
 4. Press `{{testConnection}}`. On success you see `{{connectedToServer}}`
 5. Press `{{save}}`.
 
-`{{save}}` stays disabled until `{{testConnection}}` has passed. After saving, a dialog reads `App will reload in 5 seconds` — *"Your changes have been saved and will be reflected after the app has refreshed."* — and the app reloads itself.
+`{{save}}` stays disabled until `{{testConnection}}` has passed. After saving, a dialog reads `App will reload in 5 seconds` — _"Your changes have been saved and will be reflected after the app has refreshed."_ — and the app reloads itself.
+
 == Mobile
+
 1. Log out.
 2. Open `{{settings}}` → `{{customization}}` → `{{servers}}`.
 3. Fill in all four URLs. Each field is labelled with the server id and an example, such as `notesnook-sync e.g. http://localhost:4326`.
@@ -79,12 +234,15 @@ Only when all four pass does the app report `{{connectedToServer}}` and let you 
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Log out.
 2. Open `{{settings}}` → `{{customization}}` → `{{servers}}`.
 3. Press `{{reset}}`.
 
-The app reloads after 5 seconds, back on the default hosts.
+The app reloads after 5 seconds.
+
 == Mobile
+
 1. Log out.
 2. Open `{{settings}}` → `{{customization}}` → `{{servers}}`.
 3. Tap `{{resetServerUrls}}`.
@@ -92,11 +250,11 @@ The app reloads after 5 seconds, back on the default hosts.
 You get a `{{serverUrlsReset}}` dialog reading `{{restartAppToTakeEffect}}` — close and reopen the app.
 :::
 
-Your local notes are untouched by a reset, but the account you used on your own instance does not exist on Notesnook's servers. You log in (or sign up) again, and restore a backup.
+Your notes on your hosted server are untouched by the app reset, but the account you used on your own instance does not exist on Notesnook's servers. You'll have to log in (or sign up) again, and restore a backup to transfer your data back over.
 
 ## Can I self-host the Inbox API too?
 
-Yes, and separately from the four servers above. The inbox service — the one that accepts notes posted in from scripts and automations — can run on your own machine, or you can skip it entirely and encrypt payloads locally before posting them. See [self-hosting the Inbox API](/inbox-api/self-hosting-inbox-api).
+Yes, and separately from the entire list of servers above. The inbox service, the one that accepts notes posted in from scripts and automations, can be hosted separately from the sync server. This means that you can host your own inbox server, even while using the official Notesnook server. See [self-hosting the Inbox API](/inbox-api/self-hosting-inbox-api) for more information.
 
 ## Related pages
 

--- a/docs/help/contents/two-factor-authentication.md
+++ b/docs/help/contents/two-factor-authentication.md
@@ -15,16 +15,16 @@ schema: howto
 Two-factor authentication (2FA) asks for a 6-digit code in addition to your password every time you log in. You set it up from `{{settings}}`, choose one of three methods — an authenticator app, email or SMS — and save the recovery codes Notesnook shows you at the end.
 
 ::: info 2FA protects your account, not your notes
-Your notes are already end-to-end encrypted with a key derived from your password. 2FA stops someone from *logging in* as you. It is a separate protection from [the encryption on your data](/how-is-my-data-encrypted).
+Your notes are already end-to-end encrypted with a key derived from your password. 2FA stops someone from _logging in_ as you. It is a separate protection from [the encryption of your data.](/how-is-my-data-encrypted)
 :::
 
 ## The three 2FA methods
 
-| Method | What it is | Plan |
-| --- | --- | --- |
-| `{{mfaAuthAppTitle}}` | Use an authenticator app to generate 2FA codes. Marked `{{recommended}}`. | All plans |
-| `{{mfaEmailTitle}}` | Notesnook sends a 2FA code to your account email when prompted. | All plans |
-| `{{mfaSmsTitle}}` | Notesnook sends an SMS with a 2FA code when prompted. | Pro and Believer |
+| Method                | What it is                                                                | Plan             |
+| --------------------- | ------------------------------------------------------------------------- | ---------------- |
+| `{{mfaAuthAppTitle}}` | Use an authenticator app to generate 2FA codes. Marked `{{recommended}}`. | All plans        |
+| `{{mfaEmailTitle}}`   | Notesnook sends a 2FA code to your account email when prompted.           | All plans        |
+| `{{mfaSmsTitle}}`     | Notesnook sends an SMS with a 2FA code when prompted.                     | Pro and Believer |
 
 An authenticator app is the recommended option because it generates codes on your device and keeps working without a network connection.
 
@@ -32,6 +32,7 @@ An authenticator app is the recommended option because it generates codes on you
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Go to `{{settings}}` → `{{authentication}}`.
 2. Under `{{twoFactorAuth}}`, press `{{change}}` next to `{{change2faMethod}}`.
 3. Confirm the `{{verifyItsYou}}` prompt with your account password.
@@ -40,7 +41,9 @@ An authenticator app is the recommended option because it generates codes on you
 6. Save the codes on the `{{saveRecoveryCodes}}` screen, then finish.
 
 You should now see `{{twoFactorAuthEnabled}}`.
+
 == Mobile
+
 1. Go to `{{settings}}` → `{{account}}` → `{{manageAccount}}`.
 2. Open `{{twoFactorAuth}}`, then tap `{{change2faMethod}}`.
 3. Confirm your identity with your account password.
@@ -56,6 +59,7 @@ You should now see `{{twoFactorAuthEnabled}}`.
 :::tabs key:platform
 == Desktop/Web
 Notesnook shows a QR code with the instruction `{{mfaScanQrCode}}`. If your app cannot scan it, copy the text key shown underneath instead — spaces do not matter. Your app then displays a rotating 6-digit code to enter.
+
 == Mobile
 Notesnook shows the setup key in a field with a `{{copy}}` button. Tapping it copies the key and opens your installed authenticator app directly. Your app then displays a rotating 6-digit code to enter.
 :::
@@ -78,13 +82,16 @@ A fallback is a second method you can use when your primary one is unavailable �
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Go to `{{settings}}` → `{{authentication}}`.
 2. Press `{{addFallback2faMethod}}` (it reads `{{change2faFallbackMethod}}` once one exists).
 3. Confirm the `{{verifyItsYou}}` prompt.
 4. Pick a method and complete the same setup steps as above.
 
 You should now see `{{fallbackMethodEnabled}}`.
+
 == Mobile
+
 1. Go to `{{settings}}` → `{{account}}` → `{{manageAccount}}` → `{{twoFactorAuth}}`.
 2. Tap `{{addFallback2faMethod}}` (it reads `{{change2faFallbackMethod}}` once one exists).
 3. Confirm your identity.
@@ -99,11 +106,14 @@ Recovery codes are single-use codes that log you in when no 2FA method is reacha
 
 :::tabs key:platform
 == Desktop/Web
+
 1. Go to `{{settings}}` → `{{authentication}}`.
 2. Press `{{viewRecoveryCodes}}` and confirm the `{{verifyItsYou}}` prompt.
 3. Use `{{print}}`, `{{copy}}` or `Download` to keep a copy. `Download` saves a `notesnook-recovery-codes.txt` file.
 4. Press `{{regenerate}}` to replace the current set with a new one.
+
 == Mobile
+
 1. Go to `{{settings}}` → `{{account}}` → `{{manageAccount}}` → `{{twoFactorAuth}}`.
 2. Tap `{{viewRecoveryCodes}}` and confirm your identity.
 3. Use `{{copyCodes}}` or `{{saveToFile}}` — the file is saved as `notesnook_recoverycodes.txt`.

--- a/docs/help/contents/web-clipper/clipping-your-first-web-page-with-web-clipper.md
+++ b/docs/help/contents/web-clipper/clipping-your-first-web-page-with-web-clipper.md
@@ -104,17 +104,22 @@ You can choose to append your web clip to an existing note and it'll be automati
 
 1. Click on `Select a note to append to`
 2. Select the note you want to append to
-   == Add to notebook
-   ::: info
-   You can only assign the web clip to an existing notebook. Creating new notebooks is not supported from inside the web clipper.
-   :::
 
-3. Click on `Select a notebook`
-4. Select the notebook you want to add the web clip to
-   == Assign tags
-5. Click on `Assign a tag`
-6. Select the tag you want to assign (you can assign multiple tags)
-7. You can also create & assign a new tag by typing in the search bar
+== Add to notebook
+
+::: info
+You can only assign the web clip to an existing notebook. Creating new notebooks is not supported from inside the web clipper.
+:::
+
+1. Click on `Select a notebook`
+2. Select the notebook you want to add the web clip to
+
+== Assign tags
+
+1. Click on `Assign a tag`
+2. Select the tag you want to assign (you can assign multiple tags)
+3. You can also create & assign a new tag by typing in the search bar
+
    ![Assigning a tag to a web clip from the web clipper](/static/web-clipper/assign-a-tag.gif)
    ::::
 

--- a/docs/help/contents/web-clipper/clipping-your-first-web-page-with-web-clipper.md
+++ b/docs/help/contents/web-clipper/clipping-your-first-web-page-with-web-clipper.md
@@ -64,7 +64,10 @@ The `Selected nodes` mode allows you to select exactly which nodes you want to c
 3. Click on all the nodes you want to clip (they can be in any part of the screen).
    ::: info
    The web clipper stacks all the selected nodes vertically during final processing.
-   ::: 4. Clicking again on the selected nodes will deselect them. 5. Once you are done, click on the Clip button 6. Activate the Notesnook Web Clipper and save your clip.
+   :::
+4. Clicking again on the selected nodes will deselect them.
+5. Once you are done, click on the Clip button
+6. Activate the Notesnook Web Clipper and save your clip.
 
 ## Selecting the clipping mode
 

--- a/docs/help/contents/web-clipper/clipping-your-first-web-page-with-web-clipper.md
+++ b/docs/help/contents/web-clipper/clipping-your-first-web-page-with-web-clipper.md
@@ -24,6 +24,7 @@ Before you can clip pages, you must connect the web clipper with the Notesnook w
 
 2. Click on `Connect with Notesnook`
 3. Notesnook web app will open in a new tab in the background. Wait a few seconds and the web clipper should automatically connect.
+
    ::: details What to do if the web clipper doesn't connect?
    There are a few things you can do to troubleshoot:
 
@@ -31,7 +32,7 @@ Before you can clip pages, you must connect the web clipper with the Notesnook w
    2. Make sure you have the Notesnook web app opened in the background
    3. The web clipper doesn't yet support multiple browser windows so make sure there aren't any additional browser windows opened in the background.
    4. Try restarting the browser
-   :::
+      :::
 
 ## Selecting the clipping area
 
@@ -56,15 +57,14 @@ The `Visible area` mode clips only the nodes that fit in the viewport. Any nodes
 The `Selected nodes` mode allows you to select exactly which nodes you want to clip:
 
 1. Select the `Selected nodes` mode from the Notesnook Web Clipper
-2. You should now see a small popup in the bottom-right corner of the page
-   ![The selected-nodes popup shown in the bottom-right corner of the page](/static/web-clipper/selected-nodes-popup.png)
+2. You should now see a small popup in the bottom-right corner of the page.
+
+![The selected-nodes popup shown in the bottom-right corner of the page](/static/web-clipper/selected-nodes-popup.png)
+
 3. Click on all the nodes you want to clip (they can be in any part of the screen).
    ::: info
    The web clipper stacks all the selected nodes vertically during final processing.
-   :::
-4. Clicking again on the selected nodes will deselect them.
-5. Once you are done, click on the Clip button
-6. Activate the Notesnook Web Clipper and save your clip.
+   ::: 4. Clicking again on the selected nodes will deselect them. 5. Once you are done, click on the Clip button 6. Activate the Notesnook Web Clipper and save your clip.
 
 ## Selecting the clipping mode
 
@@ -104,19 +104,19 @@ You can choose to append your web clip to an existing note and it'll be automati
 
 1. Click on `Select a note to append to`
 2. Select the note you want to append to
-== Add to notebook
-::: info
-You can only assign the web clip to an existing notebook. Creating new notebooks is not supported from inside the web clipper.
-:::
+   == Add to notebook
+   ::: info
+   You can only assign the web clip to an existing notebook. Creating new notebooks is not supported from inside the web clipper.
+   :::
 
-1. Click on `Select a notebook`
-2. Select the notebook you want to add the web clip to
-== Assign tags
-1. Click on `Assign a tag`
-2. Select the tag you want to assign (you can assign multiple tags)
-3. You can also create & assign a new tag by typing in the search bar
+3. Click on `Select a notebook`
+4. Select the notebook you want to add the web clip to
+   == Assign tags
+5. Click on `Assign a tag`
+6. Select the tag you want to assign (you can assign multiple tags)
+7. You can also create & assign a new tag by typing in the search bar
    ![Assigning a tag to a web clip from the web clipper](/static/web-clipper/assign-a-tag.gif)
-::::
+   ::::
 
 ## Saving your web clip
 

--- a/docs/help/contents/web-clipper/installation.md
+++ b/docs/help/contents/web-clipper/installation.md
@@ -7,7 +7,7 @@ description: Notesnook Web Clipper is open source and available to download for 
 
 ## Chromium-based browsers
 
-[Go to chrome webstore](https://chrome.google.com/webstore/detail/notesnook-web-clipper/kljhpemdlcnjohmfmkogahelkcidieaj) to get the latest version of [web clipper for Notesnook](https://notesnook.com/notesnook-web-clipper).
+[Go to chrome webstore](https://chrome.google.com/webstore/detail/notesnook-web-clipper/kljhpemdlcnjohmfmkogahelkcidieaj) to get the latest version of the [web clipper for Notesnook](https://notesnook.com/notesnook-web-clipper).
 
 ## Firefox-based browsers
 


### PR DESCRIPTION
## Description
- Reformats some files so editing in VSCode isn't a pita.
- Fixes image embedding in a number of pages
- Removes AI hallucinations
- Fleshes out self-hosting guide, replaces #8744  (still need to reorganize inbox self-hosting page, basically all of that page should be folded into using the inbox api, just as a separate section)
  - I chose to not carry over the ngnix config and to instruct users following the guide to use cloudflare tunnels instead. I think it's easier for most people that way.
- Doesn't allow the `<PlanTag>` markers to show up in headings on the right heading sidebar.
- Incorporates feedback from @thecodrr in #10169 
- I have not taken screenshots from apps yet, but I agree that some pages need them.

A few questions:
Are Notesnook's servers in UTC time? I assume yes, but I'd like to make sure.
Are self-hosting docs meant to be a part of the help rework? They're fleshed out but since #8744 has been a draft for a long, long while, I'm not too sure.

## Type of Change
- [ ] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [ ] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [ ] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
