### PR TITLE
Bound API request time with abort timeout

### DIFF
--- a/packages/core/src/utils/http.ts
+++ b/packages/core/src/utils/http.ts
@@ -139,9 +139,11 @@ export function errorTransformer(errorJson: {
   };
 }
 
-async function fetchWrapped(input: string, init: RequestInit) {
+async function fetchWrapped(input: string, init: RequestInit, timeoutMs = 30000) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const response = await fetch(input, init);
+    const response = await fetch(input, { ...init, signal: controller.signal });
     return response;
   } catch (e) {
     const host = extractHostname(input);
@@ -154,6 +156,8 @@ async function fetchWrapped(input: string, init: RequestInit) {
       );
 
     throw e;
+  } finally {
+    clearTimeout(timeout);
   }
 }
 


### PR DESCRIPTION
## Description
Fixes #10345. Adds an AbortController-based timeout (default 30s, overridable per call) to fetchWrapped in packages/core/src/utils/http.ts; timer cleared in finally. Timeout surfaces through the existing error path unchanged.

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
No existing tests cover the HTTP layer timeout; change is 6 lines in one function, verified by reading all fetchWrapped callers. Needs CI.

## Platform
- [x] Mobile
- [x] Web
- [x] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed