### PR TITLE
web: fix dialog footer buttons not visible on Safari

### DIFF
--- a/apps/web/src/dialogs/move-note-dialog.tsx
+++ b/apps/web/src/dialogs/move-note-dialog.tsx
@@ -177,6 +177,8 @@ export const MoveNoteDialog = DialogManager.register(function MoveNoteDialog({
         variant="columnFill"
         sx={{
           height: "80vh",
+          minHeight: 0,
+          overflow: "hidden",
           px: 4
         }}
       >

--- a/apps/web/src/dialogs/move-notebook-dialog.tsx
+++ b/apps/web/src/dialogs/move-notebook-dialog.tsx
@@ -114,6 +114,8 @@ export const MoveNotebookDialog = DialogManager.register(
           variant="columnFill"
           sx={{
             height: "80vh",
+            minHeight: 0,
+            overflow: "hidden",
             px: 4
           }}
         >


### PR DESCRIPTION


## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

web: fix dialog footer buttons not visible on Safari

Fixed for the following dialogs:
* Move note dialog
* Move notebook dialog

## QA Scope

Web only. Test for the following dialogs on Safari:
1. Move note dialog (the assign notebooks to note dialog)
2. Move notebook dialog

## Type of Change
- [X] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [X] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [X] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [X] Web
- [ ] Mobile
- [X] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
