### PR TITLE
core: Skip relations that reference attachments not yet uploaded

### DIFF
--- a/packages/core/__tests__/attachments.test.ts
+++ b/packages/core/__tests__/attachments.test.ts
@@ -58,3 +58,38 @@ test("remove orphaned attachments should remove only orphaned attachments", () =
     expect(await db.attachments.exists(hash1)).toBe(true);
     expect(await db.attachments.orphaned.count()).toBe(0);
   }));
+
+test("relations wait for their pending attachment to upload before syncing", () =>
+  databaseTest().then(async (db) => {
+    await loginFakeUser(db);
+
+    const hash = await db.attachments.save(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEEAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+      "image/png",
+      "test.png"
+    );
+    if (!hash) throw new Error("Failed to create attachment");
+
+    const attachment = await db.attachments.attachment(hash);
+    if (!attachment) throw new Error("Failed to find attachment");
+
+    const noteId = await db.notes.add({ title: "Test Note" });
+    await db.relations.add(
+      { id: noteId, type: "note" },
+      { id: attachment.id, type: "attachment" }
+    );
+
+    const pendingRelations: unknown[] = [];
+    for await (const chunk of db.relations.collection.unsynced(100))
+      pendingRelations.push(...chunk);
+    expect(pendingRelations).toHaveLength(0);
+    expect(await db.relations.collection.unsyncedCount()).toBe(0);
+
+    await db.attachments.markAsUploaded(attachment.id);
+
+    const syncableRelations: unknown[] = [];
+    for await (const chunk of db.relations.collection.unsynced(100))
+      syncableRelations.push(...chunk);
+    expect(syncableRelations).toHaveLength(1);
+    expect(await db.relations.collection.unsyncedCount()).toBe(1);
+  }));

--- a/packages/core/src/database/sql-collection.ts
+++ b/packages/core/src/database/sql-collection.ts
@@ -68,8 +68,7 @@ export const MAX_SQL_PARAMETERS = 200;
 export class SQLCollection<
   TCollectionType extends keyof DatabaseSchema,
   T extends DatabaseSchema[TCollectionType] = DatabaseSchema[TCollectionType]
-> implements DatabaseCollection<SQLiteItem<T>, true>
-{
+> implements DatabaseCollection<SQLiteItem<T>, true> {
   constructor(
     private readonly db: DatabaseAccessor,
     _startTransaction: (
@@ -78,13 +77,13 @@ export class SQLCollection<
     public readonly type: TCollectionType,
     private readonly eventManager: EventManager,
     private readonly sanitizer: Sanitizer
-  ) {}
+  ) { }
 
   async clear() {
     await this.db().deleteFrom(this.type).execute();
   }
 
-  async init() {}
+  async init() { }
 
   async upsert(item: SQLiteItem<T>) {
     if (!item.id) throw new Error("The item must contain the id field.");
@@ -297,6 +296,26 @@ export class SQLCollection<
             eb.or([eb("dateUploaded", ">", 0), eb("deleted", "==", true)])
           )
         )
+        // Relations shouldn't be created on the server before the attachment
+        // exists there. Keep them unsynced while an attachment is still
+        // waiting to be uploaded.
+        .$if(this.type === "relations", (eb) =>
+          eb.where((eb) =>
+            eb.not(
+              eb.exists(
+                eb
+                  .selectFrom("attachments")
+                  .select("attachments.id")
+                  .where(isFalse("dateUploaded"))
+                  .where((eb) => eb.and([
+                    eb("relations.toType", "==", "attachment"),
+                    eb("attachments.id", "==", eb.ref("relations.toId"))
+                  ])
+                  )
+              )
+            )
+          )
+        )
         .executeTakeFirst()) || {};
     return count || 0;
   }
@@ -321,6 +340,23 @@ export class SQLCollection<
         .$if(this.type === "attachments", (eb) =>
           eb.where((eb) =>
             eb.or([eb("dateUploaded", ">", 0), eb("deleted", "==", true)])
+          )
+        )
+        .$if(this.type === "relations", (eb) =>
+          eb.where((eb) =>
+            eb.not(
+              eb.exists(
+                eb
+                  .selectFrom("attachments")
+                  .select("attachments.id")
+                  .where(isFalse("dateUploaded"))
+                  .where((eb) => eb.and([
+                    eb("relations.toType", "==", "attachment"),
+                    eb("attachments.id", "==", eb.ref("relations.toId"))
+                  ])
+                  )
+              )
+            )
           )
         )
         .orderBy("id")


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->
An attachment is skipped when it is not uploaded, so relations that reference this attachment should also be skipped. This creates data inconsistency across devices if the attachment object never makes it to the server. Not skipping the applicable relations when relations are synced violates the entire point of syncing relations at the end to avoid cross-device mid-sync inconsistencies.


## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [x] Added/updated tests for this change (if needed)
- [ ] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [x] Web
- [x] Mobile
- [x] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
