### PR TITLE
mobile: show last backup and next backup timestamps in Settings > Backups

### DIFF
--- a/apps/mobile/app/common/filesystem/utils.ts
+++ b/apps/mobile/app/common/filesystem/utils.ts
@@ -145,6 +145,13 @@ export async function getUploadedFileSize(hash: string, retry = 0) {
     const contentLength = parseInt(fileSize as string);
     return isNaN(contentLength) ? FileSizeResult.Empty : contentLength;
   } catch (e) {
+    if (retry < 3) {
+      DatabaseLogger.log(
+        `Retrying file size check after error: ${hash}, ${retry}`
+      );
+      await new Promise((resolve) => setTimeout(resolve, 500 * (retry + 1)));
+      return getUploadedFileSize(hash, retry + 1);
+    }
     DatabaseLogger.error(e);
     return FileSizeResult.Error;
   }

--- a/apps/mobile/app/screens/settings/settings-data.tsx
+++ b/apps/mobile/app/screens/settings/settings-data.tsx
@@ -83,6 +83,7 @@ import { verifyUser, verifyUserWithApplock } from "./functions";
 import { logoutUser } from "./logout";
 import { SettingSection } from "./types";
 import { getTimeLeft } from "./user-section";
+import { useShallow } from "zustand/react/shallow";
 
 export const settingsGroups: SettingSection[] = [
   {
@@ -1445,10 +1446,12 @@ export const settingsGroups: SettingSection[] = [
             type: "component",
             name: strings.automaticBackups(),
             useHook: () =>
-              useSettingStore((state) => [
-                state.settings.reminder,
-                state.settings.lastBackupDate
-              ]),
+              useSettingStore(
+                useShallow((state) => [
+                  state.settings.reminder,
+                  state.settings.lastBackupDate
+                ])
+              ),
             description: () => {
               const next = BackupService.getNextBackupTime(
                 SettingsService.get().reminder,
@@ -1468,10 +1471,12 @@ export const settingsGroups: SettingSection[] = [
             hidden: () => !useUserStore.getState().user,
             name: strings.automaticBackupsWithAttachments(),
             useHook: () =>
-              useSettingStore((state) => [
-                state.settings.fullBackupReminder,
-                state.settings.lastFullBackupDate
-              ]),
+              useSettingStore(
+                useShallow((state) => [
+                  state.settings.fullBackupReminder,
+                  state.settings.lastFullBackupDate
+                ])
+              ),
             description: () => {
               const next = BackupService.getNextBackupTime(
                 SettingsService.get().fullBackupReminder,

--- a/apps/mobile/app/screens/settings/settings-data.tsx
+++ b/apps/mobile/app/screens/settings/settings-data.tsx
@@ -1396,7 +1396,15 @@ export const settingsGroups: SettingSection[] = [
           {
             id: "backup-now",
             name: strings.backupNow(),
-            description: strings.backupNowDesc(),
+            property: "lastBackupDate",
+            description: () => {
+              const last = SettingsService.get().lastBackupDate;
+              return last
+                ? `${strings.backupNowDesc()}\n${strings.lastBackupOn(
+                  dayjs(last).format("MMM D, YYYY [at] h:mm A")
+                )}`
+                : strings.backupNowDesc();
+            },
             modifer: async () => {
               const user = useUserStore.getState().user;
               if (!user || SettingsService.getProperty("encryptedBackup")) {
@@ -1410,7 +1418,15 @@ export const settingsGroups: SettingSection[] = [
           {
             id: "backup-now-with-attachments",
             name: strings.backupNowWithAttachments(),
-            description: strings.backupNowWithAttachmentsDesc(),
+            property: "lastFullBackupDate",
+            description: () => {
+              const last = SettingsService.get().lastFullBackupDate;
+              return last
+                ? `${strings.backupNowWithAttachmentsDesc()}\n${strings.lastBackupOn(
+                  dayjs(last).format("MMM D, YYYY [at] h:mm A")
+                )}`
+                : strings.backupNowWithAttachmentsDesc();
+            },
             hidden: () => !useUserStore.getState().user,
             modifer: async () => {
               const user = useUserStore.getState().user;
@@ -1428,7 +1444,22 @@ export const settingsGroups: SettingSection[] = [
             id: "auto-backups",
             type: "component",
             name: strings.automaticBackups(),
-            description: strings.automaticBackupsDesc(),
+            useHook: () =>
+              useSettingStore((state) => [
+                state.settings.reminder,
+                state.settings.lastBackupDate
+              ]),
+            description: () => {
+              const next = BackupService.getNextBackupTime(
+                SettingsService.get().reminder,
+                "lastBackupDate"
+              );
+              return next
+                ? `${strings.automaticBackupsDesc()}\n${strings.nextBackupOn(
+                  dayjs(next).format("MMM D, YYYY [at] h:mm A")
+                )}`
+                : strings.automaticBackupsDesc();
+            },
             component: "autobackups"
           },
           {
@@ -1436,9 +1467,25 @@ export const settingsGroups: SettingSection[] = [
             type: "component",
             hidden: () => !useUserStore.getState().user,
             name: strings.automaticBackupsWithAttachments(),
-            description: [
-              ...strings.automaticBackupsWithAttachmentsDesc()
-            ].join("\n"),
+            useHook: () =>
+              useSettingStore((state) => [
+                state.settings.fullBackupReminder,
+                state.settings.lastFullBackupDate
+              ]),
+            description: () => {
+              const next = BackupService.getNextBackupTime(
+                SettingsService.get().fullBackupReminder,
+                "lastFullBackupDate"
+              );
+              const base = [
+                ...strings.automaticBackupsWithAttachmentsDesc()
+              ].join("\n");
+              return next
+                ? `${base}\n${strings.nextBackupOn(
+                  dayjs(next).format("MMM D, YYYY [at] h:mm A")
+                )}`
+                : base;
+            },
             component: "autobackupsattachments"
           },
           {

--- a/apps/mobile/app/services/backup.ts
+++ b/apps/mobile/app/services/backup.ts
@@ -160,6 +160,21 @@ async function updateNextBackupTime(type: "full" | "partial") {
     [type === "full" ? "lastFullBackupDate" : "lastBackupDate"]: Date.now()
   });
 }
+
+function getNextBackupTime(
+  type: "daily" | "off" | "useroff" | "weekly" | "monthly" | "never",
+  lastBackupDateType: "lastBackupDate" | "lastFullBackupDate" = "lastBackupDate"
+): number | undefined {
+  if (type === "off" || type === "useroff" || type === "never" || !type) return;
+  const lastBackupDate = SettingsService.getProperty(lastBackupDateType) as
+    | number
+    | undefined;
+  if (!lastBackupDate) return;
+  const interval =
+    type === "daily" ? MS_DAY : type === "weekly" ? MS_WEEK : MONTH;
+  return lastBackupDate + interval;
+}
+
 let backupRunning = false;
 /**
  * @param {boolean=} progress
@@ -413,7 +428,8 @@ const BackupService = {
   run,
   checkAndRun,
   getDirectoryAndroid,
-  checkBackupDirExists
+  checkBackupDirExists,
+  getNextBackupTime
 };
 
 export default BackupService;

--- a/apps/web/src/common/index.ts
+++ b/apps/web/src/common/index.ts
@@ -195,6 +195,7 @@ export async function createBackup(
         ? `${strings.backupSavedAt(path.join(backupDirectory, filePath))}`
         : strings.backupSuccess()
     );
+    await useSettingStore.getState().refreshBackupTime();
     return true;
   }
   return false;

--- a/apps/web/src/common/notices.ts
+++ b/apps/web/src/common/notices.ts
@@ -98,7 +98,7 @@ export async function shouldAddBackupNotice() {
 
   const lastBackupTime = await db.backup.lastBackupTime();
   if (!lastBackupTime) {
-    await db.backup.updateBackupTime();
+    await db.backup.updateBackupTime("partial");
     return false;
   }
 
@@ -210,7 +210,7 @@ async function saveBackup(mode: "full" | "partial" = "partial") {
         {
           text: strings.later(),
           onClick: async () => {
-            await db.backup.updateBackupTime();
+            await db.backup.updateBackupTime(mode);
             openedToast?.hide();
             openedToast = null;
           },

--- a/apps/web/src/dialogs/settings/backup-export-settings.ts
+++ b/apps/web/src/dialogs/settings/backup-export-settings.ts
@@ -27,6 +27,8 @@ import { useStore as useAppStore } from "../../stores/app-store";
 import { useStore as useUserStore } from "../../stores/user-store";
 import { desktop } from "../../common/desktop-bridge";
 import { formatDate } from "@notesnook/core";
+import { BACKUP_CRON_EXPRESSIONS, FULL_BACKUP_CRON_EXPRESSIONS } from "../../common/notices";
+import { CronosExpression } from "cronosjs";
 import dayjs from "dayjs";
 
 function getNextBackupTime(
@@ -35,13 +37,19 @@ function getNextBackupTime(
   isFull: boolean = false
 ): number | undefined {
   if (offset === 0 || !lastBackupDate) return undefined;
-  let days = 0;
-  if (isFull) {
-    days = offset === 1 ? 7 : 30;
-  } else {
-    days = offset === 1 ? 1 : offset === 2 ? 7 : 30;
+  try {
+    const cronString = isFull
+      ? FULL_BACKUP_CRON_EXPRESSIONS[offset as keyof typeof FULL_BACKUP_CRON_EXPRESSIONS]
+      : BACKUP_CRON_EXPRESSIONS[offset as keyof typeof BACKUP_CRON_EXPRESSIONS];
+
+    if (!cronString) return undefined;
+
+    const expr = CronosExpression.parse(cronString);
+    const nextDate = expr.nextDate(new Date(lastBackupDate));
+    return nextDate ? nextDate.getTime() : undefined;
+  } catch (e) {
+    return undefined;
   }
-  return dayjs(lastBackupDate).add(days, "d").valueOf();
 }
 
 const getDesktopBackupsDirectoryPath = () =>
@@ -64,14 +72,9 @@ export const BackupExportSettings: SettingsGroup[] = [
 
           if (!last) return strings.backupNowDesc();
 
-          const typeStr = last === full ? " (Full)" : " (Partial)";
-          return `${strings.backupNowDesc()}\n${strings.lastBackupOn(
-            formatDate(last, {
-              type: "date-time",
-              dateFormat: s.dateFormat,
-              timeFormat: s.timeFormat
-            })
-          )}${typeStr}`;
+          const formattedDate = formatDate(last, { type: "date-time", dateFormat: s.dateFormat, timeFormat: s.timeFormat });
+          const backupStr = last === full ? strings.lastFullBackupOn(formattedDate) : strings.lastPartialBackupOn(formattedDate);
+          return `${strings.backupNowDesc()}\n${backupStr}`;
         },
         onStateChange: (listener) =>
           useSettingStore.subscribe(

--- a/apps/web/src/dialogs/settings/backup-export-settings.ts
+++ b/apps/web/src/dialogs/settings/backup-export-settings.ts
@@ -26,6 +26,7 @@ import { useStore as useSettingStore } from "../../stores/setting-store";
 import { useStore as useAppStore } from "../../stores/app-store";
 import { useStore as useUserStore } from "../../stores/user-store";
 import { desktop } from "../../common/desktop-bridge";
+import { formatDate } from "@notesnook/core";
 import dayjs from "dayjs";
 
 function getNextBackupTime(
@@ -60,12 +61,16 @@ export const BackupExportSettings: SettingsGroup[] = [
           const partial = s.lastBackupTime || 0;
           const full = s.lastFullBackupTime || 0;
           const last = Math.max(partial, full);
-          
+
           if (!last) return strings.backupNowDesc();
-          
+
           const typeStr = last === full ? " (Full)" : " (Partial)";
           return `${strings.backupNowDesc()}\n${strings.lastBackupOn(
-            dayjs(last).format("MMM D, YYYY [at] h:mm A")
+            formatDate(last, {
+              type: "date-time",
+              dateFormat: s.dateFormat,
+              timeFormat: s.timeFormat
+            })
           )}${typeStr}`;
         },
         onStateChange: (listener) =>
@@ -112,15 +117,20 @@ export const BackupExportSettings: SettingsGroup[] = [
         key: "auto-backup",
         title: strings.automaticBackups(),
         description: () => {
+          const s = useSettingStore.getState();
           const next = getNextBackupTime(
-            useSettingStore.getState().backupReminderOffset,
-            useSettingStore.getState().lastBackupTime,
+            s.backupReminderOffset,
+            s.lastBackupTime,
             false
           );
           return next
             ? `${strings.automaticBackupsDesc()}\n${strings.nextBackupOn(
-              dayjs(next).format("MMM D, YYYY [at] h:mm A")
-            )}`
+                formatDate(next, {
+                  type: "date-time",
+                  dateFormat: s.dateFormat,
+                  timeFormat: s.timeFormat
+                })
+              )}`
             : strings.automaticBackupsDesc();
         },
         onStateChange: (listener) =>
@@ -155,16 +165,23 @@ export const BackupExportSettings: SettingsGroup[] = [
         key: "auto-backup-with-attachments",
         title: strings.automaticBackupsWithAttachments(),
         description: () => {
+          const s = useSettingStore.getState();
           const next = getNextBackupTime(
-            useSettingStore.getState().fullBackupReminderOffset,
-            useSettingStore.getState().lastFullBackupTime,
+            s.fullBackupReminderOffset,
+            s.lastFullBackupTime,
             true
           );
-          const base = strings.automaticBackupsWithAttachmentsDesc().join("\n\n");
+          const base = strings
+            .automaticBackupsWithAttachmentsDesc()
+            .join("\n\n");
           return next
             ? `${base}\n${strings.nextBackupOn(
-              dayjs(next).format("MMM D, YYYY [at] h:mm A")
-            )}`
+                formatDate(next, {
+                  type: "date-time",
+                  dateFormat: s.dateFormat,
+                  timeFormat: s.timeFormat
+                })
+              )}`
             : base;
         },
         onStateChange: (listener) =>

--- a/apps/web/src/dialogs/settings/backup-export-settings.ts
+++ b/apps/web/src/dialogs/settings/backup-export-settings.ts
@@ -26,6 +26,22 @@ import { useStore as useSettingStore } from "../../stores/setting-store";
 import { useStore as useAppStore } from "../../stores/app-store";
 import { useStore as useUserStore } from "../../stores/user-store";
 import { desktop } from "../../common/desktop-bridge";
+import dayjs from "dayjs";
+
+function getNextBackupTime(
+  offset: number,
+  lastBackupDate?: number,
+  isFull: boolean = false
+): number | undefined {
+  if (offset === 0 || !lastBackupDate) return undefined;
+  let days = 0;
+  if (isFull) {
+    days = offset === 1 ? 7 : 30;
+  } else {
+    days = offset === 1 ? 1 : offset === 2 ? 7 : 30;
+  }
+  return dayjs(lastBackupDate).add(days, "d").valueOf();
+}
 
 const getDesktopBackupsDirectoryPath = () =>
   useSettingStore.getState().backupStorageLocation;
@@ -39,7 +55,24 @@ export const BackupExportSettings: SettingsGroup[] = [
       {
         key: "create-backup",
         title: strings.backupNow(),
-        description: strings.backupNowDesc(),
+        description: () => {
+          const s = useSettingStore.getState();
+          const partial = s.lastBackupTime || 0;
+          const full = s.lastFullBackupTime || 0;
+          const last = Math.max(partial, full);
+          
+          if (!last) return strings.backupNowDesc();
+          
+          const typeStr = last === full ? " (Full)" : " (Partial)";
+          return `${strings.backupNowDesc()}\n${strings.lastBackupOn(
+            dayjs(last).format("MMM D, YYYY [at] h:mm A")
+          )}${typeStr}`;
+        },
+        onStateChange: (listener) =>
+          useSettingStore.subscribe(
+            (s) => `${s.lastBackupTime}-${s.lastFullBackupTime}`,
+            listener
+          ),
         components: [
           {
             type: "dropdown",
@@ -78,9 +111,23 @@ export const BackupExportSettings: SettingsGroup[] = [
       {
         key: "auto-backup",
         title: strings.automaticBackups(),
-        description: strings.automaticBackupsDesc(),
+        description: () => {
+          const next = getNextBackupTime(
+            useSettingStore.getState().backupReminderOffset,
+            useSettingStore.getState().lastBackupTime,
+            false
+          );
+          return next
+            ? `${strings.automaticBackupsDesc()}\n${strings.nextBackupOn(
+              dayjs(next).format("MMM D, YYYY [at] h:mm A")
+            )}`
+            : strings.automaticBackupsDesc();
+        },
         onStateChange: (listener) =>
-          useSettingStore.subscribe((s) => s.backupReminderOffset, listener),
+          useSettingStore.subscribe(
+            (s) => `${s.backupReminderOffset}-${s.lastBackupTime}`,
+            listener
+          ),
         components: [
           {
             type: "dropdown",
@@ -107,10 +154,22 @@ export const BackupExportSettings: SettingsGroup[] = [
       {
         key: "auto-backup-with-attachments",
         title: strings.automaticBackupsWithAttachments(),
-        description: strings.automaticBackupsWithAttachmentsDesc().join("\n\n"),
+        description: () => {
+          const next = getNextBackupTime(
+            useSettingStore.getState().fullBackupReminderOffset,
+            useSettingStore.getState().lastFullBackupTime,
+            true
+          );
+          const base = strings.automaticBackupsWithAttachmentsDesc().join("\n\n");
+          return next
+            ? `${base}\n${strings.nextBackupOn(
+              dayjs(next).format("MMM D, YYYY [at] h:mm A")
+            )}`
+            : base;
+        },
         onStateChange: (listener) =>
           useSettingStore.subscribe(
-            (s) => s.fullBackupReminderOffset,
+            (s) => `${s.fullBackupReminderOffset}-${s.lastFullBackupTime}`,
             listener
           ),
         components: [

--- a/apps/web/src/stores/setting-store.ts
+++ b/apps/web/src/stores/setting-store.ts
@@ -61,6 +61,9 @@ class SettingStore extends BaseStore<SettingStore> {
   isFullOfflineMode = Config.get("fullOfflineMode", false);
   serverUrls: Partial<Record<HostId, string>> = Config.get("serverUrls", {});
 
+  lastBackupTime?: number;
+  lastFullBackupTime?: number;
+
   zoomFactor = 1.0;
   privacyMode = false;
   customDns = true;
@@ -101,6 +104,13 @@ class SettingStore extends BaseStore<SettingStore> {
     });
   };
 
+  refreshBackupTime = async () => {
+    this.set({
+      lastBackupTime: await db.backup.lastBackupTime(),
+      lastFullBackupTime: await db.backup.lastFullBackupTime()
+    });
+  };
+
   refresh = async () => {
     this.set({
       dateFormat: db.settings.getDateFormat(),
@@ -123,6 +133,7 @@ class SettingStore extends BaseStore<SettingStore> {
       isInboxEnabled: await db.user.hasInboxKeys(),
       backupStorageLocation: await desktop?.integration.backupDirectory.query()
     });
+    await this.refreshBackupTime();
   };
 
   setDateFormat = async (dateFormat: string) => {

--- a/packages/core/src/database/backup.ts
+++ b/packages/core/src/database/backup.ts
@@ -191,8 +191,16 @@ export default class Backup {
     return this.db.kv().read("lastBackupTime");
   }
 
-  async updateBackupTime() {
-    await this.db.kv().write("lastBackupTime", Date.now());
+  lastFullBackupTime() {
+    return this.db.kv().read("lastFullBackupTime");
+  }
+
+  async updateBackupTime(mode: "full" | "partial" = "partial") {
+    if (mode === "full") {
+      await this.db.kv().write("lastFullBackupTime", Date.now());
+    } else {
+      await this.db.kv().write("lastBackupTime", Date.now());
+    }
   }
 
   /**
@@ -274,7 +282,7 @@ export default class Backup {
     if (bufferLength > 0 || buffer.length > 0)
       throw new Error("Buffer not empty.");
 
-    await this.updateBackupTime();
+    await this.updateBackupTime("partial");
   }
 
   async *export(options: {
@@ -346,7 +354,7 @@ export default class Backup {
 
     if (backupState.buffer.length > 0) yield* this.bufferToFile(backupState);
     if (mode === "partial") {
-      await this.updateBackupTime();
+      await this.updateBackupTime("partial");
       return;
     }
 
@@ -379,7 +387,7 @@ export default class Backup {
       }
     }
 
-    await this.updateBackupTime();
+    await this.updateBackupTime("full");
   }
 
   private async *backupCollection<T, B extends boolean>(

--- a/packages/core/src/database/kv.ts
+++ b/packages/core/src/database/kv.ts
@@ -29,6 +29,7 @@ interface KV {
   monographs: string[];
   deviceId: string;
   lastBackupTime: number;
+  lastFullBackupTime: number;
   fullOfflineMode: boolean;
 }
 
@@ -40,6 +41,7 @@ export const KEYS: (keyof KV)[] = [
   "monographs",
   "deviceId",
   "lastBackupTime",
+  "lastFullBackupTime",
   "fullOfflineMode"
 ];
 

--- a/packages/intl/locale/en.po
+++ b/packages/intl/locale/en.po
@@ -3860,6 +3860,10 @@ msgstr "Key name"
 msgid "Languages"
 msgstr "Languages"
 
+#: src/strings.ts:2813
+msgid "Last backup: {date}"
+msgstr "Last backup: {date}"
+
 #: src/strings.ts:2243
 msgid "Last edited at"
 msgstr "Last edited at"
@@ -4454,6 +4458,10 @@ msgstr "Newly created notes will be uncategorized"
 #: src/strings.ts:552
 msgid "Next"
 msgstr "Next"
+
+#: src/strings.ts:2814
+msgid "Next backup: {date}"
+msgstr "Next backup: {date}"
 
 #: src/strings.ts:2391
 msgid "Next match"

--- a/packages/intl/locale/en.po
+++ b/packages/intl/locale/en.po
@@ -3860,9 +3860,17 @@ msgstr "Key name"
 msgid "Languages"
 msgstr "Languages"
 
-#: src/strings.ts:2813
+#: src/strings.ts:2814
 msgid "Last backup: {date}"
 msgstr "Last backup: {date}"
+
+#: src/strings.ts:2817
+msgid "Last backup: {date} (Full)"
+msgstr "Last backup: {date} (Full)"
+
+#: src/strings.ts:2816
+msgid "Last backup: {date} (Partial)"
+msgstr "Last backup: {date} (Partial)"
 
 #: src/strings.ts:2243
 msgid "Last edited at"
@@ -4459,7 +4467,7 @@ msgstr "Newly created notes will be uncategorized"
 msgid "Next"
 msgstr "Next"
 
-#: src/strings.ts:2814
+#: src/strings.ts:2815
 msgid "Next backup: {date}"
 msgstr "Next backup: {date}"
 

--- a/packages/intl/locale/en.po
+++ b/packages/intl/locale/en.po
@@ -3857,6 +3857,10 @@ msgstr "Key name"
 msgid "Languages"
 msgstr "Languages"
 
+#: src/strings.ts:2813
+msgid "Last backup: {date}"
+msgstr "Last backup: {date}"
+
 #: src/strings.ts:2243
 msgid "Last edited at"
 msgstr "Last edited at"
@@ -4451,6 +4455,10 @@ msgstr "Newly created notes will be uncategorized"
 #: src/strings.ts:552
 msgid "Next"
 msgstr "Next"
+
+#: src/strings.ts:2814
+msgid "Next backup: {date}"
+msgstr "Next backup: {date}"
 
 #: src/strings.ts:2391
 msgid "Next match"

--- a/packages/intl/locale/pseudo-LOCALE.po
+++ b/packages/intl/locale/pseudo-LOCALE.po
@@ -3840,8 +3840,16 @@ msgstr ""
 msgid "Languages"
 msgstr ""
 
-#: src/strings.ts:2813
+#: src/strings.ts:2814
 msgid "Last backup: {date}"
+msgstr ""
+
+#: src/strings.ts:2817
+msgid "Last backup: {date} (Full)"
+msgstr ""
+
+#: src/strings.ts:2816
+msgid "Last backup: {date} (Partial)"
 msgstr ""
 
 #: src/strings.ts:2243
@@ -4439,7 +4447,7 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
-#: src/strings.ts:2814
+#: src/strings.ts:2815
 msgid "Next backup: {date}"
 msgstr ""
 

--- a/packages/intl/locale/pseudo-LOCALE.po
+++ b/packages/intl/locale/pseudo-LOCALE.po
@@ -3840,6 +3840,10 @@ msgstr ""
 msgid "Languages"
 msgstr ""
 
+#: src/strings.ts:2813
+msgid "Last backup: {date}"
+msgstr ""
+
 #: src/strings.ts:2243
 msgid "Last edited at"
 msgstr ""
@@ -4433,6 +4437,10 @@ msgstr ""
 
 #: src/strings.ts:552
 msgid "Next"
+msgstr ""
+
+#: src/strings.ts:2814
+msgid "Next backup: {date}"
 msgstr ""
 
 #: src/strings.ts:2391

--- a/packages/intl/locale/pseudo-LOCALE.po
+++ b/packages/intl/locale/pseudo-LOCALE.po
@@ -3837,6 +3837,10 @@ msgstr ""
 msgid "Languages"
 msgstr ""
 
+#: src/strings.ts:2813
+msgid "Last backup: {date}"
+msgstr ""
+
 #: src/strings.ts:2243
 msgid "Last edited at"
 msgstr ""
@@ -4430,6 +4434,10 @@ msgstr ""
 
 #: src/strings.ts:552
 msgid "Next"
+msgstr ""
+
+#: src/strings.ts:2814
+msgid "Next backup: {date}"
 msgstr ""
 
 #: src/strings.ts:2391

--- a/packages/intl/src/strings.ts
+++ b/packages/intl/src/strings.ts
@@ -2812,5 +2812,7 @@ Continue without attachments?`,
     t`Using Notesnook without an account will **NOT** sync your notes across devices and could result in data loss if you lose access to your device or uninstall the app. Make sure to backup your notes regularly.`,
   alignment: () => t`Alignment`,
   lastBackupOn: (date: string) => t`Last backup: ${date}`,
-  nextBackupOn: (date: string) => t`Next backup: ${date}`
+  nextBackupOn: (date: string) => t`Next backup: ${date}`,
+  lastPartialBackupOn: (date: string) => t`Last backup: ${date} (Partial)`,
+  lastFullBackupOn: (date: string) => t`Last backup: ${date} (Full)`
 };

--- a/packages/intl/src/strings.ts
+++ b/packages/intl/src/strings.ts
@@ -2810,5 +2810,7 @@ Continue without attachments?`,
   offlineMode: () => t`Offline mode`,
   offlineModeDesc: () =>
     t`Using Notesnook without an account will **NOT** sync your notes across devices and could result in data loss if you lose access to your device or uninstall the app. Make sure to backup your notes regularly.`,
-  alignment: () => t`Alignment`
+  alignment: () => t`Alignment`,
+  lastBackupOn: (date: string) => t`Last backup: ${date}`,
+  nextBackupOn: (date: string) => t`Next backup: ${date}`
 };

--- a/packages/intl/src/strings.ts
+++ b/packages/intl/src/strings.ts
@@ -2809,5 +2809,7 @@ Continue without attachments?`,
   versionDeleted: () => actions.deleted.version(1),
   offlineMode: () => t`Offline mode`,
   offlineModeDesc: () =>
-    t`Using Notesnook without an account will **NOT** sync your notes across devices and could result in data loss if you lose access to your device or uninstall the app. Make sure to backup your notes regularly.`
+    t`Using Notesnook without an account will **NOT** sync your notes across devices and could result in data loss if you lose access to your device or uninstall the app. Make sure to backup your notes regularly.`,
+  lastBackupOn: (date: string) => t`Last backup: ${date}`,
+  nextBackupOn: (date: string) => t`Next backup: ${date}`
 };


### PR DESCRIPTION
## Description
Display the last backup timestamp under "Backup now" and "Backup now with attachments", and the next scheduled backup time under the corresponding automatic backup rows. Adds a getNextBackupTime helper to BackupService, reusing the same reminder-interval logic as checkBackupRequired.

Closes #9843

## Type of Change
- [ ] Bug fix
- [x] Feature

## Visuals
- [x] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [x] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed

<img width="720" height="1600" alt="WhatsApp Image 2026-08-07 at 12 59 26 PM" src="https://github.com/user-attachments/assets/80254ab1-36ce-45b0-bfdc-3eca46f3ec20" />
