### PR TITLE
web: remove false timeout notification on note save

### DIFF
--- a/apps/web/src/components/editor/index.tsx
+++ b/apps/web/src/components/editor/index.tsx
@@ -96,30 +96,25 @@ export async function saveContent(
     ignoreEdit,
     length: content.length
   });
-  await Promise.race([
-    useEditorStore.getState().saveSessionContent(noteId, ignoreEdit, {
+  await useEditorStore
+    .getState()
+    .saveSessionContent(noteId, ignoreEdit, {
       type: "tiptap",
       data: content
-    }),
-    new Promise((_, reject) =>
-      setTimeout(
-        () => reject(new Error(strings.savingNoteTakingTooLong())),
-        30 * 1000
-      )
-    )
-  ]).catch((e) => {
-    const { hide } = showToast(
-      "error",
-      (e as Error).message,
-      [
-        {
-          text: strings.dismiss(),
-          onClick: () => hide()
-        }
-      ],
-      0
-    );
-  });
+    })
+    .catch((e) => {
+      const { hide } = showToast(
+        "error",
+        (e as Error).message,
+        [
+          {
+            text: strings.dismiss(),
+            onClick: () => hide()
+          }
+        ],
+        0
+      );
+    });
 }
 const deferredSave = debounceWithId(saveContent, 100);
 


### PR DESCRIPTION
## Description
Fixes #10110

Removed the unnecessary 30-second `Promise.race` timeout and false error toast notification (`savingNoteTakingTooLong`) during note saving in the web editor.

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [x] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
Removal of an artificial timer/toast notification logic that was falsely reporting note saving timeouts.

## Platform
- [x] Web
- [ ] Mobile
- [x] Desktop

## Sign off
- [x] QA passed
- [x] UI/UX passed
