### PR TITLE
web: persist theme's color scheme when setting a new theme

### DIFF
--- a/apps/web/src/stores/theme-store.ts
+++ b/apps/web/src/stores/theme-store.ts
@@ -50,6 +50,7 @@ class ThemeStore extends BaseStore<ThemeStore> {
 
   setTheme = (theme: ThemeDefinition) => {
     changeDesktopTheme(theme, this.get().followSystemTheme);
+    Config.set("colorScheme", theme.colorScheme);
     Config.set(`theme:${theme.colorScheme}`, theme);
     this.set({
       [getKey(theme)]: theme,


### PR DESCRIPTION

## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

web: persist theme's color scheme when setting a new theme

Closes https://github.com/streetwriters/notesnook/issues/9997

## QA Scope

Web and desktop

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [X] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [ ] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
