### PR TITLE
Fix android widget shortcut navigation

### DIFF
--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -120,9 +120,11 @@
         <activity
             android:name=".NotePreviewConfigureActivity"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
+            android:excludeFromRecents="true"
             android:exported="true"
             android:label="NotePreviewConfigure"
             android:launchMode="singleTask"
+            android:taskAffinity=""
             android:theme="@style/AppTheme"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>

--- a/apps/mobile/app/app.tsx
+++ b/apps/mobile/app/app.tsx
@@ -59,19 +59,21 @@ if (appLockEnabled || appLockMode !== "none") {
   useUserStore.getState().lockApp(true);
 }
 
-const App = (props: { configureMode: "note-preview" }) => {
+const App = (props: { configureMode?: "note-preview" }) => {
   useAppEvents();
-  //@ts-ignore
-  globalThis["IS_MAIN_APP_RUNNING"] = true;
+  if (!props.configureMode) {
+    //@ts-ignore
+    globalThis["IS_MAIN_APP_RUNNING"] = true;
+  }
   const introCompleted = useSettingStore(
     (state) => state.settings.introCompleted
   );
 
   useEffect(() => {
-    if (introCompleted) {
+    if (introCompleted && !props.configureMode) {
       registerAppShortcuts();
     }
-  }, [introCompleted]);
+  }, [introCompleted, props.configureMode]);
 
   useEffect(() => {
     RNBootSplash.hide({ fade: true });
@@ -80,14 +82,16 @@ const App = (props: { configureMode: "note-preview" }) => {
     SettingsService.setPrivacyScreen(
       SettingsService.getProperty("privacyScreen")
     );
-    setTimeout(async () => {
-      await Notifications.get();
-      if (SettingsService.get().notifNotes) {
-        Notifications.pinQuickNote();
-      }
-      TipManager.init();
-    }, 100);
-  }, []);
+    if (!props.configureMode) {
+      setTimeout(async () => {
+        await Notifications.get();
+        if (SettingsService.get().notifNotes) {
+          Notifications.pinQuickNote();
+        }
+        TipManager.init();
+      }, 100);
+    }
+  }, [props.configureMode]);
 
   return (
     <SafeAreaProvider>
@@ -188,14 +192,22 @@ export const withTheme = (
 };
 
 export const withStartupBoundry = (
-  Element: (props: PropsWithChildren) => JSX.Element
+  Element: (
+    props: PropsWithChildren & { configureMode?: "note-preview" }
+  ) => JSX.Element
 ) => {
-  return function AppWithStartupBoundary(props: PropsWithChildren) {
+  return function AppWithStartupBoundary(
+    props: PropsWithChildren & { configureMode?: "note-preview" }
+  ) {
     const [ready, setReady] = useState(false);
 
     useEffect(() => {
       async function init() {
         try {
+          if (props.configureMode === "note-preview") {
+            return;
+          }
+
           const [url, shortcut] = await Promise.all([
             Linking.getInitialURL(),
             Shortcuts.getInitialShortcut()
@@ -216,7 +228,7 @@ export const withStartupBoundry = (
       }
 
       init();
-    }, []);
+    }, [props.configureMode]);
 
     if (!ready) return null;
 

--- a/apps/mobile/app/hooks/use-app-events.tsx
+++ b/apps/mobile/app/hooks/use-app-events.tsx
@@ -188,6 +188,7 @@ const onAppOpenedFromURL = async (event: {
         const note = await db.notes.note(id);
         if (note) {
           editorState().initialLoadCalled = true;
+          Navigation.navigate("FluidPanelsView", { initialPage: "editor" });
           eSendEvent(eOnLoadNote, {
             item: note
           });


### PR DESCRIPTION
## Description
Fixes launcher shortcut hijacking during Android widget setup by preventing NotePreviewConfigureActivity from executing main app shortcut registration and flags, and ensures opening a note from a home screen widget properly navigates to FluidPanelsView so backgrounded modal screens like AddReminder are dismissed and the note editor is shown.

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [ ] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
