### PR TITLE
web: increase expand notebook button size for better click target

### DIFF
--- a/apps/web/src/components/notebook/index.tsx
+++ b/apps/web/src/components/notebook/index.tsx
@@ -129,7 +129,7 @@ export function Notebook(props: NotebookProps) {
           {isExpandable ? (
             <Button
               variant="secondary"
-              sx={{ bg: "transparent", p: 0, borderRadius: 100 }}
+              sx={{ bg: "transparent", p: "2px", borderRadius: 100 }}
               onClick={(e) => {
                 e.stopPropagation();
                 isExpanded ? collapse() : expand();
@@ -137,19 +137,19 @@ export function Notebook(props: NotebookProps) {
             >
               {isExpanded ? (
                 <ChevronDown
-                  size={14}
+                  size={18}
                   color={isOpened ? "icon-selected" : "icon"}
                 />
               ) : (
                 <ChevronRight
-                  size={14}
+                  size={18}
                   color={isOpened ? "icon-selected" : "icon"}
                 />
               )}
             </Button>
           ) : (
             <NotebookIcon
-              size={14}
+              size={18}
               color={isOpened ? "icon-selected" : "icon"}
             />
           )}


### PR DESCRIPTION
## Description
Increased the expand/collapse notebook button size from 14px to 18px and added 2px padding for a better click target.

Fixes #8933

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
Visual-only change — increased icon size and padding

## Platform
<!-- Describe which platforms this PR is related to -->

- [x] Web
- [ ] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
