### PR TITLE
core: fix attachment extension detection

### DIFF
--- a/packages/core/src/utils/__tests__/filename.test.ts
+++ b/packages/core/src/utils/__tests__/filename.test.ts
@@ -1,0 +1,35 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { describe, expect, it } from "vitest";
+import { getFileNameWithExtension } from "../filename";
+
+describe("getFileNameWithExtension", () => {
+  it("does not duplicate an existing uppercase extension", async () => {
+    await expect(
+      getFileNameWithExtension("report.PDF", "application/pdf")
+    ).resolves.toBe("report.PDF");
+  });
+
+  it("does not treat a filename suffix as an extension", async () => {
+    await expect(
+      getFileNameWithExtension("reportpdf", "application/pdf")
+    ).resolves.toBe("reportpdf.pdf");
+  });
+});

--- a/packages/core/src/utils/filename.ts
+++ b/packages/core/src/utils/filename.ts
@@ -30,7 +30,8 @@ export async function getFileNameWithExtension(
   if (!extensions || extensions.length === 0) return filename;
 
   for (const ext of extensions) {
-    if (filename.endsWith(ext)) return filename;
+    if (filename.toLowerCase().endsWith(`.${ext.toLowerCase()}`))
+      return filename;
   }
 
   const extension = extensions.values().next().value;


### PR DESCRIPTION
## Description

Fixes #10370.

Attachment extension detection now checks for the complete dotted extension without case sensitivity. This keeps `report.PDF` unchanged and still adds `.pdf` to `reportpdf`.

## Type of Change

- [x] Bug fix
- [ ] Feature

## Visuals

- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (no UI changes)

## Testing

- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [x] Added/updated tests for this change
- [ ] N/A (tests not needed)

### If tests were not added, explain why

Not applicable. Regression tests cover uppercase extensions and filenames that only end with the extension text.

## Platform

- [x] Web
- [x] Mobile
- [x] Desktop

The helper is part of the shared core package.

## Sign-off

- [ ] QA passed
- [ ] UI/UX passed

Focused test run: `src/utils/__tests__/filename.test.ts`, 2 tests passed.