### PR TITLE
mobile: show selection checkbox for reminders in multi-selection mode

### DIFF
--- a/apps/mobile/app/components/list-items/reminder/index.tsx
+++ b/apps/mobile/app/components/list-items/reminder/index.tsx
@@ -167,7 +167,7 @@ const ReminderItem = React.memo(
           </View>
         </View>
 
-        {selectionMode === "note" || selectionMode === "trash" ? (
+        {selectionMode === "reminder" || selectionMode === "trash" ? (
           <>
             <View
               style={{


### PR DESCRIPTION
## Description
Long-pressing a reminder card on mobile entered multi-selection mode but failed to render the selection checkboxes because `ReminderItem` checked for `selectionMode === "note"` instead of `selectionMode === "reminder"`.
Closes #10272

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
