### PR TITLE
ui: truncate long menu titles

### DIFF
--- a/packages/ui/src/components/menu/index.tsx
+++ b/packages/ui/src/components/menu/index.tsx
@@ -204,6 +204,7 @@ function MenuContainer(props: PropsWithChildren<MenuContainerProps>) {
         boxShadow: "menu",
         border: "1px solid var(--border)",
         minWidth: 220,
+        maxWidth: "min(95vw, 350px)",
         maxHeight: "80vh",
         ...sx
       }}

--- a/packages/ui/src/components/menu/menu-button.tsx
+++ b/packages/ui/src/components/menu/menu-button.tsx
@@ -62,7 +62,7 @@ export function MenuButton(props: MenuButtonProps) {
         ref={itemRef}
         tabIndex={-1}
         variant="menuitem"
-        title={tooltip}
+        title={tooltip || title}
         disabled={isDisabled}
         onClick={(e) => onClick?.(e.nativeEvent)}
         sx={{
@@ -73,7 +73,12 @@ export function MenuButton(props: MenuButtonProps) {
         }}
       >
         <Flex
-          sx={{ fontSize: "inherit", fontFamily: "inherit", flexShrink: 0 }}
+          sx={{
+            fontSize: "inherit",
+            fontFamily: "inherit",
+            minWidth: 0,
+            overflow: "hidden"
+          }}
         >
           <Icon
             path={icon || ""}
@@ -92,7 +97,10 @@ export function MenuButton(props: MenuButtonProps) {
               fontFamily: "inherit",
               color: variant === "dangerous" ? "paragraph-error" : "paragraph",
               textAlign: "left",
-              flexShrink: 0,
+              minWidth: 0,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
               ...styles?.title
             }}
           >


### PR DESCRIPTION


## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

ui: truncate long menu titles

* On web, long tags in menu items in the editor header would take a lot of width. The fix in the ui package will fix it for all usages of long menu items on web

### Before

<img width="1512" height="167" alt="image" src="https://github.com/user-attachments/assets/faa67cfe-9f73-47d8-8103-ddf395049e31" />


### After

<img width="817" height="227" alt="image" src="https://github.com/user-attachments/assets/99a206ab-5ace-45be-8e21-d44ee5ec9456" />


## QA Scope

Web only

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [X] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [ ] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
