### PR TITLE
mobile: prevent search text from overflowing search field

### DIFF
--- a/apps/mobile/app/screens/search/search-bar.tsx
+++ b/apps/mobile/app/screens/search/search-bar.tsx
@@ -84,7 +84,7 @@ export const SearchBar = ({
           style={{
             fontSize: AppFontSize.sm,
             fontFamily: "Inter-Regular",
-            flexGrow: 1,
+            flex: 1,
             color: colors.primary.paragraph,
             paddingTop: 0,
             paddingBottom: 0


### PR DESCRIPTION
## Description
Change `flexGrow: 1` to `flex: 1` on the `TextInput` in `SearchBar` so long search text stays constrained within the input field bounds instead of overflowing on Android.

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
