### PR TITLE
clipper: strip event-handler attributes when cloning a page

### DIFF
--- a/packages/clipper/__unit_tests__/clone.test.ts
+++ b/packages/clipper/__unit_tests__/clone.test.ts
@@ -1,0 +1,69 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { DOMParser } from "linkedom";
+import { describe, expect, it } from "vitest";
+import { cloneNode } from "../src/clone.js";
+
+function parseBody(html: string): HTMLElement {
+  const document = new DOMParser().parseFromString(
+    `<!doctype html><html><body>${html}</body></html>`,
+    "text/html"
+  );
+  return document.body as unknown as HTMLElement;
+}
+
+describe("cloneNode", () => {
+  it("removes script and noscript elements", () => {
+    const body = parseBody(
+      `<p>hello</p><script>evil()</script><noscript>fallback</noscript>`
+    );
+    const clone = cloneNode(body, {});
+    expect(clone.querySelector("script")).toBeNull();
+    expect(clone.querySelector("noscript")).toBeNull();
+    expect(clone.textContent).toContain("hello");
+  });
+
+  it("strips event-handler attributes from descendant elements", () => {
+    const body = parseBody(
+      `<svg onload="evil()"><a href="#" onclick="evil()">x</a></svg><img onerror="evil()"/><details ontoggle="evil()"></details>`
+    );
+    const clone = cloneNode(body, { images: true });
+    for (const element of [clone, ...Array.from(clone.querySelectorAll("*"))]) {
+      for (const attribute of Array.from(element.attributes)) {
+        expect(attribute.name.toLowerCase().startsWith("on")).toBe(false);
+      }
+    }
+  });
+
+  it("strips an event-handler attribute set on the root node itself", () => {
+    const body = parseBody(`<p>hello</p>`);
+    body.setAttribute("onmouseover", "evil()");
+    const clone = cloneNode(body, {});
+    expect(clone.getAttribute("onmouseover")).toBeNull();
+  });
+
+  it("keeps ordinary, non-handler attributes intact", () => {
+    const body = parseBody(`<a href="https://example.com" title="ok">x</a>`);
+    const clone = cloneNode(body, {});
+    const link = clone.querySelector("a");
+    expect(link?.getAttribute("href")).toBe("https://example.com");
+    expect(link?.getAttribute("title")).toBe("ok");
+  });
+});

--- a/packages/clipper/package.json
+++ b/packages/clipper/package.json
@@ -12,7 +12,9 @@
   "devDependencies": {
     "@playwright/test": "1.48.2",
     "@rsbuild/core": "^1.5.13",
-    "slugify": "1.6.6"
+    "linkedom": "^0.14.17",
+    "slugify": "1.6.6",
+    "vitest": "2.1.8"
   },
   "publishConfig": {
     "access": "public"
@@ -25,6 +27,7 @@
     "build": "tsc && npx rsbuild build",
     "prepublishOnly": "npm run build",
     "test": "playwright test",
+    "test:unit": "vitest run",
     "postinstall": "patch-package",
     "watch": "tsc --watch"
   },

--- a/packages/clipper/src/clone.ts
+++ b/packages/clipper/src/clone.ts
@@ -24,6 +24,22 @@ type CloneNodeOptions = {
   styles?: boolean;
 };
 
+// Removes every "on*" event-handler attribute (onload, onerror, onclick,
+// onpointerover, etc.) instead of matching against a fixed list of names,
+// so newly introduced handler attributes are stripped too. Runs on the
+// root node itself as well as all of its descendants, since querySelectorAll
+// only reaches descendants.
+function removeEventHandlerAttributes(root: HTMLElement) {
+  const elements: Element[] = [root, ...Array.from(root.querySelectorAll("*"))];
+  for (const element of elements) {
+    for (const attribute of Array.from(element.attributes)) {
+      if (attribute.name.toLowerCase().startsWith("on")) {
+        element.removeAttribute(attribute.name);
+      }
+    }
+  }
+}
+
 export function cloneNode(node: HTMLElement, options: CloneNodeOptions) {
   node = node.cloneNode(true) as HTMLElement;
   const images = node.querySelectorAll("img");
@@ -44,5 +60,8 @@ export function cloneNode(node: HTMLElement, options: CloneNodeOptions) {
 
   const invalidElements = node.querySelectorAll(INVALID_ELEMENTS.join(","));
   for (const element of invalidElements) element.remove();
+
+  removeEventHandlerAttributes(node);
+
   return node;
 }

--- a/packages/clipper/src/index.ts
+++ b/packages/clipper/src/index.ts
@@ -520,6 +520,11 @@ function resolveFetchOptions(config?: Config): FetchOptions | undefined {
 function toAttributes(element: HTMLElement) {
   const attributes: Record<string, string> = {};
   for (const { name } of element.attributes) {
+    // documentElement's attributes are copied verbatim onto the already
+    // sanitized cloned body (see getPage() above), so event-handler
+    // attributes (onload, onerror, etc.) must be excluded here too or
+    // they would bypass cloneNode()'s stripping in clone.ts.
+    if (name.toLowerCase().startsWith("on")) continue;
     const value = element.getAttribute(name);
     if (!value) continue;
     attributes[name] = value;

--- a/packages/clipper/vitest.config.ts
+++ b/packages/clipper/vitest.config.ts
@@ -1,0 +1,26 @@
+/*
+This file is part of the Notesnook project (https://notesnook.com/)
+
+Copyright (C) 2023 Streetwriters (Private) Limited
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["__unit_tests__/**/*.test.ts"]
+  }
+});


### PR DESCRIPTION
## Description

`cloneNode()` in `packages/clipper/src/clone.ts` removes `<script>` and `<noscript>` elements from a clipped page, but keeps every other attribute as-is, including event-handler attributes such as `onload`, `onerror`, `onclick` and `ontoggle`. The cloned HTML this function produces is later inserted through `innerHTML` (see `apps/mobile/ios/extension.bundle/plaineditor.html:88`), so any handler attribute present in the source page executes at that point.

This change strips every attribute whose name starts with `on` (case-insensitively) rather than matching a fixed list of handler names, so newly introduced handler attributes are covered as well. The filter runs on the cloned root node and all of its descendants, since `querySelectorAll` alone only reaches descendants. `packages/clipper` is also consumed by `extensions/web-clipper` (`file:../../packages/clipper` in its `package.json`), so the browser extension picks up the same fix.

`toAttributes()` in `packages/clipper/src/index.ts` copies `document.documentElement`'s attributes onto the already-sanitized cloned body (`getPage()`, same file). That copy ran after `cloneNode()` and was unfiltered, so an `onload`/`onerror` attribute on the page's `<html>` element could reintroduce a handler attribute that `cloneNode()` had already removed. The same `on`-prefix filter is applied there.

Not covered by this change: `makeHtmlFromUrl()` in `apps/mobile/app/share/share.tsx` builds `<a href='${url}' ...>` from a string only checked with `validator`'s `isURL()`. That check rejects whitespace and angle brackets but accepts quotes, `=` and `/`, so a value can close the `href` attribute early and add its own. This is the same attribute-injection class, through a separate path, and needs its own fix rather than being folded in here. Also left unchanged: the destination WebView that assigns the clipped HTML via `innerHTML`. Sanitizing at the clipping source, before the markup exists, is the smaller and more targeted change; hardening the display layer as well would be a separate, broader change to a different package.

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [x] Added/updated tests for this change (if needed)
- [ ] N/A (tests not needed, explanation provided below)

Added `packages/clipper/__unit_tests__/clone.test.ts` (vitest + linkedom), covering: script/noscript removal still works, `on*` attributes are stripped from descendant elements, an `on*` attribute set on the root node itself is stripped, and ordinary non-handler attributes are preserved. Ran `tsc --noEmit`, `prettier --check` and `eslint` on all changed files with the repo's own configs; no errors, one pre-existing unrelated warning at `index.ts:207`. The package's existing Playwright suite (`packages/clipper/__tests__`) needs live network access to third-party sites and was not run; it is unaffected by this change (it only exercises `clipPage`'s screenshot output, not attribute content).

## Platform
- [x] Web
- [x] Mobile
- [ ] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed

## References

GHSA-rcx2-g7jh-67gc ([found during penetration test](https://www.turingpoint.de/en/security-assessments/pentests/) by [turingpoint](https://www.turingpoint.de), reported privately, unpublished at time of writing)