### PR TITLE
editor: fix some settings do not get applied automatically and need editor reload

### DIFF
--- a/apps/mobile/app/screens/editor/tiptap/use-editor-events.tsx
+++ b/apps/mobile/app/screens/editor/tiptap/use-editor-events.tsx
@@ -230,9 +230,9 @@ export const useEditorEvents = (
           ? parseInt(defaultFontSize)
           : defaultFontSize,
       fontFamily: SettingsService.get().defaultFontFamily,
-      dateFormat: db.settings?.getDateFormat(),
-      timeFormat: db.settings?.getTimeFormat(),
-      dayFormat: db.settings?.getDayFormat(),
+      dateFormat: dateFormat,
+      timeFormat: timeFormat,
+      dayFormat: dayFormat,
       fontScale,
       markdownShortcuts,
       features,

--- a/apps/mobile/app/screens/editor/tiptap/use-editor-events.tsx
+++ b/apps/mobile/app/screens/editor/tiptap/use-editor-events.tsx
@@ -209,7 +209,6 @@ export const useEditorEvents = (
     };
   }, [editor, editor.commands, editor.postMessage]);
   useEffect(() => {
-    if (loading) return;
     if (typeof defaultFontFamily === "object") {
       SettingsService.set({
         defaultFontFamily: (defaultFontFamily as any).id

--- a/apps/mobile/app/stores/use-setting-store.ts
+++ b/apps/mobile/app/stores/use-setting-store.ts
@@ -264,7 +264,7 @@ export const useSettingStore = create<SettingStore>((set, get) => ({
     set({
       dayFormat: db.settings.getDayFormat(),
       timeFormat: db.settings.getTimeFormat(),
-      dateFormat: db.settings?.getTimeFormat(),
+      dateFormat: db.settings?.getDateFormat(),
       weekFormat: db.settings.getWeekFormat(),
       vaultLockAfter: db.settings.getVaultLockAfter(),
       inboxEnabled: await db.user.hasInboxKeys()

--- a/apps/mobile/app/stores/use-setting-store.ts
+++ b/apps/mobile/app/stores/use-setting-store.ts
@@ -206,7 +206,7 @@ export const defaultSettings: SettingStore["settings"] = {
   colorScheme: "light",
   lighTheme: ThemeLight,
   darkTheme: ThemeDark,
-  markdownShortcuts: true,
+  markdownShortcuts: false,
   biometricsAuthEnabled: false,
   appLockHasPasswordSecurity: false,
   backgroundSync: true,

--- a/packages/editor-mobile/src/components/editor.tsx
+++ b/packages/editor-mobile/src/components/editor.tsx
@@ -956,7 +956,15 @@ const Tiptap = ({
         </div>
 
         <TiptapEditorWrapper
-          key={tick + tab.id + "-editor" + tab.session?.readonly}
+          key={[
+            tick,
+            tab.id,
+            settings.doubleSpacedLines ? "ds" : "ss",
+            settings.dateFormat,
+            settings.timeFormat,
+            settings.dayFormat,
+            tab.session?.readonly ? "readonly" : "edit"
+          ].join("-")}
           options={tiptapOptions}
           settings={settings}
           onEditorUpdate={(editor) => {

--- a/packages/editor-mobile/src/hooks/useSettings.ts
+++ b/packages/editor-mobile/src/hooks/useSettings.ts
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { getDefaultPresets } from "@notesnook/editor";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Settings } from "../utils";
 
 const settingsJson = localStorage.getItem("editorSettings");
@@ -73,6 +73,15 @@ export const useSettings = (): Settings => {
     ...global.settingsController.previous
   });
   global.settingsController.set = setSettings;
+
+  useEffect(() => {
+    setSettings((current) =>
+      JSON.stringify(current) ===
+      JSON.stringify(global.settingsController.previous)
+        ? current
+        : { ...global.settingsController.previous }
+    );
+  }, []);
 
   return settings;
 };

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -424,7 +424,13 @@ const useTiptap = (
       timeFormat,
       editorProps,
       copyToClipboard,
-      createInternalLink
+      createInternalLink,
+      dayFormat,
+      doubleSpacedLines,
+      enableFontLigatures,
+      getLinkData,
+      downloadCsvTable,
+      options.placeholder
     ]
   );
 


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

## QA Scope
1. Changing double spaced lines setting in Settings -> Editor should instantly work
2. Changing date/time format should immediately reflect in the editor when using /date shortcuts
3. on a fresh install markdown shortcuts should be disabled

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [ ] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [ ] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
