### PR TITLE
mobile: prevent crash when accessing route params in notes/notebook screens

### DIFF
--- a/apps/mobile/app/screens/notebook/index.tsx
+++ b/apps/mobile/app/screens/notebook/index.tsx
@@ -45,7 +45,9 @@ import { getGroupOptions } from "../../hooks/use-group-options";
 
 const NotebookScreen = ({ route, navigation }: NavigationProps<"Notebook">) => {
   const [notes, setNotes] = useState<VirtualizedGrouping<Note>>();
-  const params = useRef<NotebookScreenParams>(route?.params);
+  const params = useRef<NotebookScreenParams>(
+    route?.params || ({} as NotebookScreenParams)
+  );
   const isAppLoading = useSettingStore((state) => state.isAppLoading);
   const [notebook, setNotebook] = useState<Notebook | undefined>(
     params.current.item

--- a/apps/mobile/app/screens/notes/index.tsx
+++ b/apps/mobile/app/screens/notes/index.tsx
@@ -71,7 +71,9 @@ const NotesPage = ({
   focusControl = true,
   rightButtons
 }: RouteProps<"NotesPage" | "TaggedNotes" | "Monographs" | "ColoredNotes">) => {
-  const params = useRef<NotesScreenParams>(route?.params);
+  const params = useRef<NotesScreenParams>(
+    route?.params || ({} as NotesScreenParams)
+  );
   const [notes, setNotes] = useState<VirtualizedGrouping<Note>>();
   const [loadingNotes, setLoadingNotes] = useState(true);
   const isMonograph = route.name === "Monographs";


### PR DESCRIPTION
## Description
Fixes a fatal crash when NotesPage or NotebookScreen is mounted without route params ) by providing a fallback empty object to useRef.
Closes #10268

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
