### PR TITLE
fix(web): fix duplicate task id in deleteItemsFromTrash

### DIFF
--- a/apps/web/src/common/multi-select.ts
+++ b/apps/web/src/common/multi-select.ts
@@ -214,7 +214,7 @@ async function deleteItemsFromTrash(ids: string[]) {
 
   await TaskManager.startTask({
     type: "status",
-    id: "restoreItems",
+    id: "deleteItems",
     title: strings.inProgressActions.permanentlyDeleting.item(ids.length),
     action: async (report) => {
       report({


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Fix duplicate `TaskManager` status task id in `deleteItemsFromTrash` (`apps/web/src/common/multi-select.ts`).
`deleteItemsFromTrash` reused the `"restoreItems"` task id from `restoreItemsFromTrash` (copy-paste), so a permanent-delete and a restore running close together shared the same status entry: the one that finished first cleared the other's progress indicator, and the displayed status text could reflect the wrong operation. 
Gave the delete task its own `"deleteItems"` id.

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

- One-line id-collision fix with clear intent; no existing unit test coverage for `multi-select.ts` task orchestration.

## Platform
<!-- Describe which platforms this PR is related to -->

- [x] Web
- [ ] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
