### PR TITLE
mobile: allow opening empty trashed notes without contentId

### DIFF
--- a/apps/mobile/app/components/list-items/note/wrapper.tsx
+++ b/apps/mobile/app/components/list-items/note/wrapper.tsx
@@ -58,9 +58,9 @@ export const openNote = async (
   }
 
   if (isTrash) {
-    if (!note.contentId) return;
-
-    const content = await db.content.get(note.contentId as string);
+    const content = note.contentId
+      ? await db.content.get(note.contentId)
+      : undefined;
     presentSheet({
       component: <NotePreview note={item} content={content} />
     });

--- a/apps/mobile/app/components/note-history/preview.tsx
+++ b/apps/mobile/app/components/note-history/preview.tsx
@@ -198,7 +198,7 @@ export default function NotePreview({
         <View
           style={{
             width: "100%",
-            height: 100,
+            flex: 1,
             justifyContent: "center",
             alignItems: "center"
           }}


### PR DESCRIPTION
## Description
Fixes an issue on Android where title-only notes could not be opened from Trash.
Closes https://github.com/streetwriters/notesnook/issues/10165

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
