### PR TITLE
Isolate sync chunk failures so one bad chunk skips

### DIFF
--- a/packages/core/src/api/sync/index.ts
+++ b/packages/core/src/api/sync/index.ts
@@ -544,25 +544,16 @@ export class Sync {
     this.connection.on("SendItems", async (chunk) => {
       if (this.connection?.state !== HubConnectionState.Connected) return false;
 
-      const keys = await this.db.user.getDataEncryptionKeys();
-      if (!keys || !keys.length) {
-        this.logger.error(
-          new Error("User encryption keys not generated. Please relogin.")
-        );
-        this.db.eventManager.publish(EVENTS.userSessionExpired);
-        return false;
+      try {
+        return await this.processIncomingChunk(chunk, options);
+      } catch (e) {
+        // one bad chunk (e.g. undecryptable with current keys) must not
+        // abort the whole sync - items stay unsynced and retry next time
+        this.logger.error(e, "Failed to process incoming chunk, skipping.", {
+          type: chunk?.type
+        });
+        return true;
       }
-      this.logger.info(
-        `Received chunk for type ${chunk.type} with ${chunk.items.length} items.`,
-        {
-          ids: chunk.items.map((i: any) => i.id)
-        }
-      );
-      await this.processChunk(chunk, keys, options);
-
-      sendSyncProgressEvent(this.db.eventManager, `download`, chunk.count);
-
-      return true;
     });
 
     this.connection.on("SendMonographs", async (monographs: Monograph[]) => {
@@ -593,6 +584,31 @@ export class Sync {
         return true;
       }
     );
+  }
+
+  private async processIncomingChunk(
+    chunk: SyncTransferItem,
+    options: SyncOptions
+  ) {
+    const keys = await this.db.user.getDataEncryptionKeys();
+    if (!keys || !keys.length) {
+      this.logger.error(
+        new Error("User encryption keys not generated. Please relogin.")
+      );
+      this.db.eventManager.publish(EVENTS.userSessionExpired);
+      return false;
+    }
+    this.logger.info(
+      `Received chunk for type ${chunk.type} with ${chunk.items.length} items.`,
+      {
+        ids: chunk.items.map((i: any) => i.id)
+      }
+    );
+    await this.processChunk(chunk, keys, options);
+
+    sendSyncProgressEvent(this.db.eventManager, `download`, chunk.count);
+
+    return true;
   }
 
   private async checkConnection() {


### PR DESCRIPTION
## Description
Fixes #10347. Extracts chunk processing into processIncomingChunk and wraps the handler call so a failing chunk is logged (with its type) and skipped; remaining chunks still apply, failed items stay unsynced and retry next run. No data is dropped silently - failures remain errors in logs.

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
No existing tests cover the sync chunk path; change isolates failures in one handler, verified by reading the SendItems flow. Needs CI.

## Platform
- [x] Mobile
- [x] Web
- [x] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed