### PR TITLE
editor: add callout to escapable nodes at document start

### DIFF
--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -365,6 +365,7 @@ const useTiptap = (
             CodeBlock.name,
             Table.name,
             Blockquote.name,
+            Callout.name,
             ...LIST_NODE_TYPES
           ]
         }),


### PR DESCRIPTION
## Description
Added `Callout.name` to `escapableNodesIfAtDocumentStart` array so pressing ArrowUp at the start of a document inserts an empty paragraph above a callout block, matching existing behavior for code blocks, tables, blockquotes and lists.

Fixes #10341

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
One-line config change — added a node name to an existing array

## Platform
<!-- Describe which platforms this PR is related to -->

- [x] Web
- [ ] Mobile
- [x] Desktop

## Sign-off
- [x] QA passed
- [x] UI/UX passed
