### PR TITLE
mobile: add support for the pebble index 01 ring

### DIFF
--- a/apps/mobile/android/.project
+++ b/apps/mobile/android/.project
@@ -16,12 +16,12 @@
 	</natures>
 	<filteredResources>
 		<filter>
-			<id>1622976477541</id>
+			<id>1787398695494</id>
 			<name></name>
 			<type>30</type>
 			<matcher>
 				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
 			</matcher>
 		</filter>
 	</filteredResources>

--- a/apps/mobile/android/.settings/org.eclipse.buildship.core.prefs
+++ b/apps/mobile/android/.settings/org.eclipse.buildship.core.prefs
@@ -1,11 +1,11 @@
-arguments=
+arguments=--init-script /var/folders/cf/lx4530nn29n9wpz2x8z1qm9c0000gn/T/db3b08fc4a9ef609cb16b96b200fa13e563f396e9bb1ed0905fdab7bc3bc513b.gradle
 auto.sync=false
 build.scans.enabled=false
 connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
 connection.project.dir=
 eclipse.preferences.version=1
 gradle.user.home=
-java.home=/usr/lib/jvm/java-15-openjdk
+java.home=/opt/homebrew/Cellar/openjdk@17/17.0.20.1/libexec/openjdk.jdk/Contents/Home
 jvm.arguments=
 offline.mode=false
 override.workspace.settings=true

--- a/apps/mobile/android/.settings/org.eclipse.buildship.core.prefs
+++ b/apps/mobile/android/.settings/org.eclipse.buildship.core.prefs
@@ -1,11 +1,11 @@
-arguments=--init-script /var/folders/cf/lx4530nn29n9wpz2x8z1qm9c0000gn/T/db3b08fc4a9ef609cb16b96b200fa13e563f396e9bb1ed0905fdab7bc3bc513b.gradle
+arguments=
 auto.sync=false
 build.scans.enabled=false
 connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
 connection.project.dir=
 eclipse.preferences.version=1
 gradle.user.home=
-java.home=/opt/homebrew/Cellar/openjdk@17/17.0.20.1/libexec/openjdk.jdk/Contents/Home
+java.home=/usr/lib/jvm/java-15-openjdk
 jvm.arguments=
 offline.mode=false
 override.workspace.settings=true

--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,13 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.streetwriters.notesnook">
 
+    <permission
+        android:name="com.streetwriters.notesnook.permission.RECEIVE_INDEX_CAPTURE"
+        android:label="Receive Index 01 captures"
+        android:description="@string/permission_receive_index_capture"
+        android:protectionLevel="normal" />
+    <uses-permission android:name="com.streetwriters.notesnook.permission.RECEIVE_INDEX_CAPTURE" />
+
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="com.android.vending.BILLING" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
@@ -21,7 +28,11 @@
         tools:node="remove" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM"
+        tools:ignore="ExactAlarm" />
     <uses-permission
         android:name="android.permission.USE_FULL_SCREEN_INTENT"
         tools:node="remove" />
@@ -57,6 +68,7 @@
             <!-- If you don't know the MIME type in advance, set "mimeType" to "*/*". -->
             <data android:mimeType="audio/*" />
         </intent>
+        <package android:name="coredevices.coreapp" />
     </queries>
 
     <application
@@ -198,6 +210,7 @@
                 <data android:mimeType="video/*" />
                 <data android:mimeType="image/*" />
                 <data android:mimeType="application/*" />
+                <data android:mimeType="audio/*" />
             </intent-filter>
 
             <intent-filter android:label="Make Note">
@@ -209,6 +222,7 @@
                 <data android:mimeType="video/*" />
                 <data android:mimeType="image/*" />
                 <data android:mimeType="application/*" />
+                <data android:mimeType="audio/*" />
             </intent-filter>
 
             <intent-filter android:label="Make Note">
@@ -228,6 +242,47 @@
                 android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
                 android:value="The service is required by the app to restore notifications of pinned notes, restore notification with reply input for creating notes and restore data in note preview widgets on device reboot." />
         </service>
+
+        <service
+            android:name=".pebble.PebbleIndexCaptureService"
+            android:exported="true"
+            android:foregroundServiceType="dataSync">
+            <intent-filter>
+                <action android:name="com.streetwriters.notesnook.action.INDEX_CAPTURE" />
+            </intent-filter>
+        </service>
+
+        <service
+            android:name=".pebble.PebbleIndexKeepAliveService"
+            android:exported="false"
+            android:foregroundServiceType="specialUse">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Keeps Notesnook process-warm so Pebble Index 01 captures can be received as on-device intents without opening the app." />
+        </service>
+
+        <activity
+            android:name=".pebble.PebbleIndexCaptureActivity"
+            android:exported="true"
+            android:theme="@style/PebbleIndexCaptureTheme"
+            android:excludeFromRecents="true"
+            android:noHistory="true"
+            android:taskAffinity=""
+            android:finishOnTaskLaunch="true"
+            android:autoRemoveFromRecents="true">
+            <intent-filter>
+                <action android:name="com.streetwriters.notesnook.action.INDEX_CAPTURE" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+
+        <receiver
+            android:name=".pebble.PebbleIndexCaptureReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.streetwriters.notesnook.action.INDEX_CAPTURE" />
+            </intent-filter>
+        </receiver>
 
         <service
             android:name=".NotesnookTileService"

--- a/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/BootRecieverService.java
+++ b/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/BootRecieverService.java
@@ -28,6 +28,9 @@ public class BootRecieverService extends BroadcastReceiver {
                  }
                  HeadlessJsTaskService.acquireWakeLockNow(context);
              }
+             if (com.streetwriters.notesnook.pebble.PebbleIndexPrefs.keepAlive(context)) {
+                 com.streetwriters.notesnook.pebble.PebbleIndexKeepAliveService.start(context);
+             }
          } catch (Exception ignored) {}
     }
 

--- a/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/MainActivity.java
+++ b/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/MainActivity.java
@@ -16,6 +16,8 @@ import androidx.core.view.WindowInsetsCompat;
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint;
 import com.facebook.react.defaults.DefaultReactActivityDelegate;
+import com.streetwriters.notesnook.pebble.PebbleIndexCaptureService;
+import com.streetwriters.notesnook.pebble.PebbleIndexInbox;
 import com.zoontek.rnbootsplash.RNBootSplash;
 
 public class MainActivity extends ReactActivity {
@@ -27,7 +29,19 @@ public class MainActivity extends ReactActivity {
     if (BuildConfig.DEBUG) {
       WebView.setWebContentsDebuggingEnabled(true);
     }
+    drainPebbleIndexInbox();
+  }
 
+  private void drainPebbleIndexInbox() {
+    try {
+      if (!PebbleIndexInbox.hasPending(this)) return;
+      Intent service = new Intent(this, PebbleIndexCaptureService.class);
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        startForegroundService(service);
+      } else {
+        startService(service);
+      }
+    } catch (Exception ignored) {}
   }
 
   /**

--- a/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/MainApplication.kt
+++ b/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/MainApplication.kt
@@ -24,5 +24,8 @@ class MainApplication : Application(), ReactApplication {
     super.onCreate()
       registerActivityLifecycleCallbacks(OrientationActivityLifecycle.getInstance());
     loadReactNative(this)
+    if (com.streetwriters.notesnook.pebble.PebbleIndexPrefs.keepAlive(this)) {
+      com.streetwriters.notesnook.pebble.PebbleIndexKeepAliveService.start(this)
+    }
   }
 }

--- a/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/RCTNNativeModule.java
+++ b/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/RCTNNativeModule.java
@@ -449,4 +449,49 @@ public class RCTNNativeModule extends ReactContextBaseJavaModule {
         return colors[hash % colors.length];
     }
 
+    @ReactMethod
+    public void setPebbleIndexCaptureEnabled(boolean enabled) {
+        com.streetwriters.notesnook.pebble.PebbleIndexPrefs.setCaptureEnabled(
+                getReactApplicationContext(), enabled);
+    }
+
+    @ReactMethod
+    public void setPebbleIndexKeepAlive(boolean enabled) {
+        android.content.Context context = getReactApplicationContext();
+        com.streetwriters.notesnook.pebble.PebbleIndexPrefs.setKeepAlive(context, enabled);
+        if (enabled) {
+            com.streetwriters.notesnook.pebble.PebbleIndexKeepAliveService.start(context);
+        } else {
+            com.streetwriters.notesnook.pebble.PebbleIndexKeepAliveService.stop(context);
+        }
+    }
+
+    @ReactMethod(isBlockingSynchronousMethod = true)
+    public boolean isPebbleIndexKeepAliveRunning() {
+        return com.streetwriters.notesnook.pebble.PebbleIndexPrefs.keepAlive(
+                getReactApplicationContext());
+    }
+
+    @ReactMethod
+    public void ackPebbleIndexCapture(String id) {
+        if (id == null) return;
+        com.streetwriters.notesnook.pebble.PebbleIndexInbox.remove(
+                getReactApplicationContext(), id);
+    }
+
+    @ReactMethod
+    public void setPebbleIndexReminderPriority(String priority) {
+        com.streetwriters.notesnook.pebble.PebbleIndexPrefs.setReminderPriority(
+                getReactApplicationContext(), priority);
+    }
+
+    @ReactMethod
+    public void getPebbleIndexInbox(Promise promise) {
+        promise.resolve(
+                com.streetwriters.notesnook.pebble.PebbleIndexInbox
+                        .pendingAsJson(getReactApplicationContext())
+                        .toString()
+        );
+    }
+
 }

--- a/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/pebble/PebbleIndexCaptureActivity.java
+++ b/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/pebble/PebbleIndexCaptureActivity.java
@@ -1,0 +1,49 @@
+package com.streetwriters.notesnook.pebble;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+import android.util.Log;
+
+/**
+ * Visible-window trampoline so Pebble can deliver a capture even when
+ * startForegroundService is blocked (missing custom permission, or BAL).
+ * Finishes immediately after hopping to {@link PebbleIndexCaptureService}.
+ */
+public class PebbleIndexCaptureActivity extends Activity {
+    private static final String TAG = "PebbleIndexActivity";
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        Intent intent = getIntent();
+        if (intent != null && PebbleIndexContract.ACTION.equals(intent.getAction())) {
+            if (!callerAllowed()) {
+                Log.w(TAG, "Rejected capture from " + launchedPackage());
+            } else {
+                PebbleIndexHandoff.startCaptureService(this, intent);
+            }
+        }
+        finish();
+    }
+
+    private boolean callerAllowed() {
+        String launched = launchedPackage();
+        if (launched == null) {
+            // startActivity (not for-result) often has a null calling package
+            // on older APIs; the action + explicit component is the filter.
+            return true;
+        }
+        return getPackageName().equals(launched)
+                || PebbleIndexHandoff.isAllowedPackage(launched);
+    }
+
+    private String launchedPackage() {
+        if (Build.VERSION.SDK_INT >= 31) {
+            String pkg = getLaunchedFromPackage();
+            if (pkg != null) return pkg;
+        }
+        return getCallingPackage();
+    }
+}

--- a/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/pebble/PebbleIndexCaptureReceiver.java
+++ b/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/pebble/PebbleIndexCaptureReceiver.java
@@ -1,0 +1,41 @@
+package com.streetwriters.notesnook.pebble;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.util.Log;
+
+/**
+ * Fallback path if Pebble cannot start the capture service or trampoline
+ * activity directly. Always hops to {@link PebbleIndexCaptureService}.
+ */
+public class PebbleIndexCaptureReceiver extends BroadcastReceiver {
+    private static final String TAG = "PebbleIndexReceiver";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (intent == null || !PebbleIndexContract.ACTION.equals(intent.getAction())) {
+            return;
+        }
+        if (!senderAllowed(context)) {
+            Log.w(TAG, "Rejected capture broadcast from unknown sender");
+            return;
+        }
+        PebbleIndexHandoff.startCaptureService(context, intent);
+    }
+
+    private boolean senderAllowed(Context context) {
+        if (Build.VERSION.SDK_INT >= 34) {
+            String pkg = getSentFromPackage();
+            if (pkg != null) {
+                return PebbleIndexHandoff.isAllowedPackage(pkg);
+            }
+            int uid = getSentFromUid();
+            if (uid >= 0) {
+                return PebbleIndexHandoff.isAllowedUid(context, uid);
+            }
+        }
+        return true;
+    }
+}

--- a/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/pebble/PebbleIndexCaptureService.java
+++ b/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/pebble/PebbleIndexCaptureService.java
@@ -1,0 +1,134 @@
+package com.streetwriters.notesnook.pebble;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.ServiceInfo;
+import android.os.Binder;
+import android.os.Build;
+import android.util.Log;
+
+import androidx.core.app.NotificationCompat;
+
+import com.facebook.react.HeadlessJsTaskService;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.jstasks.HeadlessJsTaskConfig;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.streetwriters.notesnook.R;
+
+import javax.annotation.Nullable;
+
+/**
+ * Receives an explicit Index capture intent, copies audio into the private
+ * inbox, then runs a Headless JS task that creates the Notesnook note.
+ *
+ * Started from Pebble's connected-device FGS via startForegroundService, so
+ * it works with the screen off and without a user tap.
+ */
+public class PebbleIndexCaptureService extends HeadlessJsTaskService {
+    private static final String TAG = "PebbleIndexCapture";
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        promoteToForeground();
+        if (intent != null && PebbleIndexContract.ACTION.equals(intent.getAction())) {
+            int uid = Binder.getCallingUid();
+            if (uid != android.os.Process.SYSTEM_UID
+                    && !PebbleIndexHandoff.isAllowedUid(this, uid)) {
+                Log.w(TAG, "Rejected capture from uid " + uid);
+                stopSelf(startId);
+                return START_NOT_STICKY;
+            }
+            if (!PebbleIndexPrefs.captureEnabled(this)) {
+                Log.i(TAG, "Capture disabled");
+                stopSelf(startId);
+                return START_NOT_STICKY;
+            }
+            try {
+                String inboxId = PebbleIndexInbox.enqueue(this, intent);
+                Log.i(TAG, "Enqueued capture " + inboxId);
+                notifyJs();
+            } catch (Exception e) {
+                Log.e(TAG, "Failed to enqueue capture", e);
+            }
+        }
+        return super.onStartCommand(intent, flags, startId);
+    }
+
+    @Override
+    protected @Nullable HeadlessJsTaskConfig getTaskConfig(Intent intent) {
+        WritableMap data = Arguments.createMap();
+        data.putString("inbox", PebbleIndexInbox.pendingAsJson(this).toString());
+        return new HeadlessJsTaskConfig(
+                PebbleIndexContract.HEADLESS_TASK,
+                data,
+                120000,
+                true
+        );
+    }
+
+    @Override
+    public void onHeadlessJsTaskFinish(int taskId) {
+        super.onHeadlessJsTaskFinish(taskId);
+        stopSelf();
+    }
+
+    private void notifyJs() {
+        try {
+            ReactContext ctx = null;
+            try {
+                ctx = getReactNativeHost()
+                        .getReactInstanceManager()
+                        .getCurrentReactContext();
+            } catch (Throwable ignored) {
+            }
+            if (ctx == null) {
+                Log.i(TAG, "No React context yet; headless/AppState will drain inbox");
+                return;
+            }
+            String json = PebbleIndexInbox.pendingAsJson(this).toString();
+            ctx.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                    .emit("PEBBLE_INDEX_CAPTURE", json);
+            Log.i(TAG, "Emitted PEBBLE_INDEX_CAPTURE to JS");
+        } catch (Exception e) {
+            Log.w(TAG, "Could not emit capture to JS", e);
+        }
+    }
+
+    private void promoteToForeground() {
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                NotificationChannel channel = new NotificationChannel(
+                        PebbleIndexContract.CHANNEL_ID,
+                        PebbleIndexContract.CHANNEL_NAME,
+                        NotificationManager.IMPORTANCE_LOW
+                );
+                channel.setDescription("Receives Index 01 recordings on this phone");
+                NotificationManager manager =
+                        (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+                manager.createNotificationChannel(channel);
+            }
+            Notification notification = new NotificationCompat.Builder(this, PebbleIndexContract.CHANNEL_ID)
+                    .setContentTitle("Saving Index recording")
+                    .setContentText("Writing transcription and audio into Notesnook")
+                    .setSmallIcon(R.drawable.ic_stat_name)
+                    .setOngoing(true)
+                    .build();
+            if (Build.VERSION.SDK_INT >= 34) {
+                startForeground(
+                        PebbleIndexContract.CAPTURE_NOTIFICATION_ID,
+                        notification,
+                        ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+                );
+            } else {
+                startForeground(PebbleIndexContract.CAPTURE_NOTIFICATION_ID, notification);
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Could not promote capture service", e);
+        }
+    }
+}

--- a/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/pebble/PebbleIndexContract.java
+++ b/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/pebble/PebbleIndexContract.java
@@ -1,0 +1,49 @@
+package com.streetwriters.notesnook.pebble;
+
+/**
+ * Shared names for the on-device Pebble Index 01 → Notesnook intent.
+ * Keep in lockstep with Pebble Core's IndexLocalCaptureContract.
+ */
+public final class PebbleIndexContract {
+    private PebbleIndexContract() {}
+
+    public static final String ACTION = "com.streetwriters.notesnook.action.INDEX_CAPTURE";
+    public static final String RECEIVE_PERMISSION =
+            "com.streetwriters.notesnook.permission.RECEIVE_INDEX_CAPTURE";
+
+    public static final String PEBBLE_PACKAGE = "coredevices.coreapp";
+
+    public static final String EXTRA_TRANSCRIPTION = "transcription";
+    public static final String EXTRA_RECORDED_AT = "recordedAt";
+    public static final String EXTRA_CLIENT = "client";
+    public static final String EXTRA_RECORDING_ID = "recordingId";
+    public static final String EXTRA_TRIGGER = "trigger";
+    public static final String EXTRA_PAYLOAD_MODE = "payloadMode";
+    public static final String EXTRA_AUDIO_SIZE = "audioSize";
+    public static final String EXTRA_AUDIO_URI = "audioUri";
+    public static final String EXTRA_AUDIO_BASE64 = "audioBase64";
+    public static final String EXTRA_TEST = "test";
+    public static final String EXTRA_KIND = "kind";
+    public static final String EXTRA_TITLE = "title";
+    public static final String EXTRA_HAS_DEADLINE = "hasDeadline";
+    public static final String EXTRA_DEADLINE_EPOCH_MS = "deadlineEpochMs";
+    public static final String EXTRA_DEADLINE_ISO = "deadlineIso";
+    public static final String EXTRA_NOTIFY_BEFORE_SECONDS = "notifyBeforeSeconds";
+
+    public static final String KIND_NOTE = "note";
+    public static final String KIND_REMINDER = "reminder";
+
+    public static final String PREFS = "pebble_index";
+    public static final String PREF_CAPTURE_ENABLED = "capture_enabled";
+    public static final String PREF_KEEP_ALIVE = "keep_alive";
+    public static final String PREF_REMINDER_PRIORITY = "reminder_priority";
+
+    public static final String INBOX_DIR = "pebble-index/inbox";
+    public static final String CHANNEL_ID = "com.streetwriters.notesnook.pebble_index";
+    public static final String CHANNEL_NAME = "Pebble Index 01";
+
+    public static final int KEEP_ALIVE_NOTIFICATION_ID = 41;
+    public static final int CAPTURE_NOTIFICATION_ID = 42;
+
+    public static final String HEADLESS_TASK = "com.streetwriters.notesnook.PEBBLE_INDEX_CAPTURE";
+}

--- a/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/pebble/PebbleIndexHandoff.java
+++ b/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/pebble/PebbleIndexHandoff.java
@@ -1,0 +1,74 @@
+package com.streetwriters.notesnook.pebble;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.os.Process;
+import android.util.Log;
+
+import com.facebook.react.HeadlessJsTaskService;
+
+/**
+ * Shared hop from Activity / Receiver into the capture FGS, plus the
+ * Pebble-package allowlist (replaces the custom permission, which Android
+ * does not grant across independently-installed apps).
+ */
+public final class PebbleIndexHandoff {
+    private static final String TAG = "PebbleIndexHandoff";
+
+    private PebbleIndexHandoff() {}
+
+    public static boolean isAllowedUid(Context context, int uid) {
+        if (uid == Process.myUid()) return true;
+        PackageManager pm = context.getPackageManager();
+        String[] packages = pm.getPackagesForUid(uid);
+        if (packages == null) return false;
+        for (String pkg : packages) {
+            if (isAllowedPackage(pkg)) return true;
+        }
+        return false;
+    }
+
+    public static boolean isAllowedPackage(String pkg) {
+        return PebbleIndexContract.PEBBLE_PACKAGE.equals(pkg);
+    }
+
+    public static boolean startCaptureService(Context context, Intent source) {
+        if (!PebbleIndexPrefs.captureEnabled(context)) {
+            Log.i(TAG, "Capture disabled, dropping Index intent");
+            return false;
+        }
+        Intent service = new Intent(context, PebbleIndexCaptureService.class);
+        service.setAction(PebbleIndexContract.ACTION);
+        if (source != null) {
+            if (source.getExtras() != null) {
+                service.putExtras(source.getExtras());
+            }
+            service.setData(source.getData());
+            service.setClipData(source.getClipData());
+            if (source.getType() != null) {
+                service.setType(source.getType());
+            }
+            service.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        }
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(service);
+            } else {
+                context.startService(service);
+            }
+            HeadlessJsTaskService.acquireWakeLockNow(context);
+            Log.i(TAG, "Started capture service");
+            return true;
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to start capture service, enqueueing only", e);
+            if (source != null) {
+                try {
+                    PebbleIndexInbox.enqueue(context, source);
+                } catch (Exception ignored) {}
+            }
+            return false;
+        }
+    }
+}

--- a/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/pebble/PebbleIndexInbox.java
+++ b/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/pebble/PebbleIndexInbox.java
@@ -1,0 +1,281 @@
+package com.streetwriters.notesnook.pebble;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Bundle;
+import android.util.Base64;
+import android.util.Log;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Copies a capture intent onto app-private storage so the FileProvider grant
+ * can expire while Headless JS still has the audio and metadata.
+ */
+public final class PebbleIndexInbox {
+    private static final String TAG = "PebbleIndexInbox";
+
+    private PebbleIndexInbox() {}
+
+    public static boolean hasPending(Context context) {
+        File[] files = inboxDir(context).listFiles();
+        if (files == null) return false;
+        for (File file : files) {
+            if (file.getName().endsWith(".json")) return true;
+        }
+        return false;
+    }
+
+    static File inboxDir(Context context) {
+        File dir = new File(context.getFilesDir(), PebbleIndexContract.INBOX_DIR);
+        if (!dir.exists() && !dir.mkdirs()) {
+            Log.w(TAG, "Could not create inbox dir " + dir);
+        }
+        return dir;
+    }
+
+    public static String enqueue(Context context, Intent intent) {
+        String id = UUID.randomUUID().toString();
+        Uri audioUri = extractAudioUri(intent);
+        long claimedSize = extraLong(intent, PebbleIndexContract.EXTRA_AUDIO_SIZE, 0);
+        File audioFile = null;
+        long audioSize = 0;
+        if (audioUri != null) {
+            audioFile = new File(inboxDir(context), id + ".m4a");
+            audioSize = copyUri(context, audioUri, audioFile);
+            if (audioSize <= 0) {
+                Log.e(TAG, "Audio copy produced 0 bytes from " + audioUri);
+                if (audioFile.exists()) audioFile.delete();
+                audioFile = null;
+            } else {
+                Log.i(TAG, "Copied " + audioSize + " bytes of audio from " + audioUri);
+            }
+        }
+        if (audioFile == null) {
+            String b64 = extraString(intent, PebbleIndexContract.EXTRA_AUDIO_BASE64, null);
+            if (b64 != null && b64.length() > 0) {
+                try {
+                    byte[] bytes = Base64.decode(b64, Base64.DEFAULT);
+                    if (bytes != null && bytes.length > 0) {
+                        audioFile = new File(inboxDir(context), id + ".m4a");
+                        try (FileOutputStream out = new FileOutputStream(audioFile)) {
+                            out.write(bytes);
+                        }
+                        audioSize = bytes.length;
+                        Log.i(TAG, "Wrote " + audioSize + " bytes of audio from base64 extra");
+                    }
+                } catch (Exception e) {
+                    Log.e(TAG, "Failed to decode audioBase64 extra", e);
+                    if (audioFile != null && audioFile.exists()) audioFile.delete();
+                    audioFile = null;
+                    audioSize = 0;
+                }
+            }
+        }
+        if (audioFile == null && claimedSize > 0) {
+            Log.e(TAG, "Pebble claimed " + claimedSize
+                    + " audio bytes but no URI/base64 could be copied. extras="
+                    + (intent.getExtras() != null ? intent.getExtras().keySet().toString() : "null")
+                    + " data=" + intent.getData()
+                    + " clip=" + intent.getClipData());
+        } else if (audioFile == null) {
+            Log.i(TAG, "No audio on capture intent (transcription-only or missing audio)");
+        }
+
+        JSONObject json = new JSONObject();
+        try {
+            json.put("id", id);
+            json.put("recordingId", extraString(intent, PebbleIndexContract.EXTRA_RECORDING_ID, id));
+            json.put("transcription", extraString(intent, PebbleIndexContract.EXTRA_TRANSCRIPTION, ""));
+            json.put("recordedAt", extraLong(intent, PebbleIndexContract.EXTRA_RECORDED_AT, System.currentTimeMillis()));
+            json.put("client", extraString(intent, PebbleIndexContract.EXTRA_CLIENT, "ring"));
+            json.put("trigger", extraString(intent, PebbleIndexContract.EXTRA_TRIGGER, ""));
+            json.put("payloadMode", extraString(intent, PebbleIndexContract.EXTRA_PAYLOAD_MODE, "both"));
+            json.put("test", intent.getBooleanExtra(PebbleIndexContract.EXTRA_TEST, false));
+            json.put("kind", extraString(intent, PebbleIndexContract.EXTRA_KIND, PebbleIndexContract.KIND_NOTE));
+            String title = extraString(intent, PebbleIndexContract.EXTRA_TITLE, "");
+            if (title.length() > 0) json.put("title", title);
+            boolean hasDeadline = extraBoolean(intent, PebbleIndexContract.EXTRA_HAS_DEADLINE, false);
+            json.put("hasDeadline", hasDeadline);
+            if (hasDeadline) {
+                long epochMs = extraLong(intent, PebbleIndexContract.EXTRA_DEADLINE_EPOCH_MS, 0);
+                if (epochMs > 0) json.put("deadlineEpochMs", epochMs);
+                String iso = extraString(intent, PebbleIndexContract.EXTRA_DEADLINE_ISO, "");
+                if (iso.length() > 0) json.put("deadlineIso", iso);
+            }
+            long notifyBefore = extraLong(intent, PebbleIndexContract.EXTRA_NOTIFY_BEFORE_SECONDS, -1);
+            if (notifyBefore >= 0) json.put("notifyBeforeSeconds", notifyBefore);
+            if (claimedSize > 0) json.put("audioSizeClaimed", claimedSize);
+            if (audioFile != null) {
+                json.put("audioPath", audioFile.getAbsolutePath());
+                json.put("audioSize", audioSize);
+                json.put("audioMime", "audio/mp4");
+                json.put("audioName", extraString(intent, PebbleIndexContract.EXTRA_RECORDING_ID, id) + ".m4a");
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to serialize capture", e);
+        }
+
+        File meta = new File(inboxDir(context), id + ".json");
+        try (FileOutputStream out = new FileOutputStream(meta)) {
+            out.write(json.toString().getBytes("UTF-8"));
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to write inbox metadata", e);
+        }
+        return id;
+    }
+
+    public static JSONArray pendingAsJson(Context context) {
+        JSONArray array = new JSONArray();
+        File[] files = inboxDir(context).listFiles();
+        if (files == null) return array;
+        for (File file : files) {
+            if (!file.getName().endsWith(".json")) continue;
+            try {
+                byte[] bytes = readAll(file);
+                array.put(new JSONObject(new String(bytes, "UTF-8")));
+            } catch (Exception e) {
+                Log.w(TAG, "Skipping corrupt inbox item " + file.getName(), e);
+            }
+        }
+        return array;
+    }
+
+    public static void remove(Context context, String id) {
+        File dir = inboxDir(context);
+        new File(dir, id + ".json").delete();
+        new File(dir, id + ".m4a").delete();
+    }
+
+    static List<String> pendingIds(Context context) {
+        List<String> ids = new ArrayList<>();
+        File[] files = inboxDir(context).listFiles();
+        if (files == null) return ids;
+        for (File file : files) {
+            String name = file.getName();
+            if (name.endsWith(".json")) {
+                ids.add(name.substring(0, name.length() - 5));
+            }
+        }
+        return ids;
+    }
+
+    private static Uri extractAudioUri(Intent intent) {
+        if (intent == null) return null;
+        Uri stream = parcelableUri(intent, Intent.EXTRA_STREAM);
+        if (stream != null) return stream;
+        String extra = extraString(intent, PebbleIndexContract.EXTRA_AUDIO_URI, null);
+        if (extra != null && extra.length() > 0) {
+            try {
+                return Uri.parse(extra);
+            } catch (Exception ignored) {
+            }
+        }
+        if (intent.getClipData() != null && intent.getClipData().getItemCount() > 0) {
+            Uri clipUri = intent.getClipData().getItemAt(0).getUri();
+            if (clipUri != null) return clipUri;
+        }
+        if (intent.getData() != null) return intent.getData();
+        return null;
+    }
+
+    @SuppressWarnings("deprecation")
+    private static Uri parcelableUri(Intent intent, String key) {
+        try {
+            if (Build.VERSION.SDK_INT >= 33) {
+                Uri typed = intent.getParcelableExtra(key, Uri.class);
+                if (typed != null) return typed;
+            }
+            Object raw = intent.getParcelableExtra(key);
+            if (raw instanceof Uri) return (Uri) raw;
+            if (raw instanceof String) return Uri.parse((String) raw);
+        } catch (Exception e) {
+            Log.w(TAG, "Could not read parcelable URI extra " + key, e);
+        }
+        return null;
+    }
+
+    private static long copyUri(Context context, Uri uri, File dest) {
+        try (InputStream in = context.getContentResolver().openInputStream(uri);
+             FileOutputStream out = new FileOutputStream(dest)) {
+            if (in == null) {
+                Log.e(TAG, "ContentResolver.openInputStream returned null for " + uri);
+                return 0;
+            }
+            byte[] buf = new byte[16 * 1024];
+            long total = 0;
+            int n;
+            while ((n = in.read(buf)) != -1) {
+                out.write(buf, 0, n);
+                total += n;
+            }
+            return total;
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to copy audio from " + uri, e);
+            return 0;
+        }
+    }
+
+    private static byte[] readAll(File file) throws Exception {
+        byte[] bytes = new byte[(int) file.length()];
+        try (java.io.FileInputStream in = new java.io.FileInputStream(file)) {
+            int off = 0;
+            while (off < bytes.length) {
+                int n = in.read(bytes, off, bytes.length - off);
+                if (n < 0) break;
+                off += n;
+            }
+        }
+        return bytes;
+    }
+
+    private static String extraString(Intent intent, String key, String fallback) {
+        if (intent == null) return fallback;
+        String value = intent.getStringExtra(key);
+        return value == null ? fallback : value;
+    }
+
+    private static long extraLong(Intent intent, String key, long fallback) {
+        if (intent == null) return fallback;
+        Bundle extras = intent.getExtras();
+        if (extras == null || !extras.containsKey(key)) return fallback;
+        Object raw = extras.get(key);
+        if (raw instanceof Number) return ((Number) raw).longValue();
+        if (raw instanceof String) {
+            try {
+                return Long.parseLong((String) raw);
+            } catch (NumberFormatException ignored) {
+                return fallback;
+            }
+        }
+        if (Build.VERSION.SDK_INT >= 12) {
+            return extras.getLong(key, fallback);
+        }
+        return fallback;
+    }
+
+    private static boolean extraBoolean(Intent intent, String key, boolean fallback) {
+        if (intent == null) return fallback;
+        Bundle extras = intent.getExtras();
+        if (extras == null || !extras.containsKey(key)) return fallback;
+        Object raw = extras.get(key);
+        if (raw instanceof Boolean) return (Boolean) raw;
+        if (raw instanceof Number) return ((Number) raw).intValue() != 0;
+        if (raw instanceof String) {
+            String s = ((String) raw).trim();
+            if ("true".equalsIgnoreCase(s) || "1".equals(s)) return true;
+            if ("false".equalsIgnoreCase(s) || "0".equals(s)) return false;
+        }
+        return extras.getBoolean(key, fallback);
+    }
+}

--- a/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/pebble/PebbleIndexKeepAliveService.java
+++ b/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/pebble/PebbleIndexKeepAliveService.java
@@ -1,0 +1,104 @@
+package com.streetwriters.notesnook.pebble;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.ServiceInfo;
+import android.os.Build;
+import android.os.IBinder;
+import android.util.Log;
+
+import androidx.annotation.Nullable;
+import androidx.core.app.NotificationCompat;
+
+import com.streetwriters.notesnook.MainActivity;
+import com.streetwriters.notesnook.R;
+
+/**
+ * Optional sticky foreground service so Notesnook stays process-warm and can
+ * accept Index captures without the user opening the app. Toggled from
+ * Settings → Pebble Index 01 → Keep ready in background.
+ */
+public class PebbleIndexKeepAliveService extends Service {
+    private static final String TAG = "PebbleIndexKeepAlive";
+
+    public static void start(Context context) {
+        Intent intent = new Intent(context, PebbleIndexKeepAliveService.class);
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(intent);
+            } else {
+                context.startService(intent);
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to start keep-alive", e);
+        }
+    }
+
+    public static void stop(Context context) {
+        context.stopService(new Intent(context, PebbleIndexKeepAliveService.class));
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        if (!PebbleIndexPrefs.keepAlive(this)) {
+            stopSelf();
+            return START_NOT_STICKY;
+        }
+        promoteToForeground();
+        return START_STICKY;
+    }
+
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    private void promoteToForeground() {
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                NotificationChannel channel = new NotificationChannel(
+                        PebbleIndexContract.CHANNEL_ID,
+                        PebbleIndexContract.CHANNEL_NAME,
+                        NotificationManager.IMPORTANCE_LOW
+                );
+                channel.setShowBadge(false);
+                NotificationManager manager =
+                        (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+                manager.createNotificationChannel(channel);
+            }
+            Intent launch = new Intent(this, MainActivity.class);
+            PendingIntent pending = PendingIntent.getActivity(
+                    this,
+                    0,
+                    launch,
+                    PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
+            );
+            Notification notification = new NotificationCompat.Builder(this, PebbleIndexContract.CHANNEL_ID)
+                    .setContentTitle("Listening for Index 01")
+                    .setContentText("Notesnook will save ring recordings on this phone, offline")
+                    .setSmallIcon(R.drawable.ic_stat_name)
+                    .setContentIntent(pending)
+                    .setOngoing(true)
+                    .setSilent(true)
+                    .build();
+            if (Build.VERSION.SDK_INT >= 34) {
+                startForeground(
+                        PebbleIndexContract.KEEP_ALIVE_NOTIFICATION_ID,
+                        notification,
+                        ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
+                );
+            } else {
+                startForeground(PebbleIndexContract.KEEP_ALIVE_NOTIFICATION_ID, notification);
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Could not promote keep-alive", e);
+            stopSelf();
+        }
+    }
+}

