### PR TITLE
editor: sequentially insert multiple attachments to support mixed typ…

### DIFF
--- a/packages/editor/src/extensions/attachment/attachment.ts
+++ b/packages/editor/src/extensions/attachment/attachment.ts
@@ -113,40 +113,37 @@ export const AttachmentNode = Node.create<AttachmentOptions>({
     return {
       insertAttachment:
         (...attachments) =>
-        ({ commands, state }) => {
+        ({ chain, state }) => {
           if (!hasPermission("insertAttachment") || attachments.length === 0) {
             return false;
           }
 
           const { $from } = state.selection;
           const selectedNode = state.doc.nodeAt($from.pos);
-          if (
+          const isSelectedAttachment =
             selectedNode &&
             [
               ImageNode.name,
               WebClipNode.name,
               AudioNode.name,
               this.name
-            ].includes(selectedNode.type.name)
-          ) {
-            console.log(
-              "Inserting attachment after the selected node",
-              selectedNode
-            );
-            return commands.insertContentAt(
-              $from.pos + selectedNode.nodeSize,
-              attachments.map((a) => ({
-                type: mimeToExtension(a.mime),
-                attrs: a
-              }))
-            );
-          }
-          return commands.insertContent(
-            attachments.map((a) => ({
+            ].includes(selectedNode.type.name);
+
+          const ch = chain();
+          let first = true;
+          for (const a of attachments) {
+            const content = {
               type: mimeToExtension(a.mime),
               attrs: a
-            }))
-          );
+            };
+            if (first && isSelectedAttachment) {
+              ch.insertContentAt($from.pos + selectedNode.nodeSize, content);
+              first = false;
+            } else {
+              ch.insertContent(content);
+            }
+          }
+          return ch.run();
         },
       removeAttachment:
         () =>


### PR DESCRIPTION
## Description
Fixes #9514
Fixes #9515
- Sequentially insert multiple attachments using `chain()` in `insertAttachment` command.
- Ensures multiple audio files (block nodes) and mixed attachment types (inline file + block audio/image) are all inserted properly without dropping items.


## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
Tested existing editor test suite (`npm --prefix packages/editor test`).

## Platform
<!-- Describe which platforms this PR is related to -->

- [x] Web
- [ ] Mobile
- [x] Desktop

## Sign-off
- [x] QA passed
- [x] UI/UX passed
