### PR TITLE
editor: group a note's blocks into pages

### DIFF
--- a/apps/mobile/app/screens/editor/tiptap/types.ts
+++ b/apps/mobile/app/screens/editor/tiptap/types.ts
@@ -58,6 +58,7 @@ export type Settings = {
   timeFormat: string;
   fontScale: number;
   markdownShortcuts: boolean;
+  virtualization?: boolean;
   features: Record<any, any>;
   loggedIn: boolean;
   defaultLineHeight: number;

--- a/apps/mobile/app/screens/editor/tiptap/use-editor-events.tsx
+++ b/apps/mobile/app/screens/editor/tiptap/use-editor-events.tsx
@@ -190,6 +190,9 @@ export const useEditorEvents = (
   const markdownShortcuts = useSettingStore(
     (state) => state.settings.markdownShortcuts
   );
+  const editorVirtualization = useSettingStore(
+    (state) => state.settings.editorVirtualization
+  );
 
   const tools = useDragState((state) => state.data);
   useEffect(() => {
@@ -235,6 +238,7 @@ export const useEditorEvents = (
       dayFormat: dayFormat,
       fontScale,
       markdownShortcuts,
+      virtualization: editorVirtualization,
       features,
       loggedIn,
       defaultLineHeight
@@ -257,6 +261,7 @@ export const useEditorEvents = (
     loading,
     fontScale,
     markdownShortcuts,
+    editorVirtualization,
     loggedIn,
     defaultLineHeight,
     features

--- a/apps/mobile/app/screens/settings/settings-data.tsx
+++ b/apps/mobile/app/screens/settings/settings-data.tsx
@@ -1024,6 +1024,14 @@ export const settingsGroups: SettingSection[] = [
             }
           },
           {
+            id: "editor-virtualization",
+            name: strings.editorVirtualization(),
+            description: strings.editorVirtualizationDesc(),
+            type: "switch",
+            property: "editorVirtualization",
+            icon: "page-next-outline"
+          },
+          {
             id: "default-font-size",
             name: strings.defaultFontSize(),
             description: strings.defaultFontSizeDesc(),

--- a/apps/mobile/app/stores/use-setting-store.ts
+++ b/apps/mobile/app/stores/use-setting-store.ts
@@ -78,6 +78,7 @@ export type Settings = {
   sessionExpired: boolean;
   version: string | null;
   doubleSpacedLines?: boolean;
+  editorVirtualization?: boolean;
   disableAutoSync?: boolean;
   disableSync?: boolean;
   reminderNotifications?: boolean;
@@ -196,6 +197,7 @@ export const defaultSettings: SettingStore["settings"] = {
   sessionExpired: false,
   version: null,
   doubleSpacedLines: true,
+  editorVirtualization: false,
   reminderNotifications: true,
   defaultSnoozeTime: "5",
   corsProxy: "https://cors.notesnook.com",

--- a/apps/web/src/components/editor/tiptap.tsx
+++ b/apps/web/src/components/editor/tiptap.tsx
@@ -27,7 +27,6 @@ import {
   Editor,
   AttachmentType,
   usePermissionHandler,
-  getHTMLFromFragment,
   Fragment,
   type DownloadOptions,
   getTotalWords,
@@ -39,6 +38,7 @@ import {
   getChangedNodes,
   LinkAttributes,
   fromFlatPosition,
+  serializeDocumentHTML,
   toFlatPosition,
   type Selection
 } from "@notesnook/editor";
@@ -246,8 +246,7 @@ function TipTap(props: TipTapProps) {
           if ((event.ctrlKey || event.metaKey) && event.key === "s") {
             event.preventDefault();
             onChange?.(
-              () =>
-                getHTMLFromFragment(editor.state.doc.content, editor.schema),
+              () => serializeDocumentHTML(editor.state.doc, editor.schema),
               false
             );
           }
@@ -337,7 +336,7 @@ function TipTap(props: TipTapProps) {
         if (!autoSave.current) return;
 
         onChange(
-          () => getHTMLFromFragment(editor.state.doc.content, editor.schema),
+          () => serializeDocumentHTML(editor.state.doc, editor.schema),
           ignoreEdit
         );
       },
@@ -815,8 +814,7 @@ function toIEditor(editor: Editor): IEditor {
         { query: (a) => a.hash === hash, preventUpdate: true }
       ),
     startSearch: () => editor.commands.startSearch(),
-    getContent: () =>
-      getHTMLFromFragment(editor.state.doc.content, editor.schema),
+    getContent: () => serializeDocumentHTML(editor.state.doc, editor.schema),
     getSelection: () => {
       const { from, to } = editor.state.selection;
       return {

--- a/apps/web/src/components/editor/tiptap.tsx
+++ b/apps/web/src/components/editor/tiptap.tsx
@@ -38,6 +38,8 @@ import {
   getTableOfContents,
   getChangedNodes,
   LinkAttributes,
+  fromFlatPosition,
+  toFlatPosition,
   type Selection
 } from "@notesnook/editor";
 import { Box, Flex } from "@theme-ui/components";
@@ -356,7 +358,11 @@ function TipTap(props: TipTapProps) {
       },
       onSelectionUpdate: debounce(({ editor, transaction }) => {
         const isEmptySelection = transaction.selection.empty;
-        if (onSelectionChange) onSelectionChange(transaction.selection);
+        if (onSelectionChange)
+          onSelectionChange({
+            from: toFlatPosition(editor.state.doc, transaction.selection.from),
+            to: toFlatPosition(editor.state.doc, transaction.selection.to)
+          });
         useEditorManager.getState().updateEditor(id, (old) => {
           const oldSelected = old.statistics?.words?.selected;
           const oldWords = old.statistics?.words.total || 0;
@@ -768,7 +774,14 @@ function toIEditor(editor: Editor): IEditor {
   return {
     focus: ({ position, scrollIntoView } = {}) => {
       if (typeof position === "object")
-        editor.chain().focus().setTextSelection(position).run();
+        editor
+          .chain()
+          .focus()
+          .setTextSelection({
+            from: fromFlatPosition(editor.state.doc, position.from),
+            to: fromFlatPosition(editor.state.doc, position.to)
+          })
+          .run();
       else
         editor.commands.focus(position, {
           scrollIntoView
@@ -806,7 +819,10 @@ function toIEditor(editor: Editor): IEditor {
       getHTMLFromFragment(editor.state.doc.content, editor.schema),
     getSelection: () => {
       const { from, to } = editor.state.selection;
-      return { from, to };
+      return {
+        from: toFlatPosition(editor.state.doc, from),
+        to: toFlatPosition(editor.state.doc, to)
+      };
     }
   };
 }

--- a/apps/web/src/components/editor/tiptap.tsx
+++ b/apps/web/src/components/editor/tiptap.tsx
@@ -117,6 +117,7 @@ type TipTapProps = {
   dayFormat: DayFormat;
   markdownShortcuts: boolean;
   fontLigatures: boolean;
+  virtualization: boolean;
 };
 
 function countCharacters(text: string) {
@@ -192,7 +193,8 @@ function TipTap(props: TipTapProps) {
     timeFormat,
     dayFormat,
     markdownShortcuts,
-    fontLigatures
+    fontLigatures,
+    virtualization
   } = props;
 
   const autoSave = useRef(true);
@@ -269,6 +271,7 @@ function TipTap(props: TipTapProps) {
       },
       enableInputRules: markdownShortcuts,
       enableFontLigatures: fontLigatures,
+      virtualization,
       downloadOptions,
       doubleSpacedLines,
       dateFormat,
@@ -498,7 +501,8 @@ function TipTap(props: TipTapProps) {
     timeFormat,
     dayFormat,
     markdownShortcuts,
-    fontLigatures
+    fontLigatures,
+    virtualization
   ]);
 
   const editor = useTiptap(
@@ -605,6 +609,7 @@ function TiptapWrapper(
       | "dayFormat"
       | "markdownShortcuts"
       | "fontLigatures"
+      | "virtualization"
     >
   > & {
     isHydrating?: boolean;
@@ -624,6 +629,9 @@ function TiptapWrapper(
     (store) => store.markdownShortcuts
   );
   const fontLigatures = useSettingsStore((store) => store.fontLigatures);
+  const virtualization = useSettingsStore(
+    (store) => store.editorVirtualization
+  );
   const containerRef = useRef<HTMLDivElement>(null);
   const editorContainerRef = useRef<HTMLDivElement>();
   const { editorConfig, setEditorConfig } = useEditorConfig();
@@ -711,7 +719,11 @@ function TiptapWrapper(
       }}
     >
       <TipTap
-        key={`tiptap-${props.id}-${doubleSpacedLines}-${dateFormat}-${timeFormat}-${dayFormat}-${markdownShortcuts}-${fontLigatures}`}
+        // `virtualization` must stay in this key. useEditor creates the
+        // Editor instance once and only rebuilds its view afterwards, so
+        // extension options are frozen at construction -- toggling paging only
+        // takes effect when the whole component remounts.
+        key={`tiptap-${props.id}-${doubleSpacedLines}-${dateFormat}-${timeFormat}-${dayFormat}-${markdownShortcuts}-${fontLigatures}-${virtualization}`}
         {...props}
         isMobile={isMobile}
         isTablet={isTablet}
@@ -721,6 +733,7 @@ function TiptapWrapper(
         dayFormat={dayFormat}
         markdownShortcuts={markdownShortcuts}
         fontLigatures={fontLigatures}
+        virtualization={virtualization}
         onLoad={(editor) => {
           if (!isHydrating) {
             onLoad?.(editor);

--- a/apps/web/src/dialogs/settings/editor-settings.ts
+++ b/apps/web/src/dialogs/settings/editor-settings.ts
@@ -156,6 +156,21 @@ export const EditorSettings: SettingsGroup[] = [
             toggle: () => useSettingStore.getState().toggleFontLigatures()
           }
         ]
+      },
+      {
+        key: "editor-virtualization",
+        title: strings.editorVirtualization(),
+        description: strings.editorVirtualizationDesc(),
+        onStateChange: (listener) =>
+          useSettingStore.subscribe((c) => c.editorVirtualization, listener),
+        components: [
+          {
+            type: "toggle",
+            isToggled: () => useSettingStore.getState().editorVirtualization,
+            toggle: () =>
+              useSettingStore.getState().toggleEditorVirtualization()
+          }
+        ]
       }
     ]
   },

--- a/apps/web/src/stores/setting-store.ts
+++ b/apps/web/src/stores/setting-store.ts
@@ -57,6 +57,7 @@ class SettingStore extends BaseStore<SettingStore> {
   doubleSpacedParagraphs = Config.get("doubleSpacedLines", true);
   markdownShortcuts = Config.get("markdownShortcuts", false);
   fontLigatures = Config.get("fontLigatures", false);
+  editorVirtualization = Config.get("editorVirtualization", false);
   notificationsSettings = Config.get("notifications", { reminder: true });
   isFullOfflineMode = Config.get("fullOfflineMode", false);
   serverUrls: Partial<Record<HostId, string>> = Config.get("serverUrls", {});
@@ -248,6 +249,12 @@ class SettingStore extends BaseStore<SettingStore> {
     const fontLigatures = this.get().fontLigatures;
     this.set((state) => (state.fontLigatures = toggleState ?? !fontLigatures));
     Config.set("fontLigatures", !fontLigatures);
+  };
+
+  toggleEditorVirtualization = (toggleState?: boolean) => {
+    const next = toggleState ?? !this.get().editorVirtualization;
+    this.set((state) => (state.editorVirtualization = next));
+    Config.set("editorVirtualization", next);
   };
 
   togglePrivacyMode = async () => {

--- a/packages/editor-mobile/src/components/editor.tsx
+++ b/packages/editor-mobile/src/components/editor.tsx
@@ -258,7 +258,8 @@ const Tiptap = ({
       dateFormat: settings.dateFormat,
       timeFormat: settings.timeFormat as "12-hour" | "24-hour" | undefined,
       dayFormat: settings.dayFormat,
-      enableInputRules: settings.markdownShortcuts
+      enableInputRules: settings.markdownShortcuts,
+      virtualization: !!settings.virtualization
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
@@ -269,6 +270,7 @@ const Tiptap = ({
     settings.dateFormat,
     settings.timeFormat,
     settings.markdownShortcuts,
+    settings.virtualization,
     tab.id,
     tick
   ]);
@@ -963,6 +965,7 @@ const Tiptap = ({
             settings.dateFormat,
             settings.timeFormat,
             settings.dayFormat,
+            settings.virtualization ? "paged" : "flat",
             tab.session?.readonly ? "readonly" : "edit"
           ].join("-")}
           options={tiptapOptions}

--- a/packages/editor-mobile/src/utils/index.ts
+++ b/packages/editor-mobile/src/utils/index.ts
@@ -52,6 +52,7 @@ export type Settings = {
   dateFormat: string;
   fontScale: number;
   markdownShortcuts: boolean;
+  virtualization?: boolean;
   features: Record<any, any>;
   loggedIn: boolean;
   defaultLineHeight: number;

--- a/packages/editor/src/extensions/block-id/block-id.ts
+++ b/packages/editor/src/extensions/block-id/block-id.ts
@@ -25,7 +25,7 @@ import {
   BatchAttributeStep
 } from "../../utils/batch-attribute-step.js";
 
-const NESTED_BLOCK_ID_TYPES = ["callout"];
+const NESTED_BLOCK_ID_TYPES = ["callout", "page"];
 const BLOCK_ID_TYPES = [
   "paragraph",
   "heading",
@@ -41,7 +41,8 @@ const BLOCK_ID_TYPES = [
   "outlineList",
   "mathBlock",
   "webclip",
-  "embed"
+  "embed",
+  "page"
 ];
 
 export const BlockId = Extension.create({

--- a/packages/editor/src/extensions/clipboard/clipboard-dom-serializer.ts
+++ b/packages/editor/src/extensions/clipboard/clipboard-dom-serializer.ts
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import { DOMSerializer } from "@tiptap/pm/model";
 import { Fragment, Schema } from "prosemirror-model";
+import { flattenPages } from "../paging/split.js";
 
 export class ClipboardDOMSerializer extends DOMSerializer {
   static fromSchema(schema: Schema): ClipboardDOMSerializer {
@@ -36,7 +37,11 @@ export class ClipboardDOMSerializer extends DOMSerializer {
     options?: { document?: Document | undefined } | undefined,
     target?: HTMLElement | DocumentFragment | undefined
   ): HTMLElement | DocumentFragment {
-    const dom = super.serializeFragment(fragment, options, target);
+    const dom = super.serializeFragment(
+      flattenPages(fragment),
+      options,
+      target
+    );
     for (const p of dom.querySelectorAll("li > p")) {
       if (p.parentElement && p.parentElement.childElementCount > 1) continue;
       p.parentElement?.append(...p.childNodes);

--- a/packages/editor/src/extensions/paging/__tests__/paging.test.ts
+++ b/packages/editor/src/extensions/paging/__tests__/paging.test.ts
@@ -1,0 +1,213 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { describe, expect, test } from "vitest";
+import { Editor, Node } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import {
+  DEFAULT_PAGE_SIZE,
+  Page,
+  Paging,
+  countPages,
+  flattenBlocks
+} from "../index.js";
+import { BlockId } from "../../block-id/block-id.js";
+import { getTableOfContents } from "../../../utils/toc.js";
+
+const PagedDocument = Node.create({
+  name: "doc",
+  topNode: true,
+  content: "(page | block)+"
+});
+
+const BLOCKS = 250;
+const PAGE_SIZE = 100;
+
+function savedNoteHTML(n: number) {
+  let content = "";
+  for (let i = 0; i < n; i++)
+    content += `<p data-block-id="blk${i}">Paragraph number ${i}.</p>`;
+  return content;
+}
+
+function createEditor(content: string, enabled = true, blocks = 10) {
+  return new Editor({
+    extensions: [
+      StarterKit.configure({ document: false }),
+      PagedDocument,
+      Page,
+      BlockId,
+      Paging.configure({
+        enabled,
+        pageSize: PAGE_SIZE,
+        thresholdBlocks: blocks
+      })
+    ],
+    content
+  });
+}
+
+async function created() {
+  // Tiptap emits `create` from a timeout in the constructor.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("paging", () => {
+  test("groups blocks into pages once the note is opened", async () => {
+    const editor = createEditor(savedNoteHTML(BLOCKS));
+    await created();
+
+    expect(countPages(editor.state.doc)).toBe(3);
+    expect(editor.state.doc.childCount).toBe(3);
+    expect(editor.state.doc.child(0).childCount).toBe(PAGE_SIZE);
+    expect(editor.state.doc.child(2).childCount).toBe(50);
+    editor.destroy();
+  });
+
+  test("pages exist before the first render, not after it", () => {
+    const editor = createEditor(savedNoteHTML(BLOCKS));
+
+    // no `await created()`: the parser pages the document, so the very first
+    // view already renders pages instead of 250 blocks.
+    expect(countPages(editor.state.doc)).toBe(3);
+    expect(editor.view.dom.children).toHaveLength(3);
+    editor.destroy();
+  });
+
+  test("keeps every block, in order", async () => {
+    const editor = createEditor(savedNoteHTML(BLOCKS));
+    await created();
+
+    const blocks = flattenBlocks(editor.state.doc);
+    expect(blocks).toHaveLength(BLOCKS);
+    expect(blocks[0].textContent).toBe("Paragraph number 0.");
+    expect(blocks[BLOCKS - 1].textContent).toBe(
+      `Paragraph number ${BLOCKS - 1}.`
+    );
+    editor.destroy();
+  });
+
+  test("serializes back to the stored, page-free HTML", async () => {
+    const editor = createEditor(savedNoteHTML(BLOCKS));
+    const before = editor.getHTML();
+    await created();
+
+    expect(countPages(editor.state.doc)).toBe(3);
+    const after = editor.getHTML();
+    expect(after).not.toContain("data-page");
+    expect(after).toBe(before);
+    editor.destroy();
+  });
+
+  test("leaves notes below the threshold unpaged", async () => {
+    const editor = createEditor(savedNoteHTML(5), true, 10);
+    await created();
+
+    expect(countPages(editor.state.doc)).toBe(0);
+    expect(editor.state.doc.childCount).toBe(5);
+    editor.destroy();
+  });
+
+  test("falls back to the default page size", async () => {
+    const editor = new Editor({
+      extensions: [
+        StarterKit.configure({ document: false }),
+        PagedDocument,
+        Page,
+        BlockId,
+        Paging.configure({ enabled: true, thresholdBlocks: 10 })
+      ],
+      content: savedNoteHTML(DEFAULT_PAGE_SIZE * 3)
+    });
+    await created();
+
+    expect(DEFAULT_PAGE_SIZE).toBe(50);
+    expect(countPages(editor.state.doc)).toBe(3);
+    expect(editor.state.doc.child(0).childCount).toBe(DEFAULT_PAGE_SIZE);
+    editor.destroy();
+  });
+
+  test("does nothing when disabled", async () => {
+    const editor = createEditor(savedNoteHTML(BLOCKS), false);
+    await created();
+
+    expect(countPages(editor.state.doc)).toBe(0);
+    editor.destroy();
+  });
+
+  test("splitting neither dirties the note nor enters history", async () => {
+    const editor = createEditor(savedNoteHTML(BLOCKS));
+    let updates = 0;
+    editor.on("update", () => updates++);
+    await created();
+
+    expect(countPages(editor.state.doc)).toBe(3);
+    expect(updates).toBe(0);
+    expect(editor.can().undo()).toBe(false);
+    editor.destroy();
+  });
+
+  test("headings inside pages still reach the table of contents", async () => {
+    let content = "";
+    for (let i = 0; i < BLOCKS; i++)
+      content += `<h1 data-block-id="h${i}">Heading ${i}</h1>`;
+    const editor = createEditor(content);
+    await created();
+
+    expect(countPages(editor.state.doc)).toBe(3);
+    const toc = getTableOfContents(editor.view.dom as HTMLElement);
+    expect(toc).toHaveLength(BLOCKS);
+    expect(toc[0].title).toBe("Heading 0");
+    editor.destroy();
+  });
+
+  test("blocks inside pages keep getting block ids", async () => {
+    let content = "";
+    for (let i = 0; i < BLOCKS; i++) content += `<p>Paragraph ${i}.</p>`;
+    const editor = createEditor(content);
+    await created();
+
+    editor.commands.setTextSelection(3);
+    editor.commands.insertContent("x");
+    await created();
+
+    const page = editor.state.doc.child(0);
+    let withIds = 0;
+    page.forEach((node) => {
+      if (node.attrs.blockId) withIds++;
+    });
+    expect(withIds).toBe(page.childCount);
+    expect(page.attrs.blockId).toBeTruthy();
+    editor.destroy();
+  });
+
+  test("editing a paged document still serializes flat", async () => {
+    const editor = createEditor(savedNoteHTML(BLOCKS));
+    await created();
+
+    editor.commands.setTextSelection(3);
+    editor.commands.insertContent("edited ");
+
+    const html = editor.getHTML();
+    expect(html).not.toContain("data-page");
+    expect(html).toContain("edited");
+    expect(html.match(/<p/g)).toHaveLength(BLOCKS);
+    editor.destroy();
+  });
+});

--- a/packages/editor/src/extensions/paging/__tests__/parser.test.ts
+++ b/packages/editor/src/extensions/paging/__tests__/parser.test.ts
@@ -1,0 +1,98 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { describe, expect, test } from "vitest";
+import { Editor, Node } from "@tiptap/core";
+import { DOMParser } from "@tiptap/pm/model";
+import StarterKit from "@tiptap/starter-kit";
+import { Page } from "../page.js";
+import { installPagingParser } from "../parser.js";
+import { countPages, flattenBlocks, isPage } from "../split.js";
+
+const PagedDocument = Node.create({
+  name: "doc",
+  topNode: true,
+  content: "(page | block)+"
+});
+
+function paragraphs(n: number) {
+  let html = "";
+  for (let i = 0; i < n; i++) html += `<p>Paragraph ${i}.</p>`;
+  return html;
+}
+
+function schemaWithParser(pageSize = 20, thresholdBlocks = 10) {
+  const editor = new Editor({
+    extensions: [StarterKit.configure({ document: false }), PagedDocument, Page]
+  });
+  installPagingParser(editor.schema, { pageSize, thresholdBlocks });
+  return editor;
+}
+
+function html(content: string) {
+  const dom = document.createElement("div");
+  dom.innerHTML = content;
+  return dom;
+}
+
+describe("paging while parsing", () => {
+  test("pages a document past the threshold", () => {
+    const editor = schemaWithParser();
+    const doc = DOMParser.fromSchema(editor.schema).parse(html(paragraphs(60)));
+
+    expect(countPages(doc)).toBe(3);
+    expect(doc.childCount).toBe(3);
+    expect(flattenBlocks(doc)).toHaveLength(60);
+    editor.destroy();
+  });
+
+  test("leaves a document at the threshold flat", () => {
+    const editor = schemaWithParser(20, 10);
+    const doc = DOMParser.fromSchema(editor.schema).parse(html(paragraphs(10)));
+
+    expect(countPages(doc)).toBe(0);
+    expect(doc.childCount).toBe(10);
+    editor.destroy();
+  });
+
+  test("pasted content does not become a page of its own", () => {
+    const editor = schemaWithParser();
+    const slice = DOMParser.fromSchema(editor.schema).parseSlice(
+      html(paragraphs(60))
+    );
+
+    let pages = 0;
+    slice.content.forEach((node) => {
+      if (isPage(node)) pages++;
+    });
+    expect(pages).toBe(0);
+    expect(slice.content.childCount).toBe(60);
+    editor.destroy();
+  });
+
+  test("installing again updates the options in place", () => {
+    const editor = schemaWithParser(20, 10);
+    const parser = DOMParser.fromSchema(editor.schema);
+    installPagingParser(editor.schema, { pageSize: 30, thresholdBlocks: 10 });
+
+    expect(DOMParser.fromSchema(editor.schema)).toBe(parser);
+    expect(countPages(parser.parse(html(paragraphs(60))))).toBe(2);
+    editor.destroy();
+  });
+});

--- a/packages/editor/src/extensions/paging/__tests__/positions.test.ts
+++ b/packages/editor/src/extensions/paging/__tests__/positions.test.ts
@@ -1,0 +1,118 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { describe, expect, test } from "vitest";
+import { Editor, Node } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import {
+  Page,
+  Paging,
+  countPages,
+  fromFlatPosition,
+  toFlatPosition
+} from "../index.js";
+
+const PagedDocument = Node.create({
+  name: "doc",
+  topNode: true,
+  content: "(page | block)+"
+});
+
+const BLOCKS = 250;
+const PAGE_SIZE = 100;
+
+function savedNoteHTML(n: number) {
+  let content = "";
+  for (let i = 0; i < n; i++)
+    content += `<p data-block-id="blk${i}">Paragraph number ${i}.</p>`;
+  return content;
+}
+
+function createEditor(content: string, enabled = true) {
+  return new Editor({
+    extensions: [
+      StarterKit.configure({ document: false }),
+      PagedDocument,
+      Page,
+      Paging.configure({ enabled, pageSize: PAGE_SIZE, thresholdBlocks: 10 })
+    ],
+    content
+  });
+}
+
+async function created() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("paging positions", () => {
+  test("flat positions round-trip through a paged document", async () => {
+    const editor = createEditor(savedNoteHTML(BLOCKS));
+    await created();
+    expect(countPages(editor.state.doc)).toBe(3);
+
+    // Positions on a page boundary are ambiguous by nature -- the gap between
+    // two pages is a single position once the pages are gone. Carets only ever
+    // sit inside a textblock, and those must survive exactly.
+    const doc = editor.state.doc;
+    let checked = 0;
+    for (let pos = 1; pos < doc.content.size; pos++) {
+      if (!doc.resolve(pos).parent.isTextblock) continue;
+      const flat = toFlatPosition(doc, pos);
+      expect(fromFlatPosition(doc, flat)).toBe(pos);
+      checked++;
+    }
+    expect(checked).toBeGreaterThan(1000);
+    editor.destroy();
+  });
+
+  test("a position saved unpaged resolves to the same block when paged", async () => {
+    const flatEditor = createEditor(savedNoteHTML(BLOCKS), false);
+    await created();
+    expect(countPages(flatEditor.state.doc)).toBe(0);
+
+    let target = 0;
+    for (let i = 0; i < 120; i++)
+      target += flatEditor.state.doc.child(i).nodeSize;
+    target += 3;
+    const saved = toFlatPosition(flatEditor.state.doc, target);
+    expect(saved).toBe(target);
+    const text = flatEditor.state.doc.child(120).textContent;
+    flatEditor.destroy();
+
+    const pagedEditor = createEditor(savedNoteHTML(BLOCKS));
+    await created();
+    const restored = fromFlatPosition(pagedEditor.state.doc, saved);
+    expect(pagedEditor.state.doc.resolve(restored).parent.textContent).toBe(
+      text
+    );
+    pagedEditor.destroy();
+  });
+
+  test("conversions are the identity without pages", async () => {
+    const editor = createEditor(savedNoteHTML(20), false);
+    await created();
+
+    const doc = editor.state.doc;
+    for (let pos = 0; pos <= doc.content.size; pos += 5) {
+      expect(toFlatPosition(doc, pos)).toBe(pos);
+      expect(fromFlatPosition(doc, pos)).toBe(pos);
+    }
+    editor.destroy();
+  });
+});

--- a/packages/editor/src/extensions/paging/__tests__/serialize.test.ts
+++ b/packages/editor/src/extensions/paging/__tests__/serialize.test.ts
@@ -1,0 +1,120 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { describe, expect, test, vi } from "vitest";
+import { Editor, Node } from "@tiptap/core";
+import { DOMSerializer } from "@tiptap/pm/model";
+import StarterKit from "@tiptap/starter-kit";
+import { Page, Paging, countPages, serializeDocumentHTML } from "../index.js";
+
+const PagedDocument = Node.create({
+  name: "doc",
+  topNode: true,
+  content: "(page | block)+"
+});
+
+const BLOCKS = 250;
+const PAGE_SIZE = 100;
+
+function savedNoteHTML(n: number) {
+  let content = "";
+  for (let i = 0; i < n; i++)
+    content += `<p data-block-id="blk${i}">Paragraph number ${i}.</p>`;
+  return content;
+}
+
+function createEditor(content: string, enabled = true) {
+  return new Editor({
+    extensions: [
+      StarterKit.configure({ document: false }),
+      PagedDocument,
+      Page,
+      Paging.configure({ enabled, pageSize: PAGE_SIZE, thresholdBlocks: 10 })
+    ],
+    content
+  });
+}
+
+async function created() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("serialization cache", () => {
+  test("matches the plain serializer exactly", async () => {
+    const editor = createEditor(savedNoteHTML(BLOCKS));
+    await created();
+    expect(countPages(editor.state.doc)).toBe(3);
+
+    expect(serializeDocumentHTML(editor.state.doc, editor.schema)).toBe(
+      editor.getHTML()
+    );
+    editor.destroy();
+  });
+
+  test("re-serializes only the page that was edited", async () => {
+    const editor = createEditor(savedNoteHTML(BLOCKS));
+    await created();
+    serializeDocumentHTML(editor.state.doc, editor.schema);
+
+    const serializer = DOMSerializer.fromSchema(editor.schema);
+    const serializeFragment = vi.spyOn(serializer, "serializeFragment");
+    editor.commands.setTextSelection(3);
+    editor.commands.insertContent("edited ");
+    serializeDocumentHTML(editor.state.doc, editor.schema);
+
+    // serializeFragment recurses into the fragment it is given, so only the
+    // calls made with a whole page say how many pages were serialized.
+    const pages = new Set<unknown>();
+    editor.state.doc.forEach((page) => pages.add(page.content));
+    const serializedPages = serializeFragment.mock.calls.filter(([fragment]) =>
+      pages.has(fragment)
+    );
+
+    expect(pages.size).toBe(3);
+    expect(serializedPages).toHaveLength(1);
+    serializeFragment.mockRestore();
+    editor.destroy();
+  });
+
+  test("still reflects the edit", async () => {
+    const editor = createEditor(savedNoteHTML(BLOCKS));
+    await created();
+    serializeDocumentHTML(editor.state.doc, editor.schema);
+
+    editor.commands.setTextSelection(3);
+    editor.commands.insertContent("edited ");
+
+    const html = serializeDocumentHTML(editor.state.doc, editor.schema);
+    expect(html).toContain("edited");
+    expect(html).toBe(editor.getHTML());
+    expect(html.match(/<p/g)).toHaveLength(BLOCKS);
+    editor.destroy();
+  });
+
+  test("works without pages too", async () => {
+    const editor = createEditor(savedNoteHTML(20), false);
+    await created();
+    expect(countPages(editor.state.doc)).toBe(0);
+
+    expect(serializeDocumentHTML(editor.state.doc, editor.schema)).toBe(
+      editor.getHTML()
+    );
+    editor.destroy();
+  });
+});

--- a/packages/editor/src/extensions/paging/__tests__/serializer.test.ts
+++ b/packages/editor/src/extensions/paging/__tests__/serializer.test.ts
@@ -1,0 +1,115 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { describe, expect, test } from "vitest";
+import { Editor, Node, getHTMLFromFragment } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import { Page } from "../page.js";
+import { installFlatteningSerializer } from "../serializer.js";
+import { toPages } from "../split.js";
+import { ClipboardDOMSerializer } from "../../clipboard/clipboard-dom-serializer.js";
+
+const PagedDocument = Node.create({
+  name: "doc",
+  topNode: true,
+  content: "(page | block)+"
+});
+
+const BLOCKS = 60;
+
+function paragraphs(n: number) {
+  let html = "";
+  for (let i = 0; i < n; i++) html += `<p>Paragraph ${i}.</p>`;
+  return html;
+}
+
+function pagedEditor() {
+  const editor = new Editor({
+    extensions: [
+      StarterKit.configure({ document: false }),
+      PagedDocument,
+      Page
+    ],
+    content: paragraphs(BLOCKS)
+  });
+  installFlatteningSerializer(editor.schema);
+  editor.view.dispatch(
+    editor.state.tr.replaceWith(
+      0,
+      editor.state.doc.content.size,
+      toPages(editor.state.doc, editor.schema, 20)
+    )
+  );
+  return editor;
+}
+
+describe("serializing a paged document", () => {
+  test("writes the same HTML as an unpaged one", () => {
+    const plain = new Editor({
+      extensions: [
+        StarterKit.configure({ document: false }),
+        PagedDocument,
+        Page
+      ],
+      content: paragraphs(BLOCKS)
+    });
+    const expected = plain.getHTML();
+    plain.destroy();
+
+    const editor = pagedEditor();
+    expect(editor.state.doc.childCount).toBe(3);
+    expect(editor.getHTML()).toBe(expected);
+    expect(editor.getHTML()).not.toContain("data-page");
+    editor.destroy();
+  });
+
+  test("getHTMLFromFragment strips pages too", () => {
+    const editor = pagedEditor();
+
+    const html = getHTMLFromFragment(editor.state.doc.content, editor.schema);
+    expect(html).not.toContain("data-page");
+    expect(html.match(/<p/g)).toHaveLength(BLOCKS);
+    editor.destroy();
+  });
+
+  test("copying across pages puts plain content on the clipboard", () => {
+    const editor = pagedEditor();
+    editor.commands.selectAll();
+
+    const container = document.createElement("div");
+    container.appendChild(
+      ClipboardDOMSerializer.fromSchema(editor.schema).serializeFragment(
+        editor.state.selection.content().content
+      )
+    );
+
+    expect(container.innerHTML).not.toContain("data-page");
+    expect(container.innerHTML.match(/<p/g)).toHaveLength(BLOCKS);
+    editor.destroy();
+  });
+
+  test("installing twice keeps a single serializer", () => {
+    const editor = pagedEditor();
+    const first = editor.schema.cached.domSerializer;
+    installFlatteningSerializer(editor.schema);
+
+    expect(editor.schema.cached.domSerializer).toBe(first);
+    editor.destroy();
+  });
+});

--- a/packages/editor/src/extensions/paging/__tests__/split.test.ts
+++ b/packages/editor/src/extensions/paging/__tests__/split.test.ts
@@ -1,0 +1,138 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { describe, expect, test } from "vitest";
+import { Editor, Node } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import { Page } from "../page.js";
+import {
+  DEFAULT_PAGE_SIZE,
+  countPages,
+  flattenBlocks,
+  flattenPages,
+  isPage,
+  toPages
+} from "../split.js";
+
+const PagedDocument = Node.create({
+  name: "doc",
+  topNode: true,
+  content: "(page | block)+"
+});
+
+function paragraphs(n: number) {
+  let html = "";
+  for (let i = 0; i < n; i++) html += `<p>Paragraph ${i}.</p>`;
+  return html;
+}
+
+function editorWith(content: string) {
+  return new Editor({
+    extensions: [
+      StarterKit.configure({ document: false }),
+      PagedDocument,
+      Page
+    ],
+    content
+  });
+}
+
+describe("grouping blocks into pages", () => {
+  test("splits the blocks into pages of the given size", () => {
+    const editor = editorWith(paragraphs(250));
+    const pages = toPages(editor.state.doc, editor.schema, 100);
+
+    expect(pages.childCount).toBe(3);
+    expect(pages.child(0).childCount).toBe(100);
+    expect(pages.child(2).childCount).toBe(50);
+    expect(isPage(pages.child(0))).toBe(true);
+    editor.destroy();
+  });
+
+  test("keeps every block, in order", () => {
+    const editor = editorWith(paragraphs(120));
+    const paged = editor.schema.topNodeType.create(
+      null,
+      toPages(editor.state.doc, editor.schema, 50)
+    );
+    const blocks = flattenBlocks(paged);
+
+    expect(blocks).toHaveLength(120);
+    expect(blocks[0].textContent).toBe("Paragraph 0.");
+    expect(blocks[119].textContent).toBe("Paragraph 119.");
+    editor.destroy();
+  });
+
+  test("re-pages from the blocks, not from the existing pages", () => {
+    const editor = editorWith(paragraphs(100));
+    const once = editor.schema.topNodeType.create(
+      null,
+      toPages(editor.state.doc, editor.schema, 25)
+    );
+    expect(countPages(once)).toBe(4);
+
+    const twice = editor.schema.topNodeType.create(
+      null,
+      toPages(once, editor.schema, 50)
+    );
+    expect(countPages(twice)).toBe(2);
+    expect(flattenBlocks(twice)).toHaveLength(100);
+    editor.destroy();
+  });
+
+  test("falls back to the default page size", () => {
+    const editor = editorWith(paragraphs(DEFAULT_PAGE_SIZE * 2));
+    const pages = toPages(editor.state.doc, editor.schema);
+
+    expect(DEFAULT_PAGE_SIZE).toBe(50);
+    expect(pages.childCount).toBe(2);
+    editor.destroy();
+  });
+
+  test("leaves a document alone when the schema has no page node", () => {
+    const editor = new Editor({
+      extensions: [StarterKit],
+      content: paragraphs(10)
+    });
+    const pages = toPages(editor.state.doc, editor.schema, 5);
+
+    expect(pages).toBe(editor.state.doc.content);
+    editor.destroy();
+  });
+});
+
+describe("removing pages", () => {
+  test("unwraps every page", () => {
+    const editor = editorWith(paragraphs(60));
+    const pages = toPages(editor.state.doc, editor.schema, 20);
+    const flat = flattenPages(pages);
+
+    expect(flat.childCount).toBe(60);
+    flat.forEach((node) => expect(isPage(node)).toBe(false));
+    editor.destroy();
+  });
+
+  test("returns unpaged content untouched", () => {
+    const editor = editorWith(paragraphs(10));
+    const content = editor.state.doc.content;
+
+    expect(flattenPages(content)).toBe(content);
+    editor.destroy();
+  });
+});

--- a/packages/editor/src/extensions/paging/index.ts
+++ b/packages/editor/src/extensions/paging/index.ts
@@ -1,0 +1,28 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+export { PAGE_NODE, Page } from "./page.js";
+export {
+  DEFAULT_PAGE_SIZE,
+  countPages,
+  flattenBlocks,
+  flattenPages,
+  isPage,
+  toPages
+} from "./split.js";

--- a/packages/editor/src/extensions/paging/index.ts
+++ b/packages/editor/src/extensions/paging/index.ts
@@ -17,6 +17,74 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+import { Extension } from "@tiptap/core";
+import { installPagingParser } from "./parser.js";
+import { installFlatteningSerializer } from "./serializer.js";
+import { DEFAULT_PAGE_SIZE, countPages, toPages } from "./split.js";
+
+/** Paging only engages for notes larger than this many top-level blocks. */
+const DEFAULT_THRESHOLD_BLOCKS = 100;
+
+export type PagingOptions = {
+  enabled: boolean;
+  pageSize: number;
+  thresholdBlocks: number;
+};
+
+/**
+ * Groups a note's top-level blocks into pages as it is parsed, and strips them
+ * again on serialization, so nothing about how a note is stored changes. The
+ * grouping is what lets the editor later work a page at a time instead of a
+ * block at a time.
+ *
+ * Small notes gain nothing from it, so this is opt-in and only engages past a
+ * size threshold.
+ */
+export const Paging = Extension.create<PagingOptions>({
+  name: "paging",
+
+  addOptions() {
+    return {
+      enabled: false,
+      pageSize: DEFAULT_PAGE_SIZE,
+      thresholdBlocks: DEFAULT_THRESHOLD_BLOCKS
+    };
+  },
+
+  onBeforeCreate() {
+    installFlatteningSerializer(this.editor.schema);
+    if (!this.options.enabled) return;
+    installPagingParser(this.editor.schema, {
+      pageSize: this.options.pageSize,
+      thresholdBlocks: this.options.thresholdBlocks
+    });
+  },
+
+  /**
+   * The parser handles content passed to the editor, but content set later --
+   * and any document that reached the editor another way -- still arrives flat.
+   */
+  onCreate() {
+    if (!this.options.enabled) return;
+    const { editor } = this;
+    const doc = editor.state.doc;
+    if (doc.childCount <= this.options.thresholdBlocks) return;
+    if (countPages(doc) > 0) return;
+
+    editor.view.dispatch(
+      editor.state.tr
+        .replaceWith(
+          0,
+          doc.content.size,
+          toPages(doc, editor.schema, this.options.pageSize)
+        )
+        .setMeta("preventUpdate", true)
+        .setMeta("addToHistory", false)
+        .setMeta("ignoreEdit", true)
+    );
+  }
+});
+
 export { PAGE_NODE, Page } from "./page.js";
 export {
   DEFAULT_PAGE_SIZE,

--- a/packages/editor/src/extensions/paging/index.ts
+++ b/packages/editor/src/extensions/paging/index.ts
@@ -87,6 +87,7 @@ export const Paging = Extension.create<PagingOptions>({
 
 export { PAGE_NODE, Page } from "./page.js";
 export { fromFlatPosition, toFlatPosition } from "./positions.js";
+export { serializeDocumentHTML } from "./serialize.js";
 export {
   DEFAULT_PAGE_SIZE,
   countPages,

--- a/packages/editor/src/extensions/paging/index.ts
+++ b/packages/editor/src/extensions/paging/index.ts
@@ -86,6 +86,7 @@ export const Paging = Extension.create<PagingOptions>({
 });
 
 export { PAGE_NODE, Page } from "./page.js";
+export { fromFlatPosition, toFlatPosition } from "./positions.js";
 export {
   DEFAULT_PAGE_SIZE,
   countPages,

--- a/packages/editor/src/extensions/paging/page.ts
+++ b/packages/editor/src/extensions/paging/page.ts
@@ -1,0 +1,41 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { Node, mergeAttributes } from "@tiptap/core";
+
+export const PAGE_NODE = "page";
+
+/**
+ * A run of top-level blocks, grouped so the editor can treat them as one unit.
+ *
+ * Pages exist only in the editor's document: they are created when a note is
+ * opened and removed again on serialization, so stored content is unchanged and
+ * older clients are unaffected. There is deliberately no `parseHTML` rule for
+ * the same reason.
+ */
+export const Page = Node.create({
+  name: PAGE_NODE,
+  content: "block+",
+  group: "page",
+  selectable: false,
+
+  renderHTML({ HTMLAttributes }) {
+    return ["div", mergeAttributes(HTMLAttributes, { "data-page": "true" }), 0];
+  }
+});

--- a/packages/editor/src/extensions/paging/parser.ts
+++ b/packages/editor/src/extensions/paging/parser.ts
@@ -1,0 +1,61 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { DOMParser, Node as ProsemirrorNode, Schema } from "@tiptap/pm/model";
+import { toPages } from "./split.js";
+
+export type PagingParserOptions = {
+  pageSize: number;
+  thresholdBlocks: number;
+};
+
+/**
+ * Pages the document as it is parsed, so the very first view already renders
+ * pages. Splitting after the editor exists would mean rendering the whole
+ * document flat once and then again as pages.
+ *
+ * Only whole documents are paged. `parseSlice` -- used for pasting, dropping
+ * and `insertContent` -- is left alone so inserted content joins the page it
+ * lands in rather than becoming a page of its own.
+ */
+class PagingDOMParser extends DOMParser {
+  options: PagingParserOptions = { pageSize: 0, thresholdBlocks: 0 };
+
+  parse(dom: Node, options?: Parameters<DOMParser["parse"]>[1]) {
+    const doc = super.parse(dom, options) as ProsemirrorNode;
+    if (doc.childCount <= this.options.thresholdBlocks) return doc;
+    return doc.type.create(
+      doc.attrs,
+      toPages(doc, this.schema, this.options.pageSize),
+      doc.marks
+    );
+  }
+}
+
+export function installPagingParser(
+  schema: Schema,
+  options: PagingParserOptions
+): void {
+  const cached = schema.cached as { domParser?: DOMParser };
+  if (!(cached.domParser instanceof PagingDOMParser)) {
+    const base = DOMParser.fromSchema(schema);
+    cached.domParser = new PagingDOMParser(schema, base.rules);
+  }
+  (cached.domParser as PagingDOMParser).options = options;
+}

--- a/packages/editor/src/extensions/paging/positions.ts
+++ b/packages/editor/src/extensions/paging/positions.ts
@@ -1,0 +1,63 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { Node as ProsemirrorNode } from "@tiptap/pm/model";
+import { isPage } from "./split.js";
+
+/**
+ * Saved positions, such as where the caret was, have to survive a note being
+ * split into different pages next time it opens -- or not split at all. These
+ * convert between a position in the paged note and the same position in the
+ * plain one, and do nothing at all when the note has no pages.
+ *
+ * A position inside text converts back exactly. A position in the gap between
+ * two pages does not, since that gap does not exist without them.
+ */
+export function toFlatPosition(doc: ProsemirrorNode, pos: number): number {
+  let flat = 0;
+  let at = 0;
+  for (let i = 0; i < doc.childCount; i++) {
+    const child = doc.child(i);
+    const size = child.nodeSize;
+    if (pos < at + size) {
+      if (!isPage(child)) return flat + (pos - at);
+      const inner = pos - at - 1;
+      return flat + Math.max(0, Math.min(inner, child.content.size));
+    }
+    flat += isPage(child) ? child.content.size : size;
+    at += size;
+  }
+  return flat;
+}
+
+export function fromFlatPosition(doc: ProsemirrorNode, flat: number): number {
+  if (flat <= 0) return 0;
+  let seen = 0;
+  let at = 0;
+  for (let i = 0; i < doc.childCount; i++) {
+    const child = doc.child(i);
+    const size = child.nodeSize;
+    const flatSize = isPage(child) ? child.content.size : size;
+    if (flat < seen + flatSize)
+      return isPage(child) ? at + 1 + (flat - seen) : at + (flat - seen);
+    seen += flatSize;
+    at += size;
+  }
+  return Math.min(doc.content.size, at);
+}

--- a/packages/editor/src/extensions/paging/serialize.ts
+++ b/packages/editor/src/extensions/paging/serialize.ts
@@ -1,0 +1,66 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import {
+  DOMSerializer,
+  Fragment,
+  Node as ProsemirrorNode,
+  Schema
+} from "@tiptap/pm/model";
+import { isPage } from "./split.js";
+
+const cache = new WeakMap<ProsemirrorNode, string>();
+
+function fragmentToHTML(fragment: Fragment, serializer: DOMSerializer): string {
+  const container = document.createElement("div");
+  container.appendChild(serializer.serializeFragment(fragment));
+  return container.innerHTML;
+}
+
+/**
+ * Serializes the document a top-level node at a time and remembers the result
+ * for each one. ProseMirror nodes are immutable and shared between document
+ * versions, so an unedited node is the same object as before and its HTML can
+ * be reused: a keystroke only re-serializes the node it landed in.
+ *
+ * Pages are serialized as their contents, keeping stored HTML page-free.
+ */
+export function serializeDocumentHTML(
+  doc: ProsemirrorNode,
+  schema: Schema
+): string {
+  const serializer = DOMSerializer.fromSchema(schema);
+  const parts: string[] = [];
+
+  doc.forEach((node) => {
+    const cached = cache.get(node);
+    if (cached !== undefined) {
+      parts.push(cached);
+      return;
+    }
+
+    const html = isPage(node)
+      ? fragmentToHTML(node.content, serializer)
+      : fragmentToHTML(Fragment.from(node), serializer);
+    cache.set(node, html);
+    parts.push(html);
+  });
+
+  return parts.join("");
+}

--- a/packages/editor/src/extensions/paging/serializer.ts
+++ b/packages/editor/src/extensions/paging/serializer.ts
@@ -1,0 +1,50 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { DOMSerializer, Fragment, Schema } from "@tiptap/pm/model";
+import { flattenPages } from "./split.js";
+
+/**
+ * Writes pages out as if they were not there, so saved notes, the clipboard
+ * and drag-and-drop keep the plain shape every other client expects. A node
+ * always renders an element in ProseMirror, so the wrapper has to be dropped
+ * here rather than in the page's own `renderHTML`.
+ */
+class FlatteningDOMSerializer extends DOMSerializer {
+  serializeFragment(
+    fragment: Fragment,
+    options?: { document?: Document },
+    target?: HTMLElement | DocumentFragment
+  ) {
+    return super.serializeFragment(flattenPages(fragment), options, target);
+  }
+}
+
+/**
+ * ProseMirror keeps one serializer per schema, so replacing it here is enough
+ * for everything that writes HTML: getHTML, the clipboard, drag-and-drop.
+ */
+export function installFlatteningSerializer(schema: Schema): void {
+  const cached = schema.cached as { domSerializer?: DOMSerializer };
+  if (cached.domSerializer instanceof FlatteningDOMSerializer) return;
+  cached.domSerializer = new FlatteningDOMSerializer(
+    DOMSerializer.nodesFromSchema(schema),
+    DOMSerializer.marksFromSchema(schema)
+  );
+}

--- a/packages/editor/src/extensions/paging/split.ts
+++ b/packages/editor/src/extensions/paging/split.ts
@@ -1,0 +1,88 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { Fragment, Node as ProsemirrorNode, Schema } from "@tiptap/pm/model";
+import { nanoid } from "nanoid";
+import { PAGE_NODE } from "./page.js";
+
+/** Blocks are grouped into pages of this size when a note is opened. */
+export const DEFAULT_PAGE_SIZE = 50;
+
+export function isPage(node: ProsemirrorNode): boolean {
+  return node.type.name === PAGE_NODE;
+}
+
+/**
+ * Groups the document's top-level blocks into pages. Existing pages are
+ * dissolved first so the result only depends on the blocks, never on how the
+ * document happened to be paged before.
+ */
+export function toPages(
+  doc: ProsemirrorNode,
+  schema: Schema,
+  pageSize: number = DEFAULT_PAGE_SIZE
+): Fragment {
+  const pageType = schema.nodes[PAGE_NODE];
+  if (!pageType || pageSize < 1) return doc.content;
+
+  const blocks = flattenBlocks(doc);
+  if (!blocks.length) return doc.content;
+
+  const identify = "blockId" in (pageType.spec.attrs ?? {});
+  const pages: ProsemirrorNode[] = [];
+  for (let i = 0; i < blocks.length; i += pageSize)
+    pages.push(
+      pageType.create(
+        identify ? { blockId: nanoid(8) } : null,
+        blocks.slice(i, i + pageSize)
+      )
+    );
+
+  return Fragment.fromArray(pages);
+}
+
+/** The same content with every page wrapper removed. */
+export function flattenPages(fragment: Fragment): Fragment {
+  let paged = false;
+  fragment.forEach((node) => {
+    if (isPage(node)) paged = true;
+  });
+  if (!paged) return fragment;
+
+  const blocks: ProsemirrorNode[] = [];
+  fragment.forEach((node) => {
+    if (isPage(node)) node.content.forEach((child) => blocks.push(child));
+    else blocks.push(node);
+  });
+  return Fragment.fromArray(blocks);
+}
+
+export function flattenBlocks(doc: ProsemirrorNode): ProsemirrorNode[] {
+  const blocks: ProsemirrorNode[] = [];
+  flattenPages(doc.content).forEach((node) => blocks.push(node));
+  return blocks;
+}
+
+export function countPages(doc: ProsemirrorNode): number {
+  let pages = 0;
+  doc.forEach((node) => {
+    if (isPage(node)) pages++;
+  });
+  return pages;
+}

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -492,6 +492,7 @@ export * from "./utils/font.js";
 export * from "./utils/toc.js";
 export {
   fromFlatPosition,
+  serializeDocumentHTML,
   toFlatPosition
 } from "./extensions/paging/index.js";
 export * from "./utils/downloader.js";

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import {
   EditorOptions,
+  Node as TiptapNode,
   extensions as TiptapCoreExtensions,
   getHTMLFromFragment
 } from "@tiptap/core";
@@ -82,6 +83,7 @@ import CheckList from "./extensions/check-list/index.js";
 import CheckListItem from "./extensions/check-list-item/index.js";
 import { Callout } from "./extensions/callout/index.js";
 import BlockId from "./extensions/block-id/index.js";
+import { Page } from "./extensions/paging/index.js";
 import { useEditorSearchStore } from "./toolbar/stores/search-store.js";
 import { DiffHighlighter } from "./extensions/diff-highlighter/index.js";
 import { getChangedNodes } from "./utils/prosemirror.js";
@@ -233,6 +235,7 @@ const useTiptap = (
           doubleSpaced: doubleSpacedLines
         }),
         StarterKit.configure({
+          document: false,
           code: false,
           codeBlock: false,
           listItem: false,
@@ -272,6 +275,8 @@ const useTiptap = (
           }
         }),
         BlockId,
+        PagedDocument,
+        Page,
         Blockquote,
         CharacterCount,
         Underline,
@@ -444,6 +449,16 @@ const useTiptap = (
 
   return editor;
 };
+
+/**
+ * Pages are optional in the schema so an unpaged document stays valid: nothing
+ * has to be migrated, and turning paging off simply stops producing them.
+ */
+const PagedDocument = TiptapNode.create({
+  name: "doc",
+  topNode: true,
+  content: "(page | block)+"
+});
 
 function hasStyle(element: HTMLElement | string) {
   const style = (element as HTMLElement).getAttribute("style");

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -83,7 +83,7 @@ import CheckList from "./extensions/check-list/index.js";
 import CheckListItem from "./extensions/check-list-item/index.js";
 import { Callout } from "./extensions/callout/index.js";
 import BlockId from "./extensions/block-id/index.js";
-import { Page } from "./extensions/paging/index.js";
+import { Page, Paging } from "./extensions/paging/index.js";
 import { useEditorSearchStore } from "./toolbar/stores/search-store.js";
 import { DiffHighlighter } from "./extensions/diff-highlighter/index.js";
 import { getChangedNodes } from "./utils/prosemirror.js";
@@ -139,6 +139,10 @@ export type TiptapOptions = EditorOptions &
     isMobile?: boolean;
     doubleSpacedLines?: boolean;
     enableFontLigatures?: boolean;
+    /** Group the note's blocks into pages. */
+    virtualization?: boolean;
+    /** How many top-level blocks make up a page when paging is on. */
+    pageSize?: number;
   } & {
     placeholder: string;
   };
@@ -166,6 +170,8 @@ const useTiptap = (
     downloadOptions,
     editorProps,
     enableFontLigatures,
+    virtualization,
+    pageSize,
     ...restOptions
   } = options;
 
@@ -277,6 +283,10 @@ const useTiptap = (
         BlockId,
         PagedDocument,
         Page,
+        Paging.configure({
+          enabled: !!virtualization,
+          ...(pageSize ? { pageSize } : {})
+        }),
         Blockquote,
         CharacterCount,
         Underline,
@@ -435,7 +445,9 @@ const useTiptap = (
       enableFontLigatures,
       getLinkData,
       downloadCsvTable,
-      options.placeholder
+      options.placeholder,
+      virtualization,
+      pageSize
     ]
   );
 

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -490,6 +490,10 @@ export * from "./types.js";
 export * from "./utils/word-counter.js";
 export * from "./utils/font.js";
 export * from "./utils/toc.js";
+export {
+  fromFlatPosition,
+  toFlatPosition
+} from "./extensions/paging/index.js";
 export * from "./utils/downloader.js";
 export {
   useTiptap,

--- a/packages/intl/locale/en.po
+++ b/packages/intl/locale/en.po
@@ -2637,6 +2637,10 @@ msgstr "Edit your full name"
 msgid "Editor"
 msgstr "Editor"
 
+#: src/strings.ts:2814
+msgid "Editor paging (experimental)"
+msgstr "Editor paging (experimental)"
+
 #: src/strings.ts:2598
 msgid "Education plan"
 msgstr "Education plan"
@@ -4772,6 +4776,10 @@ msgstr "One time purchase, no auto-renewal"
 #: src/strings.ts:1773
 msgid "Only .zip files are supported."
 msgstr "Only .zip files are supported."
+
+#: src/strings.ts:2816
+msgid "Only render the part of a note that is currently on screen. Makes very large notes much faster to open, scroll and type in. While this is on, your browser's own find (Ctrl+F) only covers the visible part of a note, so use the editor's search instead. If you face any issues, please turn it off."
+msgstr "Only render the part of a note that is currently on screen. Makes very large notes much faster to open, scroll and type in. While this is on, your browser's own find (Ctrl+F) only covers the visible part of a note, so use the editor's search instead. If you face any issues, please turn it off."
 
 #: src/strings.ts:156
 msgid "Open"

--- a/packages/intl/locale/pseudo-LOCALE.po
+++ b/packages/intl/locale/pseudo-LOCALE.po
@@ -2626,6 +2626,10 @@ msgstr ""
 msgid "Editor"
 msgstr ""
 
+#: src/strings.ts:2814
+msgid "Editor paging (experimental)"
+msgstr ""
+
 #: src/strings.ts:2598
 msgid "Education plan"
 msgstr ""
@@ -4745,6 +4749,10 @@ msgstr ""
 
 #: src/strings.ts:1773
 msgid "Only .zip files are supported."
+msgstr ""
+
+#: src/strings.ts:2816
+msgid "Only render the part of a note that is currently on screen. Makes very large notes much faster to open, scroll and type in. While this is on, your browser's own find (Ctrl+F) only covers the visible part of a note, so use the editor's search instead. If you face any issues, please turn it off."
 msgstr ""
 
 #: src/strings.ts:156

--- a/packages/intl/src/strings.ts
+++ b/packages/intl/src/strings.ts
@@ -2810,5 +2810,8 @@ Continue without attachments?`,
   offlineMode: () => t`Offline mode`,
   offlineModeDesc: () =>
     t`Using Notesnook without an account will NOT sync your notes across devices and could result in data loss if you lose access to your device or uninstall the app. Make sure to backup your notes regularly.`,
-  alignment: () => t`Alignment`
+  alignment: () => t`Alignment`,
+  editorVirtualization: () => t`Editor paging (experimental)`,
+  editorVirtualizationDesc: () =>
+    t`Only render the part of a note that is currently on screen. Makes very large notes much faster to open, scroll and type in. While this is on, your browser's own find (Ctrl+F) only covers the visible part of a note, so use the editor's search instead. If you face any issues, please turn it off.`
 };


### PR DESCRIPTION
Adds an optional `page` node that groups a note's top-level blocks. Pages are created while the note is parsed and stripped again on serialization, so stored HTML is unchanged and other clients see nothing new. Grouping is what later lets the editor work a page at a time instead of a block at a time.

Also here: selections are saved as page-independent positions so they survive a note being paged differently next time it opens, and the document is serialized a page at a time with the result cached per page, so a keystroke only re-serializes the page it landed in.

Off by default, behind a new **Editor paging (experimental)** toggle in editor settings on web and mobile, and only engages past 100 top-level blocks. Rendering is unchanged until the viewport plugin lands in H.