### PR TITLE
Mobile: Reset backupRunning when no backup directory is selected

### DIFF
--- a/apps/mobile/app/services/backup.ts
+++ b/apps/mobile/app/services/backup.ts
@@ -192,11 +192,13 @@ async function run(
     context
   )) as ScopedStorage.FileType;
 
-  if (!androidBackupDirectory)
+  if (!androidBackupDirectory) {
+    backupRunning = false;
     return {
       error: new Error(strings.backupDirectoryNotSelected()),
       report: false
     };
+  }
 
   let path;
 


### PR DESCRIPTION
## Description
Resets the flag on the early return so later attempts run normally.
Three lines (brace the early return); matches the reset already done on
the success and catch paths.

Fixes #10338.

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
No existing tests cover the logout backup flow; change is confined to
one early return. Needs CI.

## Platform
- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed