### PR TITLE
Mobile: Fix signup stuck on loading screen for self-hosted servers

### DIFF
--- a/apps/mobile/app/components/auth/signup.tsx
+++ b/apps/mobile/app/components/auth/signup.tsx
@@ -42,6 +42,7 @@ import FormInput, { createFormRef, validators } from "../ui/input/form-input";
 import Heading from "../ui/typography/heading";
 import Paragraph from "../ui/typography/paragraph";
 import { AuthHeader } from "./header";
+import { hideAuth } from "./common";
 import { SignupContext } from "./signup-context";
 import { RouteParams } from "../../stores/use-navigation-store";
 import SettingsService from "../../services/settings";
@@ -102,6 +103,10 @@ export const Signup = ({
           state: route.params.state,
           context: "signup"
         });
+      } else {
+        // custom (self-hosted) servers have no paywall to go through,
+        // dismiss auth or the loading screen stays up forever
+        hideAuth();
       }
       return true;
     } catch (e) {


### PR DESCRIPTION
## Description
After a successful signup against a self-hosted backend, the app stays on
"Setting up your account..." forever. The success path only navigates
when no custom serverUrls are set (PayWall branch); with self-hosted URLs
there is no navigation and no dismiss call. This calls hideAuth() on that
path, mirroring what login already does on success. No behavior change
for official signups.

Fixes #10335.

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
No existing tests cover post-signup navigation; 5-line change on one
success path, verified by reading both auth flows. Needs CI.

## Platform
- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed