### PR TITLE
mobile: prevent dropping uncompressed image attachments on new notes

### DIFF
--- a/apps/mobile/app/screens/editor/tiptap/picker.ts
+++ b/apps/mobile/app/screens/editor/tiptap/picker.ts
@@ -123,10 +123,19 @@ const file = async (fileOptions: PickerOptions) => {
       console.log(e, "error");
     });
 
+    const currentFileNoteId =
+      fileOptions.tabId !== undefined
+        ? useTabStore.getState().getNoteIdForTab(fileOptions.tabId)
+        : undefined;
+
+    if (!fileOptions.noteId && currentFileNoteId) {
+      fileOptions.noteId = currentFileNoteId;
+    }
+
     if (
       fileOptions.tabId !== undefined &&
-      useTabStore.getState().getNoteIdForTab(fileOptions.tabId) ===
-        fileOptions.noteId
+      (currentFileNoteId === fileOptions.noteId ||
+        fileOptions.noteId === undefined)
     ) {
       editorController.current?.commands.insertAttachment(
         {
@@ -245,6 +254,7 @@ const handleImageResponse = async (
   response: Image[],
   options: PickerOptions
 ) => {
+  const isNewNote = options.noteId === undefined;
   const result = await AttachImage.present(response, options.context);
 
   if (!result) return;
@@ -295,9 +305,16 @@ const handleImageResponse = async (
 
     RNFetchBlob.fs.unlink(uri).catch((e) => {});
 
+    const currentNoteId =
+      options.tabId !== undefined
+        ? useTabStore.getState().getNoteIdForTab(options.tabId)
+        : undefined;
+
+    const isSameNote = currentNoteId === options.noteId;
+
     if (
       options.tabId !== undefined &&
-      useTabStore.getState().getNoteIdForTab(options.tabId) === options.noteId
+      (isSameNote || isNewNote)
     ) {
       editorController.current?.commands.insertImage(
         {

--- a/apps/mobile/app/screens/editor/tiptap/picker.ts
+++ b/apps/mobile/app/screens/editor/tiptap/picker.ts
@@ -123,19 +123,17 @@ const file = async (fileOptions: PickerOptions) => {
       console.log(e, "error");
     });
 
+    const isNewNote = fileOptions.noteId === undefined;
     const currentFileNoteId =
       fileOptions.tabId !== undefined
         ? useTabStore.getState().getNoteIdForTab(fileOptions.tabId)
         : undefined;
 
-    if (!fileOptions.noteId && currentFileNoteId) {
-      fileOptions.noteId = currentFileNoteId;
-    }
+    const isSameNote = currentFileNoteId === fileOptions.noteId;
 
     if (
       fileOptions.tabId !== undefined &&
-      (currentFileNoteId === fileOptions.noteId ||
-        fileOptions.noteId === undefined)
+      (isSameNote || isNewNote)
     ) {
       editorController.current?.commands.insertAttachment(
         {


### PR DESCRIPTION
## Description
When a user selects multiple images (e.g. 8 images) to attach to a new, unsaved note, only the first 2-4 images would appear in the editor, while the remaining images were silently dropped and never inserted.
Closes #10256

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
