### PR TITLE
Fix 9053 restore editor scroll position

### DIFF
--- a/apps/mobile/app/screens/editor/tiptap/use-editor.ts
+++ b/apps/mobile/app/screens/editor/tiptap/use-editor.ts
@@ -749,12 +749,13 @@ export const useEditor = (
           await postMessage(NativeEvents.title, item.title, tabId);
           overlay(false);
 
+          const updatedTab = useTabStore.getState().getTab(tabId!);
           await postMessage(
             NativeEvents.html,
             {
               data: currentContents.current[item.id]?.data || "",
-              scrollTop: tab?.session?.scrollTop,
-              selection: tab?.session?.selection,
+              scrollTop: updatedTab?.session?.scrollTop,
+              selection: updatedTab?.session?.selection,
               searchResultIndex: event.searchResultIndex
             },
             tabId,

--- a/packages/editor-mobile/src/hooks/useEditorController.ts
+++ b/packages/editor-mobile/src/hooks/useEditorController.ts
@@ -139,6 +139,7 @@ export function useEditorController({
     wordCounter: null,
     scroll: null
   });
+  const hasRestored = useRef(false);
 
   if (!tabRef.current.session?.noteId && loading) {
     setTimeout(() => {
@@ -300,6 +301,7 @@ export function useEditorController({
 
   const scroll = useCallback(
     (_event: React.UIEvent<HTMLDivElement, UIEvent>) => {
+      if (!hasRestored.current) return;
       const value = _event.currentTarget.scrollTop;
       if (timers.current.scroll !== null) clearTimeout(timers.current.scroll);
       timers.current.scroll = setTimeout(() => {
@@ -367,6 +369,7 @@ export function useEditorController({
             }
 
             scrollTo?.(value.scrollTop || 0);
+            hasRestored.current = true;
             setLoading(false);
             countWords(0);
           }
@@ -382,6 +385,7 @@ export function useEditorController({
           logger("info", "LOADING NOTE HTML");
           if (!editor) break;
           update(value.scrollTop, value.selection, value.searchResultIndex);
+          hasRestored.current = true;
           setTimeout(() => {
             countWords(0);
           }, 300);


### PR DESCRIPTION
## Description
Two independent bugs were found and fixed:
- Note switching was showing the last note's scroll position instead of its own.
- On cold launch, scroll position was overridden to the initial position after the real saved position was restored.
Closes [#9053.](https://github.com/streetwriters/notesnook/issues/9053)

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
