### PR TITLE
editor: let go of the element's link back to the editor on teardown

### DIFF
--- a/packages/editor/src/hooks/use-editor.ts
+++ b/packages/editor/src/hooks/use-editor.ts
@@ -129,4 +129,5 @@ function destroyView(view: EditorView) {
   view.dispatchEvent = () => {};
   view.setProps = () => {};
   view.destroy();
+  delete (view.dom as HTMLElement & { editor?: unknown }).editor;
 }


### PR DESCRIPTION
## Description
<!-- Add a detailed summary of what this feature/bugfix does -->

Tiptap points the editor's element back at the editor when it builds the view and never clears it, so anything still holding that element keeps the editor, its state and the whole note alive. Detached elements are easy to hold by accident, and ProseMirror already clears its own back-reference when a view desc is destroyed.

## Type of Change
- [ ] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [ ] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [ ] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [ ] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
