### PR TITLE
web: fix custom dictionary words squishing by wrapping list in flex c…

### DIFF
--- a/apps/web/src/dialogs/settings/components/dictionary-words.tsx
+++ b/apps/web/src/dialogs/settings/components/dictionary-words.tsx
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { Button, Text } from "@theme-ui/components";
+import { Button, Flex, Text } from "@theme-ui/components";
 import { FlexScrollContainer } from "../../../components/scroll-container";
 import { useSpellChecker } from "../../../hooks/use-spell-checker";
 import { strings } from "@notesnook/intl";
@@ -28,27 +28,22 @@ export function DictionaryWords() {
 
   return (
     <>
-      <FlexScrollContainer
-        suppressAutoHide
-        style={{
-          maxHeight: 400,
-          display: "flex",
-          flexDirection: "column"
-        }}
-      >
-        <Text variant="body" sx={{ my: 1 }}>
-          {strings.customDictWords(words.length)}
-        </Text>
-        {words.map((word) => (
-          <Button
-            key={word}
-            variant="menuitem"
-            sx={{ textAlign: "left", p: 1 }}
-            onClick={() => deleteWord(word)}
-          >
-            {word}
-          </Button>
-        ))}
+      <Text variant="body" sx={{ my: 1 }}>
+        {strings.customDictWords(words.length)}
+      </Text>
+      <FlexScrollContainer suppressAutoHide style={{ maxHeight: 400 }}>
+        <Flex sx={{ flexDirection: "column" }}>
+          {words.map((word) => (
+            <Button
+              key={word}
+              variant="menuitem"
+              sx={{ textAlign: "left", p: 1 }}
+              onClick={() => deleteWord(word)}
+            >
+              {word}
+            </Button>
+          ))}
+        </Flex>
       </FlexScrollContainer>
     </>
   );


### PR DESCRIPTION
## Description
Fixes #9733 
#web: fix custom dictionary words squishing by wrapping list in flex column
In `DictionaryWords`, `FlexScrollContainer` previously had `display: "flex", flexDirection: "column"` directly applied alongside `maxHeight: 400`. Due to CSS flexbox default `flex-shrink: 1`, multiple dictionary words (e.g. 50+ words) were squished into thin horizontal slivers instead of expanding and scrolling.

This PR:
- Moves the word count `Text` outside the scroll container to keep it stationary as a header.
- Removes flexbox container styles from `FlexScrollContainer`.
- Wraps the words inside an inner `<Flex sx={{ flexDirection: "column" }}>` so each button retains its full height and the list scrolls vertically as expected.

## Type of Change
- [x] Bug fix
- [ ] Feature

## Visuals
- [ ] Attached relevant screenshots / screen recording / GIF
- [x] N/A (not a feature or no UI changes)

## Testing
- [ ] Ran all E2E tests
- [ ] Ran all integration tests
- [ ] Added/updated tests for this change (if needed)
- [x] N/A (tests not needed — explanation provided below)

### If tests were not added, explain why
<!-- explanation -->

## Platform
<!-- Describe which platforms this PR is related to -->

- [x] Web
- [] Mobile
- [x] Desktop

## Sign-off
- [ ] QA passed
- [ ] UI/UX passed
