### PR TITLE
core: support `<audio>` HTML Elements in inbox api

### DIFF
--- a/packages/common/src/utils/export-notes.ts
+++ b/packages/common/src/utils/export-notes.ts
@@ -25,6 +25,7 @@ import {
   ResolveInternalLink,
   isImage,
   isWebClip,
+  isAudio,
   FilteredSelector,
   EMPTY_CONTENT
 } from "@notesnook/core";
@@ -333,10 +334,12 @@ function resolveAttachment(
       attachment.filename
     }" width="${attributes.width}" height="${attributes.height}" />`;
   }
-  // markdown doesn't allow arbitrary iframes in its html so no need
-  // to support that
+  // markdown doesn't allow arbitrary iframes/audio embeds in its html so
+  // no need to support that
   else if (isWebClip(attachment.mimeType) && format === "html") {
     return `<iframe src="${relativePath} "width="${attributes.width}" height="${attributes.height}" />`;
+  } else if (isAudio(attachment.mimeType) && format === "html") {
+    return `<audio controls src="${relativePath}"></audio>`;
   }
 
   return `<a href="${relativePath}" title="${attachment.filename}">${attachment.filename}</a>`;

--- a/packages/core/src/content-types/__tests__/tiptap.test.js
+++ b/packages/core/src/content-types/__tests__/tiptap.test.js
@@ -35,6 +35,26 @@ test("img src is empty after extract attachments", async () => {
   expect(result.data).toContain(`data-hash="helloworld"`);
 });
 
+test("audio data URLs are extracted with attachment metadata", async () => {
+  const audioData =
+    "UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAIA+AAACABAAZGF0YQAAAAA=";
+  const tiptap = new Tiptap(
+    `<audio src="data:audio/wav;base64,${audioData}"></audio>`
+  );
+
+  const result = await tiptap.postProcess(async (data, mime) => {
+    expect(data).toBe(audioData);
+    expect(mime).toBe("audio/wav");
+    return "audiohash";
+  });
+
+  expect(result.hashes).toEqual(["audiohash"]);
+  expect(result.data).not.toContain("src=");
+  expect(result.data).toContain('data-hash="audiohash"');
+  expect(result.data).toContain('data-mime="audio/wav"');
+  expect(result.data).toContain('data-size="44"');
+});
+
 test("img src is present after insert attachments", async () => {
   const tiptap = new Tiptap(IMG_CONTENT);
   const result = await tiptap.postProcess(async () => {

--- a/packages/core/src/content-types/tiptap.ts
+++ b/packages/core/src/content-types/tiptap.ts
@@ -64,6 +64,7 @@ const ATTRIBUTES = {
   hash: "data-hash",
   mime: "data-mime",
   filename: "data-filename",
+  size: "data-size",
   src: "src",
   href: "href",
   blockId: "data-block-id"
@@ -300,18 +301,20 @@ export class Tiptap {
       filename?: string;
       mime?: string;
       id: string;
+      tag: string;
     }[] = [];
     new HTMLParser({
       ontag: (name, attr, pos) => {
         const hash = attr[ATTRIBUTES.hash];
         const src = attr[ATTRIBUTES.src];
         const href = attr[ATTRIBUTES.href];
-        if (name === "img" && !hash && src) {
+        if ((name === "img" || name === "audio") && !hash && src) {
           sources.push({
             src,
             filename: attr[ATTRIBUTES.filename],
             mime: attr[ATTRIBUTES.mime],
-            id: `${pos.start}${pos.end}`
+            id: `${pos.start}${pos.end}`,
+            tag: name
           });
         } else if (name === "a" && href && href.startsWith("nn://")) {
           const internalLink = parseInternalLink(href);
@@ -321,20 +324,23 @@ export class Tiptap {
       }
     }).parse(this.data);
 
-    const images: Record<string, string | false> = {};
-    for (const image of sources) {
+    const mediaHashes: Record<
+      string,
+      { hash: string; mime: string; size?: number } | false
+    > = {};
+    for (const media of sources) {
       try {
-        const { data, mimeType } = dataurl.toObject(image.src);
+        const { data, mimeType, size } = dataurl.toObject(media.src);
         if (!data || !mimeType) continue;
-        const hash = await saveAttachment(data, mimeType, image.filename);
+        const hash = await saveAttachment(data, mimeType, media.filename);
         if (!hash) continue;
 
-        images[image.id] = hash;
+        mediaHashes[media.id] = { hash, mime: mimeType, size };
       } catch (e) {
-        logger.error(e, "Failed to save image attachment.", {
-          filename: image.filename
+        logger.error(e, `Failed to save ${media.tag} attachment.`, {
+          filename: media.filename
         });
-        images[image.id] = false;
+        mediaHashes[media.id] = false;
       }
     }
 
@@ -344,25 +350,28 @@ export class Tiptap {
         switch (name) {
           case "nn-search-result":
             return null;
-          case "img": {
+          case "img":
+          case "audio": {
             const hash = attr[ATTRIBUTES.hash];
 
             if (hash) {
               hashes.push(hash);
               delete attr[ATTRIBUTES.src];
             } else {
-              const hash = images[`${pos.start}${pos.end}`];
-              if (!hash) return;
+              const media = mediaHashes[`${pos.start}${pos.end}`];
+              if (!media) return;
 
-              hashes.push(hash);
+              hashes.push(media.hash);
 
-              attr[ATTRIBUTES.hash] = hash;
+              attr[ATTRIBUTES.hash] = media.hash;
+              if (!attr[ATTRIBUTES.mime]) attr[ATTRIBUTES.mime] = media.mime;
+              if (media.size !== undefined && !attr[ATTRIBUTES.size])
+                attr[ATTRIBUTES.size] = `${media.size}`;
               delete attr[ATTRIBUTES.src];
             }
             break;
           }
           case "iframe":
-          case "audio":
           case "span": {
             const hash = attr[ATTRIBUTES.hash];
             if (!hash) return;

--- a/packages/core/src/utils/dataurl.ts
+++ b/packages/core/src/utils/dataurl.ts
@@ -19,13 +19,23 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import { parse, validate } from "@readme/data-urls";
 
-function toObject(dataurl: string): { mimeType?: string; data?: string } {
+function toObject(dataurl: string): {
+  mimeType?: string;
+  data?: string;
+  size?: number;
+} {
   const result = parse(dataurl);
   if (!result) return {};
   return {
     mimeType: result.contentType,
-    data: result.data
+    data: result.data,
+    size: result.base64 ? getBase64Size(result.data) : undefined
   };
+}
+
+function getBase64Size(data: string) {
+  const padding = data.endsWith("==") ? 2 : data.endsWith("=") ? 1 : 0;
+  return Math.floor((data.length * 3) / 4) - padding;
 }
 
 function fromObject({ mimeType, data }: { mimeType: string; data: string }) {

--- a/packages/editor/src/extensions/attachment/types.ts
+++ b/packages/editor/src/extensions/attachment/types.ts
@@ -31,6 +31,7 @@ export type FileAttachment = BaseAttachment & {
 
 export type AudioAttachment = BaseAttachment & {
   type: "audio";
+  src?: string;
 };
 
 export type WebClipAttachment = BaseAttachment & {

--- a/packages/editor/src/extensions/audio/__tests__/audio.test.ts
+++ b/packages/editor/src/extensions/audio/__tests__/audio.test.ts
@@ -1,0 +1,43 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { describe, expect, test } from "vitest";
+import { createEditor } from "../../../../test-utils/index.js";
+import { AudioNode } from "../audio.js";
+
+const AUDIO_DATA_URL =
+  "data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAIA+AAACABAAZGF0YQAAAAA=";
+
+describe("audio data URLs", () => {
+  test("derives attachment metadata while parsing HTML", () => {
+    const { editor } = createEditor({
+      initialContent: `<audio src="${AUDIO_DATA_URL}"></audio>`,
+      extensions: { audio: AudioNode }
+    });
+
+    expect(editor.getJSON().content?.[0]).toMatchObject({
+      type: "audio",
+      attrs: {
+        src: AUDIO_DATA_URL,
+        mime: "audio/wav",
+        size: 44
+      }
+    });
+  });
+});

--- a/packages/editor/src/extensions/audio/audio.ts
+++ b/packages/editor/src/extensions/audio/audio.ts
@@ -18,10 +18,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { Node, mergeAttributes } from "@tiptap/core";
+import { DataURL } from "@notesnook/common";
 import { hasSameAttributes } from "../../utils/prosemirror.js";
 import { AudioAttachment, getDataAttribute } from "../attachment/index.js";
 import { createNodeView } from "../react/index.js";
 import { AudioComponent } from "./component.js";
+import { getDataURLMetadata } from "../../utils/downloader.js";
 
 export interface AudioOptions {
   HTMLAttributes: Record<string, unknown>;
@@ -59,6 +61,11 @@ export const AudioNode = Node.create<AudioOptions>({
         default: 0,
         rendered: false
       },
+      // plain (non data-*) attribute so it round-trips through the native
+      // <audio src="..."> markup, mirroring how the image node keeps `src`.
+      // this is what carries a pasted data: URI or an external https URL
+      // until postProcess() turns it into a real hashed attachment.
+      src: { default: null },
       filename: getDataAttribute("filename"),
       size: getDataAttribute("size"),
       hash: getDataAttribute("hash"),
@@ -69,7 +76,17 @@ export const AudioNode = Node.create<AudioOptions>({
   parseHTML() {
     return [
       {
-        tag: "audio"
+        tag: "audio",
+        getAttrs: (element) => {
+          const src = element.getAttribute("src");
+          if (!src || !DataURL.isValid(src)) return null;
+
+          const { mimeType, size } = getDataURLMetadata(src);
+          return {
+            mime: element.dataset.mime || mimeType,
+            size: element.dataset.size || size
+          };
+        }
       }
     ];
   },

--- a/packages/editor/src/extensions/audio/component.tsx
+++ b/packages/editor/src/extensions/audio/component.tsx
@@ -18,15 +18,23 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { Box, Text } from "@theme-ui/components";
-import { AudioAttachment } from "../attachment/types.js";
-import { useRef, useState, useEffect } from "react";
+import { Attachment, AudioAttachment } from "../attachment/types.js";
+import { useRef, useState, useEffect, useMemo } from "react";
 import { Icon } from "@notesnook/ui";
 import { Icons } from "../../toolbar/icons.js";
 import { ReactNodeViewProps } from "../react/index.js";
 import { ToolbarGroup } from "../../toolbar/components/toolbar-group.js";
 import { DesktopOnly } from "../../components/responsive/index.js";
-import { toBlobURL, revokeBloburl } from "../../utils/downloader.js";
-import { formatBytes } from "@notesnook/common";
+import {
+  corsify,
+  downloadAudio,
+  getDataURLMetadata,
+  revokeBloburl,
+  toBlobURL,
+  toDataURL
+} from "../../utils/downloader.js";
+import { DataURL, formatBytes } from "@notesnook/common";
+import { useToolbarStore } from "../../toolbar/stores/toolbar-store.js";
 
 const SAMPLE_AUDIO = toBlobURL(
   "data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAIA+AAACABAAZGF0YQAAAAA=",
@@ -35,16 +43,41 @@ const SAMPLE_AUDIO = toBlobURL(
   "sample-audio"
 );
 
+function canParse(src: string) {
+  if (!src) return false;
+  try {
+    new URL(src);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function makeAudioQuery(src?: string, hash?: string) {
+  return (a: Attachment) =>
+    a.type === "audio" &&
+    ((!!a.src && !!src && a.src === src) ||
+      (!!a.hash && !!hash && a.hash === hash));
+}
+
 export function AudioComponent(props: ReactNodeViewProps<AudioAttachment>) {
   const { editor, node, selected } = props;
-  const { filename, size, progress, mime, hash } = node.attrs;
+  const { filename, size, progress, mime, hash, src } = node.attrs;
   const elementRef = useRef<HTMLDivElement>();
   const [isDragging, setIsDragging] = useState(false);
   const isLoading = useRef(false);
   const [error, setError] = useState<string>();
+  const controllerRef = useRef(new AbortController());
+  const downloadOptions = useToolbarStore((store) => store.downloadOptions);
+  const embeddedMetadata = useMemo(
+    () => (size === undefined && src ? getDataURLMetadata(src) : undefined),
+    [size, src]
+  );
+  const displaySize = size ?? embeddedMetadata?.size;
 
   useEffect(() => {
     return () => {
+      controllerRef.current.abort();
       if (hash) {
         revokeBloburl(hash);
       }
@@ -107,7 +140,11 @@ export function AudioComponent(props: ReactNodeViewProps<AudioAttachment>) {
             flexShrink: 0
           }}
         >
-          {progress ? `${progress}%` : formatBytes(size, 1)}
+          {progress
+            ? `${progress}%`
+            : displaySize !== undefined
+            ? formatBytes(displaySize, 1)
+            : ""}
         </Text>
       </Box>
       {error ? (
@@ -123,12 +160,24 @@ export function AudioComponent(props: ReactNodeViewProps<AudioAttachment>) {
           }}
         >
           <audio
+            crossOrigin="anonymous"
             onMouseDown={(e) => e.stopPropagation()}
             onDragStart={(e) => e.stopPropagation()}
             onClick={(e) => e.stopPropagation()}
             controls
             controlsList="nodownload nofullscreen"
-            src={SAMPLE_AUDIO}
+            src={
+              // already-hashed audio is lazy-loaded on first play (below).
+              // otherwise, hand the raw src straight to the browser: a
+              // data: URI plays natively (corsify is a no-op on it), and
+              // an external URL is resolved into a real attachment in the
+              // background (see onLoadedMetadata).
+              hash
+                ? SAMPLE_AUDIO
+                : src
+                ? corsify(src, downloadOptions?.corsHost)
+                : SAMPLE_AUDIO
+            }
             onPause={(e) => {
               if (isLoading.current) {
                 e.preventDefault();
@@ -161,6 +210,38 @@ export function AudioComponent(props: ReactNodeViewProps<AudioAttachment>) {
                     isLoading.current = false;
                     setError((e as Error).message);
                   });
+              }
+            }}
+            onLoadedMetadata={async () => {
+              // mirrors ImageComponent's onLoad: once the browser has
+              // resolved an external URL, fetch it ourselves, convert to a
+              // data URI, and stash it back on the node so that on save
+              // Tiptap.postProcess() can turn it into a real encrypted,
+              // hashed attachment (see packages/core content-types/tiptap.ts).
+              // a raw data: URI needs no fetch here - its size/mime are
+              // derived locally by the effect above.
+              if (!hash && src && !DataURL.isValid(src) && canParse(src)) {
+                const audio = await downloadAudio(src, {
+                  ...downloadOptions,
+                  signal: controllerRef.current.signal
+                }).catch((e) => {
+                  setError((e as Error).message);
+                  return undefined;
+                });
+                if (!audio) return;
+
+                const { blob, size, mimeType } = audio;
+                const dataurl = await toDataURL(blob);
+                await editor.threadsafe((editor) =>
+                  editor.commands.updateAttachment(
+                    {
+                      src: dataurl,
+                      size,
+                      mime: mimeType
+                    },
+                    { query: makeAudioQuery(src, hash) }
+                  )
+                );
               }
             }}
           >

--- a/packages/editor/src/utils/downloader.ts
+++ b/packages/editor/src/utils/downloader.ts
@@ -67,7 +67,11 @@ export function corsify(url?: string, host?: string) {
   return url;
 }
 
-export async function downloadImage(url: string, options?: DownloadOptions) {
+export async function downloadMedia(
+  url: string,
+  mimePrefix: "image/" | "audio/",
+  options?: DownloadOptions
+) {
   const corsifiedURL = corsify(url, options?.corsHost);
   if (!corsifiedURL) return;
 
@@ -83,7 +87,7 @@ export async function downloadImage(url: string, options?: DownloadOptions) {
 
   if (contentType && UTITypes[contentType]) contentType = UTITypes[contentType];
 
-  if (!contentType || !contentType.startsWith("image/")) return;
+  if (!contentType || !contentType.startsWith(mimePrefix)) return;
 
   let blob = await response.blob();
   if (UTITypes[blob.type])
@@ -96,6 +100,29 @@ export async function downloadImage(url: string, options?: DownloadOptions) {
     url: URL.createObjectURL(blob),
     mimeType: contentType,
     size: blob.size
+  };
+}
+
+export async function downloadImage(url: string, options?: DownloadOptions) {
+  return downloadMedia(url, "image/", options);
+}
+
+export async function downloadAudio(url: string, options?: DownloadOptions) {
+  return downloadMedia(url, "audio/", options);
+}
+
+export function getDataURLMetadata(dataurl: string): {
+  mimeType?: string;
+  size?: number;
+} {
+  const { data, mimeType } = DataURL.toObject(dataurl);
+  if (!data || !dataurl.slice(0, dataurl.indexOf(",")).endsWith(";base64"))
+    return { mimeType };
+
+  const padding = data.endsWith("==") ? 2 : data.endsWith("=") ? 1 : 0;
+  return {
+    mimeType,
+    size: Math.floor((data.length * 3) / 4) - padding
   };
 }
 


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->
Adds support for `<audio src="data:mime;base64,aaaaaaa...">` and `<audio src="https://somewhere.example.com/file.mp3">` blocks. They're handled like images sent to the inbox api are, where the file referenced in the src becomes an attachment after processing. The majority of the changes in this PR were made with AI.
This PR also ships a fix to prevent `<audio>` blocks from becoming `<a>` blocks when exported as HTML.

## Type of Change
- [ ] Bug fix
- [x] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [x] Added/updated tests for this change (if needed)
- [ ] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [x] Web
- [x] Mobile
- [x] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
