### PR TITLE
mobile: fix groupOptions causes unnecessary rerenders on first load

### DIFF
--- a/apps/mobile/app/components/sheets/sort/index.tsx
+++ b/apps/mobile/app/components/sheets/sort/index.tsx
@@ -33,7 +33,6 @@ import {
   setGroupOptionsById
 } from "../../../hooks/use-group-options";
 import { eSendEvent } from "../../../services/event-manager";
-import Navigation from "../../../services/navigation";
 import { RouteName } from "../../../stores/use-navigation-store";
 import { useNotebookStore } from "../../../stores/use-notebook-store";
 import { useTagStore } from "../../../stores/use-tag-store";
@@ -46,6 +45,7 @@ import { Button } from "../../ui/button";
 import { Pressable } from "../../ui/pressable";
 import Heading from "../../ui/typography/heading";
 import Paragraph from "../../ui/typography/paragraph";
+import Navigation from "../../../services/navigation";
 const Sort = ({
   dataType,
   screen,
@@ -87,8 +87,7 @@ const Sort = ({
   };
 
   const updateGroupOptions = async (_groupOptions: GroupOptions) => {
-    console.log(groupId, type);
-    setGroupOptionsById(groupType, _groupOptions, groupId, type);
+    await setGroupOptionsById(groupType, _groupOptions, groupId, type);
     setGroupOptions(_groupOptions);
     setTimeout(() => {
       if (screen) Navigation.queueRoutesForUpdate(screen);

--- a/apps/mobile/app/hooks/use-group-options.ts
+++ b/apps/mobile/app/hooks/use-group-options.ts
@@ -54,15 +54,13 @@ export function useGroupOptions(
   const [groupOptions, setGroupOptions] = useState(
     getGroupOptions(groupingKey, id, type)
   );
-  console.log(groupingKey, id, type, groupOptions, "options");
   const groupOptionsRef = useRef(groupOptions);
   groupOptionsRef.current = groupOptions;
 
   useEffect(() => {
     const onUpdate = (_groupingKey: string, _id?: string, _type?: string) => {
-      if (_groupingKey !== groupingKey) return;
-      if (_id && _type && _id !== id && _type !== type) return;
-
+      if (_groupingKey !== groupingKey || _type !== type) return;
+      if (_id && _type && _id !== id) return;
       const options = getGroupOptions(groupingKey, id, type);
       if (!options) return;
       if (
@@ -70,9 +68,7 @@ export function useGroupOptions(
         groupOptionsRef.current?.sortBy !== options.sortBy ||
         groupOptionsRef.current?.sortDirection !== options?.sortDirection
       ) {
-        console.log("onUpdate", _id, _type);
         setGroupOptions({ ...options });
-        Navigation.queueRoutesForUpdate();
       }
     };
 


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Fixes unnecessary rerenders happening when any component is using `useGroupOptions` hook.

## QA SCOPE
Test sorting/grouping works properly. Test notebooks/tags in sidebar are sorted correctly on app launch

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [ ] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
