### PR TITLE
mobile: add WebP image support across paste, upload, and rendering

### DIFF
--- a/apps/mobile/app/screens/editor/tiptap/picker.ts
+++ b/apps/mobile/app/screens/editor/tiptap/picker.ts
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import Sodium from "@ammarahmed/react-native-sodium";
 import { isFeatureAvailable } from "@notesnook/common";
 import { strings } from "@notesnook/intl";
+import { getImageMimeTypeFromFilename } from "@notesnook/core";
 import {
   DocumentPickerOptions,
   keepLocalCopy,
@@ -107,15 +108,14 @@ const file = async (fileOptions: PickerOptions) => {
       uri: uri,
       type: "url"
     });
-    if (
-      !(await attachFile(
-        uri,
-        hash,
-        file.type || "application/octet-stream",
-        fileName,
-        fileOptions
-      ))
-    ) {
+
+    const detectedMime =
+      getImageMimeTypeFromFilename(fileName) ||
+      file.type ||
+      "application/octet-stream";
+    const isPickedFileImage = detectedMime.startsWith("image/");
+
+    if (!(await attachFile(uri, hash, detectedMime, fileName, fileOptions))) {
       throw new Error("Failed to attach file");
     }
 
@@ -128,16 +128,29 @@ const file = async (fileOptions: PickerOptions) => {
       useTabStore.getState().getNoteIdForTab(fileOptions.tabId) ===
         fileOptions.noteId
     ) {
-      editorController.current?.commands.insertAttachment(
-        {
-          hash: hash,
-          filename: fileName,
-          mime: file.type || "application/octet-stream",
-          size: file.size || 0,
-          type: "file"
-        },
-        fileOptions.tabId
-      );
+      if (isPickedFileImage) {
+        editorController.current?.commands.insertImage(
+          {
+            hash: hash,
+            mime: detectedMime,
+            type: "image",
+            size: file.size || 0,
+            filename: fileName as string
+          },
+          fileOptions.tabId
+        );
+      } else {
+        editorController.current?.commands.insertAttachment(
+          {
+            hash: hash,
+            filename: fileName,
+            mime: detectedMime,
+            size: file.size || 0,
+            type: "file"
+          },
+          fileOptions.tabId
+        );
+      }
     } else {
       throw new Error("Failed to attach file, no tabId is set");
     }
@@ -251,6 +264,13 @@ const handleImageResponse = async (
   const compress = result.compress;
 
   for (const image of response) {
+    if (!image.mime || image.mime === "application/octet-stream") {
+      const inferred = getImageMimeTypeFromFilename(
+        image.filename || image.sourceURL || image.path
+      );
+      if (inferred !== undefined) image.mime = inferred;
+    }
+
     const isPng = /(png)/g.test(image.mime);
     const isJpeg = /(jpeg|jpg)/g.test(image.mime);
     if (compress && (isPng || isJpeg)) {

--- a/apps/mobile/app/share/share.tsx
+++ b/apps/mobile/app/share/share.tsx
@@ -27,7 +27,7 @@ import {
   isFeatureAvailable,
   useIsFeatureAvailable
 } from "@notesnook/common";
-import { isImage } from "@notesnook/core";
+import { isImageFile } from "@notesnook/core";
 import { useThemeColors } from "@notesnook/theme";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
@@ -421,8 +421,8 @@ const ShareView = () => {
         const html = !rawData.value
           ? ""
           : isURL(rawData?.value)
-            ? makeHtmlFromUrl(rawData?.value)
-            : makeHtmlFromPlainText(rawData?.value);
+          ? makeHtmlFromUrl(rawData?.value)
+          : makeHtmlFromPlainText(rawData?.value);
         setNote((note) => {
           note.content.data = html;
           noteContent.current = html;
@@ -628,7 +628,7 @@ const ShareView = () => {
                       </Paragraph>
                       <ScrollView horizontal>
                         {rawFiles.map((item) =>
-                          isImage(item.type) || item.value?.endsWith(".png") ? (
+                          isImageFile(item.name, item.type) ? (
                             <TouchableOpacity
                               onPress={() => onRemoveFile(item)}
                               key={item.name}
@@ -701,7 +701,9 @@ const ShareView = () => {
                       >
                         Tap to remove an attachment.
                       </Paragraph>
-                      {rawFiles.some((item) => isImage(item.type)) ? (
+                      {rawFiles.some((item) =>
+                        isImageFile(item.name, item.type)
+                      ) ? (
                         <TouchableOpacity
                           activeOpacity={1}
                           style={{

--- a/apps/mobile/app/utils/note-bundle.js
+++ b/apps/mobile/app/utils/note-bundle.js
@@ -18,7 +18,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 import Sodium from "@ammarahmed/react-native-sodium";
-import { isImage } from "@notesnook/core";
+import {
+  isImage,
+  isImageFile,
+  getImageMimeTypeFromFilename
+} from "@notesnook/core";
 import { Platform } from "react-native";
 import RNFetchBlob from "react-native-blob-util";
 import { DatabaseLogger, db } from "../common/database";
@@ -124,8 +128,12 @@ async function createNotes(bundle) {
     let content = ``;
 
     if (attached) {
-      if (isImage(file.type)) {
-        content = `<img data-hash="${hash}" data-mime="${file.type}" data-filename="${file.name}" data-size="${file.size}" />`;
+      const detectedMime =
+        file.type && isImage(file.type)
+          ? file.type
+          : getImageMimeTypeFromFilename(file.name) || file.type;
+      if (isImageFile(file.name, file.type)) {
+        content = `<img data-hash="${hash}" data-mime="${detectedMime}" data-filename="${file.name}" data-size="${file.size}" />`;
       } else {
         content = `<p><span data-hash="${hash}" data-mime="${file.type}" data-filename="${file.name}" data-size="${file.size}" /></p>`;
       }

--- a/apps/web/src/components/editor/picker.ts
+++ b/apps/web/src/components/editor/picker.ts
@@ -30,6 +30,7 @@ import {
 import { checkFeature } from "../../common";
 import { AttachFilesDialog } from "../../dialogs/attach-files-dialog";
 import { strings } from "@notesnook/intl";
+import { isImageFile } from "@notesnook/core";
 import Queue from "p-queue";
 
 export async function insertAttachments(
@@ -71,7 +72,7 @@ export async function reuploadAttachment(
     forceWrite: true
   };
 
-  if (selectedFile.type.startsWith("image/")) {
+  if (isImageFile(selectedFile.name, selectedFile.type)) {
     const image = await pickImage(selectedFile, options);
     if (!image) return;
   } else {
@@ -111,7 +112,7 @@ export async function attachFiles(
         }
 
         const attachment =
-          !skipSpecialImageHandling && file.type.startsWith("image/")
+          !skipSpecialImageHandling && isImageFile(file.name, file.type)
             ? await pickImage(file)
             : await pickFile(file);
 

--- a/apps/web/src/dialogs/attach-files-dialog.tsx
+++ b/apps/web/src/dialogs/attach-files-dialog.tsx
@@ -35,6 +35,7 @@ import {
   CloseCircle
 } from "../components/icons";
 import { compressImage } from "../utils/image-compressor";
+import { isImageFile } from "@notesnook/core";
 import Queue from "p-queue";
 
 type FileStatus = "pending" | "compressing" | "encrypting" | "done" | "error";
@@ -61,7 +62,7 @@ export const AttachFilesDialog = DialogManager.register(
     onDone,
     onClose
   }: AttachFilesDialogProps) {
-    const hasImages = files.some((f) => f.type.startsWith("image/"));
+    const hasImages = files.some((f) => isImageFile(f.name, f.type));
     const imageCompressionConfig = Config.get<ImageCompressionOptions>(
       "imageCompression",
       ImageCompressionOptions.ASK_EVERY_TIME
@@ -69,8 +70,8 @@ export const AttachFilesDialog = DialogManager.register(
     const [fileStates, setFileStates] = useState<FileState[]>(() =>
       files
         .sort((a, b) => {
-          const aIsImage = a.type.startsWith("image/");
-          const bIsImage = b.type.startsWith("image/");
+          const aIsImage = isImageFile(a.name, a.type);
+          const bIsImage = isImageFile(b.name, b.type);
           if (aIsImage && !bIsImage) return -1;
           if (!aIsImage && bIsImage) return 1;
           return a.type.localeCompare(b.type);
@@ -79,7 +80,7 @@ export const AttachFilesDialog = DialogManager.register(
           file,
           status: "pending",
           progress: 0,
-          compress: file.type.startsWith("image/")
+          compress: isImageFile(file.name, file.type)
             ? imageCompressionConfig !== ImageCompressionOptions.DISABLE
             : false
         }))
@@ -291,7 +292,7 @@ function FileRow({
   onToggleCompress?: () => void;
 }) {
   const { file, status, progress, error, compress, compressedFile } = state;
-  const isImage = file.type.startsWith("image/");
+  const isImage = isImageFile(file.name, file.type);
   const activeFile = compress && compressedFile ? compressedFile : file;
   const thumbnail = useMemo(
     () => (isImage ? URL.createObjectURL(activeFile) : undefined),

--- a/packages/core/__tests__/utils/filename.test.ts
+++ b/packages/core/__tests__/utils/filename.test.ts
@@ -1,0 +1,105 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { describe, test, expect } from "vitest";
+import {
+  isImage,
+  isImageFile,
+  getImageMimeTypeFromFilename
+} from "../../src/utils/filename.js";
+
+describe("isImage", () => {
+  test("returns true for any image/* MIME type", () => {
+    expect(isImage("image/png")).toBe(true);
+    expect(isImage("image/webp")).toBe(true);
+    expect(isImage("image/gif")).toBe(true);
+    expect(isImage("image/jpeg")).toBe(true);
+    expect(isImage("image/svg+xml")).toBe(true);
+  });
+
+  test("returns false for non-image MIME types", () => {
+    expect(isImage("application/pdf")).toBe(false);
+    expect(isImage("audio/mpeg")).toBe(false);
+    expect(isImage("video/mp4")).toBe(false);
+    expect(isImage("application/octet-stream")).toBe(false);
+  });
+});
+
+describe("getImageMimeTypeFromFilename", () => {
+  test("maps common image extensions to MIME types", () => {
+    expect(getImageMimeTypeFromFilename("photo.webp")).toBe("image/webp");
+    expect(getImageMimeTypeFromFilename("photo.WEBP")).toBe("image/webp");
+    expect(getImageMimeTypeFromFilename("icon.png")).toBe("image/png");
+    expect(getImageMimeTypeFromFilename("img.JPG")).toBe("image/jpeg");
+    expect(getImageMimeTypeFromFilename("scan.tiff")).toBe("image/tiff");
+    expect(getImageMimeTypeFromFilename("anim.gif")).toBe("image/gif");
+    expect(getImageMimeTypeFromFilename("logo.svg")).toBe("image/svg+xml");
+  });
+
+  test("returns undefined for non-image extensions", () => {
+    expect(getImageMimeTypeFromFilename("doc.pdf")).toBeUndefined();
+    expect(getImageMimeTypeFromFilename("song.mp3")).toBeUndefined();
+    expect(getImageMimeTypeFromFilename("clip.mp4")).toBeUndefined();
+    expect(getImageMimeTypeFromFilename("archive.zip")).toBeUndefined();
+  });
+
+  test("handles edge cases", () => {
+    expect(getImageMimeTypeFromFilename("")).toBeUndefined();
+    expect(getImageMimeTypeFromFilename("noext")).toBeUndefined();
+    expect(getImageMimeTypeFromFilename(undefined)).toBeUndefined();
+    expect(getImageMimeTypeFromFilename("path/to/file.webp")).toBe(
+      "image/webp"
+    );
+    expect(getImageMimeTypeFromFilename("file.name.with.dots.png")).toBe(
+      "image/png"
+    );
+  });
+});
+
+describe("isImageFile", () => {
+  test("trusts a valid image MIME type regardless of extension", () => {
+    expect(isImageFile("file.bin", "image/webp")).toBe(true);
+    expect(isImageFile("file.dat", "image/png")).toBe(true);
+    expect(isImageFile(undefined, "image/jpeg")).toBe(true);
+  });
+
+  test("rejects non-image MIME types even with an image extension", () => {
+    expect(isImageFile("photo.png", "application/pdf")).toBe(false);
+    expect(isImageFile("photo.png", "audio/mpeg")).toBe(false);
+  });
+
+  test("falls back to extension when MIME is missing", () => {
+    expect(isImageFile("photo.webp", undefined)).toBe(true);
+    expect(isImageFile("photo.webp", "")).toBe(true);
+    expect(isImageFile("icon.png", undefined)).toBe(true);
+    expect(isImageFile("img.jpg", undefined)).toBe(true);
+  });
+
+  test("falls back to extension when MIME is application/octet-stream", () => {
+    expect(isImageFile("photo.webp", "application/octet-stream")).toBe(true);
+    expect(isImageFile("icon.png", "application/octet-stream")).toBe(true);
+  });
+
+  test("returns false for non-image files with missing MIME", () => {
+    expect(isImageFile("doc.pdf", undefined)).toBe(false);
+    expect(isImageFile("song.mp3", "")).toBe(false);
+    expect(isImageFile("archive.zip", "application/octet-stream")).toBe(false);
+    expect(isImageFile(undefined, undefined)).toBe(false);
+  });
+});

--- a/packages/core/src/utils/filename.ts
+++ b/packages/core/src/utils/filename.ts
@@ -65,6 +65,67 @@ export function isImage(mime: string) {
   return mime.startsWith("image/");
 }
 
+/**
+ * A static map of common image file extensions to their MIME types.
+ * This is used as a fallback when the MIME type reported by the
+ * platform is missing or generic (e.g. `application/octet-stream`),
+ * which is common for WebP and some other formats on mobile
+ * document pickers and browser paste operations.
+ *
+ * Kept intentionally small — only formats the editor/renderer can
+ * actually display.  Raw formats (CR2, NEF, …) are intentionally
+ * excluded because they must be treated as file attachments.
+ */
+const IMAGE_EXTENSION_MIME: Readonly<Record<string, string>> = {
+  webp: "image/webp",
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  bmp: "image/bmp",
+  svg: "image/svg+xml",
+  avif: "image/avif",
+  ico: "image/x-icon",
+  tif: "image/tiff",
+  tiff: "image/tiff"
+};
+
+/**
+ * Infer the image MIME type from a filename's extension.
+ * Returns `undefined` when the extension is not a recognised image
+ * format.
+ */
+export function getImageMimeTypeFromFilename(
+  filename: string | undefined
+): string | undefined {
+  if (!filename) return undefined;
+  const ext = filename.split(".").pop()?.toLowerCase();
+  if (!ext) return undefined;
+  return IMAGE_EXTENSION_MIME[ext];
+}
+
+/**
+ * Determine whether a file is an image, looking at both the MIME
+ * type *and* the file extension.
+ *
+ * The MIME type is authoritative when it starts with `image/`.
+ * When the MIME type is missing, empty, or the generic
+ * `application/octet-stream` (which browsers and mobile document
+ * pickers frequently report for WebP and other formats) the
+ * decision falls back to the file extension via
+ * {@link getImageMimeTypeFromFilename}.
+ */
+export function isImageFile(
+  filename: string | undefined,
+  mime: string | undefined
+): boolean {
+  if (mime && mime.startsWith("image/")) return true;
+  if (!mime || mime === "" || mime === "application/octet-stream") {
+    return getImageMimeTypeFromFilename(filename) !== undefined;
+  }
+  return false;
+}
+
 export function isVideo(mime: string) {
   return mime.startsWith("video/");
 }


### PR DESCRIPTION
## Description

Image detection relied solely on `mime.startsWith('image/')`, so WebP (and other formats) silently fell through to the generic file attachment path when a browser or mobile document picker reported an empty or `application/octet-stream` MIME type.

## Root Cause

Every image-detection point in the codebase used `mime.startsWith(image/)` or `file.type.startsWith(image/)`. On many platforms (especially Android document pickers, some browser paste operations, and React Native share extensions), `.webp` files are reported with an empty MIME type or `application/octet-stream`, causing them to be stored and rendered as generic file attachments instead of image nodes.

## Changes

### Shared utility (`packages/core/src/utils/filename.ts`)
- Added `getImageMimeTypeFromFilename(filename)` — maps common image extensions to MIME types, returning `undefined` for non-image extensions
- Added `isImageFile(filename?, mime?)` — returns true when MIME starts with `image/`, falls back to extension-based detection when MIME is missing/empty

### Tests (`packages/core/__tests__/utils/filename.test.ts`)
- 10 tests covering MIME detection, extension inference, `application/octet-stream` fallback, case-insensitivity, edge cases, and non-image rejection

### Web app
- `apps/web/src/components/editor/picker.ts` — `isImageFile` in `attachFiles` and `reuploadAttachment`
- `apps/web/src/dialogs/attach-files-dialog.tsx` — `isImageFile` for sorting, compression toggle, and thumbnail detection

### Mobile app
- `apps/mobile/app/screens/editor/tiptap/picker.ts` — document picker now detects image files by extension and inserts them as image nodes; gallery response MIME normalized for missing MIME
- `apps/mobile/app/utils/note-bundle.js` — `isImageFile` detection; inferred MIME written into `<img>` data-mime attribute
- `apps/mobile/app/share/share.tsx` — removed hardcoded `.png`-only fallback; replaced `isImage` with `isImageFile`

## Type of Change
- [x] Bug fix
- [ ] Feature

## Testing
- [x] 10 unit tests in `packages/core/__tests__/utils/filename.test.ts` (all passing)
- [x] Prettier applied
- [x] ESLint clean (0 new warnings)
- [ ] Ran all E2E tests — N/A (no E2E environment)

## Platform
- [x] Web
- [x] Mobile
- [ ] Desktop

Closes #10178

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed