### PR TITLE
web: isolate archive route cache and clear stale context notes on switch

### DIFF
--- a/apps/web/src/navigation/routes.tsx
+++ b/apps/web/src/navigation/routes.tsx
@@ -107,7 +107,7 @@ const routes = defineRoutes({
   "/archive": () => {
     useNoteStore.getState().setContext({ type: "archive" });
     return defineRoute({
-      key: "notes",
+      key: "archive",
       title: strings.archive(),
       type: "notes",
       component: Notes

--- a/apps/web/src/stores/note-store.ts
+++ b/apps/web/src/stores/note-store.ts
@@ -58,6 +58,7 @@ class NoteStore extends BaseStore<NoteStore> {
   };
 
   setContext = async (context?: Context) => {
+    this.set({ context, contextNotes: undefined });
     const groupOptions =
       context?.type === "notebook" ||
       context?.type === "tag" ||


### PR DESCRIPTION
## Description
Fixes #9792
- Gave `/archive` its own route cache key (`key: "archive"`) in `routes.tsx` so the cached router does not reuse and bleed items from the Notes tab.
- Cleared stale `contextNotes` in `setContext` immediately on context switch to prevent ghost items from rendering while fetching new items.


## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
Route cache key update & store state reset

## Platform
<!-- Describe which platforms this PR is related to -->

- [x] Web
- [ ] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
