### PR TITLE
web: fix notes not exporting from archive list multiple selection

### DIFF
--- a/apps/web/src/components/note/index.tsx
+++ b/apps/web/src/components/note/index.tsx
@@ -550,7 +550,7 @@ export const noteMenuItems: (
 
             await exportNotes(
               format.type,
-              db.notes.all.where((eb) => eb("id", "in", ids))
+              db.notes.exportable.where((eb) => eb("id", "in", ids))
             );
           }
         }))


### PR DESCRIPTION


## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

web: fix notes not exporting from archive list multiple selection

Closes https://github.com/streetwriters/notesnook/issues/10214

## QA Scope

Web only. Selecting multiple notes in archive list and using "Export as" option should work.

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [X] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [ ] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
