### PR TITLE
Mobile/fix desktop mode

### DIFF
--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -30,6 +30,23 @@
         android:name="android.hardware.camera"
         android:required="false" />
 
+    <!-- Desktop mode / external display support (Samsung DeX, Android freeform windows). -->
+    <uses-feature
+        android:name="android.software.freeform_window_management"
+        android:required="false" />
+    <!--
+      Google Play implicitly treats touchscreen as required. Declaring it optional keeps the app
+      available on, and usable with, mouse + keyboard in desktop mode. Do not add
+      <uses-configuration android:reqTouchScreen="finger"> or mark these required: per Samsung's
+      DeX guidance that disables mouse and keyboard support.
+    -->
+    <uses-feature
+        android:name="android.hardware.touchscreen"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.faketouch"
+        android:required="false" />
+
     <queries>
         <intent>
             <action android:name="android.intent.action.VIEW" />
@@ -66,8 +83,20 @@
         android:label="@string/app_name"
         android:largeHeap="true"
         android:requestLegacyExternalStorage="true"
+        android:resizeableActivity="true"
         android:supportsRtl="true"
         android:theme="@style/BootTheme">
+
+        <!--
+          Keeps the process alive across the density change when entering/leaving Samsung DeX
+          instead of tearing it down. The two keys cover DeX < 3.0 and >= 3.0 respectively.
+        -->
+        <meta-data
+            android:name="com.samsung.android.keepalive.density"
+            android:value="true" />
+        <meta-data
+            android:name="com.samsung.android.multidisplay.keep_process_alive"
+            android:value="true" />
 
         <receiver
             android:name=".NoteWidget"
@@ -119,7 +148,7 @@
 
         <activity
             android:name=".NotePreviewConfigureActivity"
-            android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
+            android:configChanges="density|keyboard|keyboardHidden|navigation|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
             android:exported="true"
             android:label="NotePreviewConfigure"
             android:launchMode="singleTask"
@@ -132,7 +161,7 @@
 
         <activity
             android:name=".MainActivity"
-            android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
+            android:configChanges="density|keyboard|keyboardHidden|navigation|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
             android:exported="true"
             android:label="@string/app_name"
             android:launchMode="singleTask"
@@ -180,7 +209,7 @@
             android:exported="false" />
         <activity
             android:name=".ShareActivity"
-            android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
+            android:configChanges="density|keyboard|keyboardHidden|navigation|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
             android:excludeFromRecents="true"
             android:exported="true"
             android:label="@string/title_activity_share"

--- a/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/DisplayMetricsSync.java
+++ b/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/DisplayMetricsSync.java
@@ -1,0 +1,159 @@
+package com.streetwriters.notesnook;
+
+import android.app.Activity;
+import android.os.Build;
+import android.util.DisplayMetrics;
+import android.util.Log;
+import android.view.Display;
+
+import com.facebook.react.ReactHost;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.uimanager.DisplayMetricsHolder;
+import com.facebook.react.uimanager.PixelUtil;
+
+/**
+ * Keeps React Native's display metrics pointed at the display the foreground activity is actually
+ * on, so the app renders correctly on external displays and in desktop mode (Samsung DeX, freeform
+ * windows).
+ *
+ * <p>React Native initializes {@link DisplayMetricsHolder} from the *application* context, whose
+ * WindowManager always resolves to {@code Display.DEFAULT_DISPLAY} -- the built-in panel -- no
+ * matter which display the activity is on. Everything downstream reads those metrics:
+ * {@code PixelUtil} converts every dp/px value with {@code getScreenDisplayMetrics().density}, and
+ * react-native-screens converts each Screen's measured pixel frame back to dp with it before
+ * pushing that frame into the shadow tree.
+ *
+ * <p>DeX runs at 160dpi (density 1.0) while a modern phone panel is ~2.8-3.5. So a 1920px-wide
+ * window is reported to JS as {@code 1920 / phoneDensity} dp, while the surface itself lays out at
+ * the real display density (that one comes from the activity context and is already correct). The
+ * app ends up rendered into the top-left {@code externalDensity / phoneDensity} fraction of the
+ * window and never sees the remaining space.
+ *
+ * <p>Note this holder is process-global, but every {@code ReactActivity} in this app has its own
+ * surface and can be on a different display. Whichever activity most recently resumed or handled a
+ * configuration change wins, which is why each of them syncs rather than only the main one.
+ *
+ * <p>Uses only public React Native API, so it works against the prebuilt AAR -- no patching.
+ */
+final class DisplayMetricsSync {
+
+  static final String TAG = "NNDisplayMetrics";
+
+  private DisplayMetricsSync() {
+  }
+
+  /**
+   * Diagnostic: dumps what the activity's display says versus what React Native is actually using.
+   * On a correctly synced app these agree; a mismatch on {@code PixelUtil.density} is the bug this
+   * class exists to fix, and the ratio between the two is the fraction of the window the UI ends
+   * up rendering into. Debug builds only. Filter logcat on {@link #TAG}.
+   */
+  static void logState(Activity activity, String where) {
+    if (!BuildConfig.DEBUG) return;
+    try {
+      DisplayMetrics res = activity.getResources().getDisplayMetrics();
+      android.content.res.Configuration cfg = activity.getResources().getConfiguration();
+
+      int displayId = -1;
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && activity.getDisplay() != null) {
+        displayId = activity.getDisplay().getDisplayId();
+      }
+
+      String rnScreen = "<uninitialized>";
+      String rnWindow = "<uninitialized>";
+      String pixelUtil = "<uninitialized>";
+      try {
+        DisplayMetrics s = DisplayMetricsHolder.getScreenDisplayMetrics();
+        rnScreen = s.widthPixels + "x" + s.heightPixels + " density=" + s.density
+                + " dpi=" + s.densityDpi;
+      } catch (Throwable ignored) {
+      }
+      try {
+        DisplayMetrics w = DisplayMetricsHolder.getWindowDisplayMetrics();
+        rnWindow = w.widthPixels + "x" + w.heightPixels + " density=" + w.density
+                + " dpi=" + w.densityDpi;
+      } catch (Throwable ignored) {
+      }
+      try {
+        pixelUtil = String.valueOf(PixelUtil.getDisplayMetricDensity());
+      } catch (Throwable ignored) {
+      }
+
+      Log.i(TAG, "[" + where + "] displayId=" + displayId
+              + " | activity: " + res.widthPixels + "x" + res.heightPixels
+              + " density=" + res.density + " dpi=" + res.densityDpi
+              + " cfg=" + cfg.screenWidthDp + "x" + cfg.screenHeightDp + "dp"
+              + " sw=" + cfg.smallestScreenWidthDp + "dp cfgDpi=" + cfg.densityDpi
+              + " | RN screen: " + rnScreen
+              + " | RN window: " + rnWindow
+              + " | PixelUtil.density=" + pixelUtil);
+    } catch (Throwable ignored) {
+    }
+  }
+
+  /**
+   * Re-points React Native's window and screen metrics at {@code activity}'s display.
+   *
+   * <p>Must be called *after* {@code super.onCreate()}, and after {@code super} in
+   * {@code onResume()} and {@code onConfigurationChanged()}. React Native calls the unconditional
+   * {@code initDisplayMetrics()} during startup and again from
+   * {@code ReactHostImpl.onConfigurationChanged()}; that method assigns the window metrics from the
+   * given context's resources but then overwrites the *screen* metrics from
+   * {@code wm.defaultDisplay}, so it re-installs the built-in panel's density every time. Since
+   * {@code PixelUtil} reads the screen metrics, ours have to be applied last to win.
+   *
+   * <p>Measured on an emulator with a 213dpi secondary display and a 544dpi built-in panel:
+   * syncing before {@code super.onCreate()} alone left {@code PixelUtil.density} at 3.4 instead of
+   * 1.33, and the UI rendered into the top-left 39% (= 213/544) of the window.
+   */
+  static void sync(Activity activity) {
+    try {
+      // The activity's configuration is the authority on what a dp means for this window.
+      DisplayMetrics windowMetrics = new DisplayMetrics();
+      windowMetrics.setTo(activity.getResources().getDisplayMetrics());
+
+      DisplayMetrics screenMetrics = new DisplayMetrics();
+      screenMetrics.setTo(windowMetrics);
+
+      Display display = null;
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        display = activity.getDisplay();
+      }
+      if (display == null) {
+        display = activity.getWindowManager().getDefaultDisplay();
+      }
+      if (display != null) {
+        // Full size of the display the activity is on, for Dimensions.get("screen").
+        display.getRealMetrics(screenMetrics);
+        // getRealMetrics can report the panel's physical density rather than the effective one the
+        // activity is configured with. PixelUtil scales the entire UI by this value, so it has to
+        // match the activity configuration or we reintroduce the very mismatch we're fixing.
+        screenMetrics.density = windowMetrics.density;
+        screenMetrics.densityDpi = windowMetrics.densityDpi;
+        screenMetrics.scaledDensity = windowMetrics.scaledDensity;
+      }
+
+      DisplayMetricsHolder.setWindowDisplayMetrics(windowMetrics);
+      DisplayMetricsHolder.setScreenDisplayMetrics(screenMetrics);
+    } catch (Throwable ignored) {
+      // Never let display syncing take the app down; worst case we keep React Native's own metrics.
+    }
+  }
+
+  /**
+   * Tells JS to re-read Dimensions after {@link #sync(Activity)} changed them. Mirrors the payload
+   * React Native's own DeviceInfoModule emits, which is not reachable from app code.
+   */
+  static void emitDimensionsChanged(Activity activity, ReactHost reactHost) {
+    try {
+      if (reactHost == null) return;
+      ReactContext reactContext = reactHost.getCurrentReactContext();
+      if (reactContext == null) return;
+      reactContext.emitDeviceEvent(
+              "didUpdateDimensions",
+              DisplayMetricsHolder.getDisplayMetricsWritableMap(
+                      activity.getResources().getConfiguration().fontScale));
+    } catch (Throwable ignored) {
+    }
+  }
+}

--- a/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/MainActivity.java
+++ b/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/MainActivity.java
@@ -23,11 +23,32 @@ public class MainActivity extends ReactActivity {
   protected void onCreate(Bundle savedInstanceState) {
     RNBootSplash.init(this, R.style.BootTheme);
 
+    // Seed the metrics before React Native starts up...
+    DisplayMetricsSync.sync(this);
+
     super.onCreate(null);
+
+    // ...and again afterwards: super.onCreate() runs React Native's own
+    // initDisplayMetrics(), which unconditionally overwrites the screen metrics with the
+    // *default* display's. This second call is the one that actually sticks.
+    DisplayMetricsSync.sync(this);
+    DisplayMetricsSync.logState(this, "onCreate:after-super+sync");
+
     if (BuildConfig.DEBUG) {
       WebView.setWebContentsDebuggingEnabled(true);
     }
 
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+
+    // Belt and braces: the first real layout pass happens after this, so make sure the metrics
+    // are still ours by then, and let JS re-read Dimensions if anything did change them.
+    DisplayMetricsSync.sync(this);
+    DisplayMetricsSync.emitDimensionsChanged(this, getReactHost());
+    DisplayMetricsSync.logState(this, "onResume");
   }
 
   /**
@@ -53,6 +74,14 @@ public class MainActivity extends ReactActivity {
   public void onConfigurationChanged(Configuration newConfig) {
     super.onConfigurationChanged(newConfig);
     getReactHost().onConfigurationChanged(this);
+
+    DisplayMetricsSync.logState(this, "onConfigurationChanged:before-sync");
+    // Must run after the calls above, which put the built-in panel's metrics back.
+    // See DisplayMetricsSync.
+    DisplayMetricsSync.sync(this);
+    DisplayMetricsSync.emitDimensionsChanged(this, getReactHost());
+    DisplayMetricsSync.logState(this, "onConfigurationChanged:after-sync");
+
     Intent intent = new Intent("onConfigurationChanged");
     intent.putExtra("newConfig", newConfig);
     this.sendBroadcast(intent);

--- a/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/NotePreviewConfigureActivity.java
+++ b/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/NotePreviewConfigureActivity.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.appwidget.AppWidgetManager;
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.os.Bundle;
 
 import com.facebook.react.ReactActivity;
@@ -35,9 +36,30 @@ public class NotePreviewConfigureActivity extends ReactActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        // Seed before startup, then re-apply: super.onCreate() runs React Native's own
+        // initDisplayMetrics(), which overwrites the screen metrics. See DisplayMetricsSync.
+        DisplayMetricsSync.sync(this);
         super.onCreate(null);
+        DisplayMetricsSync.sync(this);
         activity = this;
         readAppWidgetId(getIntent());
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        DisplayMetricsSync.sync(this);
+        DisplayMetricsSync.emitDimensionsChanged(this, getReactHost());
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
+        // Must run after super, which puts the built-in panel's metrics back.
+        // See DisplayMetricsSync.
+        DisplayMetricsSync.sync(this);
+        DisplayMetricsSync.emitDimensionsChanged(this, getReactHost());
     }
 
     /**

--- a/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/ShareActivity.java
+++ b/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/ShareActivity.java
@@ -1,5 +1,6 @@
 package com.streetwriters.notesnook;
 
+import android.content.res.Configuration;
 import android.os.Bundle;
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
@@ -28,7 +29,28 @@ public class ShareActivity extends ReactActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        // Seed before startup, then re-apply: super.onCreate() runs React Native's own
+        // initDisplayMetrics(), which overwrites the screen metrics. See DisplayMetricsSync.
+        DisplayMetricsSync.sync(this);
         super.onCreate(null);
+        DisplayMetricsSync.sync(this);
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        DisplayMetricsSync.sync(this);
+        DisplayMetricsSync.emitDimensionsChanged(this, getReactHost());
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
+        // Must run after super, which puts the built-in panel's metrics back.
+        // See DisplayMetricsSync.
+        DisplayMetricsSync.sync(this);
+        DisplayMetricsSync.emitDimensionsChanged(this, getReactHost());
     }
 
     @Override

--- a/apps/mobile/android/build.gradle
+++ b/apps/mobile/android/build.gradle
@@ -41,3 +41,23 @@ allprojects {
         maven { url 'https://www.jitpack.io' }
     }
 }
+
+/**
+ * Pin every Android module to the NDK this project declares above.
+ *
+ * Most native modules already honour rootProject's ndkVersion, but a module that has an
+ * externalNativeBuild and never sets ndkVersion on its android extension silently falls back to
+ * whatever NDK the Android Gradle Plugin defaults to. That default is a different version than the
+ * one we pin, so the build then demands an NDK nobody asked for and fails at configuration time
+ * with "[CXX1101] NDK at .../<version> did not have a source.properties file" if it isn't installed
+ * (or is a partial install). react-native-nitro-cloud-uploader is one such module.
+ *
+ * Setting it here keeps every module on a single NDK regardless of what each one declares.
+ */
+subprojects { subproject ->
+    ["com.android.application", "com.android.library"].each { pluginId ->
+        subproject.plugins.withId(pluginId) {
+            subproject.android.ndkVersion = rootProject.ext.ndkVersion
+        }
+    }
+}

--- a/apps/mobile/app/screens/editor/index.tsx
+++ b/apps/mobile/app/screens/editor/index.tsx
@@ -19,11 +19,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /* eslint-disable @typescript-eslint/no-var-requires */
 
+import { i18n } from "@lingui/core";
+import { NativeEvents } from "@notesnook/editor-mobile/src/utils/native-events";
+import { strings } from "@notesnook/intl";
 import React, {
-  forwardRef,
   useCallback,
   useEffect,
-  useImperativeHandle,
   useLayoutEffect,
   useRef,
   useState
@@ -33,12 +34,14 @@ import WebView from "react-native-webview";
 import { ShouldStartLoadRequest } from "react-native-webview/lib/WebViewTypes";
 import { notesnook } from "../../../e2e/test.ids";
 import { db } from "../../common/database";
+import { useVaultStatus } from "../../hooks/use-vault-status";
 import BiometricService from "../../services/biometrics";
 import {
   ToastManager,
   eSendEvent,
   eSubscribeEvent
 } from "../../services/event-manager";
+import { useSettingStore } from "../../stores/use-setting-store";
 import {
   eEditorReset,
   eOnLoadNote,
@@ -47,9 +50,10 @@ import {
   eUnlockWithPassword
 } from "../../utils/events";
 import { openLinkInBrowser } from "../../utils/functions";
+import { fluidTabsRef } from "../../utils/global-refs";
 import EditorOverlay from "./loading";
 import { EDITOR_URI } from "./source";
-import { EditorProps, useEditorType } from "./tiptap/types";
+import { EditorProps } from "./tiptap/types";
 import { useEditor } from "./tiptap/use-editor";
 import { useEditorEvents } from "./tiptap/use-editor-events";
 import { syncTabs, useTabStore } from "./tiptap/use-tab-store";
@@ -59,12 +63,6 @@ import {
   openInternalLink,
   randId
 } from "./tiptap/utils";
-import { fluidTabsRef } from "../../utils/global-refs";
-import { strings } from "@notesnook/intl";
-import { i18n } from "@lingui/core";
-import { useVaultStatus } from "../../hooks/use-vault-status";
-import { useSettingStore } from "../../stores/use-setting-store";
-import { NativeEvents } from "@notesnook/editor-mobile/src/utils/native-events";
 
 const style: ViewStyle = {
   height: "100%",
@@ -86,74 +84,60 @@ const onShouldStartLoadWithRequest = (request: ShouldStartLoadRequest) => {
   }
 };
 
-const Editor = React.memo(
-  forwardRef<
-    {
-      get: () => useEditorType;
-    },
-    EditorProps
-  >(
-    (
-      {
-        readonly = false,
-        noToolbar = false,
-        noHeader = false,
-        withController = true,
-        editorId = "",
-        onLoad,
-        onChange
-      },
-      ref
-    ) => {
-      const editor = useEditor(editorId || "", readonly, onChange);
-      const onMessage = useEditorEvents(editor, {
-        readonly,
-        noToolbar,
-        noHeader
-      });
-      const [renderKey, setRenderKey] = useState(
-        randId("editor-id") + editorId
-      );
-      useImperativeHandle(ref, () => ({
-        get: () => editor
-      }));
-      useLockedNoteHandler();
+const Editor = ({
+  readonly = false,
+  noToolbar = false,
+  noHeader = false,
+  withController = true,
+  editorId = "",
+  onLoad,
+  onChange
+}: EditorProps) => {
+  const editor = useEditor(editorId || "", readonly, onChange);
+  const onMessage = useEditorEvents(editor, {
+    readonly,
+    noToolbar,
+    noHeader
+  });
+  const [renderKey, setRenderKey] = useState(randId("editor-id") + editorId);
 
-      const onError = useCallback(() => {
-        setRenderKey(randId("editor-id") + editorId);
-        editor.state.current.ready = false;
-        editor.state.current.initialLoadCalled = false;
-        editor.setLoading(true);
-      }, [editor]);
+  useLockedNoteHandler();
 
-      useEffect(() => {
-        const sub = [eSubscribeEvent(eEditorReset, onError)];
-        return () => {
-          sub.forEach((s) => s?.unsubscribe());
-        };
-      }, [onError]);
+  const onError = useCallback(() => {
+    setRenderKey(randId("editor-id") + editorId);
+    editor.state.current.ready = false;
+    editor.state.current.initialLoadCalled = false;
+    editor.setLoading(true);
+  }, [editor]);
 
-      useLayoutEffect(() => {
-        setImmediate(() => {
-          onLoad && onLoad();
-        });
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-      }, [onLoad]);
+  useEffect(() => {
+    const sub = [eSubscribeEvent(eEditorReset, onError)];
+    return () => {
+      sub.forEach((s) => s?.unsubscribe());
+    };
+  }, [onError]);
 
-      if (withController) {
-        editorController.current = editor;
-      }
+  useLayoutEffect(() => {
+    setImmediate(() => {
+      onLoad && onLoad();
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onLoad]);
 
-      return editor.loading ? null : (
-        <>
-          <WebView
-            testID={notesnook.editor.id}
-            ref={editor.ref}
-            key={renderKey}
-            onRenderProcessGone={onError}
-            nestedScrollEnabled
-            onError={onError}
-            injectedJavaScript={`
+  if (withController) {
+    editorController.current = editor;
+  }
+
+  return editor.loading ? null : (
+    <>
+      <WebView
+        testID={notesnook.editor.id}
+        ref={editor.ref}
+        key={renderKey}
+        onRenderProcessGone={onError}
+        nestedScrollEnabled
+        onError={onError}
+        injectedJavaScript={`
               globalThis.__DEV__ = ${__DEV__}
               globalThis.readonly=${readonly};
               globalThis.noToolbar=${noToolbar};
@@ -164,43 +148,40 @@ const Editor = React.memo(
               })};
               globalThis.loadApp();
           `}
-            useSharedProcessPool={false}
-            javaScriptEnabled={true}
-            focusable={true}
-            onContentProcessDidTerminate={onError}
-            setSupportMultipleWindows={false}
-            overScrollMode="never"
-            scrollEnabled={false}
-            keyboardDisplayRequiresUserAction={false}
-            onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
-            cacheMode="LOAD_DEFAULT"
-            cacheEnabled={true}
-            domStorageEnabled={true}
-            bounces={false}
-            setBuiltInZoomControls={false}
-            setDisplayZoomControls={false}
-            allowFileAccess={true}
-            scalesPageToFit={true}
-            hideKeyboardAccessoryView={false}
-            allowsFullscreenVideo={true}
-            allowFileAccessFromFileURLs={true}
-            allowsInlineMediaPlayback
-            allowUniversalAccessFromFileURLs={true}
-            originWhitelist={["*"]}
-            source={{
-              uri: EDITOR_URI
-            }}
-            style={style}
-            autoManageStatusBarEnabled={false}
-            onMessage={onMessage || undefined}
-          />
-          <EditorOverlay editor={editor} editorId={editorId} />
-        </>
-      );
-    }
-  ),
-  () => true
-);
+        useSharedProcessPool={false}
+        javaScriptEnabled={true}
+        focusable={true}
+        onContentProcessDidTerminate={onError}
+        setSupportMultipleWindows={false}
+        overScrollMode="never"
+        scrollEnabled={false}
+        keyboardDisplayRequiresUserAction={false}
+        onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
+        cacheMode="LOAD_DEFAULT"
+        cacheEnabled={true}
+        domStorageEnabled={true}
+        bounces={false}
+        setBuiltInZoomControls={false}
+        setDisplayZoomControls={false}
+        allowFileAccess={true}
+        scalesPageToFit={true}
+        hideKeyboardAccessoryView={false}
+        allowsFullscreenVideo={true}
+        allowFileAccessFromFileURLs={true}
+        allowsInlineMediaPlayback
+        allowUniversalAccessFromFileURLs={true}
+        originWhitelist={["*"]}
+        source={{
+          uri: EDITOR_URI
+        }}
+        style={style}
+        autoManageStatusBarEnabled={false}
+        onMessage={onMessage || undefined}
+      />
+      <EditorOverlay editor={editor} editorId={editorId} />
+    </>
+  );
+};
 
 export default Editor;
 

--- a/apps/mobile/app/screens/editor/tiptap/types.ts
+++ b/apps/mobile/app/screens/editor/tiptap/types.ts
@@ -72,6 +72,7 @@ export type EditorProps = {
   editorId?: string;
   onLoad?: () => void;
   onChange?: (html: string) => void;
+  deviceMode?: string | null;
 };
 
 export type EditorMessage<T> = {

--- a/apps/mobile/app/screens/editor/wrapper.tsx
+++ b/apps/mobile/app/screens/editor/wrapper.tsx
@@ -136,7 +136,7 @@ export const EditorWrapper = ({ widths }: { widths: PaneWidths }) => {
             style={{ height: 1, padding: 0, width: 1, position: "absolute" }}
             blurOnSubmit={false}
           />
-          <Editor key="editor" withController={true} />
+          <Editor key={"editor" + deviceMode} withController={true} />
         </KeyboardAvoidingView>
       )}
     </View>


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Fixes desktop mode on android that was unusable before this. App would render in one small corner of the screen. This has been fixed now.

Closes https://github.com/streetwriters/notesnook/issues/9685

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [ ] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
