### PR TITLE
Fix checkboxes being checked when scrolling

### DIFF
--- a/packages/editor/src/extensions/check-list-item/check-list-item.ts
+++ b/packages/editor/src/extensions/check-list-item/check-list-item.ts
@@ -157,8 +157,8 @@ export const CheckListItem = Node.create<CheckListItemOptions>({
         }
       }
 
-      li.onmousedown = onClick;
-      li.ontouchstart = onClick;
+      li.onclick = onClick;
+      // li.ontouchstart = onClick;
 
       return {
         dom: li,


### PR DESCRIPTION

## Description
This is an attempt to fix #9534

This prevents checkboxes from being checked when the finger touches a checkbox when scrolling in the editor.

In electron the onclick event is fired for taps as well, when other events don't cancel it, so we can just use it for everything.

I have tested Windows both touch and mouse, and Android. I cannot test other platforms so perhaps you had a good reason to not use onclick to begin with?

If so, I believe an alternative way could be:
- bind touchstart and mousedown and have a handler to save the scroll position.
- bind touchend and mouseup to the current handler and have it reject the click if document scroll position has changed.


## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [x] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [ ] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ x] Web
- [ x] Mobile
- [ x] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
