### PR TITLE
editor: fix multiple link hover popups from opening

### DIFF
--- a/packages/editor/src/toolbar/floating-menus/hover-popup/index.tsx
+++ b/packages/editor/src/toolbar/floating-menus/hover-popup/index.tsx
@@ -70,16 +70,12 @@ export function HoverPopupHandler(props: FloatingMenuProps) {
         const element = e.target;
 
         if (activePopup.current) {
-          const isOutsideEditor = !element.closest(".ProseMirror");
           const isInsidePopup = element.closest(".popup-presenter-portal");
           const isActiveElement = activePopup.current.element === element;
-          if (isInsidePopup) return;
+          if (isInsidePopup || isActiveElement) return;
 
-          if (isOutsideEditor || !isActiveElement) {
-            activePopup.current.hide();
-            activePopup.current = undefined;
-            return;
-          }
+          activePopup.current.hide();
+          activePopup.current = undefined;
         }
 
         clearTimeout(hoverTimeoutId.current);


### PR DESCRIPTION

## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

editor: fix multiple link hover popups from opening
* also fix the popup not opening when quickly hovering one link after another

## QA Scope

Web only. Multiple link hover popups shouldn't be opened. This also fixes another bug where when hovering one link after another, the second link which was hovered doesn't show the hover popup

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [X] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [ ] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
