### PR TITLE
editor: copy code block as raw text to avoid HTML entities

### DIFF
--- a/packages/editor/src/extensions/code-block/component.tsx
+++ b/packages/editor/src/extensions/code-block/component.tsx
@@ -170,10 +170,7 @@ export function CodeblockComponent(
                 bg: "transparent"
               }}
               onClick={() => {
-                editor.storage.copyToClipboard?.(
-                  node.textContent,
-                  elementRef?.current?.innerHTML
-                );
+                editor.storage.copyToClipboard?.(node.textContent);
                 start();
               }}
               title={strings.copyToClipboard()}


### PR DESCRIPTION
## Description
- Avoid passing `elementRef?.current?.innerHTML` to `copyToClipboard` in code block component.
- Copies only clean raw text (`node.textContent`) to prevent quotes `"` from converting into HTML entities (`&quot;`) when pasted.

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
Tested clipboard copy output to ensure pure text without HTML entities is copied.

## Platform
<!-- Describe which platforms this PR is related to -->

- [x] Web
- [ ] Mobile
- [x] Desktop

## Sign-off
- [x] QA passed
- [x] UI/UX passed
