### PR TITLE
Give collapsible blocks finger-sized touch targets on mobile

### DIFF
--- a/packages/editor/src/extensions/callout/__tests__/callout.test.ts
+++ b/packages/editor/src/extensions/callout/__tests__/callout.test.ts
@@ -1,0 +1,71 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { describe, expect, test } from "vitest";
+import { createEditor } from "../../../../test-utils/index.js";
+import { Callout } from "../callout.js";
+import { Heading } from "../../heading/heading.js";
+import { Paragraph } from "../../paragraph/paragraph.js";
+
+describe("callout", () => {
+  test("tapping the chevron corner of a callout toggles it collapsed", () => {
+    const { editor } = createEditor({
+      initialContent: `<div class="callout" data-callout-type="info"><h4>INFO</h4><p>body</p></div>`,
+      extensions: {
+        callout: Callout,
+        heading: Heading,
+        paragraph: Paragraph
+      }
+    });
+
+    const dom = editor.view.dom as HTMLElement;
+    const heading = dom.querySelector(".callout > h4") as HTMLElement;
+    expect(heading).toBeTruthy();
+
+    const collapsed = () => {
+      let value: boolean | undefined;
+      editor.state.doc.descendants((node) => {
+        if (node.type.name === Callout.name) value = node.attrs.collapsed;
+      });
+      return value;
+    };
+
+    const tapAt = (clientX: number) =>
+      heading.dispatchEvent(
+        new MouseEvent("mousedown", {
+          button: 0,
+          clientX,
+          clientY: 5,
+          bubbles: true,
+          cancelable: true
+        })
+      );
+
+    expect(collapsed()).toBe(false);
+    tapAt(-10);
+    expect(collapsed()).toBe(true);
+    tapAt(-10);
+    expect(collapsed()).toBe(false);
+
+    tapAt(8);
+    expect(collapsed()).toBe(true);
+    tapAt(8);
+    expect(collapsed()).toBe(false);
+  });
+});

--- a/packages/editor/src/extensions/callout/__tests__/callout.test.ts
+++ b/packages/editor/src/extensions/callout/__tests__/callout.test.ts
@@ -1,0 +1,69 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { describe, expect, test } from "vitest";
+import { createEditor } from "../../../../test-utils/index.js";
+import { Callout } from "../callout.js";
+import { Heading } from "../../heading/heading.js";
+import { Paragraph } from "../../paragraph/paragraph.js";
+
+describe("callout", () => {
+  test("tapping the chevron corner of a callout toggles it collapsed", () => {
+    const { editor } = createEditor({
+      initialContent: `<div class="callout" data-callout-type="info"><h4>INFO</h4><p>body</p></div>`,
+      extensions: {
+        callout: Callout,
+        heading: Heading,
+        paragraph: Paragraph
+      }
+    });
+
+    const dom = editor.view.dom as HTMLElement;
+    const heading = dom.querySelector(".callout > h4") as HTMLElement;
+    expect(heading).toBeTruthy();
+
+    const collapsed = () => {
+      let value: boolean | undefined;
+      editor.state.doc.descendants((node) => {
+        if (node.type.name === Callout.name) value = node.attrs.collapsed;
+      });
+      return value;
+    };
+
+    // a tap in the top-right corner — where `.callout > :first-child::before`
+    // sits — is within the handler's right-side hit zone (jsdom rects are all
+    // zero, so any small -x/+y tap qualifies)
+    const tapChevron = () =>
+      heading.dispatchEvent(
+        new MouseEvent("mousedown", {
+          button: 0,
+          clientX: -10,
+          clientY: 5,
+          bubbles: true,
+          cancelable: true
+        })
+      );
+
+    expect(collapsed()).toBe(false);
+    tapChevron();
+    expect(collapsed()).toBe(true);
+    tapChevron();
+    expect(collapsed()).toBe(false);
+  });
+});

--- a/packages/editor/src/extensions/callout/callout.ts
+++ b/packages/editor/src/extensions/callout/callout.ts
@@ -240,7 +240,13 @@ export const Callout = Node.create({
         if (typeof pos !== "number") return;
 
         const resolvedPos = editor.state.doc.resolve(pos);
-        if (isClickWithinBounds(e, resolvedPos, "right")) {
+        if (
+          isClickWithinBounds(e, resolvedPos, "right", {
+            width: 40,
+            height: 40,
+            offset: 11
+          })
+        ) {
           e.preventDefault();
           e.stopImmediatePropagation();
 

--- a/packages/editor/src/extensions/heading/heading.ts
+++ b/packages/editor/src/extensions/heading/heading.ts
@@ -34,6 +34,7 @@ import {
   AttributeUpdate,
   BatchAttributeStep
 } from "../../utils/batch-attribute-step.js";
+import { useToolbarStore } from "../../toolbar/stores/toolbar-store.js";
 
 const COLLAPSIBLE_BLOCK_TYPES = [
   "paragraph",
@@ -223,24 +224,34 @@ export const Heading = TiptapHeading.extend({
         const range = document.createRange();
         range.selectNodeContents(e.target);
 
-        const hitArea = { height: 40, width: 40 };
-
         const rects = range.getClientRects();
         const lines = rectsToLines(rects);
         const lastLine = lines[lines.length - 1];
         if (!lastLine) return;
         const targetRect = isRtl ? lastLine[0] : lastLine[lastLine.length - 1];
 
-        const { x, y, width } = targetRect;
+        const { x, y, width, height } = targetRect;
 
-        let xStart = clientX >= x + width;
-        let xEnd = clientX <= x + width + hitArea.width;
-        const yStart = clientY >= y;
-        const yEnd = clientY <= y + hitArea.height;
+        const isMobile = useToolbarStore.getState().isMobile;
 
-        if (isRtl) {
-          xStart = clientX >= x - hitArea.width;
-          xEnd = clientX <= x;
+        let xStart: boolean, xEnd: boolean, yStart: boolean, yEnd: boolean;
+        if (isMobile) {
+          const hitWidth = 40;
+          const gap = 10;
+          xStart = isRtl
+            ? clientX >= x - gap - hitWidth
+            : clientX >= x + width + gap;
+          xEnd = isRtl ? clientX <= x - gap : clientX <= x + width + gap + hitWidth;
+          yStart = clientY >= y;
+          yEnd = clientY <= y + height;
+        } else {
+          const size = 15;
+          const centerX = isRtl ? x - 20 : x + width + 20;
+          const centerY = y + height / 2;
+          xStart = clientX >= centerX - size / 2;
+          xEnd = clientX <= centerX + size / 2;
+          yStart = clientY >= centerY - size / 2;
+          yEnd = clientY <= centerY + size / 2;
         }
 
         if (xStart && xEnd && yStart && yEnd) {

--- a/packages/editor/src/extensions/outline-list-item/__tests__/outline-list-item.test.ts
+++ b/packages/editor/src/extensions/outline-list-item/__tests__/outline-list-item.test.ts
@@ -73,6 +73,71 @@ describe("outline list item", () => {
     expect(editor.getJSON()).toMatchSnapshot();
   });
 
+  test("tapping the gutter of a nested item toggles it; a flat item ignores it", () => {
+    const el = outlineList(
+      outlineListItem(["flat item"]),
+      li(
+        [
+          h("p", ["Parent"]),
+          outlineList(
+            outlineListItem(["Child one"]),
+            outlineListItem(["Child two"])
+          )
+        ],
+        { "data-type": "outlineListItem" }
+      )
+    );
+
+    const { editor } = createEditor({
+      initialContent: el.outerHTML,
+      extensions: {
+        outlineList: OutlineList,
+        outlineListItem: OutlineListItem,
+        paragraph: Paragraph
+      }
+    });
+
+    const dom = editor.view.dom as HTMLElement;
+    const nested = dom.querySelector("li.nested");
+    const flat = Array.from(dom.querySelectorAll("li")).find(
+      (item) => !item.classList.contains("nested")
+    );
+    expect(nested).toBeTruthy();
+    expect(flat).toBeTruthy();
+
+    const collapsed = () => {
+      let value: boolean | undefined;
+      editor.state.doc.descendants((node) => {
+        if (
+          node.type.name === OutlineListItem.name &&
+          node.lastChild?.type.name === OutlineList.name
+        )
+          value = node.attrs.collapsed;
+      });
+      return value;
+    };
+
+    const tapGutter = (item: Element) =>
+      item.dispatchEvent(
+        new MouseEvent("mousedown", {
+          button: 0,
+          clientX: -10,
+          clientY: 0,
+          bubbles: true,
+          cancelable: true
+        })
+      );
+
+    expect(collapsed()).toBe(false);
+    tapGutter(nested!);
+    expect(collapsed()).toBe(true);
+    tapGutter(nested!);
+    expect(collapsed()).toBe(false);
+
+    tapGutter(flat!);
+    expect(collapsed()).toBe(false);
+  });
+
   /**
    * Two changes happened:
    * 1. Images were converted from inline nodes to block nodes (https://github.com/streetwriters/notesnook/pull/8563)

--- a/packages/editor/src/extensions/outline-list-item/__tests__/outline-list-item.test.ts
+++ b/packages/editor/src/extensions/outline-list-item/__tests__/outline-list-item.test.ts
@@ -73,6 +73,74 @@ describe("outline list item", () => {
     expect(editor.getJSON()).toMatchSnapshot();
   });
 
+  test("tapping the gutter of a nested item toggles it; a flat item ignores it", () => {
+    const el = outlineList(
+      outlineListItem(["flat item"]),
+      li(
+        [
+          h("p", ["Parent"]),
+          outlineList(
+            outlineListItem(["Child one"]),
+            outlineListItem(["Child two"])
+          )
+        ],
+        { "data-type": "outlineListItem" }
+      )
+    );
+
+    const { editor } = createEditor({
+      initialContent: el.outerHTML,
+      extensions: {
+        outlineList: OutlineList,
+        outlineListItem: OutlineListItem,
+        paragraph: Paragraph
+      }
+    });
+
+    const dom = editor.view.dom as HTMLElement;
+    const nested = dom.querySelector("li.nested");
+    const flat = Array.from(dom.querySelectorAll("li")).find(
+      (item) => !item.classList.contains("nested")
+    );
+    expect(nested).toBeTruthy();
+    expect(flat).toBeTruthy();
+
+    const collapsed = () => {
+      let value: boolean | undefined;
+      editor.state.doc.descendants((node) => {
+        if (
+          node.type.name === OutlineListItem.name &&
+          node.lastChild?.type.name === OutlineList.name
+        )
+          value = node.attrs.collapsed;
+      });
+      return value;
+    };
+
+    // a tap in the left gutter — where `li.nested::after` sits — is within the
+    // handler's hit zone (jsdom rects are all zero, so any -x tap qualifies)
+    const tapGutter = (item: Element) =>
+      item.dispatchEvent(
+        new MouseEvent("mousedown", {
+          button: 0,
+          clientX: -10,
+          clientY: 5,
+          bubbles: true,
+          cancelable: true
+        })
+      );
+
+    expect(collapsed()).toBe(false);
+    tapGutter(nested!);
+    expect(collapsed()).toBe(true);
+    tapGutter(nested!);
+    expect(collapsed()).toBe(false);
+
+    // the same tap on a flat item does nothing — it can't collapse
+    tapGutter(flat!);
+    expect(collapsed()).toBe(false);
+  });
+
   /**
    * Two changes happened:
    * 1. Images were converted from inline nodes to block nodes (https://github.com/streetwriters/notesnook/pull/8563)

--- a/packages/editor/src/extensions/outline-list-item/outline-list-item.ts
+++ b/packages/editor/src/extensions/outline-list-item/outline-list-item.ts
@@ -24,7 +24,6 @@ import {
 } from "@tiptap/core";
 import {
   findParentNodeOfTypeClosestToPos,
-  isClickWithinBounds,
   ensureLeadingParagraph
 } from "../../utils/prosemirror.js";
 import { OutlineList } from "../outline-list/outline-list.js";
@@ -147,14 +146,24 @@ export const OutlineListItem = Node.create<ListItemOptions>({
 
       function onClick(e: MouseEvent | TouchEvent) {
         if (e instanceof MouseEvent && e.button !== 0) return;
-        if (!(e.target instanceof HTMLElement)) return;
         if (!li.classList.contains("nested")) return;
 
         const pos = typeof getPos === "function" ? getPos() : 0;
         if (typeof pos !== "number") return;
 
-        const resolvedPos = editor.state.doc.resolve(pos);
-        if (isClickWithinBounds(e, resolvedPos, "left")) {
+        const point = e instanceof MouseEvent ? e : e.touches[0];
+        if (!point) return;
+
+        const rect = li.getBoundingClientRect();
+        const row = (li.firstElementChild ?? li).getBoundingClientRect();
+        const rtl = getComputedStyle(li).direction === "rtl";
+
+        const withinX = rtl
+          ? point.clientX >= rect.right && point.clientX <= rect.right + 40
+          : point.clientX >= rect.left - 40 && point.clientX <= rect.left;
+        const withinY = point.clientY >= row.top && point.clientY <= row.bottom;
+
+        if (withinX && withinY) {
           e.preventDefault();
           e.stopImmediatePropagation();
           editor.commands.command(({ tr }) => {

--- a/packages/editor/src/utils/prosemirror.ts
+++ b/packages/editor/src/utils/prosemirror.ts
@@ -353,12 +353,16 @@ export function isClickWithinBounds(
   e: MouseEvent | TouchEvent,
   pos: ResolvedPos,
   hitPosition: "left" | "right",
-  hitArea: { width: number; height: number } = { width: 40, height: 40 }
+  hitArea: { width: number; height: number; offset?: number } = {
+    width: 40,
+    height: 40
+  }
 ) {
   const { target } = e;
   if (!(target instanceof HTMLElement)) return false;
 
   const { x, y, right, width } = target.getBoundingClientRect();
+  const offset = hitArea.offset ?? 0;
   const clientX = e instanceof MouseEvent ? e.clientX : e.touches[0].clientX;
   const clientY = e instanceof MouseEvent ? e.clientY : e.touches[0].clientY;
   const isRtl =
@@ -368,27 +372,27 @@ export function isClickWithinBounds(
 
   switch (hitPosition) {
     case "left": {
-      let xStart = clientX >= x - hitArea.width;
-      let xEnd = clientX <= x;
+      let xStart = clientX >= x - hitArea.width - offset;
+      let xEnd = clientX <= x - offset;
       const yStart = clientY >= y;
       const yEnd = clientY <= y + hitArea.height;
 
       if (isRtl) {
-        xEnd = clientX <= right + hitArea.width;
-        xStart = clientX >= right;
+        xEnd = clientX <= right + hitArea.width + offset;
+        xStart = clientX >= right + offset;
       }
 
       return xStart && xEnd && yStart && yEnd;
     }
     case "right": {
-      let xEnd = clientX <= x + width;
-      let xStart = clientX >= x + width - hitArea.width;
+      let xEnd = clientX <= x + width + offset;
+      let xStart = clientX >= x + width - hitArea.width + offset;
       const yStart = clientY >= y;
       const yEnd = clientY <= y + hitArea.height;
 
       if (isRtl) {
-        xStart = clientX >= x;
-        xEnd = clientX <= x + hitArea.width;
+        xStart = clientX >= x - offset;
+        xEnd = clientX <= x + hitArea.width - offset;
       }
 
       return xStart && xEnd && yStart && yEnd;

--- a/packages/editor/styles/styles.css
+++ b/packages/editor/styles/styles.css
@@ -657,6 +657,21 @@ p > *::selection {
   border-left: 1px solid var(--hover);
 }
 
+.outline-list > li.nested::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -40px;
+  width: 40px;
+  height: 1lh;
+  cursor: pointer;
+}
+
+.outline-list[dir="rtl"] > li.nested::after {
+  left: unset;
+  right: -40px;
+}
+
 /* IMAGE */
 
 .image-view-content-wrap.ProseMirror-selectednode .resizer::before {

--- a/packages/editor/styles/styles.css
+++ b/packages/editor/styles/styles.css
@@ -819,6 +819,7 @@ p > *::selection {
   position: absolute;
   top: calc((1lh - 18px) / 2);
   right: 0px;
+  margin: 0;
   cursor: pointer;
   content: "";
   background-size: 18px;
@@ -839,6 +840,22 @@ p > *::selection {
 .ProseMirror div.callout > :first-child[dir="rtl"]::after {
   right: unset;
   left: 0px;
+}
+
+.ProseMirror div.callout > :first-child::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: -11px;
+  width: 40px;
+  height: 40px;
+  cursor: pointer;
+  z-index: 1;
+}
+
+.ProseMirror div.callout > :first-child[dir="rtl"]::before {
+  right: unset;
+  left: -11px;
 }
 
 .ProseMirror div.callout.collapsed > :first-child::after  {
@@ -930,13 +947,14 @@ del.diffdel {
   cursor: pointer;
   content: "";
   background-size: var(--icon-size, 18px);
-  width: var(--icon-size, 18px);
+  width: 40px;
   height: var(--icon-size, 18px);
+  margin-inline-end: calc(var(--icon-size, 18px) - 40px);
 
   background-color: var(--icon);
   mask: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxZW0iIGhlaWdodD0iMWVtIiB2aWV3Qm94PSIwIDAgMjQgMjQiPjxwYXRoIGZpbGw9IiM4ODg4ODgiIGQ9Ik03LjQxIDguNThMMTIgMTMuMTdsNC41OS00LjU5TDE4IDEwbC02IDZsLTYtNmwxLjQxLTEuNDJaIi8+PC9zdmc+)
     no-repeat 50% 50%;
-  mask-size: cover;
+  mask-size: var(--icon-size, 18px);
 
   transform: rotate(0);
   transition: transform 250ms ease, opacity 200ms ease;

--- a/packages/editor/styles/styles.css
+++ b/packages/editor/styles/styles.css
@@ -823,6 +823,10 @@ p > *::selection {
   position: absolute;
   top: calc((1lh - 18px) / 2);
   right: 0px;
+  /* the callout title is an h1-h6, so reset the heading chevron's negative
+     end-margin — on this absolutely-positioned chevron it would shift it out
+     of the callout instead of just tightening inline advance */
+  margin: 0;
   cursor: pointer;
   content: "";
   background-size: 18px;
@@ -843,6 +847,25 @@ p > *::selection {
 .ProseMirror div.callout > :first-child[dir="rtl"]::after {
   right: unset;
   left: 0px;
+}
+
+/* an invisible, finger-sized hit surface over the collapse chevron so a tap in
+   the corner reliably toggles the callout instead of selecting the title text.
+   matches the 40px zone the click handler checks (isClickWithinBounds). */
+.ProseMirror div.callout > :first-child::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 40px;
+  height: 40px;
+  cursor: pointer;
+  z-index: 1;
+}
+
+.ProseMirror div.callout > :first-child[dir="rtl"]::before {
+  right: unset;
+  left: 0;
 }
 
 .ProseMirror div.callout.collapsed > :first-child::after  {
@@ -934,13 +957,18 @@ del.diffdel {
   cursor: pointer;
   content: "";
   background-size: var(--icon-size, 18px);
-  width: var(--icon-size, 18px);
+  /* the box is finger-sized so it's easy to tap, while the icon itself stays
+     --icon-size (mask-size, centered) — a hidden touch area, not a bigger icon.
+     the negative end-margin keeps the inline advance at the old icon width so
+     long headings wrap exactly as before instead of pushing a blank line. */
+  width: 40px;
   height: var(--icon-size, 18px);
+  margin-inline-end: calc(var(--icon-size, 18px) - 40px);
 
   background-color: var(--icon);
   mask: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxZW0iIGhlaWdodD0iMWVtIiB2aWV3Qm94PSIwIDAgMjQgMjQiPjxwYXRoIGZpbGw9IiM4ODg4ODgiIGQ9Ik03LjQxIDguNThMMTIgMTMuMTdsNC41OS00LjU5TDE4IDEwbC02IDZsLTYtNmwxLjQxLTEuNDJaIi8+PC9zdmc+)
     no-repeat 50% 50%;
-  mask-size: cover;
+  mask-size: var(--icon-size, 18px);
 
   transform: rotate(0);
   transition: transform 250ms ease, opacity 200ms ease;

--- a/packages/editor/styles/styles.css
+++ b/packages/editor/styles/styles.css
@@ -657,6 +657,25 @@ p > *::selection {
   border-left: 1px solid var(--hover);
 }
 
+/* an invisible, finger-sized hit surface over the collapse chevron's gutter, so
+   a tap near the tiny chevron still lands on the item (which toggles it) instead
+   of missing or starting a text selection. matches the 40px zone the click
+   handler checks (isClickWithinBounds). */
+.outline-list > li.nested::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -40px;
+  width: 40px;
+  height: 40px;
+  cursor: pointer;
+}
+
+.outline-list[dir="rtl"] > li.nested::after {
+  left: unset;
+  right: -40px;
+}
+
 /* IMAGE */
 
 .image-view-content-wrap.ProseMirror-selectednode .resizer::before {


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

On touch devices, the collapse/expand chevrons on outline lists, callouts, and headings are small and easy to miss — a tap often lands beside the icon and starts a text selection instead of toggling.

This adds an invisible, finger-sized hit area over each chevron so a tap in the gutter always toggles the block and never selects text. The visible icons are unchanged.

## Type of Change
- [ ] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [ ] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [ ] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
