### PR TITLE
mobile: check if email is confirmed on confirm-email banner press

### DIFF
--- a/apps/mobile/app/services/message.tsx
+++ b/apps/mobile/app/services/message.tsx
@@ -34,6 +34,9 @@ import SettingsService from "./settings";
 import { Update } from "../components/sheets/update";
 import { GithubVersionInfo } from "../utils/github-version";
 import { CheckVersionResponse } from "react-native-check-version";
+import { db } from "../common/database";
+
+let isCheckingEmail = false;
 
 const APP_MESSAGES: Message[] = [
   {
@@ -91,7 +94,21 @@ const APP_MESSAGES: Message[] = [
     visible: true,
     message: strings.syncDisabled(),
     actionText: strings.syncDisabledActionText(),
-    onPress: () => {
+    onPress: async () => {
+      if (isCheckingEmail) return;
+      isCheckingEmail = true;
+      try {
+        const user = await db.user.fetchUser();
+        if (user?.isEmailConfirmed) {
+          clearMessage();
+          return;
+        }
+      } catch (e) {
+        /* empty */
+      } finally {
+        isCheckingEmail = false;
+      }
+
       PremiumService.showVerifyEmailDialog();
     },
     data: {},

--- a/apps/mobile/app/services/message.tsx
+++ b/apps/mobile/app/services/message.tsx
@@ -35,6 +35,7 @@ import { Update } from "../components/sheets/update";
 import { GithubVersionInfo } from "../utils/github-version";
 import { CheckVersionResponse } from "react-native-check-version";
 import { db } from "../common/database";
+import { Walkthrough } from "../components/walkthroughs";
 
 let isCheckingEmail = false;
 
@@ -101,6 +102,10 @@ const APP_MESSAGES: Message[] = [
         const user = await db.user.fetchUser();
         if (user?.isEmailConfirmed) {
           clearMessage();
+          SettingsService.set({
+            userEmailConfirmed: true
+          });
+          Walkthrough.present("emailconfirmed", false, true);
           return;
         }
       } catch (e) {


### PR DESCRIPTION
## Description
Fixes an issue where the "Please confirm your account" / "Sync is disabled" message banner continues to display on Android even after the user has confirmed their email in an external browser.

In cases where network reconnection latency upon returning to the app causes the background check to miss or delay, clicking the "Confirm email" banner now first checks whether the user's account has already been confirmed:
- **If confirmed:** Directly clears the banner, refreshes the token, starts sync, and triggers the celebration walkthrough without opening an unnecessary bottom sheet.
- **If not confirmed (or offline):** Opens the standard confirmation bottom sheet with instructions and the "Resend email" button.

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
This change adjusts the event handler on the mobile message banner to check user confirmation status before presenting the sheet. Verified manually on device across account creation, backgrounding, external browser confirmation, and returning to the app.

## Platform
- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
