### PR TITLE
mobile: improve skip & go directly to app

### DIFF
--- a/apps/mobile/app/components/auth/header.tsx
+++ b/apps/mobile/app/components/auth/header.tsx
@@ -63,7 +63,6 @@ export const AuthHeader = (props: { welcome?: boolean }) => {
               presentDialog({
                 title: strings.offlineMode(),
                 paragraph: strings.offlineModeDesc(),
-                paragraphColor: colors.primary.accent,
                 positiveText: strings.understand(),
                 positivePress: hideAuth as any
               });

--- a/apps/mobile/app/components/auth/header.tsx
+++ b/apps/mobile/app/components/auth/header.tsx
@@ -24,6 +24,8 @@ import { Button } from "../ui/button";
 import { IconButton } from "../ui/icon-button";
 import { hideAuth } from "./common";
 import { AuthParams } from "../../stores/use-navigation-store";
+import { strings } from "@notesnook/intl";
+import { presentDialog } from "../dialog/functions";
 export const AuthHeader = (props: { welcome?: boolean }) => {
   const { colors } = useThemeColors();
   const route = useRoute();
@@ -56,18 +58,18 @@ export const AuthHeader = (props: { welcome?: boolean }) => {
 
         {!props.welcome ? null : (
           <Button
-            title="Skip"
+            title={strings.skipAndGoToApp()}
             onPress={() => {
-              hideAuth();
+              presentDialog({
+                title: strings.offlineMode(),
+                paragraph: strings.offlineModeDesc(),
+                paragraphColor: colors.primary.accent,
+                positiveText: strings.understand(),
+                positivePress: hideAuth as any
+              });
             }}
-            iconSize={16}
             type="plain"
-            iconPosition="right"
-            icon="chevron-right"
             height={25}
-            iconStyle={{
-              marginTop: 2
-            }}
             style={{
               paddingHorizontal: 6
             }}

--- a/packages/intl/locale/en.po
+++ b/packages/intl/locale/en.po
@@ -7490,8 +7490,8 @@ msgid "Using {instance} (v{version})"
 msgstr "Using {instance} (v{version})"
 
 #: src/strings.ts:2812
-msgid "Using Notesnook without an account will **NOT** sync your notes across devices and could result in data loss if you lose access to your device or uninstall the app. Make sure to backup your notes regularly."
-msgstr "Using Notesnook without an account will **NOT** sync your notes across devices and could result in data loss if you lose access to your device or uninstall the app. Make sure to backup your notes regularly."
+msgid "Using Notesnook without an account will NOT sync your notes across devices and could result in data loss if you lose access to your device or uninstall the app. Make sure to backup your notes regularly."
+msgstr "Using Notesnook without an account will NOT sync your notes across devices and could result in data loss if you lose access to your device or uninstall the app. Make sure to backup your notes regularly."
 
 #: src/strings.ts:2265
 msgid "Using official Notesnook instance"

--- a/packages/intl/locale/pseudo-LOCALE.po
+++ b/packages/intl/locale/pseudo-LOCALE.po
@@ -7440,7 +7440,7 @@ msgid "Using {instance} (v{version})"
 msgstr ""
 
 #: src/strings.ts:2812
-msgid "Using Notesnook without an account will **NOT** sync your notes across devices and could result in data loss if you lose access to your device or uninstall the app. Make sure to backup your notes regularly."
+msgid "Using Notesnook without an account will NOT sync your notes across devices and could result in data loss if you lose access to your device or uninstall the app. Make sure to backup your notes regularly."
 msgstr ""
 
 #: src/strings.ts:2265

--- a/packages/intl/src/strings.ts
+++ b/packages/intl/src/strings.ts
@@ -2809,5 +2809,5 @@ Continue without attachments?`,
   versionDeleted: () => actions.deleted.version(1),
   offlineMode: () => t`Offline mode`,
   offlineModeDesc: () =>
-    t`Using Notesnook without an account will **NOT** sync your notes across devices and could result in data loss if you lose access to your device or uninstall the app. Make sure to backup your notes regularly.`
+    t`Using Notesnook without an account will NOT sync your notes across devices and could result in data loss if you lose access to your device or uninstall the app. Make sure to backup your notes regularly.`
 };


### PR DESCRIPTION
## Description
This PR changes the "Skip" button text to "Use offline" which is more clear and direct. It also adds a dialog to notify users about the trade offs of using Notesnook offline.

## Type of Change
- [ ] Bug fix
- [x] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
