### PR TITLE
editor: fix three failing editor tests

### DIFF
--- a/packages/editor/src/extensions/check-list-item/__tests__/check-list-item.test.ts
+++ b/packages/editor/src/extensions/check-list-item/__tests__/check-list-item.test.ts
@@ -21,7 +21,6 @@ import { describe, expect, test } from "vitest";
 import {
   createEditor,
   h,
-  p,
   checkList,
   checkListItem
 } from "../../../../test-utils/index.js";
@@ -36,7 +35,7 @@ describe("check list item", () => {
    */
   test("inline image as first child in check list item", async () => {
     const el = checkList(
-      checkListItem([p(["item 1"])]),
+      checkListItem(["item 1"]),
       checkListItem([h("img", [], { src: "image.png" })])
     );
 

--- a/packages/editor/src/extensions/image/tests/image.test.ts
+++ b/packages/editor/src/extensions/image/tests/image.test.ts
@@ -55,17 +55,19 @@ test("copy image to clipboard when Ctrl+C is pressed on selected image", async (
   const editorElement = h("div");
   const { editor } = createEditor({
     element: editorElement,
+    // the image is put there as content rather than with `insertImage`, which
+    // needs the attachment extension: what is under test is the copying
+    initialContent: h("img", [], {
+      src: "test.png",
+      "data-hash": testHash,
+      "data-mime": "image/png",
+      "data-filename": "test.png"
+    }).outerHTML,
     extensions: {
       image: ImageNode
     }
   });
   editor.storage.getAttachmentData = vi.fn().mockResolvedValue(mockImageData);
-  editor.commands.insertImage({
-    src: "test.png",
-    hash: testHash,
-    mime: "image/png",
-    filename: "test.png"
-  });
   editor.commands.setNodeSelection(0);
 
   expect(editor.isActive("image")).toBe(true);

--- a/packages/editor/src/extensions/task-item/__tests__/task-item.test.ts
+++ b/packages/editor/src/extensions/task-item/__tests__/task-item.test.ts
@@ -21,7 +21,6 @@ import { describe, expect, test } from "vitest";
 import {
   createEditor,
   h,
-  p,
   taskList,
   taskItem
 } from "../../../../test-utils/index.js";
@@ -36,7 +35,7 @@ describe("task list item", () => {
    */
   test("inline image as first child in task list item", async () => {
     const el = taskList(
-      taskItem([p(["item 1"])]),
+      taskItem(["item 1"]),
       taskItem([h("img", [], { src: "image.png" })])
     );
 


### PR DESCRIPTION
These three have been failing on `master`, so CI is red on every PR.

- The task/check list fixtures passed a paragraph into `taskItem`/`checkListItem`, which already wrap their children in one. The nested markup reparsed into an extra empty paragraph, so the snapshots never matched. Every other caller passes strings.
- The image test called `insertImage`, which has delegated to `insertAttachment` since 08cf21b0 and isn't registered there. It now puts the image in as content — copying it is what the test is about.

Tests only, no production code. Editor suite goes from 3 failed / 121 passed to 124 passed.