--- a/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/pebble/PebbleIndexPrefs.java
+++ b/apps/mobile/android/app/src/main/java/com/streetwriters/notesnook/pebble/PebbleIndexPrefs.java
@@ -1,0 +1,48 @@
+package com.streetwriters.notesnook.pebble;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+public final class PebbleIndexPrefs {
+    private PebbleIndexPrefs() {}
+
+    static SharedPreferences prefs(Context context) {
+        return context.getApplicationContext()
+                .getSharedPreferences(PebbleIndexContract.PREFS, Context.MODE_PRIVATE);
+    }
+
+    public static boolean captureEnabled(Context context) {
+        return prefs(context).getBoolean(PebbleIndexContract.PREF_CAPTURE_ENABLED, true);
+    }
+
+    public static void setCaptureEnabled(Context context, boolean enabled) {
+        prefs(context).edit()
+                .putBoolean(PebbleIndexContract.PREF_CAPTURE_ENABLED, enabled)
+                .apply();
+    }
+
+    public static boolean keepAlive(Context context) {
+        return prefs(context).getBoolean(PebbleIndexContract.PREF_KEEP_ALIVE, false);
+    }
+
+    public static void setKeepAlive(Context context, boolean enabled) {
+        prefs(context).edit()
+                .putBoolean(PebbleIndexContract.PREF_KEEP_ALIVE, enabled)
+                .apply();
+    }
+
+    public static String reminderPriority(Context context) {
+        String value = prefs(context).getString(PebbleIndexContract.PREF_REMINDER_PRIORITY, "urgent");
+        if ("silent".equals(value) || "vibrate".equals(value) || "urgent".equals(value)) {
+            return value;
+        }
+        return "urgent";
+    }
+
+    public static void setReminderPriority(Context context, String priority) {
+        if (priority == null) priority = "urgent";
+        prefs(context).edit()
+                .putString(PebbleIndexContract.PREF_REMINDER_PRIORITY, priority)
+                .apply();
+    }
+}

--- a/apps/mobile/android/app/src/main/res/values/strings.xml
+++ b/apps/mobile/android/app/src/main/res/values/strings.xml
@@ -28,4 +28,5 @@
     <string name="reminder_yesterday">Yesterday, %1$s</string>
     <string name="reminder_upcoming">Upcoming: %1$s</string>
     <string name="reminder_last">Last: %1$s</string>
+    <string name="permission_receive_index_capture">Allows Pebble Core to send Index 01 transcriptions and audio recordings to Notesnook on this phone, without the internet.</string>
 </resources>

--- a/apps/mobile/android/app/src/main/res/values/styles.xml
+++ b/apps/mobile/android/app/src/main/res/values/styles.xml
@@ -38,4 +38,13 @@
     <style name="DialogDatePicker.Theme" parent="Theme.AppCompat.Light.Dialog">
         <item name="colorAccent">#2b2b2b</item>
     </style>
+    <style name="PebbleIndexCaptureTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowDisablePreview">true</item>
+        <item name="android:windowIsFloating">true</item>
+        <item name="android:backgroundDimEnabled">false</item>
+        <item name="android:windowAnimationStyle">@null</item>
+    </style>
 </resources>

--- a/apps/mobile/app/screens/settings/components.tsx
+++ b/apps/mobile/app/screens/settings/components.tsx
@@ -54,6 +54,11 @@ import {
   SetupInboxKeys
 } from "./manage-inbox-keys";
 import { FailedInboxItems } from "./failed-inbox-items";
+import {
+  PebbleIndexNotebookPicker,
+  PebbleIndexReminderAlertPicker,
+  PebbleIndexReminderNotebookPicker
+} from "./pebble-index-notebook";
 
 export const components: { [name: string]: ReactElement } = {
   homeselector: <HomePicker />,
@@ -89,5 +94,8 @@ export const components: { [name: string]: ReactElement } = {
   "manage-inbox-keys": <ManageInboxKeys />,
   "inbox-keys": <InboxKeysList />,
   "failed-inbox-items": <FailedInboxItems />,
-  "setup-inbox-keys": <SetupInboxKeys />
+  "setup-inbox-keys": <SetupInboxKeys />,
+  "pebble-index-notebook": <PebbleIndexNotebookPicker />,
+  "pebble-index-reminder-notebook": <PebbleIndexReminderNotebookPicker />,
+  "pebble-index-reminder-alert": <PebbleIndexReminderAlertPicker />
 };

--- a/apps/mobile/app/screens/settings/pebble-index-notebook.tsx
+++ b/apps/mobile/app/screens/settings/pebble-index-notebook.tsx
@@ -1,0 +1,311 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+import { Notebook } from "@notesnook/core";
+import { useNavigation } from "@react-navigation/native";
+import { useThemeColors } from "@notesnook/theme";
+import React, { useEffect, useMemo, useState } from "react";
+import { FlatList, View } from "react-native";
+import { db } from "../../common/database";
+import Input from "../../components/ui/input";
+import { Pressable } from "../../components/ui/pressable";
+import Heading from "../../components/ui/typography/heading";
+import Paragraph from "../../components/ui/typography/paragraph";
+import SettingsService from "../../services/settings";
+import { Settings, useSettingStore } from "../../stores/use-setting-store";
+import { NotesnookModule } from "../../utils/notesnook-module";
+import { AppFontSize } from "../../utils/size";
+import { DefaultAppStyles } from "../../utils/styles";
+
+async function loadAllNotebooks(): Promise<Notebook[]> {
+  const seen = new Map<string, Notebook>();
+
+  const add = (notebook?: Notebook | null) => {
+    if (notebook?.id && notebook.type !== "trash") {
+      seen.set(notebook.id, notebook);
+    }
+  };
+
+  try {
+    const ids =
+      typeof db.notebooks.all.ids === "function"
+        ? await db.notebooks.all.ids()
+        : [];
+    if (ids?.length) {
+      const items = await db.notebooks.all.items(ids);
+      for (const notebook of items || []) add(notebook);
+    }
+  } catch (e) {
+    console.warn("PEBBLE INDEX notebooks ids() failed", e);
+  }
+
+  if (seen.size === 0) {
+    try {
+      const grouped = await db.notebooks.all.sorted(
+        db.settings.getGroupOptions("notebooks")
+      );
+      const total = grouped?.placeholders?.length ?? 0;
+      for (let i = 0; i < total; i++) {
+        const row = await grouped.item(i);
+        add((row as { item?: Notebook })?.item);
+      }
+    } catch (e) {
+      console.warn("PEBBLE INDEX notebooks sorted() failed", e);
+    }
+  }
+
+  if (seen.size === 0) {
+    try {
+      const roots = await db.notebooks.roots.sorted(
+        db.settings.getGroupOptions("notebooks")
+      );
+      const total = roots?.placeholders?.length ?? 0;
+      for (let i = 0; i < total; i++) {
+        const row = await roots.item(i);
+        add((row as { item?: Notebook })?.item);
+      }
+    } catch (e) {
+      console.warn("PEBBLE INDEX notebooks roots failed", e);
+    }
+  }
+
+  return Array.from(seen.values()).sort((a, b) =>
+    (a.title || "").localeCompare(b.title || "", undefined, {
+      sensitivity: "base"
+    })
+  );
+}
+
+type RowItem = {
+  id: string;
+  title: string;
+  subtitle?: string;
+};
+
+type NotebookKeys = {
+  idKey: keyof Settings;
+  titleKey: keyof Settings;
+  description: string;
+  noneSubtitle: string;
+};
+
+function PebbleNotebookPicker({
+  idKey,
+  titleKey,
+  description,
+  noneSubtitle
+}: NotebookKeys) {
+  const { colors } = useThemeColors();
+  const navigation = useNavigation();
+  const selected = (useSettingStore((state) => state.settings[idKey]) as string) || "";
+  const [notebooks, setNotebooks] = useState<Notebook[]>([]);
+  const [query, setQuery] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const all = await loadAllNotebooks();
+        if (!cancelled) setNotebooks(all);
+      } catch {
+        if (!cancelled) setNotebooks([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const rows = useMemo<RowItem[]>(() => {
+    const q = query.trim().toLowerCase();
+    const matches = q
+      ? notebooks.filter((notebook) =>
+          (notebook.title || "").toLowerCase().includes(q)
+        )
+      : notebooks;
+    return [
+      {
+        id: "",
+        title: "None",
+        subtitle: noneSubtitle
+      },
+      ...matches.map((notebook) => ({
+        id: notebook.id,
+        title: notebook.title || "Untitled"
+      }))
+    ];
+  }, [notebooks, query, noneSubtitle]);
+
+  const pick = (id: string, title: string) => {
+    SettingsService.set({
+      [idKey]: id,
+      [titleKey]: title
+    });
+    navigation.goBack();
+  };
+
+  return (
+    <View style={{ flex: 1 }}>
+      <Paragraph
+        size={AppFontSize.xs}
+        color={colors.secondary.paragraph}
+        style={{
+          paddingHorizontal: DefaultAppStyles.GAP,
+          marginBottom: DefaultAppStyles.GAP_VERTICAL
+        }}
+      >
+        {description}
+      </Paragraph>
+      <View style={{ paddingHorizontal: DefaultAppStyles.GAP }}>
+        <Input
+          testID="pebble-index-notebook-search"
+          placeholder="Search notebooks"
+          onChangeText={(text) => setQuery(text)}
+        />
+      </View>
+      <FlatList
+        data={rows}
+        keyExtractor={(item) => item.id || "none"}
+        keyboardShouldPersistTaps="handled"
+        style={{ flex: 1 }}
+        contentContainerStyle={{
+          paddingHorizontal: DefaultAppStyles.GAP,
+          paddingBottom: DefaultAppStyles.GAP
+        }}
+        renderItem={({ item }) => {
+          const isSelected = selected === item.id;
+          return (
+            <Pressable
+              onPress={() => pick(item.id, item.id ? item.title : "")}
+              type={isSelected ? "selected" : "transparent"}
+              style={{
+                paddingVertical: DefaultAppStyles.GAP_VERTICAL,
+                paddingHorizontal: DefaultAppStyles.GAP,
+                borderRadius: 10,
+                marginBottom: DefaultAppStyles.GAP_VERTICAL_SMALL
+              }}
+            >
+              <Heading size={AppFontSize.md}>{item.title}</Heading>
+              {!!item.subtitle && (
+                <Paragraph
+                  size={AppFontSize.xs}
+                  color={colors.secondary.paragraph}
+                >
+                  {item.subtitle}
+                </Paragraph>
+              )}
+            </Pressable>
+          );
+        }}
+        ListEmptyComponent={
+          <Paragraph
+            size={AppFontSize.xs}
+            color={colors.secondary.paragraph}
+            style={{ padding: DefaultAppStyles.GAP }}
+          >
+            {loading
+              ? "Loading notebooks…"
+              : query
+                ? "No notebooks match that search."
+                : "No notebooks yet. Create one first, then pick it here."}
+          </Paragraph>
+        }
+      />
+    </View>
+  );
+}
+
+export function PebbleIndexNotebookPicker() {
+  return (
+    <PebbleNotebookPicker
+      idKey="pebbleIndexNotebookId"
+      titleKey="pebbleIndexNotebookTitle"
+      description="New Index 01 notes go here. Choose none to keep the current behavior."
+      noneSubtitle="Notes list only (or your default notebook)"
+    />
+  );
+}
+
+export function PebbleIndexReminderNotebookPicker() {
+  return (
+    <PebbleNotebookPicker
+      idKey="pebbleIndexReminderNotebookId"
+      titleKey="pebbleIndexReminderNotebookTitle"
+      description="Index reminders become notes in this notebook, with an alarm on the note."
+      noneSubtitle="Notes list only (or your default notebook)"
+    />
+  );
+}
+
+const ALERT_MODES: {
+  id: "silent" | "vibrate" | "urgent";
+  title: string;
+  subtitle: string;
+}[] = [
+  { id: "silent", title: "Silent", subtitle: "No sound or vibration" },
+  { id: "vibrate", title: "Vibrate", subtitle: "Vibrate only" },
+  { id: "urgent", title: "Urgent", subtitle: "Sound and vibration" }
+];
+
+export function PebbleIndexReminderAlertPicker() {
+  const { colors } = useThemeColors();
+  const navigation = useNavigation();
+  const selected =
+    useSettingStore((state) => state.settings.pebbleIndexReminderPriority) ||
+    "urgent";
+
+  return (
+    <View style={{ flex: 1, paddingHorizontal: DefaultAppStyles.GAP }}>
+      <Paragraph
+        size={AppFontSize.xs}
+        color={colors.secondary.paragraph}
+        style={{ marginBottom: DefaultAppStyles.GAP_VERTICAL }}
+      >
+        Alert style for Index reminder notes.
+      </Paragraph>
+      {ALERT_MODES.map((mode) => {
+        const isSelected = selected === mode.id;
+        return (
+          <Pressable
+            key={mode.id}
+            onPress={() => {
+              SettingsService.set({ pebbleIndexReminderPriority: mode.id });
+              NotesnookModule.setPebbleIndexReminderPriority?.(mode.id);
+              navigation.goBack();
+            }}
+            type={isSelected ? "selected" : "transparent"}
+            style={{
+              paddingVertical: DefaultAppStyles.GAP_VERTICAL,
+              paddingHorizontal: DefaultAppStyles.GAP,
+              borderRadius: 10,
+              marginBottom: DefaultAppStyles.GAP_VERTICAL_SMALL
+            }}
+          >
+            <Heading size={AppFontSize.md}>{mode.title}</Heading>
+            <Paragraph size={AppFontSize.xs} color={colors.secondary.paragraph}>
+              {mode.subtitle}
+            </Paragraph>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}

--- a/apps/mobile/app/screens/settings/settings-data.tsx
+++ b/apps/mobile/app/screens/settings/settings-data.tsx
@@ -82,6 +82,7 @@ import { useDragState } from "./editor/state";
 import { verifyUser, verifyUserWithApplock } from "./functions";
 import { logoutUser } from "./logout";
 import { SettingSection } from "./types";
+import { NotesnookModule } from "../../utils/notesnook-module";
 import { getTimeLeft } from "./user-section";
 
 export const settingsGroups: SettingSection[] = [
@@ -1574,6 +1575,100 @@ export const settingsGroups: SettingSection[] = [
         },
         hidden: () => Platform.OS !== "android",
         featureId: "createNoteFromNotificationDrawer"
+      },
+      {
+        id: "pebble-index",
+        type: "screen",
+        name: "Pebble Index 01",
+        icon: "watch",
+        description:
+          "Receive Index notes, transcriptions, audio, and reminders from the Pebble Core app on this phone. No internet.",
+        hidden: () => Platform.OS !== "android",
+        sections: [
+          {
+            id: "pebble-index-capture",
+            name: "Receive Index captures",
+            description:
+              "Accept transcriptions and audio from the Pebble Core app via an explicit intent. No internet.",
+            type: "switch",
+            property: "pebbleIndexCapture",
+            icon: "microphone",
+            onChange: (value) => {
+              NotesnookModule.setPebbleIndexCaptureEnabled?.(!!value);
+            }
+          },
+          {
+            id: "pebble-index-keepalive",
+            name: "Keep ready in background",
+            description:
+              "Run a quiet foreground service so captures land even when Notesnook has not been opened. Uses a persistent notification.",
+            type: "switch",
+            property: "pebbleIndexKeepAlive",
+            icon: "power-sleep",
+            onChange: (value) => {
+              NotesnookModule.setPebbleIndexKeepAlive?.(!!value);
+            }
+          },
+          {
+            id: "pebble-index-notebook",
+            type: "screen",
+            name: "Notes notebook",
+            icon: "notebook-outline",
+            component: "pebble-index-notebook",
+            useHook: () =>
+              useSettingStore((state) => state.settings.pebbleIndexNotebookId),
+            description: () => {
+              const title = SettingsService.getProperty(
+                "pebbleIndexNotebookTitle"
+              );
+              const id = SettingsService.getProperty("pebbleIndexNotebookId");
+              return id
+                ? `Saving Index notes to “${title || "selected notebook"}”`
+                : "None — Index notes stay in the notes list";
+            }
+          },
+          {
+            id: "pebble-index-reminder-notebook",
+            type: "screen",
+            name: "Reminders notebook",
+            icon: "notebook-outline",
+            component: "pebble-index-reminder-notebook",
+            useHook: () =>
+              useSettingStore(
+                (state) => state.settings.pebbleIndexReminderNotebookId
+              ),
+            description: () => {
+              const title = SettingsService.getProperty(
+                "pebbleIndexReminderNotebookTitle"
+              );
+              const id = SettingsService.getProperty(
+                "pebbleIndexReminderNotebookId"
+              );
+              return id
+                ? `Saving Index reminders to “${title || "selected notebook"}”`
+                : "None — reminder notes stay in the notes list";
+            }
+          },
+          {
+            id: "pebble-index-reminder-alert",
+            type: "screen",
+            name: "Reminder alert",
+            icon: "bell-ring",
+            component: "pebble-index-reminder-alert",
+            useHook: () =>
+              useSettingStore(
+                (state) => state.settings.pebbleIndexReminderPriority
+              ),
+            description: () => {
+              const mode =
+                SettingsService.getProperty("pebbleIndexReminderPriority") ||
+                "urgent";
+              if (mode === "silent") return "Silent";
+              if (mode === "vibrate") return "Vibrate";
+              return "Urgent";
+            }
+          }
+        ]
       },
       {
         id: "reminders",

--- a/apps/mobile/app/services/notifications.ts
+++ b/apps/mobile/app/services/notifications.ts
@@ -380,7 +380,12 @@ async function scheduleNotification(
           title: title,
           message: description || "",
           ongoing: true,
-          // subtitle: description || "",
+          channelId:
+            priority === "silent" ||
+            priority === "vibrate" ||
+            priority === "urgent"
+              ? priority
+              : "urgent",
           actions: [strings.unpin()]
         });
       }
@@ -464,7 +469,7 @@ async function scheduleNotification(
     }
     updateRemindersForWidget();
   } catch (e) {
-    /* empty */
+    console.error("scheduleNotification failed", reminder?.id, e);
   }
 }
 

--- a/apps/mobile/app/services/pebble-index-capture.ts
+++ b/apps/mobile/app/services/pebble-index-capture.ts
@@ -1,0 +1,626 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+import { AppRegistry, AppState, NativeModules, Platform } from "react-native";
+import RNFetchBlob from "react-native-blob-util";
+import NetInfo from "@react-native-community/netinfo";
+import { getId } from "@notesnook/core";
+import { DatabaseLogger, db, setupDatabase } from "../common/database";
+import { getCryptoKey, getDatabaseKey } from "../common/database/encryption";
+import { writeEncryptedBase64 } from "../common/filesystem/io";
+import { useUserStore } from "../stores/use-user-store";
+import { NoteBundle } from "../utils/note-bundle";
+import { NotesnookModule } from "../utils/notesnook-module";
+import SettingsService from "./settings";
+import Notifications from "./notifications";
+
+type InboxItem = {
+  id: string;
+  recordingId?: string;
+  transcription?: string;
+  recordedAt?: number;
+  client?: string;
+  trigger?: string;
+  payloadMode?: string;
+  test?: boolean;
+  audioPath?: string;
+  audioSize?: number;
+  audioMime?: string;
+  audioName?: string;
+  kind?: string;
+  title?: string;
+  hasDeadline?: boolean;
+  deadlineEpochMs?: number | string;
+  deadlineIso?: string;
+  notifyBeforeSeconds?: number | string;
+  mergedIds?: string[];
+};
+
+const processedIds = new Set<string>();
+const notesByRecording = new Map<string, string>();
+let ingesting = false;
+let appStateSub: { remove: () => void } | undefined;
+
+function escapeHtml(text: string): string {
+  return text.replace(/[&<>"]/g, (ch) => {
+    switch (ch) {
+      case "&":
+        return "\u0026amp;";
+      case "<":
+        return "\u0026lt;";
+      case ">":
+        return "\u0026gt;";
+      default:
+        return "\u0026quot;";
+    }
+  });
+}
+
+function htmlFromTranscription(text: string): string {
+  if (!text) return "";
+  const parts = escapeHtml(text).split(/\r\n|\r|\n/);
+  return `<p>${parts.join("</p><p>")}</p>`;
+}
+
+function titleFor(item: InboxItem): string {
+  if (item.title && item.title.trim()) return item.title.trim();
+  const when = item.recordedAt
+    ? new Date(item.recordedAt).toLocaleString()
+    : new Date().toLocaleString();
+  if (item.test) return `Index 01 test · ${when}`;
+  const firstLine = (item.transcription || "")
+    .split("\n")
+    .map((line) => line.trim())
+    .find(Boolean);
+  if (firstLine && firstLine.length < 80) return firstLine;
+  return `Index 01 · ${when}`;
+}
+
+async function selectedNotebooks(kind?: string): Promise<string[]> {
+  const id =
+    kind === "reminder"
+      ? SettingsService.getProperty("pebbleIndexReminderNotebookId")
+      : SettingsService.getProperty("pebbleIndexNotebookId");
+  if (!id) return [];
+  try {
+    const notebook = await db.notebooks.notebook(id);
+    if (!notebook) {
+      console.warn("PEBBLE INDEX notebook missing, using none", id);
+      return [];
+    }
+    return [id];
+  } catch (e) {
+    console.warn("PEBBLE INDEX notebook lookup failed", e);
+    return [];
+  }
+}
+
+function ack(id: string) {
+  try {
+    if (typeof NotesnookModule.ackPebbleIndexCapture === "function") {
+      NotesnookModule.ackPebbleIndexCapture(id);
+      return;
+    }
+    NativeModules.NNativeModule?.ackPebbleIndexCapture?.(id);
+  } catch (e) {
+    console.error("PEBBLE INDEX ACK FAILED", id, e);
+  }
+}
+
+async function getAttachmentKey(): Promise<{ key?: string; salt?: string }> {
+  try {
+    const user = await db.user?.getUser?.();
+    console.log("PEBBLE INDEX USER", user ? (user as { id?: string }).id : null);
+    const key = await db.attachments.generateKey();
+    console.log("PEBBLE INDEX KEY from attachments.generateKey");
+    return key as { key?: string; salt?: string };
+  } catch (e) {
+    console.warn("PEBBLE INDEX generateKey failed", String(e));
+  }
+  const userKey = await getCryptoKey();
+  if (userKey) {
+    console.log("PEBBLE INDEX KEY from getCryptoKey");
+    return { key: userKey as string };
+  }
+  const dbKey = await getDatabaseKey();
+  if (dbKey) {
+    console.log("PEBBLE INDEX KEY from getDatabaseKey (offline fallback)");
+    return { key: dbKey };
+  }
+  throw new Error("No encryption key available");
+}
+
+async function embedDataUriAudio(
+  noteId: string,
+  b64: string,
+  mime: string,
+  name: string,
+  sessionId: number
+) {
+  const note = await db.notes.note(noteId);
+  const rawContent = note?.contentId
+    ? await db.content.get(note.contentId)
+    : null;
+  const existing = (rawContent as { data?: string } | null)?.data || "";
+  const embed = `<p><audio controls src="data:${mime};base64,${b64}"></audio></p><p><em>${escapeHtml(name)}</em></p>`;
+  await db.notes.add({
+    id: noteId,
+    content: {
+      type: "tiptap",
+      data: embed + existing
+    },
+    sessionId
+  });
+  console.log("PEBBLE INDEX AUDIO DATA-URI EMBEDDED", name, b64.length);
+}
+
+async function attachAudioToNote(
+  noteId: string,
+  item: InboxItem,
+  sessionId: number
+): Promise<void> {
+  if (!item.audioPath) return;
+  const src = item.audioPath.replace(/^file:\/\//, "");
+  console.log("PEBBLE INDEX ATTACH START", src, item.audioSize);
+  const exists = await RNFetchBlob.fs.exists(src);
+  if (!exists) {
+    throw new Error(`Index audio missing at ${src}`);
+  }
+
+  const mime = "audio/mp4";
+  let name = item.audioName || `${item.recordingId || item.id}.m4a`;
+  if (!/\.m4a$/i.test(name)) name = `${name}.m4a`;
+  const size = item.audioSize || 0;
+  const b64 = await RNFetchBlob.fs.readFile(src, "base64");
+  console.log("PEBBLE INDEX READ B64", b64?.length || 0);
+
+  try {
+    const key = await getAttachmentKey();
+    console.log("PEBBLE INDEX KEY", !!key?.key);
+    const encryptionInfo: any = await writeEncryptedBase64(b64, key, mime);
+    encryptionInfo.mimeType = mime;
+    encryptionInfo.filename = name;
+    encryptionInfo.alg = encryptionInfo.alg || "xcha-stream";
+    encryptionInfo.key = key;
+    console.log(
+      "PEBBLE INDEX ENCRYPTED",
+      encryptionInfo.hash,
+      encryptionInfo.size
+    );
+
+    await db.attachments.add(encryptionInfo, noteId);
+    const hash = encryptionInfo.hash;
+    if (!hash) throw new Error("encryptFile returned no hash");
+
+    const note = await db.notes.note(noteId);
+    const rawContent = note?.contentId
+      ? await db.content.get(note.contentId)
+      : null;
+    const embed = `<audio data-hash="${hash}" data-mime="audio/mp4" data-filename="${escapeHtml(name)}" data-size="${size || encryptionInfo.size || 0}"></audio>`;
+    await db.notes.add({
+      id: noteId,
+      content: {
+        type: "tiptap",
+        data: embed + ((rawContent as { data?: string } | null)?.data || "")
+      },
+      sessionId
+    });
+    console.log("PEBBLE INDEX AUDIO ATTACHED", name, size, hash, mime);
+  } catch (e) {
+    console.warn("PEBBLE INDEX encrypted attach failed, embedding data URI", e);
+    await embedDataUriAudio(noteId, b64, mime, name, sessionId);
+  }
+}
+
+function parseDeadlineMs(item: InboxItem): number | null {
+  if (
+    item.hasDeadline === false &&
+    item.deadlineEpochMs == null &&
+    !item.deadlineIso
+  ) {
+    return null;
+  }
+  const epochRaw = item.deadlineEpochMs;
+  if (typeof epochRaw === "number" && Number.isFinite(epochRaw) && epochRaw > 0) {
+    return Math.trunc(epochRaw);
+  }
+  if (typeof epochRaw === "string" && epochRaw.trim()) {
+    const n = Number(epochRaw);
+    if (Number.isFinite(n) && n > 0) return Math.trunc(n);
+  }
+  if (item.deadlineIso && item.deadlineIso.trim()) {
+    const parsed = Date.parse(item.deadlineIso);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function reminderPriority(): "silent" | "vibrate" | "urgent" {
+  const value = SettingsService.getProperty("pebbleIndexReminderPriority");
+  if (value === "silent" || value === "vibrate" || value === "urgent") {
+    return value;
+  }
+  return "urgent";
+}
+
+async function attachReminderToNote(
+  noteId: string,
+  item: InboxItem,
+  title: string
+): Promise<void> {
+  const deadlineMs = parseDeadlineMs(item);
+  const mode = deadlineMs == null ? "permanent" : "once";
+  const priority = reminderPriority();
+  try {
+    await Notifications.checkAndRequestPermissions(
+      AppState.currentState === "active"
+    );
+  } catch (e) {
+    console.warn("PEBBLE INDEX reminder permission", e);
+  }
+  const reminderId = await db.reminders.add({
+    date: deadlineMs ?? Date.now(),
+    priority,
+    title,
+    description: item.transcription && item.transcription !== title
+      ? item.transcription
+      : undefined,
+    mode,
+    localOnly: mode === "permanent",
+    disabled: false
+  });
+  if (!reminderId) throw new Error("Failed to create reminder");
+  const reminder = await db.reminders.reminder(reminderId);
+  if (!reminder) throw new Error("Reminder missing after add");
+  await db.relations.add({ id: noteId, type: "note" }, reminder);
+  try {
+    await Notifications.scheduleNotification(reminder);
+    console.log("PEBBLE INDEX REMINDER SCHEDULED", reminderId, mode);
+  } catch (e) {
+    console.error("PEBBLE INDEX REMINDER NOTIFICATION FAILED", item.id, e);
+    DatabaseLogger.error(
+      e as Error,
+      `PEBBLE INDEX REMINDER NOTIFICATION FAILED ${item.id}`
+    );
+  }
+  console.log(
+    "PEBBLE INDEX REMINDER",
+    reminderId,
+    mode,
+    deadlineMs,
+    item.deadlineIso,
+    priority
+  );
+}
+
+async function ingestItem(item: InboxItem): Promise<void> {
+  const existingNoteId =
+    (item.recordingId && notesByRecording.get(item.recordingId)) || undefined;
+  const isReminder = item.kind === "reminder";
+  const sessionId = Date.now();
+  const notebooks = await selectedNotebooks(item.kind);
+  const title = titleFor(item);
+
+  const meta: string[] = [];
+  if (item.trigger) meta.push(`Trigger: ${item.trigger}`);
+  if (item.client) meta.push(`Client: ${item.client}`);
+  if (item.recordingId) meta.push(`Recording: ${item.recordingId}`);
+
+  const body =
+    htmlFromTranscription(item.transcription || "") +
+    (meta.length
+      ? `<p></p><p><em>${escapeHtml(meta.join(" · "))}</em></p>`
+      : "");
+
+  let noteId = existingNoteId;
+  if (!noteId) {
+    noteId = getId();
+    await NoteBundle.createNotes({
+      files: [],
+      note: {
+        id: noteId,
+        title,
+        content: {
+          type: "tiptap",
+          data: body
+        },
+        sessionId
+      },
+      notebooks,
+      tags: [],
+      compress: false
+    });
+    if (item.recordingId) notesByRecording.set(item.recordingId, noteId);
+    console.log(
+      "PEBBLE INDEX NOTE CREATED",
+      noteId,
+      item.id,
+      item.kind || "note",
+      !!item.audioPath,
+      notebooks
+    );
+  } else {
+    if (title) {
+      await db.notes.add({
+        id: noteId,
+        title,
+        sessionId
+      });
+    }
+    console.log(
+      "PEBBLE INDEX NOTE REUSED",
+      noteId,
+      item.id,
+      item.kind || "note",
+      !!item.audioPath
+    );
+  }
+
+  if (isReminder) {
+    try {
+      await attachReminderToNote(noteId, item, title);
+    } catch (e) {
+      console.error("PEBBLE INDEX REMINDER FAILED", item.id, e);
+      DatabaseLogger.error(e as Error, `PEBBLE INDEX REMINDER FAILED ${item.id}`);
+    }
+  }
+
+  if (item.audioPath) {
+    try {
+      await attachAudioToNote(noteId, item, sessionId);
+    } catch (e) {
+      console.error("PEBBLE INDEX AUDIO FAILED", item.id, e);
+      DatabaseLogger.error(e as Error, `PEBBLE INDEX AUDIO FAILED ${item.id}`);
+    }
+  } else {
+    console.log(
+      "PEBBLE INDEX CAPTURE NO AUDIO",
+      item.id,
+      item.payloadMode,
+      item.recordingId
+    );
+  }
+}
+
+function mergeInboxItems(items: InboxItem[]): InboxItem[] {
+  const byRecording = new Map<string, InboxItem>();
+  const unmatched: InboxItem[] = [];
+  for (const item of items) {
+    if (!item) continue;
+    const key = item.recordingId;
+    if (!key) {
+      unmatched.push(item);
+      continue;
+    }
+    const existing = byRecording.get(key);
+    if (!existing) {
+      byRecording.set(key, { ...item });
+      continue;
+    }
+    byRecording.set(key, mergeCaptureItems(existing, item));
+  }
+  const merged = [...byRecording.values(), ...unmatched];
+  if (merged.length === 2) {
+    const reminder = merged.find((item) => item.kind === "reminder" && !item.audioPath);
+    const audio = merged.find((item) => item.audioPath && item !== reminder);
+    if (reminder && audio) {
+      console.log(
+        "PEBBLE INDEX MERGE PAIR",
+        reminder.recordingId,
+        audio.recordingId
+      );
+      return [mergeCaptureItems(audio, reminder)];
+    }
+  }
+  return merged;
+}
+
+function mergeCaptureItems(a: InboxItem, b: InboxItem): InboxItem {
+  const reminder = a.kind === "reminder" ? a : b.kind === "reminder" ? b : null;
+  const withAudio = a.audioPath ? a : b.audioPath ? b : a;
+  return {
+    ...withAudio,
+    id: withAudio.id,
+    kind: reminder ? "reminder" : withAudio.kind,
+    title: reminder?.title || reminder?.transcription || withAudio.title,
+    hasDeadline: reminder?.hasDeadline ?? withAudio.hasDeadline,
+    deadlineEpochMs: reminder?.deadlineEpochMs ?? withAudio.deadlineEpochMs,
+    deadlineIso: reminder?.deadlineIso ?? withAudio.deadlineIso,
+    notifyBeforeSeconds:
+      reminder?.notifyBeforeSeconds ?? withAudio.notifyBeforeSeconds,
+    transcription: withAudio.transcription || reminder?.transcription,
+    audioPath: withAudio.audioPath || reminder?.audioPath,
+    audioSize: withAudio.audioSize || reminder?.audioSize,
+    audioMime: withAudio.audioMime || reminder?.audioMime,
+    audioName: withAudio.audioName || reminder?.audioName,
+    mergedIds: [a.id, b.id, ...(a.mergedIds || []), ...(b.mergedIds || [])]
+      .filter(Boolean)
+      .filter((id, index, all) => all.indexOf(id) === index)
+  };
+}
+
+async function syncCapture(reason: string): Promise<void> {
+  try {
+    const user = await db.user?.getUser();
+    if (!user) {
+      console.log("PEBBLE INDEX SYNC skipped (signed out)", reason);
+      return;
+    }
+    if (SettingsService.get().disableSync) {
+      console.log("PEBBLE INDEX SYNC skipped (disabled)", reason);
+      return;
+    }
+    const net = await NetInfo.fetch();
+    if (net.isInternetReachable === false) {
+      console.log("PEBBLE INDEX SYNC skipped (offline)", reason);
+      return;
+    }
+    const started = Date.now();
+    while (useUserStore.getState().syncing && Date.now() - started < 20000) {
+      await new Promise((resolve) => setTimeout(resolve, 400));
+    }
+    console.log("PEBBLE INDEX SYNC start", reason);
+    useUserStore.getState().setSyncing(true);
+    await db.sync({ type: "send", force: false });
+    useUserStore.getState().setSyncing(false);
+    console.log("PEBBLE INDEX SYNC done", reason);
+  } catch (e) {
+    useUserStore.getState().setSyncing(false);
+    console.error("PEBBLE INDEX SYNC FAILED", reason, e);
+    DatabaseLogger.error(e as Error, `PEBBLE INDEX SYNC FAILED ${reason}`);
+  }
+}
+
+async function processInbox(raw?: string): Promise<void> {
+  if (Platform.OS !== "android") return;
+  if (ingesting) {
+    console.log("PEBBLE INDEX CAPTURE BUSY");
+    return;
+  }
+  ingesting = true;
+  try {
+    if (!SettingsService.getProperty("pebbleIndexCapture")) {
+      console.log("PEBBLE INDEX CAPTURE DISABLED");
+      return;
+    }
+    if (!db.isInitialized) {
+      await setupDatabase();
+      await db.init();
+    }
+    const payload =
+      raw || (await NotesnookModule.getPebbleIndexInbox?.()) ||
+      (await NativeModules.NNativeModule?.getPebbleIndexInbox?.());
+    if (!payload) return;
+    const items = mergeInboxItems(JSON.parse(payload) as InboxItem[]);
+    console.log("PEBBLE INDEX CAPTURE DRAIN", items.length);
+    let ingested = 0;
+    for (const item of items) {
+      if (!item?.id) continue;
+      if (processedIds.has(item.id)) {
+        ack(item.id);
+        continue;
+      }
+      try {
+        await ingestItem(item);
+        ingested += 1;
+      } catch (e) {
+        console.error("PEBBLE INDEX CAPTURE FAILED", item.id, e);
+        DatabaseLogger.error(e as Error, `PEBBLE INDEX CAPTURE FAILED ${item.id}`);
+      } finally {
+        processedIds.add(item.id);
+        ack(item.id);
+        for (const extraId of item.mergedIds || []) {
+          if (extraId && extraId !== item.id) {
+            processedIds.add(extraId);
+            ack(extraId);
+          }
+        }
+        console.log("PEBBLE INDEX CAPTURE ACK", item.id, item.mergedIds);
+      }
+    }
+    if (ingested > 0) {
+      await syncCapture(`${ingested} capture(s)`);
+    }
+  } catch (e) {
+    console.error("PEBBLE INDEX CAPTURE TASK", e);
+    DatabaseLogger.error(e as Error, "PEBBLE INDEX CAPTURE TASK");
+  } finally {
+    ingesting = false;
+  }
+}
+
+const onHeadless = async (data: { inbox?: string }) => {
+  console.log("PEBBLE INDEX HEADLESS");
+  await processInbox(data?.inbox);
+};
+
+function safeRegisterHeadlessTask() {
+  try {
+    if (typeof AppRegistry?.registerHeadlessTask === "function") {
+      AppRegistry.registerHeadlessTask(
+        "com.streetwriters.notesnook.PEBBLE_INDEX_CAPTURE",
+        () => onHeadless
+      );
+      console.log("PEBBLE INDEX HEADLESS REGISTERED");
+      return;
+    }
+    console.warn("PEBBLE INDEX AppRegistry.registerHeadlessTask missing");
+  } catch (e) {
+    console.warn("PEBBLE INDEX headless register failed", e);
+  }
+}
+
+function listenForNativeCapture() {
+  try {
+    const { DeviceEventEmitter } = require("react-native") as {
+      DeviceEventEmitter?: { addListener: Function };
+    };
+    DeviceEventEmitter?.addListener?.("PEBBLE_INDEX_CAPTURE", (json: string) => {
+      processInbox(typeof json === "string" ? json : undefined).catch((e) =>
+        console.error("PEBBLE INDEX EVENT", e)
+      );
+    });
+  } catch (e) {
+    console.warn("PEBBLE INDEX event listen failed", e);
+  }
+}
+
+const registerHeadlessTask = () => {
+  if (Platform.OS !== "android") return;
+  try {
+    safeRegisterHeadlessTask();
+    listenForNativeCapture();
+    if (!appStateSub && AppState?.addEventListener) {
+      appStateSub = AppState.addEventListener("change", (state) => {
+        if (state === "active") {
+          processInbox().catch((e) => console.error("PEBBLE INDEX APPSTATE", e));
+        }
+      });
+    }
+    setTimeout(() => {
+      processInbox().catch((e) => console.error("PEBBLE INDEX STARTUP", e));
+    }, 1500);
+  } catch (e) {
+    console.error("PEBBLE INDEX REGISTER FAILED", e);
+  }
+};
+
+const syncNativePrefs = () => {
+  if (Platform.OS !== "android") return;
+  try {
+    NotesnookModule.setPebbleIndexCaptureEnabled?.(
+      !!SettingsService.getProperty("pebbleIndexCapture")
+    );
+    NotesnookModule.setPebbleIndexKeepAlive?.(
+      !!SettingsService.getProperty("pebbleIndexKeepAlive")
+    );
+    const priority =
+      SettingsService.getProperty("pebbleIndexReminderPriority") || "urgent";
+    NotesnookModule.setPebbleIndexReminderPriority?.(priority);
+  } catch {
+    /* native module may be unavailable in tests */
+  }
+};
+
+export const PebbleIndexCapture = {
+  registerHeadlessTask,
+  syncNativePrefs,
+  processInbox
+};
+
+export default PebbleIndexCapture;

--- a/apps/mobile/app/stores/use-setting-store.ts
+++ b/apps/mobile/app/stores/use-setting-store.ts
@@ -106,6 +106,13 @@ export type Settings = {
   defaultLineHeight: number;
   imageCompression: "ask-every-time" | "enabled" | "disabled";
   keepScreenOn?: boolean;
+  pebbleIndexCapture?: boolean;
+  pebbleIndexKeepAlive?: boolean;
+  pebbleIndexNotebookId?: string;
+  pebbleIndexNotebookTitle?: string;
+  pebbleIndexReminderNotebookId?: string;
+  pebbleIndexReminderNotebookTitle?: string;
+  pebbleIndexReminderPriority?: "silent" | "vibrate" | "urgent";
 };
 
 type DimensionsType = {
@@ -217,7 +224,14 @@ export const defaultSettings: SettingStore["settings"] = {
   checkForUpdates: true,
   defaultLineHeight: EDITOR_LINE_HEIGHT.DEFAULT,
   imageCompression: "ask-every-time",
-  keepScreenOn: true
+  keepScreenOn: true,
+  pebbleIndexCapture: true,
+  pebbleIndexKeepAlive: false,
+  pebbleIndexNotebookId: "",
+  pebbleIndexNotebookTitle: "",
+  pebbleIndexReminderNotebookId: "",
+  pebbleIndexReminderNotebookTitle: "",
+  pebbleIndexReminderPriority: "urgent"
 };
 
 export const useSettingStore = create<SettingStore>((set, get) => ({

--- a/apps/mobile/app/utils/note-bundle.js
+++ b/apps/mobile/app/utils/note-bundle.js
@@ -62,6 +62,7 @@ export async function attachFile(uri, hash, type, filename, options) {
         /* empty */
       });
     DatabaseLogger.error(e, "Attach file error");
+    console.error("Attach file error", e);
 
     return false;
   }
@@ -69,7 +70,7 @@ export async function attachFile(uri, hash, type, filename, options) {
 
 async function createNotes(bundle) {
   const sessionId = bundle.note.sessionId;
-  const id = await db.notes.add(bundle.note);
+  const id = (await db.notes.add(bundle.note)) || bundle.note.id;
 
   if (!bundle.notebooks || !bundle.notebooks.length) {
     const defaultNotebook = db.settings?.getDefaultNotebook();
@@ -141,6 +142,7 @@ async function createNotes(bundle) {
       });
     }
   }
+  return id;
 }
 
 export const NoteBundle = {

--- a/apps/mobile/app/utils/notesnook-module.ts
+++ b/apps/mobile/app/utils/notesnook-module.ts
@@ -64,6 +64,12 @@ interface NotesnookModuleInterface {
   ) => Promise<boolean>;
   removeAllShortcuts: () => Promise<boolean>;
   getAllShortcuts: () => Promise<ShortcutInfo[]>;
+  setPebbleIndexCaptureEnabled?: (enabled: boolean) => void;
+  setPebbleIndexKeepAlive?: (enabled: boolean) => void;
+  setPebbleIndexReminderPriority?: (priority: string) => void;
+  isPebbleIndexKeepAliveRunning?: () => boolean;
+  ackPebbleIndexCapture?: (id: string) => void;
+  getPebbleIndexInbox?: () => Promise<string>;
 }
 
 export const NotesnookModule: NotesnookModuleInterface = Platform.select({

--- a/apps/mobile/index.js
+++ b/apps/mobile/index.js
@@ -7,12 +7,23 @@ import "react-native-get-random-values";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { enableFreeze } from "react-native-screens";
 import { BackgroundSync } from "./app/services/background-sync";
+import { PebbleIndexCapture } from "./app/services/pebble-index-capture";
 import Notifications from "./app/services/notifications";
 import appJson from "./app.json";
 import "./globals.js";
 
-BackgroundSync.registerHeadlessTask();
 BackgroundSync.start();
+try {
+  BackgroundSync.registerHeadlessTask();
+} catch (e) {
+  console.warn("BOOT_TASK register failed", e);
+}
+try {
+  PebbleIndexCapture.registerHeadlessTask();
+  PebbleIndexCapture.syncNativePrefs();
+} catch (e) {
+  console.warn("PEBBLE INDEX register failed", e);
+}
 Notifications.init();
 
 enableFreeze(true);


### PR DESCRIPTION
## Description
Add an on-device Android receiver for Pebble Index 01 so Notesnook can save ring recordings without a webhook or internet.

Pebble delivers audio + transcription (and optional reminder metadata) through an explicit intent to `PebbleIndexCaptureService`. The capture is written to a private inbox, then Headless JS creates a note, attaches the `.m4a` as a playable `<audio>` block, and — when the capture is a reminder — creates a Notesnook reminder on that same note (`once` at the given deadline, or `permanent` if there is no due time). After a successful ingest, a send-sync is run so other signed-in devices get the note without opening the phone app.

Settings live under **Productivity → Pebble Index 01**:
- Receive Index captures (default on)
- Keep ready in background (optional FGS so Headless JS is warm)
- Notebook for Index notes
- Notebook for Index reminders
- Reminder alert style (silent / vibrate / urgent)

The service is exported but permission-gated (`RECEIVE_INDEX_CAPTURE`) and UID-checked to `coredevices.coreapp`. No new network permission is required for the capture path; existing Notesnook sync is used only after the note exists locally.

The PR for the Pebble Core app is here: https://github.com/coredevices/mobileapp/pull/369

## Type of Change
- [ ] Bug fix
- [x] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

Settings UI is a new Productivity screen (toggles + notebook pickers + alert style). Screenshots of **Settings → Productivity → Pebble Index 01** and a resulting note with audio + reminder can be added if desired.

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
This is an Android inter-app intent + Headless JS path that depends on a physical Index 01 / Pebble Core install. Existing mobile E2E does not cover third-party explicit intents or Notifee scheduling from a headless task. Behavior was verified on-device: single note per capture, playable audio attachment, reminder `once` vs `permanent`, notebook routing, background notification with Unpin, and send-sync to other devices.

## Platform
- [ ] Web
- [x] Mobile
- [ ] Desktop

Android only. iOS is unchanged.

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed