### PR TITLE
web: truncate long tag/color/notebook titles in multiple dialogs

### DIFF
--- a/apps/web/src/common/index.ts
+++ b/apps/web/src/common/index.ts
@@ -616,3 +616,7 @@ export async function handleInternalLink(url: string, openInNewTab?: boolean) {
     navigate(`/colors/${link.id}`);
   }
 }
+
+export function truncateString(str: string, maxLength = 100) {
+  return str.length > maxLength ? str.substring(0, maxLength) + "..." : str;
+}

--- a/apps/web/src/components/dialog/index.tsx
+++ b/apps/web/src/components/dialog/index.tsx
@@ -147,7 +147,8 @@ function BaseDialog(props: React.PropsWithChildren<DialogProps>) {
                   justifyContent:
                     props.textAlignment === "center"
                       ? "center"
-                      : "space-between"
+                      : "space-between",
+                  minWidth: 0
                 }}
               >
                 <Text
@@ -157,8 +158,10 @@ function BaseDialog(props: React.PropsWithChildren<DialogProps>) {
                     fontSize: "subheading",
                     textAlign: props.textAlignment || "left",
                     color: "paragraph",
-                    overflowWrap: "anywhere",
-                    wordSpacing: "wrap"
+                    minWidth: 0,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap"
                   }}
                 >
                   {props.title}

--- a/apps/web/src/components/field/index.tsx
+++ b/apps/web/src/components/field/index.tsx
@@ -121,6 +121,7 @@ function Field(props: FieldProps) {
           type={isPasswordVisible ? "text" : type || "text"}
           sx={{
             flex: 1,
+            pr: rightActions.length > 0 ? 20 : undefined,
             ...styles?.input,
             pointerEvents: disabled ? "none" : "all",
             ":disabled": {

--- a/apps/web/src/components/filtered-list/index.tsx
+++ b/apps/web/src/components/filtered-list/index.tsx
@@ -88,14 +88,23 @@ export function FilteredList<T>(props: FilteredListProps<T>) {
             alignItems: "center",
             py: 2,
             width: "100%",
-            mt: 1
+            mt: 1,
+            minWidth: 0
           }}
           onClick={async () => {
             await _createNewItem(query);
           }}
         >
-          <Text variant={"body"}>{`${strings.add()} "${query}"`}</Text>
-          <Plus size={16} color="accent" />
+          <Text
+            variant={"body"}
+            sx={{
+              minWidth: 0,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap"
+            }}
+          >{`${strings.add()} "${query}"`}</Text>
+          <Plus size={16} color="accent" sx={{ flexShrink: 0 }} />
         </Button>
       ) : (
         <VirtualizedList {...listProps} items={items} />

--- a/apps/web/src/dialogs/add-notebook-dialog.tsx
+++ b/apps/web/src/dialogs/add-notebook-dialog.tsx
@@ -28,7 +28,7 @@ import { store as appStore } from "../stores/app-store";
 import { db } from "../common/db";
 import { BaseDialogProps, DialogManager } from "../common/dialog-manager";
 import { strings } from "@notesnook/intl";
-import { checkFeature } from "../common";
+import { checkFeature, truncateString } from "../common";
 
 type AddNotebookDialogProps = BaseDialogProps<boolean> & {
   parentId?: string;
@@ -79,7 +79,7 @@ export const AddNotebookDialog = DialogManager.register(
         title={props.edit ? strings.editNotebook() : strings.newNotebook()}
         description={
           props.edit && notebook?.title
-            ? strings.editNotebookDesc(notebook.title)
+            ? strings.editNotebookDesc(truncateString(notebook.title))
             : strings.newNotebookDesc()
         }
         onClose={() => onClose(false)}

--- a/apps/web/src/dialogs/add-tags-dialog.tsx
+++ b/apps/web/src/dialogs/add-tags-dialog.tsx
@@ -160,7 +160,18 @@ function TagItem(props: { tag: Tag }) {
     >
       <Flex sx={{ alignItems: "center" }}>
         <SelectedCheck size={18} item={tag} />
-        <Text className="title" data-test-id="tag-title" variant="body">
+        <Text
+          className="title"
+          data-test-id="tag-title"
+          variant="body"
+          title={tag.title}
+          sx={{
+            minWidth: 0,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap"
+          }}
+        >
           #{tag.title}
         </Text>
       </Flex>

--- a/apps/web/src/dialogs/command-palette/command-palette-dialog.tsx
+++ b/apps/web/src/dialogs/command-palette/command-palette-dialog.tsx
@@ -50,6 +50,7 @@ import {
   addRecentCommand
 } from "./commands";
 import { escapeUTF8 } from "entities";
+import { truncateString } from "../../common";
 
 type CommandPaletteDialogProps = BaseDialogProps<boolean> & {
   isCommandMode: boolean;
@@ -249,7 +250,9 @@ export const CommandPaletteDialog = DialogManager.register(
                 >
                   <Text
                     variant="subBody"
-                    dangerouslySetInnerHTML={{ __html: label }}
+                    dangerouslySetInnerHTML={{
+                      __html: truncateString(label, 200)
+                    }}
                   />
                 </Box>
               );
@@ -306,7 +309,9 @@ export const CommandPaletteDialog = DialogManager.register(
                         overflow: "hidden"
                       }}
                       dangerouslySetInnerHTML={{
-                        __html: command.title
+                        __html: query
+                          ? command.title
+                          : truncateString(command.title, 200)
                       }}
                     />
                   </Flex>
@@ -323,7 +328,8 @@ export const CommandPaletteDialog = DialogManager.register(
                       sx={{
                         bg: "transparent",
                         p: "small",
-                        borderRadius: 100
+                        borderRadius: 100,
+                        flexShrink: 0
                       }}
                     >
                       <Cross size={12} />

--- a/apps/web/src/dialogs/item-dialog.tsx
+++ b/apps/web/src/dialogs/item-dialog.tsx
@@ -30,7 +30,7 @@ import { useStore as useNoteStore } from "../stores/note-store";
 import { useStore as useAppStore } from "../stores/app-store";
 import { Color, Tag } from "@notesnook/core";
 import { strings } from "@notesnook/intl";
-import { checkFeature } from "../common";
+import { checkFeature, truncateString } from "../common";
 
 type ItemDialogProps = BaseDialogProps<false | string> & {
   title: string;
@@ -118,7 +118,7 @@ export const EditTagDialog = {
   show: (tag: Tag) =>
     ItemDialog.show({
       title: strings.doActions.edit.tag(1),
-      subtitle: strings.editingTagDesc(tag.title),
+      subtitle: strings.editingTagDesc(truncateString(tag.title)),
       defaultValue: tag.title
     }).then(async (title) => {
       if (
@@ -140,7 +140,7 @@ export const RenameColorDialog = {
   show: (color: Color) =>
     ItemDialog.show({
       title: strings.renameColor(),
-      subtitle: strings.renameColorDesc(color.title),
+      subtitle: strings.renameColorDesc(truncateString(color.title)),
       defaultValue: color.title
     }).then(async (title) => {
       if (

--- a/apps/web/src/dialogs/move-note-dialog.tsx
+++ b/apps/web/src/dialogs/move-note-dialog.tsx
@@ -383,7 +383,7 @@ export function NotebookItem(props: {
         toggle();
       }}
     >
-      <Flex sx={{ alignItems: "center" }}>
+      <Flex sx={{ alignItems: "center", minWidth: 0, flex: 1 }}>
         {isExpandable ? (
           isExpanded ? (
             <ChevronDown data-test-id="collapse-notebook" size={18} />
@@ -392,11 +392,25 @@ export function NotebookItem(props: {
           )
         ) : null}
         <SelectedCheck size={18} item={notebook} onClick={check} />
-        <Text className="title" data-test-id="notebook-title" variant="body">
+        <Text
+          className="title"
+          data-test-id="notebook-title"
+          variant="body"
+          title={notebook.title}
+          sx={{
+            minWidth: 0,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap"
+          }}
+        >
           {notebook.title}
         </Text>
       </Flex>
-      <Flex data-test-id="notebook-tools" sx={{ alignItems: "center" }}>
+      <Flex
+        data-test-id="notebook-tools"
+        sx={{ alignItems: "center", flexShrink: 0 }}
+      >
         <Button
           variant="secondary"
           data-test-id="add-sub-notebook"


### PR DESCRIPTION


## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

web: truncate long tag/color/notebook titles in multiple dialogs

## QA Scope

Web only

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [X] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [ ] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
